### PR TITLE
docs: mention PostgreSQL state adapter across remaining docs

### DIFF
--- a/apps/docs/content/docs/adapters/index.mdx
+++ b/apps/docs/content/docs/adapters/index.mdx
@@ -126,4 +126,8 @@ bot.onNewMention(async (thread) => {
 
 Each adapter auto-detects credentials from environment variables, so you only need to pass config when overriding defaults.
 
+<Callout type="info">
+  The examples above use Redis for state. See [State Adapters](/docs/state) for all production options including PostgreSQL and ioredis.
+</Callout>
+
 Each adapter creates a webhook handler accessible via `bot.webhooks.slack`, `bot.webhooks.teams`, etc.

--- a/apps/docs/content/docs/guides/code-review-hono.mdx
+++ b/apps/docs/content/docs/guides/code-review-hono.mdx
@@ -239,4 +239,4 @@ After deployment, set your environment variables in the Vercel dashboard (`GITHU
 ## Next steps
 
 - [GitHub adapter](/docs/adapters/github) — Authentication options, thread model, and full configuration reference
-- [Redis state](/docs/state/redis) — Production state adapter for subscriptions and distributed locking
+- [State Adapters](/docs/state) — Production state adapters (Redis, PostgreSQL, ioredis) for subscriptions and distributed locking

--- a/apps/docs/content/docs/guides/discord-nuxt.mdx
+++ b/apps/docs/content/docs/guides/discord-nuxt.mdx
@@ -224,3 +224,4 @@ After deployment, set your environment variables in the Vercel dashboard (`DISCO
 - [Actions](/docs/actions) — Handle button clicks, select menus, and other interactions
 - [Streaming](/docs/streaming) — Stream AI-generated responses to chat
 - [Discord adapter](/docs/adapters/discord) — Full configuration reference and Gateway setup
+- [State Adapters](/docs/state) — PostgreSQL, ioredis, and other state adapter options

--- a/apps/docs/content/docs/guides/slack-nextjs.mdx
+++ b/apps/docs/content/docs/guides/slack-nextjs.mdx
@@ -229,3 +229,4 @@ After deployment, set your environment variables in the Vercel dashboard (`SLACK
 - [Streaming](/docs/streaming) — Stream AI-generated responses to chat
 - [Actions](/docs/actions) — Handle button clicks, select menus, and other interactions
 - [Slack adapter](/docs/adapters/slack) — Multi-workspace OAuth, token encryption, and full configuration reference
+- [State Adapters](/docs/state) — PostgreSQL, ioredis, and other state adapter options

--- a/apps/docs/content/docs/usage.mdx
+++ b/apps/docs/content/docs/usage.mdx
@@ -33,6 +33,10 @@ bot.onNewMention(async (thread) => {
 });
 ```
 
+<Callout type="info">
+  This example uses Redis. Chat SDK also supports [PostgreSQL](/docs/state/postgres) and [ioredis](/docs/state/ioredis) as production state adapters. See [State Adapters](/docs/state) for all options.
+</Callout>
+
 Each adapter factory auto-detects credentials from environment variables (`SLACK_BOT_TOKEN`, `SLACK_SIGNING_SECRET`, `REDIS_URL`, etc.), so you can get started with zero config. Pass explicit values to override.
 
 ## Multiple adapters

--- a/packages/chat/README.md
+++ b/packages/chat/README.md
@@ -40,6 +40,8 @@ bot.onSubscribedMessage(async (thread, message) => {
 });
 ```
 
+> **Tip:** PostgreSQL and ioredis adapters are also available for production. See [State Adapters](https://chat-sdk.dev/docs/state) for all options.
+
 ## Configuration
 
 | Option | Type | Default | Description |

--- a/skills/chat/SKILL.md
+++ b/skills/chat/SKILL.md
@@ -31,7 +31,7 @@ Key docs to read based on task:
 - `docs/actions.mdx` — button/dropdown handlers
 - `docs/modals.mdx` — form dialogs (Slack only)
 - `docs/adapters/*.mdx` — platform-specific adapter setup
-- `docs/state/*.mdx` — state adapter config (Redis, ioredis, memory)
+- `docs/state/*.mdx` — state adapter config (Redis, ioredis, PostgreSQL, memory)
 
 Also read the TypeScript types from `node_modules/chat/dist/` to understand the full API surface.
 
@@ -67,7 +67,7 @@ bot.onSubscribedMessage(async (thread, message) => {
 
 - **Chat** — main entry point, coordinates adapters and routes events
 - **Adapters** — platform-specific (Slack, Teams, GChat, Discord, GitHub, Linear)
-- **State** — pluggable persistence (Redis for prod, memory for dev)
+- **State** — pluggable persistence (Redis or PostgreSQL for prod, memory for dev)
 - **Thread** — conversation thread with `post()`, `subscribe()`, `startTyping()`
 - **Message** — normalized format with `text`, `formatted` (mdast AST), `raw`
 - **Channel** — container for threads, supports listing and posting
@@ -128,6 +128,7 @@ await thread.post(
 | `@chat-adapter/linear` | Linear Issues |
 | `@chat-adapter/state-redis` | Redis state (production) |
 | `@chat-adapter/state-ioredis` | ioredis state (alternative) |
+| `@chat-adapter/state-pg` | PostgreSQL state (production) |
 | `@chat-adapter/state-memory` | In-memory state (development) |
 
 ## Changesets (Release Flow)


### PR DESCRIPTION
Several docs pages only referenced Redis as the production state adapter. Add PostgreSQL mentions to usage page, guide "Next steps" sections, adapters overview, SKILL.md, and package README.
