### PR TITLE
fix(discord): dispatch slash commands from interaction webhooks

### DIFF
--- a/.changeset/discord-slash-command-dispatch.md
+++ b/.changeset/discord-slash-command-dispatch.md
@@ -1,0 +1,7 @@
+---
+"@chat-adapter/discord": patch
+---
+
+Fix Discord slash command interactions to dispatch `ApplicationCommand` events through `chat.processSlashCommand`, while preserving deferred ACK responses.
+
+This makes `chat.onSlashCommand(...)` handlers run for Discord webhooks and includes command option text parsing for nested options.

--- a/packages/adapter-discord/src/index.test.ts
+++ b/packages/adapter-discord/src/index.test.ts
@@ -4,7 +4,7 @@
 
 import { generateKeyPairSync, sign } from "node:crypto";
 import { ValidationError } from "@chat-adapter/shared";
-import type { Logger } from "chat";
+import type { ChatInstance, Logger, StateAdapter } from "chat";
 import { InteractionType } from "discord-api-types/v10";
 import { describe, expect, it, vi } from "vitest";
 import { createDiscordAdapter, DiscordAdapter } from "./index";
@@ -65,6 +65,47 @@ function createWebhookRequest(
     },
     body,
   });
+}
+
+function createMockState(): StateAdapter & { cache: Map<string, unknown> } {
+  const cache = new Map<string, unknown>();
+  return {
+    cache,
+    connect: vi.fn().mockResolvedValue(undefined),
+    disconnect: vi.fn().mockResolvedValue(undefined),
+    subscribe: vi.fn().mockResolvedValue(undefined),
+    unsubscribe: vi.fn().mockResolvedValue(undefined),
+    isSubscribed: vi.fn().mockResolvedValue(false),
+    acquireLock: vi.fn().mockResolvedValue(null),
+    releaseLock: vi.fn().mockResolvedValue(undefined),
+    extendLock: vi.fn().mockResolvedValue(true),
+    get: vi.fn().mockImplementation((key: string) => {
+      return Promise.resolve(cache.get(key) ?? null);
+    }),
+    set: vi.fn().mockImplementation((key: string, value: unknown) => {
+      cache.set(key, value);
+      return Promise.resolve();
+    }),
+    delete: vi.fn().mockImplementation((key: string) => {
+      cache.delete(key);
+      return Promise.resolve();
+    }),
+  };
+}
+
+function createMockChatInstance(state: StateAdapter): ChatInstance {
+  return {
+    processMessage: vi.fn(),
+    handleIncomingMessage: vi.fn().mockResolvedValue(undefined),
+    processReaction: vi.fn(),
+    processAction: vi.fn(),
+    processModalSubmit: vi.fn().mockResolvedValue(undefined),
+    processModalClose: vi.fn(),
+    processSlashCommand: vi.fn(),
+    getState: () => state,
+    getUserName: () => "test-bot",
+    getLogger: () => mockLogger,
+  };
 }
 
 // ============================================================================
@@ -405,6 +446,55 @@ describe("handleWebhook - APPLICATION_COMMAND", () => {
 
     const responseBody = await response.json();
     expect(responseBody).toEqual({ type: 5 }); // DeferredChannelMessageWithSource
+  });
+
+  it("dispatches slash command to chat.processSlashCommand", async () => {
+    const state = createMockState();
+    const chatInstance = createMockChatInstance(state);
+    await adapter.initialize(chatInstance);
+
+    const body = JSON.stringify({
+      type: InteractionType.ApplicationCommand,
+      id: "interaction123",
+      application_id: "test-app-id",
+      token: "interaction-token",
+      version: 1,
+      guild_id: "guild123",
+      channel_id: "channel456",
+      member: {
+        user: {
+          id: "user789",
+          username: "testuser",
+          discriminator: "0001",
+          global_name: "Test User",
+        },
+        roles: [],
+        joined_at: "2021-01-01T00:00:00.000Z",
+      },
+      data: {
+        id: "cmd123",
+        name: "ask",
+        type: 1,
+        options: [{ type: 3, name: "prompt", value: "hello world" }],
+      },
+    });
+    const request = createWebhookRequest(body);
+
+    const response = await adapter.handleWebhook(request);
+    expect(response.status).toBe(200);
+    expect(chatInstance.processSlashCommand).toHaveBeenCalledTimes(1);
+
+    const call = (
+      chatInstance.processSlashCommand as ReturnType<typeof vi.fn>
+    ).mock.calls[0];
+    const event = call[0];
+
+    expect(event.command).toBe("/ask");
+    expect(event.text).toBe("hello world");
+    expect(event.channelId).toBe("discord:guild123:channel456");
+    expect(event.user.userId).toBe("user789");
+    expect(event.user.userName).toBe("testuser");
+    expect(event.adapter).toBe(adapter);
   });
 });
 

--- a/packages/adapter-discord/src/index.ts
+++ b/packages/adapter-discord/src/index.ts
@@ -58,6 +58,7 @@ import { DiscordFormatConverter } from "./markdown";
 import {
   type DiscordActionRow,
   type DiscordAdapterConfig,
+  type DiscordCommandOption,
   type DiscordForwardedEvent,
   type DiscordGatewayEventType,
   type DiscordGatewayMessageData,
@@ -207,7 +208,7 @@ export class DiscordAdapter implements Adapter<DiscordThreadId, unknown> {
 
     // Handle APPLICATION_COMMAND (slash commands - not implemented yet)
     if (interaction.type === InteractionType.ApplicationCommand) {
-      // For now, just ACK
+      this.handleSlashCommandInteraction(interaction, options);
       return this.respondToInteraction({
         type: InteractionResponseType.DeferredChannelMessageWithSource,
       });
@@ -363,6 +364,90 @@ export class DiscordAdapter implements Adapter<DiscordThreadId, unknown> {
     });
 
     this.chat.processAction(actionEvent, options);
+  }
+
+  private handleSlashCommandInteraction(
+    interaction: DiscordInteraction,
+    options?: WebhookOptions
+  ): void {
+    if (!this.chat) {
+      this.logger.warn("Chat instance not initialized, ignoring interaction");
+      return;
+    }
+
+    const commandName = interaction.data?.name?.trim();
+    if (!commandName) {
+      this.logger.warn("No command name in slash command interaction");
+      return;
+    }
+
+    const user = interaction.member?.user || interaction.user;
+    if (!user) {
+      this.logger.warn("No user in slash command interaction");
+      return;
+    }
+
+    const interactionChannelId = interaction.channel_id;
+    if (!interactionChannelId) {
+      this.logger.warn("Missing channel_id in slash command interaction");
+      return;
+    }
+
+    const guildId = interaction.guild_id || "@me";
+    const channel = interaction.channel;
+    const isThread = channel?.type === 11 || channel?.type === 12;
+    const parentChannelId =
+      isThread && channel?.parent_id ? channel.parent_id : interactionChannelId;
+
+    const threadId = isThread
+      ? this.encodeThreadId({
+          guildId,
+          channelId: parentChannelId,
+          threadId: interactionChannelId,
+        })
+      : this.encodeThreadId({
+          guildId,
+          channelId: interactionChannelId,
+        });
+
+    this.chat.processSlashCommand(
+      {
+        adapter: this,
+        channelId: threadId,
+        command: commandName.startsWith("/") ? commandName : `/${commandName}`,
+        text: this.extractCommandText(interaction.data?.options),
+        user: {
+          userId: user.id,
+          userName: user.username,
+          fullName: user.global_name || user.username,
+          isBot: user.bot ?? false,
+          isMe: false,
+        },
+        raw: interaction,
+      },
+      options
+    );
+  }
+
+  private extractCommandText(options?: DiscordCommandOption[]): string {
+    const queue: DiscordCommandOption[] = [...(options || [])];
+    const values: string[] = [];
+
+    while (queue.length > 0) {
+      const option = queue.shift();
+      if (!option) {
+        continue;
+      }
+
+      if (Array.isArray(option.options)) {
+        queue.push(...option.options);
+      }
+      if (option.value != null) {
+        values.push(`${option.value}`);
+      }
+    }
+
+    return values.join(" ").trim();
   }
 
   /**


### PR DESCRIPTION
## Summary

Dispatch Discord `InteractionType.ApplicationCommand` events through `chat.processSlashCommand(...)` instead of only returning a deferred ACK.

### What changed

- In `@chat-adapter/discord`, `handleWebhook` now calls `handleSlashCommandInteraction` for `ApplicationCommand` interactions before returning the deferred response.
- Added slash command event mapping logic:
  - normalizes command names to `/command`
  - maps user/channel/thread metadata to Chat SDK event fields
  - flattens nested Discord command options into `event.text`
- Added unit coverage to assert `processSlashCommand` is called with expected payload.
- Added a changeset (`patch`) for `@chat-adapter/discord`.

## Test plan

- `pnpm --filter @chat-adapter/discord typecheck`
- `pnpm --filter chat build`
- `pnpm --filter @chat-adapter/shared build`
- `pnpm --filter @chat-adapter/discord test`
  - result: 3 test files passed, 104 tests passed
