### PR TITLE
Add changeset flow documentation to CLAUDE.md, SKILL.md, and CONTRIBUTING.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -165,6 +165,42 @@ cat /tmp/recording.json | jq '[.[] | select(.type == "webhook" and .platform == 
 cat /tmp/teams-webhooks.json | jq '[.[] | {type, text, channelData, value}]'
 ```
 
+## Changesets (Release Flow)
+
+This monorepo uses [Changesets](https://github.com/changesets/changesets) to manage versioning and changelogs. **Every PR that changes a package's behavior must include a changeset.**
+
+### Creating a changeset
+
+```bash
+pnpm changeset
+```
+
+You'll be prompted to:
+1. **Select the affected package(s)** — choose which packages your change touches (e.g., `@chat-adapter/slack`, `chat`)
+2. **Choose the semver bump** — `patch` for fixes, `minor` for new features, `major` for breaking changes
+3. **Write a summary** — a short description of the change (this goes into the CHANGELOG)
+
+This creates a markdown file in `.changeset/` — commit it with your PR.
+
+### When to use which bump
+
+- **patch** — bug fixes, internal refactors with no API change
+- **minor** — new features, new exports, new options
+- **major** — breaking changes (removed exports, changed signatures, dropped support)
+
+### Example
+
+```bash
+pnpm changeset
+# → select: @chat-adapter/slack
+# → bump: minor
+# → summary: Add custom installation prefix support for preview deployments
+```
+
+### Publishing (maintainers)
+
+When changesets are merged to `main`, the Changesets GitHub Action opens a "Version Packages" PR that bumps versions and updates CHANGELOGs. Merging that PR triggers publishing to npm.
+
 ## Environment Variables
 
 Key env vars used (see `turbo.json` for full list):

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,68 @@
+# Contributing to Chat SDK
+
+## Setup
+
+```bash
+pnpm install
+pnpm build
+```
+
+## Development
+
+```bash
+pnpm dev       # Watch mode
+pnpm test      # Run tests
+pnpm validate  # Full validation (lint, typecheck, test, build)
+```
+
+Always run `pnpm validate` before declaring a task done.
+
+## Changesets (Release Flow)
+
+This monorepo uses [Changesets](https://github.com/changesets/changesets) to manage versioning and changelogs. **Every PR that changes a package's behavior must include a changeset.**
+
+### Creating a changeset
+
+```bash
+pnpm changeset
+```
+
+You'll be prompted to:
+
+1. **Select the affected package(s)** — choose which packages your change touches (e.g., `@chat-adapter/slack`, `chat`)
+2. **Choose the semver bump** — `patch` for fixes, `minor` for new features, `major` for breaking changes
+3. **Write a summary** — a short description of the change (this goes into the CHANGELOG)
+
+This creates a markdown file in `.changeset/` — commit it with your PR.
+
+### When to use which bump
+
+| Bump | Use for | Example |
+|------|---------|---------|
+| `patch` | Bug fixes, internal refactors with no API change | Fix race condition in thread locking |
+| `minor` | New features, new exports, new options | Add custom installation prefix support |
+| `major` | Breaking changes (removed exports, changed signatures) | Rename `createAdapter` to `createSlackAdapter` |
+
+### Example
+
+```bash
+pnpm changeset
+# → select: @chat-adapter/slack
+# → bump: minor
+# → summary: Add custom installation prefix support for preview deployments
+```
+
+### Publishing (maintainers)
+
+When changesets are merged to `main`, the Changesets GitHub Action opens a "Version Packages" PR that bumps versions and updates CHANGELOGs. Merging that PR triggers publishing to npm.
+
+## Code Style
+
+This project uses [Ultracite](https://github.com/haydenbleasel/ultracite) for linting and formatting:
+
+```bash
+pnpm check   # Check for issues
+pnpm fix     # Auto-fix issues
+```
+
+See `CLAUDE.md` for full code style guidelines.

--- a/skills/chat/SKILL.md
+++ b/skills/chat/SKILL.md
@@ -130,6 +130,19 @@ await thread.post(
 | `@chat-adapter/state-ioredis` | ioredis state (alternative) |
 | `@chat-adapter/state-memory` | In-memory state (development) |
 
+## Changesets (Release Flow)
+
+This monorepo uses [Changesets](https://github.com/changesets/changesets) for versioning and changelogs. Every PR that changes a package's behavior must include a changeset.
+
+```bash
+pnpm changeset
+# → select affected package(s) (e.g. @chat-adapter/slack, chat)
+# → choose bump type: patch (fixes), minor (features), major (breaking)
+# → write a short summary for the CHANGELOG
+```
+
+This creates a file in `.changeset/` — commit it with the PR. When merged to `main`, the Changesets GitHub Action opens a "Version Packages" PR to bump versions and update CHANGELOGs. Merging that PR publishes to npm.
+
 ## Webhook setup
 
 Each adapter exposes a webhook handler via `bot.webhooks.{platform}`. Wire these to your HTTP framework's routes (e.g. Next.js API routes, Hono, Express).


### PR DESCRIPTION
The changeset flow for releasing packages was undocumented. This adds instructions for creating changesets (`pnpm changeset`), choosing the correct semver bump, and how publishing works via the Changesets GitHub Action.

### What changed
- Added a "Changesets (Release Flow)" section to `CLAUDE.md` so AI coding agents know the release process
- Added a condensed version to `skills/chat/SKILL.md` for the v0 skill context
- Created `CONTRIBUTING.md` (was referenced in README but didn't exist) with setup, dev workflow, changeset instructions, and code style pointers

<a href="https://vercel.slack.com/archives/C06QB6ZPEQ6/p1771942250604959?thread_ts=1771942250.604959&cid=C06QB6ZPEQ6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://v0.app/chat-static/slack-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://v0.app/chat-static/slack-light.svg"><img alt="Slack Thread" src="https://v0.app/chat-static/slack-light.svg" width="108" height="30"></picture></a>