### PR TITLE
docs: fix edit this page on github path

### DIFF
--- a/apps/docs/components/geistdocs/edit-source.tsx
+++ b/apps/docs/components/geistdocs/edit-source.tsx
@@ -9,7 +9,7 @@ export const EditSource = ({ path }: EditSourceProps) => {
   let url: string | undefined;
 
   if (github.owner && github.repo && path) {
-    url = `https://github.com/${github.owner}/${github.repo}/edit/main/content/docs/${path}`;
+    url = `https://github.com/${github.owner}/${github.repo}/edit/main/apps/docs/content/docs/${path}`;
   }
 
   if (!url) {


### PR DESCRIPTION
## Summary

edit this page on github link had incorrect path. updated docs app to fix this.

## Test plan

tested with `pnpm dev`, able to edit pages now
