### PR TITLE
fix(teams): move microsoft-graph-client to dependencies

### DIFF
--- a/packages/adapter-teams/package.json
+++ b/packages/adapter-teams/package.json
@@ -26,11 +26,11 @@
   "dependencies": {
     "@azure/identity": "^4.13.0",
     "@chat-adapter/shared": "workspace:*",
+    "@microsoft/microsoft-graph-client": "^3.0.7",
     "botbuilder": "^4.23.1",
     "chat": "workspace:*"
   },
   "devDependencies": {
-    "@microsoft/microsoft-graph-client": "^3.0.7",
     "@types/node": "^25.3.2",
     "tsup": "^8.3.5",
     "typescript": "^5.7.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -400,6 +400,9 @@ importers:
       '@chat-adapter/shared':
         specifier: workspace:*
         version: link:../adapter-shared
+      '@microsoft/microsoft-graph-client':
+        specifier: ^3.0.7
+        version: 3.0.7(@azure/identity@4.13.0)
       botbuilder:
         specifier: ^4.23.1
         version: 4.23.3
@@ -407,9 +410,6 @@ importers:
         specifier: workspace:*
         version: link:../chat
     devDependencies:
-      '@microsoft/microsoft-graph-client':
-        specifier: ^3.0.7
-        version: 3.0.7(@azure/identity@4.13.0)
       '@types/node':
         specifier: ^25.3.2
         version: 25.3.2


### PR DESCRIPTION
Fixes vercel/chat#112.

@chat-adapter/teams imports @microsoft/microsoft-graph-client at runtime but it was listed under devDependencies. This causes consumer installs to fail if the package isn't present transitively.

Changes:
- Move @microsoft/microsoft-graph-client to dependencies in packages/adapter-teams/package.json
- Update pnpm-lock.yaml

Repro notes:
- The adapter's dist entry imports @microsoft/microsoft-graph-client/authProviders/... at runtime, so it must be a runtime dependency (not devDependency).