### PR TITLE
Fix Google Chat attachment download to use media.download API

### DIFF
--- a/packages/adapter-gchat/src/index.test.ts
+++ b/packages/adapter-gchat/src/index.test.ts
@@ -417,6 +417,108 @@ describe("GoogleChatAdapter", () => {
       expect(msg.attachments[0].type).toBe("video");
       expect(msg.attachments[1].type).toBe("audio");
     });
+
+    it("should use media.download API when attachmentDataRef is present", async () => {
+      const { adapter } = await createInitializedAdapter();
+      const mockDownload = vi.fn().mockResolvedValue({
+        data: new ArrayBuffer(4),
+      });
+      (adapter as any).chatApi = {
+        media: { download: mockDownload },
+      };
+
+      const event = makeMessageEvent({
+        attachment: [
+          {
+            name: "att1",
+            contentName: "photo.png",
+            contentType: "image/png",
+            downloadUri: "https://example.com/photo.png",
+            attachmentDataRef: {
+              resourceName: "spaces/ABC123/attachments/att1",
+            },
+          },
+        ],
+      });
+
+      const msg = adapter.parseMessage(event);
+      expect(msg.attachments[0].fetchData).toBeDefined();
+
+      const data = await msg.attachments[0].fetchData?.();
+      expect(data).toBeInstanceOf(Buffer);
+      expect(mockDownload).toHaveBeenCalledWith(
+        { resourceName: "spaces/ABC123/attachments/att1" },
+        { responseType: "arraybuffer" }
+      );
+    });
+
+    it("should provide fetchData when only attachmentDataRef is present (no downloadUri)", async () => {
+      const { adapter } = await createInitializedAdapter();
+      const mockDownload = vi.fn().mockResolvedValue({
+        data: new ArrayBuffer(4),
+      });
+      (adapter as any).chatApi = {
+        media: { download: mockDownload },
+      };
+
+      const event = makeMessageEvent({
+        attachment: [
+          {
+            name: "att1",
+            contentName: "photo.png",
+            contentType: "image/png",
+            attachmentDataRef: {
+              resourceName: "spaces/ABC123/attachments/att1",
+            },
+          },
+        ],
+      });
+
+      const msg = adapter.parseMessage(event);
+      expect(msg.attachments[0].fetchData).toBeDefined();
+
+      const data = await msg.attachments[0].fetchData?.();
+      expect(data).toBeInstanceOf(Buffer);
+      expect(mockDownload).toHaveBeenCalledWith(
+        { resourceName: "spaces/ABC123/attachments/att1" },
+        { responseType: "arraybuffer" }
+      );
+    });
+
+    it("should fall back to direct URL fetch when no attachmentDataRef", async () => {
+      const { adapter } = await createInitializedAdapter();
+      const event = makeMessageEvent({
+        attachment: [
+          {
+            name: "att1",
+            contentName: "photo.png",
+            contentType: "image/png",
+            downloadUri: "https://example.com/photo.png",
+          },
+        ],
+      });
+
+      const msg = adapter.parseMessage(event);
+      expect(msg.attachments[0].fetchData).toBeDefined();
+      // fetchData is present because downloadUri exists
+      expect(msg.attachments[0].url).toBe("https://example.com/photo.png");
+    });
+
+    it("should not provide fetchData when neither resourceName nor downloadUri exist", async () => {
+      const { adapter } = await createInitializedAdapter();
+      const event = makeMessageEvent({
+        attachment: [
+          {
+            name: "att1",
+            contentName: "unknown.bin",
+            contentType: "application/octet-stream",
+          },
+        ],
+      });
+
+      const msg = adapter.parseMessage(event);
+      expect(msg.attachments[0].fetchData).toBeUndefined();
+    });
   });
 
   describe("normalizeBotMentions (via parseMessage)", () => {

--- a/packages/adapter-gchat/src/index.ts
+++ b/packages/adapter-gchat/src/index.ts
@@ -153,6 +153,7 @@ export interface GoogleChatMessage {
     contentName: string;
     contentType: string;
     downloadUri?: string;
+    attachmentDataRef?: { resourceName?: string | null } | null;
   }>;
   createTime: string;
   formattedText?: string;
@@ -1307,9 +1308,11 @@ export class GoogleChatAdapter implements Adapter<GoogleChatThreadId, unknown> {
     downloadUri?: string | null;
     contentName?: string | null;
     thumbnailUri?: string | null;
+    attachmentDataRef?: { resourceName?: string | null } | null;
   }): Attachment {
     const url = att.downloadUri || undefined;
-    const authClient = this.authClient;
+    const resourceName = att.attachmentDataRef?.resourceName || undefined;
+    const chatApi = this.chatApi;
 
     // Determine type based on contentType
     let type: Attachment["type"] = "file";
@@ -1321,49 +1324,59 @@ export class GoogleChatAdapter implements Adapter<GoogleChatThreadId, unknown> {
       type = "audio";
     }
 
-    // Capture auth client for use in fetchData closure
-    const auth = authClient;
+    // Capture auth client for use in fetchData closure (used for URL fallback)
+    const auth = this.authClient;
 
     return {
       type,
       url,
       name: att.contentName || undefined,
       mimeType: att.contentType || undefined,
-      fetchData: url
-        ? async () => {
-            // Get access token for authenticated download
-            if (typeof auth === "string" || !auth) {
-              throw new AuthenticationError(
-                "gchat",
-                "Cannot fetch file: no auth client configured"
-              );
+      fetchData:
+        resourceName || url
+          ? async () => {
+              // Prefer media.download API (correct method for chat apps)
+              if (resourceName) {
+                const res = await chatApi.media.download(
+                  { resourceName },
+                  { responseType: "arraybuffer" }
+                );
+                return Buffer.from(res.data as ArrayBuffer);
+              }
+
+              // Fallback to direct URL fetch (downloadUri)
+              if (typeof auth === "string" || !auth) {
+                throw new AuthenticationError(
+                  "gchat",
+                  "Cannot fetch file: no auth client configured"
+                );
+              }
+              const tokenResult = await auth.getAccessToken();
+              const token =
+                typeof tokenResult === "string"
+                  ? tokenResult
+                  : tokenResult?.token;
+              if (!token) {
+                throw new AuthenticationError(
+                  "gchat",
+                  "Failed to get access token"
+                );
+              }
+              const response = await fetch(url as string, {
+                headers: {
+                  Authorization: `Bearer ${token}`,
+                },
+              });
+              if (!response.ok) {
+                throw new NetworkError(
+                  "gchat",
+                  `Failed to fetch file: ${response.status} ${response.statusText}`
+                );
+              }
+              const arrayBuffer = await response.arrayBuffer();
+              return Buffer.from(arrayBuffer);
             }
-            const tokenResult = await auth.getAccessToken();
-            const token =
-              typeof tokenResult === "string"
-                ? tokenResult
-                : tokenResult?.token;
-            if (!token) {
-              throw new AuthenticationError(
-                "gchat",
-                "Failed to get access token"
-              );
-            }
-            const response = await fetch(url, {
-              headers: {
-                Authorization: `Bearer ${token}`,
-              },
-            });
-            if (!response.ok) {
-              throw new NetworkError(
-                "gchat",
-                `Failed to fetch file: ${response.status} ${response.statusText}`
-              );
-            }
-            const arrayBuffer = await response.arrayBuffer();
-            return Buffer.from(arrayBuffer);
-          }
-        : undefined,
+          : undefined,
     };
   }
 


### PR DESCRIPTION
## Summary

- Use `chatApi.media.download()` with `attachmentDataRef.resourceName` instead of `downloadUri` for fetching attachment data — `downloadUri` is for human users and returns 401 for service accounts
- Fall back to direct URL fetch only when `resourceName` is unavailable
- Add `attachmentDataRef` to `GoogleChatMessage` attachment type

Closes #166

## Test plan

- [x] Existing attachment parsing tests still pass
- [x] New test: `media.download` called when `attachmentDataRef` present
- [x] New test: `fetchData` works with only `attachmentDataRef` (no `downloadUri`)
- [x] New test: falls back to URL fetch when no `attachmentDataRef`
- [x] New test: no `fetchData` when neither `resourceName` nor `downloadUri` exist
- [x] Full `pnpm validate` passes (knip, lint, typecheck, tests, build)