### PR TITLE
docs: mention bot.initialize before Slack OAuth callback

### DIFF
--- a/apps/docs/content/docs/adapters/slack.mdx
+++ b/apps/docs/content/docs/adapters/slack.mdx
@@ -284,6 +284,21 @@ await thread.stream(textStream, {
 
 ## Troubleshooting
 
+### `handleOAuthCallback` throws "Adapter not initialized"
+
+- Call `await bot.initialize()` before `handleOAuthCallback()` in your callback route.
+- In a Next.js app, this ensures:
+  - state adapter is connected
+  - the Slack adapter is attached to Chat
+  - installation writes succeed
+
+```typescript title="app/api/slack/install/callback/route.ts" lineNumbers
+const slackAdapter = bot.getAdapter("slack");
+
+await bot.initialize();
+await slackAdapter.handleOAuthCallback(request);
+```
+
 ### "Invalid signature" error
 
 - Verify `SLACK_SIGNING_SECRET` is correct


### PR DESCRIPTION
## Summary

- Add a troubleshooting note for `NOT_INITIALIZED` errors during OAuth callback handling to call `await bot.initialize()` before `handleOAuthCallback(...)`.

## Issue
<img width="1352" height="500" alt="CleanShot 2026-02-24 at 22 48 05@2x" src="https://github.com/user-attachments/assets/d207f7d5-b0b1-4ee7-ad35-5165c7adcca0" />

