### PR TITLE
fix(adapter-discord): stop auto-generating Card fallback text to prevent duplicate content

### DIFF
--- a/packages/adapter-discord/src/index.ts
+++ b/packages/adapter-discord/src/index.ts
@@ -55,8 +55,26 @@ import {
   InteractionResponseType as DiscordInteractionResponseType,
   verifyKey,
 } from "discord-interactions";
-import { cardToDiscordPayload, cardToFallbackText } from "./cards";
+import { cardToDiscordPayload } from "./cards";
 import { DiscordFormatConverter } from "./markdown";
+
+/**
+ * Extract explicit fallback text from a PostableCard message.
+ * Returns undefined for direct CardElement (no wrapper) or when fallbackText is absent.
+ */
+function extractFallbackText(
+  message: AdapterPostableMessage
+): string | undefined {
+  if (
+    typeof message === "object" &&
+    message !== null &&
+    "card" in message &&
+    "fallbackText" in message
+  ) {
+    return (message as { fallbackText?: string }).fallbackText ?? undefined;
+  }
+  return undefined;
+}
 import {
   type DiscordActionRow,
   type DiscordAdapterConfig,
@@ -789,8 +807,12 @@ export class DiscordAdapter implements Adapter<DiscordThreadId, unknown> {
       const cardPayload = cardToDiscordPayload(card);
       embeds.push(...cardPayload.embeds);
       components.push(...cardPayload.components);
-      // Fallback text (truncated to Discord's limit)
-      payload.content = this.truncateContent(cardToFallbackText(card));
+      // Only set content when PostableCard provides explicit fallbackText.
+      // Auto-generated fallback duplicates the embed content in the chat view.
+      const fallback = extractFallbackText(message);
+      if (fallback) {
+        payload.content = this.truncateContent(fallback);
+      }
     } else {
       // Regular text message (truncated to Discord's limit)
       payload.content = this.truncateContent(
@@ -1135,8 +1157,12 @@ export class DiscordAdapter implements Adapter<DiscordThreadId, unknown> {
       const cardPayload = cardToDiscordPayload(card);
       embeds.push(...cardPayload.embeds);
       components.push(...cardPayload.components);
-      // Fallback text (truncated to Discord's limit)
-      payload.content = this.truncateContent(cardToFallbackText(card));
+      // Only set content when PostableCard provides explicit fallbackText.
+      // Auto-generated fallback duplicates the embed content in the chat view.
+      const fallback = extractFallbackText(message);
+      if (fallback) {
+        payload.content = this.truncateContent(fallback);
+      }
     } else {
       // Regular text message (truncated to Discord's limit)
       payload.content = this.truncateContent(
@@ -2350,7 +2376,12 @@ export class DiscordAdapter implements Adapter<DiscordThreadId, unknown> {
       const cardPayload = cardToDiscordPayload(card);
       embeds.push(...cardPayload.embeds);
       components.push(...cardPayload.components);
-      payload.content = this.truncateContent(cardToFallbackText(card));
+      // Only set content when PostableCard provides explicit fallbackText.
+      // Auto-generated fallback duplicates the embed content in the chat view.
+      const fallback = extractFallbackText(message);
+      if (fallback) {
+        payload.content = this.truncateContent(fallback);
+      }
     } else {
       payload.content = this.truncateContent(
         convertEmojiPlaceholders(


### PR DESCRIPTION
## Summary

When posting a Card on Discord, the adapter generates both `payload.content` (plaintext fallback via `cardToFallbackText()`) and `payload.embeds` (the rich embed). Discord renders **both** in the chat view, causing the card content to appear twice — once as plain text above the embed, and once inside the embed itself.

**Before (duplicate rendering):**
```
📋 Tool Calls ×5 · 8.2s            ← plaintext content (auto-generated fallback)
                                  
┌─────────────────────────────┐
│ 📋 Tool Calls ×5 · 8.2s     │  ← embed (same content again)
│ ✅ tool1 (1.2s)              │
│ ✅ tool2 (2.4s)              │
└─────────────────────────────┘
```

**After (embed only):**
```
┌─────────────────────────────┐
│ 📋 Tool Calls ×5 · 8.2s     │  ← embed only, no duplication
│ ✅ tool1 (1.2s)              │
│ ✅ tool2 (2.4s)              │
└─────────────────────────────┘
```

## Changes

- Remove auto-generated `cardToFallbackText()` content from `postMessage()`, `editMessage()`, and `postChannelMessage()` in the Discord adapter
- Add `extractFallbackText()` helper that checks for explicit `PostableCard.fallbackText` — only set `payload.content` when the caller explicitly provides fallback text
- `cardToFallbackText` remains exported for advanced/external use

## Rationale

- Discord uses embed `title`/`description` for push notifications when `content` is empty, so notifications are **unaffected**
- The embed already renders the full card content — the plaintext fallback is redundant in Discord's chat view
- Users who need explicit fallback text can still provide it: `{ card: Card({...}), fallbackText: "..." }`
- Other adapters (Slack, Teams, Google Chat) are not affected by this change

## Test plan

- [ ] Post a Card on Discord → verify only the embed appears (no plaintext above it)
- [ ] Edit a Card message on Discord → verify no plaintext duplication after edit
- [ ] Post a `PostableCard` with explicit `fallbackText` → verify the text appears as `content`
- [ ] Post a Card on Discord → verify push notification still shows embed title/content
- [ ] Verify no regression on other message types (plain text, markdown)

🤖 Generated with [Claude Code](https://claude.com/claude-code)