### PR TITLE
fix: remove source maps from published packages

### DIFF
--- a/packages/adapter-discord/tsup.config.ts
+++ b/packages/adapter-discord/tsup.config.ts
@@ -5,6 +5,6 @@ export default defineConfig({
   format: ["esm"],
   dts: true,
   clean: true,
-  sourcemap: true,
+  sourcemap: false,
   external: ["discord-api-types"],
 });

--- a/packages/adapter-gchat/tsup.config.ts
+++ b/packages/adapter-gchat/tsup.config.ts
@@ -5,6 +5,6 @@ export default defineConfig({
   format: ["esm"],
   dts: true,
   clean: true,
-  sourcemap: true,
+  sourcemap: false,
   external: ["googleapis"],
 });

--- a/packages/adapter-github/tsup.config.ts
+++ b/packages/adapter-github/tsup.config.ts
@@ -5,6 +5,6 @@ export default defineConfig({
   format: ["esm"],
   dts: true,
   clean: true,
-  sourcemap: true,
+  sourcemap: false,
   external: ["@octokit/rest", "@octokit/webhooks", "@octokit/auth-app"],
 });

--- a/packages/adapter-linear/tsup.config.ts
+++ b/packages/adapter-linear/tsup.config.ts
@@ -5,6 +5,6 @@ export default defineConfig({
   format: ["esm"],
   dts: true,
   clean: true,
-  sourcemap: true,
+  sourcemap: false,
   external: ["@linear/sdk"],
 });

--- a/packages/adapter-shared/tsup.config.ts
+++ b/packages/adapter-shared/tsup.config.ts
@@ -4,7 +4,7 @@ export default defineConfig({
   entry: ["src/index.ts"],
   format: ["esm"],
   dts: true,
-  sourcemap: true,
+  sourcemap: false,
   clean: true,
   target: "es2022",
 });

--- a/packages/adapter-slack/tsup.config.ts
+++ b/packages/adapter-slack/tsup.config.ts
@@ -5,6 +5,6 @@ export default defineConfig({
   format: ["esm"],
   dts: true,
   clean: true,
-  sourcemap: true,
+  sourcemap: false,
   external: ["@slack/web-api"],
 });

--- a/packages/adapter-teams/tsup.config.ts
+++ b/packages/adapter-teams/tsup.config.ts
@@ -5,7 +5,7 @@ export default defineConfig({
   format: ["esm"],
   dts: true,
   clean: true,
-  sourcemap: true,
+  sourcemap: false,
   external: ["botbuilder"],
   noExternal: ["@microsoft/microsoft-graph-client"],
 });

--- a/packages/adapter-telegram/tsup.config.ts
+++ b/packages/adapter-telegram/tsup.config.ts
@@ -5,5 +5,5 @@ export default defineConfig({
   format: ["esm"],
   dts: true,
   clean: true,
-  sourcemap: true,
+  sourcemap: false,
 });

--- a/packages/chat/tsup.config.ts
+++ b/packages/chat/tsup.config.ts
@@ -5,5 +5,5 @@ export default defineConfig({
   format: ["esm"],
   dts: true,
   clean: true,
-  sourcemap: true,
+  sourcemap: false,
 });

--- a/packages/state-ioredis/tsup.config.ts
+++ b/packages/state-ioredis/tsup.config.ts
@@ -5,6 +5,6 @@ export default defineConfig({
   format: ["esm"],
   dts: true,
   clean: true,
-  sourcemap: true,
+  sourcemap: false,
   external: ["ioredis"],
 });

--- a/packages/state-memory/tsup.config.ts
+++ b/packages/state-memory/tsup.config.ts
@@ -5,5 +5,5 @@ export default defineConfig({
   format: ["esm"],
   dts: true,
   clean: true,
-  sourcemap: true,
+  sourcemap: false,
 });

--- a/packages/state-redis/tsup.config.ts
+++ b/packages/state-redis/tsup.config.ts
@@ -5,6 +5,6 @@ export default defineConfig({
   format: ["esm"],
   dts: true,
   clean: true,
-  sourcemap: true,
+  sourcemap: false,
   external: ["redis"],
 });


### PR DESCRIPTION
## Summary

- Disable source map generation (`sourcemap: false`) in all 12 package tsup configs

## Problem

Published packages ship `//# sourceMappingURL=index.js.map` comments in dist files. When consumers enable `experimental.serverSourceMaps` in Next.js (e.g. via Datadog integration), SWC attempts to resolve these `.map` files through Turbopack's virtual filesystem and fails:

```
ERROR  failed to read input source map: failed to find input source map file "index.js.map"
       in "node_modules/.pnpm/chat@4.14.0/node_modules/chat/dist/index.js"
```

This is non-fatal (build succeeds), but produces a noisy error on every build. Caused by [vercel/next.js#86340](https://github.com/vercel/next.js/pull/86340) which wired `serverSourceMaps` into Turbopack's input source map reading.

## Fix

Remove source maps from all published packages. Consumers don't debug into `node_modules` — these maps add ~245KB to the published tarball for no practical benefit.