### PR TITLE
fix: use createMemoryState if no REDIS_URL

### DIFF
--- a/examples/nextjs-chat/package.json
+++ b/examples/nextjs-chat/package.json
@@ -16,6 +16,7 @@
     "@chat-adapter/github": "workspace:*",
     "@chat-adapter/linear": "workspace:*",
     "@chat-adapter/slack": "workspace:*",
+    "@chat-adapter/state-memory": "workspace:*",
     "@chat-adapter/state-redis": "workspace:*",
     "@chat-adapter/telegram": "workspace:*",
     "@chat-adapter/teams": "workspace:*",

--- a/examples/nextjs-chat/src/lib/bot.tsx
+++ b/examples/nextjs-chat/src/lib/bot.tsx
@@ -1,5 +1,6 @@
 /** @jsxImportSource chat */
 // @ts-nocheck - TypeScript doesn't understand custom JSX runtimes with per-file pragmas
+import { createMemoryState } from "@chat-adapter/state-memory";
 import { createRedisState } from "@chat-adapter/state-redis";
 import { ToolLoopAgent } from "ai";
 import {
@@ -28,10 +29,12 @@ const DISABLE_AI_REGEX = /disable\s*AI/i;
 const ENABLE_AI_REGEX = /enable\s*AI/i;
 const DM_ME_REGEX = /^dm\s*me$/i;
 
-const state = createRedisState({
-  url: process.env.REDIS_URL || "",
-  keyPrefix: "chat-sdk-webhooks",
-});
+const state = process.env.REDIS_URL
+  ? createRedisState({
+      url: process.env.REDIS_URL,
+      keyPrefix: "chat-sdk-webhooks",
+    })
+  : createMemoryState();
 const adapters = buildAdapters();
 
 // Define thread state type

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -186,6 +186,9 @@ importers:
       '@chat-adapter/slack':
         specifier: workspace:*
         version: link:../../packages/adapter-slack
+      '@chat-adapter/state-memory':
+        specifier: workspace:*
+        version: link:../../packages/state-memory
       '@chat-adapter/state-redis':
         specifier: workspace:*
         version: link:../../packages/state-redis


### PR DESCRIPTION
## Summary

<!-- What does this PR do? -->

Update `examples/nextjs-chat` to use in-memory state adapter if `REDIS_URL` isn't set. 

Note that the env var is optional, as the [docs](https://github.com/vercel/chat/tree/main/examples/nextjs-chat#environment-variables) imply:

> At minimum, set `BOT_USERNAME` and credentials for one platform

So it shouldn't be mandatory.

## Test plan

<!-- How did you verify the changes? -->

- [x] `pnpm validate`
- [x] Manual testing (ran the example with Discord variables set up and navigated to `/api/webhooks/discord`)
