### PR TITLE
fix: add github username

### DIFF
--- a/examples/nextjs-chat/src/lib/adapters.ts
+++ b/examples/nextjs-chat/src/lib/adapters.ts
@@ -191,6 +191,7 @@ export function buildAdapters(): Adapters {
       adapters.github = withRecording(
         createGitHubAdapter({
           logger: logger.child("github"),
+          userName: "chat-sdk-bot",
         }),
         "github",
         GITHUB_METHODS


### PR DESCRIPTION
This pull request makes a small update to the GitHub adapter configuration in the Next.js chat example. The change sets a specific `userName` ("chat-sdk-bot") for the GitHub adapter, which can help with clearer logging and identification of actions performed by the bot.

* Set the `userName` property to "chat-sdk-bot" in the `createGitHubAdapter` call within `adapters.ts`.