### PR TITLE
feat: allow for custom install key prefix.

### DIFF
--- a/packages/adapter-slack/src/index.test.ts
+++ b/packages/adapter-slack/src/index.test.ts
@@ -1170,6 +1170,45 @@ describe("multi-workspace mode with encryption", () => {
 });
 
 // ============================================================================
+// Installation Key Prefix Tests
+// ============================================================================
+
+describe("installationKeyPrefix", () => {
+  const secret = "test-signing-secret";
+
+  it("uses custom installationKeyPrefix for storage key", async () => {
+    const state = createMockState();
+    const adapter = createSlackAdapter({
+      signingSecret: secret,
+      logger: mockLogger,
+      installationKeyPrefix: "myapp:workspaces",
+    });
+    await adapter.initialize(createMockChatInstance(state));
+
+    await adapter.setInstallation("T_CUSTOM_1", { botToken: "xoxb-token" });
+
+    expect(state.cache.has("myapp:workspaces:T_CUSTOM_1")).toBe(true);
+    expect(state.cache.has("slack:installation:T_CUSTOM_1")).toBe(false);
+
+    const retrieved = await adapter.getInstallation("T_CUSTOM_1");
+    expect(retrieved?.botToken).toBe("xoxb-token");
+  });
+
+  it("uses default slack:installation prefix when installationKeyPrefix is omitted", async () => {
+    const state = createMockState();
+    const adapter = createSlackAdapter({
+      signingSecret: secret,
+      logger: mockLogger,
+    });
+    await adapter.initialize(createMockChatInstance(state));
+
+    await adapter.setInstallation("T_DEFAULT_1", { botToken: "xoxb-token" });
+
+    expect(state.cache.has("slack:installation:T_DEFAULT_1")).toBe(true);
+  });
+});
+
+// ============================================================================
 // handleOAuthCallback Tests
 // ============================================================================
 


### PR DESCRIPTION
**Use Case**:
If you want preview deployments of your Slack app installed on a workspace and you use one database to store the installation data (which v0 currently does), you'll want to make the key something like `${preview-git-sha}:slack:installation:${team_id}`. The current setup doesn't support preview deployments because each preview deployment app will have the same `team_id`, causing installations to be overwritten.

This pull request introduces support for customizing the prefix used for workspace installation storage keys in the Slack adapter. This allows applications to control how installation data is stored and retrieved, making it easier to avoid key collisions and integrate with different storage backends. The changes also include thorough tests to ensure the new functionality works as expected.

Configuration enhancements:

* Added an `installationKeyPrefix` option to the `SlackAdapterConfig` interface, allowing users to specify a custom prefix for installation storage keys. If omitted, it defaults to `slack:installation`. (`[packages/adapter-slack/src/index.tsR77-R81](diffhunk://#diff-58a1ceb0817cf057cbb93be75aeea1543612f0deb4757c768bc9acecbc5636c5R77-R81)`)
* Updated the `SlackAdapter` class to use the `installationKeyPrefix` value when generating storage keys for workspace installations. (`[[1]](diffhunk://#diff-58a1ceb0817cf057cbb93be75aeea1543612f0deb4757c768bc9acecbc5636c5R307)`, `[[2]](diffhunk://#diff-58a1ceb0817cf057cbb93be75aeea1543612f0deb4757c768bc9acecbc5636c5R332-R333)`, `[[3]](diffhunk://#diff-58a1ceb0817cf057cbb93be75aeea1543612f0deb4757c768bc9acecbc5636c5L392-R400)`)
* Modified the `createSlackAdapter` factory function to accept and pass through the `installationKeyPrefix` option. (`[packages/adapter-slack/src/index.tsR2958](diffhunk://#diff-58a1ceb0817cf057cbb93be75aeea1543612f0deb4757c768bc9acecbc5636c5R2958)`)

Testing improvements:

* Added new tests to verify that the adapter correctly uses custom and default installation key prefixes when storing and retrieving workspace installations. (`[packages/adapter-slack/src/index.test.tsR1172-R1210](diffhunk://#diff-001f9bc0a2c11da4df8dab7d7c25d81559e632e53e3152f366fe277c7d1195d9R1172-R1210)`)## Summary