### PR TITLE
fix(adapter-slack): fix Slack link preprocessing and remove auto @mention conversion

### DIFF
--- a/packages/adapter-slack/src/markdown.test.ts
+++ b/packages/adapter-slack/src/markdown.test.ts
@@ -76,33 +76,66 @@ describe("SlackMarkdownConverter", () => {
   });
 
   describe("mentions", () => {
-    it("should not double-wrap mentions already in <@user> format", () => {
-      // renderPostable with string containing existing Slack mention
+    it("should preserve mentions already in <@user> format", () => {
       expect(converter.renderPostable("Hey <@U12345>. Please select")).toBe(
         "Hey <@U12345>. Please select"
       );
     });
 
-    it("should not double-wrap mentions in markdown input", () => {
+    it("should preserve mentions in markdown input", () => {
       expect(
         converter.renderPostable({ markdown: "Hey <@U12345>. Please select" })
       ).toBe("Hey <@U12345>. Please select");
     });
 
-    it("should still convert bare @mentions to Slack format", () => {
+    it("should not auto-convert bare @mentions to Slack mentions", () => {
+      // Bare @handles (e.g. Twitter) should NOT become Slack mentions
       expect(converter.renderPostable("Hey @george. Please select")).toBe(
-        "Hey <@george>. Please select"
+        "Hey @george. Please select"
       );
     });
 
-    it("should convert bare @mentions in markdown", () => {
+    it("should not auto-convert bare @mentions in markdown", () => {
       expect(
         converter.renderPostable({ markdown: "Hey @george. Please select" })
-      ).toBe("Hey <@george>. Please select");
+      ).toBe("Hey @george. Please select");
     });
 
-    it("should not double-wrap mentions via fromMarkdown", () => {
+    it("should preserve mentions via fromMarkdown", () => {
       expect(converter.fromMarkdown("Hey <@U12345>")).toBe("Hey <@U12345>");
+    });
+  });
+
+  describe("Slack-style link preprocessing", () => {
+    it("should convert Slack-style <url|text> links in markdown input", () => {
+      expect(
+        converter.renderPostable({
+          markdown: "Check <https://example.com|this link>",
+        })
+      ).toBe("Check <https://example.com|this link>");
+    });
+
+    it("should convert HTML-encoded Slack links in markdown input", () => {
+      expect(
+        converter.renderPostable({
+          markdown:
+            "Source: &lt;https://x.com/user/status/123|@username&gt; said hi",
+        })
+      ).toBe("Source: <https://x.com/user/status/123|@username> said hi");
+    });
+
+    it("should not touch Slack user mentions when preprocessing links", () => {
+      expect(
+        converter.renderPostable({
+          markdown: "Hey <@U12345> check <https://example.com|this>",
+        })
+      ).toBe("Hey <@U12345> check <https://example.com|this>");
+    });
+
+    it("should convert Slack-style links in plain string input", () => {
+      expect(
+        converter.renderPostable("Visit <https://example.com|our site>")
+      ).toBe("Visit <https://example.com|our site>");
     });
   });
 

--- a/packages/adapter-slack/src/markdown.ts
+++ b/packages/adapter-slack/src/markdown.ts
@@ -33,25 +33,41 @@ import {
 
 export class SlackFormatConverter extends BaseFormatConverter {
   /**
-   * Convert @mentions to Slack format in plain text.
-   * @name → <@name>
+   * Convert Slack-style links embedded in markdown/text to standard markdown
+   * links before AST parsing. LLMs frequently output `<url|text>` or
+   * HTML-encoded `&lt;url|text&gt;` even when instructed to use markdown.
+   * Only matches http(s) URLs so Slack user mentions (<@U...>) and
+   * channel mentions (<#C...>) are preserved.
    */
-  private convertMentionsToSlack(text: string): string {
-    return text.replace(/(?<!<)@(\w+)/g, "<@$1>");
+  private preprocessSlackLinks(text: string): string {
+    let result = text;
+    // HTML-encoded Slack links: &lt;url|text&gt; → [text](url)
+    result = result.replace(
+      /&lt;(https?:\/\/[^|&]+)\|([^&]+)&gt;/g,
+      "[$2]($1)"
+    );
+    // Raw Slack links: <url|text> → [text](url)
+    result = result.replace(
+      /<(https?:\/\/[^|>]+)\|([^>]+)>/g,
+      "[$2]($1)"
+    );
+    return result;
   }
 
   /**
-   * Override renderPostable to convert @mentions in plain strings.
+   * Override renderPostable to preprocess Slack-style links in all text inputs.
    */
   override renderPostable(message: AdapterPostableMessage): string {
     if (typeof message === "string") {
-      return this.convertMentionsToSlack(message);
+      return this.fromAst(parseMarkdown(this.preprocessSlackLinks(message)));
     }
     if ("raw" in message) {
-      return this.convertMentionsToSlack(message.raw);
+      return message.raw;
     }
     if ("markdown" in message) {
-      return this.fromAst(parseMarkdown(message.markdown));
+      return this.fromAst(
+        parseMarkdown(this.preprocessSlackLinks(message.markdown))
+      );
     }
     if ("ast" in message) {
       return this.fromAst(message.ast);
@@ -108,8 +124,7 @@ export class SlackFormatConverter extends BaseFormatConverter {
     }
 
     if (isTextNode(node)) {
-      // Convert @mentions to Slack format <@mention>
-      return node.value.replace(/(?<!<)@(\w+)/g, "<@$1>");
+      return node.value;
     }
 
     if (isStrongNode(node)) {


### PR DESCRIPTION
## Problem

Two bugs in `SlackFormatConverter` (`packages/adapter-slack/src/markdown.ts`):

### 1. Slack-style links broken by markdown parser

LLMs frequently output `<url|text>` (Slack mrkdwn syntax) or HTML-encoded `&lt;url|text&gt;` even when instructed to use markdown. The `renderPostable` method passes these directly to `parseMarkdown()`, which doesn't understand Slack link syntax. The angle brackets get treated as HTML/text and are escaped as `&lt;`/`&gt;` in the final output — producing unclickable raw text.

### 2. Bare `@handle` auto-converted to Slack mentions

`nodeToMrkdwn` and `convertMentionsToSlack` both apply `/(?<!<)@(\w+)/g → <@$1>`, converting **all** `@word` patterns to Slack user mentions — including Twitter/X handles, email-like text, and other non-Slack references. This breaks any message that references external social media accounts.

## Fix

### Slack link preprocessing (`preprocessSlackLinks`)

Added a preprocessing step in `renderPostable` that converts Slack-style links to standard markdown before AST parsing:
- `<https://example.com|text>` → `[text](https://example.com)`
- `&lt;https://example.com|text&gt;` → `[text](https://example.com)`

Only matches `http(s)` URLs, so Slack user mentions (`<@U...>`) and channel mentions (`<#C...>`) are preserved.

### Removed auto @mention conversion

Removed the regex that blindly converted `@word` → `<@word>` from both `nodeToMrkdwn` (text nodes) and `convertMentionsToSlack`. Callers who want Slack mentions should pass them pre-formatted as `<@UXXXX>` — the converter already preserves those correctly through the roundtrip.

## Tests

All 179 existing tests pass. Updated mention tests to reflect new behavior and added 4 new tests for Slack-style link preprocessing.