### PR TITLE
fix(chat): handle non-array children in fallback text and Actions types

### DIFF
--- a/packages/chat/src/cards.test.ts
+++ b/packages/chat/src/cards.test.ts
@@ -4,9 +4,12 @@ import {
   Button,
   Card,
   CardLink,
+  cardChildToFallbackText,
+  cardToFallbackText,
   Divider,
   Field,
   Fields,
+  getChildrenArray,
   Image,
   isCardElement,
   LinkButton,
@@ -336,6 +339,147 @@ describe("Select and RadioSelect Builder Validation", () => {
       expect(radioSelect.type).toBe("radio_select");
       expect(radioSelect.options).toHaveLength(1);
     });
+  });
+});
+
+describe("getChildrenArray", () => {
+  it("returns array when children is already an array", () => {
+    const node = { children: [Text("a"), Text("b")] };
+    expect(getChildrenArray(node)).toEqual([
+      { type: "text", content: "a", style: undefined },
+      { type: "text", content: "b", style: undefined },
+    ]);
+  });
+
+  it("wraps single child in array when children is not an array", () => {
+    const node = { children: Text("only") };
+    expect(getChildrenArray(node)).toHaveLength(1);
+    expect(getChildrenArray(node)[0]).toEqual({
+      type: "text",
+      content: "only",
+      style: undefined,
+    });
+  });
+
+  it("returns empty array when children is undefined", () => {
+    expect(getChildrenArray({})).toEqual([]);
+    expect(getChildrenArray({ children: undefined })).toEqual([]);
+  });
+
+  it("returns empty array when children is null", () => {
+    expect(getChildrenArray({ children: null })).toEqual([]);
+  });
+});
+
+describe("Fallback text with non-array children", () => {
+  it("cardToFallbackText handles card with children undefined", () => {
+    const card = {
+      type: "card" as const,
+      title: "Test",
+      subtitle: "Sub",
+      children: undefined,
+    };
+    expect(() => cardToFallbackText(card)).not.toThrow();
+    expect(cardToFallbackText(card)).toContain("**Test**");
+    expect(cardToFallbackText(card)).toContain("Sub");
+  });
+
+  it("cardToFallbackText handles card with children null", () => {
+    const card = {
+      type: "card" as const,
+      title: "Test",
+      children: null,
+    };
+    expect(() => cardToFallbackText(card)).not.toThrow();
+    expect(cardToFallbackText(card)).toBe("**Test**");
+  });
+
+  it("cardToFallbackText handles card with single child (non-array)", () => {
+    const card = {
+      type: "card" as const,
+      title: "Test",
+      children: Text("Only child"),
+    };
+    expect(() => cardToFallbackText(card)).not.toThrow();
+    expect(cardToFallbackText(card)).toContain("**Test**");
+    expect(cardToFallbackText(card)).toContain("Only child");
+  });
+
+  it("cardChildToFallbackText handles section with children undefined", () => {
+    const section = {
+      type: "section" as const,
+      children: undefined,
+    };
+    expect(() => cardChildToFallbackText(section)).not.toThrow();
+    expect(cardChildToFallbackText(section)).toBe("");
+  });
+
+  it("cardChildToFallbackText handles section with children null", () => {
+    const section = {
+      type: "section" as const,
+      children: null,
+    };
+    expect(() => cardChildToFallbackText(section)).not.toThrow();
+    expect(cardChildToFallbackText(section)).toBe("");
+  });
+
+  it("cardChildToFallbackText handles section with single child (non-array)", () => {
+    const section = {
+      type: "section" as const,
+      children: Text("Single"),
+    };
+    expect(() => cardChildToFallbackText(section)).not.toThrow();
+    expect(cardChildToFallbackText(section)).toBe("Single");
+  });
+
+  it("cardChildToFallbackText handles fields with children undefined", () => {
+    const fields = {
+      type: "fields" as const,
+      children: undefined,
+    };
+    expect(() => cardChildToFallbackText(fields)).not.toThrow();
+    expect(cardChildToFallbackText(fields)).toBe("");
+  });
+
+  it("cardChildToFallbackText handles fields with children null", () => {
+    const fields = {
+      type: "fields" as const,
+      children: null,
+    };
+    expect(() => cardChildToFallbackText(fields)).not.toThrow();
+    expect(cardChildToFallbackText(fields)).toBe("");
+  });
+
+  it("cardChildToFallbackText handles fields with single field (non-array)", () => {
+    const fields = {
+      type: "fields" as const,
+      children: Field({ label: "Name", value: "Alice" }),
+    };
+    expect(() => cardChildToFallbackText(fields)).not.toThrow();
+    expect(cardChildToFallbackText(fields)).toBe("Name: Alice");
+  });
+
+  it("cardToFallbackText with section and fields with non-array children (serialization-style)", () => {
+    const card = {
+      type: "card" as const,
+      title: "Review",
+      subtitle: "Please confirm",
+      children: [
+        {
+          type: "section" as const,
+          children: Text("Approve or reject below."),
+        },
+        {
+          type: "fields" as const,
+          children: Field({ label: "Status", value: "Pending" }),
+        },
+      ],
+    };
+    expect(() => cardToFallbackText(card)).not.toThrow();
+    const fallback = cardToFallbackText(card);
+    expect(fallback).toContain("**Review**");
+    expect(fallback).toContain("Approve or reject below.");
+    expect(fallback).toContain("Status: Pending");
   });
 });
 

--- a/packages/chat/src/cards.ts
+++ b/packages/chat/src/cards.ts
@@ -795,10 +795,10 @@ export function cardChildToFallbackText(child: CardChild): string | null {
       return `${child.label} (${child.url})`;
     case "fields":
       return getChildrenArray(child)
-        .map(
-          (f: unknown) =>
-            `${(f as FieldElement).label}: ${(f as FieldElement).value}`
-        )
+        .map((f: unknown) => {
+          const { label, value } = f as FieldElement;
+          return `${label}: ${value}`;
+        })
         .join("\n");
     case "actions":
       // Actions are interactive-only — exclude from fallback text.

--- a/packages/chat/src/cards.ts
+++ b/packages/chat/src/cards.ts
@@ -745,6 +745,18 @@ function extractTextContent(children: unknown): string {
 // Fallback Text Generation
 // ============================================================================
 
+/** Ensure children is always an array (handles JSX/serialization where it may be single or undefined). */
+export function getChildrenArray(node: { children?: unknown }): unknown[] {
+  const c = node.children;
+  if (Array.isArray(c)) {
+    return c;
+  }
+  if (c != null) {
+    return [c];
+  }
+  return [];
+}
+
 /**
  * Generate plain text fallback from a CardElement.
  * Used for platforms/clients that can't render rich cards,
@@ -761,8 +773,8 @@ export function cardToFallbackText(card: CardElement): string {
     parts.push(card.subtitle);
   }
 
-  for (const child of card.children) {
-    const text = cardChildToFallbackText(child);
+  for (const child of getChildrenArray(card)) {
+    const text = cardChildToFallbackText(child as CardChild);
     if (text) {
       parts.push(text);
     }
@@ -782,7 +794,12 @@ export function cardChildToFallbackText(child: CardChild): string | null {
     case "link":
       return `${child.label} (${child.url})`;
     case "fields":
-      return child.children.map((f) => `${f.label}: ${f.value}`).join("\n");
+      return getChildrenArray(child)
+        .map(
+          (f: unknown) =>
+            `${(f as FieldElement).label}: ${(f as FieldElement).value}`
+        )
+        .join("\n");
     case "actions":
       // Actions are interactive-only — exclude from fallback text.
       // See: https://docs.slack.dev/reference/methods/chat.postMessage
@@ -790,8 +807,8 @@ export function cardChildToFallbackText(child: CardChild): string | null {
     case "table":
       return tableElementToAscii(child.headers, child.rows);
     case "section":
-      return child.children
-        .map((c) => cardChildToFallbackText(c))
+      return getChildrenArray(child)
+        .map((c: unknown) => cardChildToFallbackText(c as CardChild))
         .filter(Boolean)
         .join("\n");
     default:

--- a/packages/chat/src/jsx-runtime.ts
+++ b/packages/chat/src/jsx-runtime.ts
@@ -299,15 +299,24 @@ export interface SectionComponent {
   (props: ContainerProps): ChatElement;
 }
 
+/** Action child type for Actions() - buttons and selects only. */
+type ActionsChild =
+  | ButtonElement
+  | LinkButtonElement
+  | SelectElement
+  | RadioSelectElement;
+
 export interface ActionsComponent {
+  /**
+   * Array form (preferred): Actions([Button(...), Button(...)]).
+   * Accepts CardChild[] so that Actions([...]) nested in Card({ children: [...] })
+   * type-checks when the array is contextually typed as CardChild[].
+   * Runtime still expects only button/select elements.
+   */
   (
-    children: (
-      | ButtonElement
-      | LinkButtonElement
-      | SelectElement
-      | RadioSelectElement
-    )[]
+    children: readonly CardChild[] | readonly ActionsChild[] | ActionsChild[]
   ): ActionsElement;
+  /** Props form for JSX: <Actions><Button ... /></Actions> */
   (props: ContainerProps): ChatElement;
 }
 

--- a/packages/chat/src/markdown.ts
+++ b/packages/chat/src/markdown.ts
@@ -26,7 +26,12 @@ import remarkGfm from "remark-gfm";
 import remarkParse from "remark-parse";
 import remarkStringify from "remark-stringify";
 import { unified } from "unified";
-import { type CardChild, type CardElement, getChildrenArray } from "./cards";
+import {
+  type CardChild,
+  type CardElement,
+  type FieldElement,
+  getChildrenArray,
+} from "./cards";
 import type { AdapterPostableMessage } from "./types";
 
 // Alias for use within this file
@@ -583,10 +588,10 @@ export abstract class BaseFormatConverter implements FormatConverter {
         return child.content;
       case "fields":
         return getChildrenArray(child)
-          .map(
-            (f: unknown) =>
-              `**${(f as { label: string; value: string }).label}**: ${(f as { label: string; value: string }).value}`
-          )
+          .map((f: unknown) => {
+            const { label, value } = f as FieldElement;
+            return `**${label}**: ${value}`;
+          })
           .join("\n");
       case "actions":
         // Actions are interactive-only — exclude from fallback text.

--- a/packages/chat/src/markdown.ts
+++ b/packages/chat/src/markdown.ts
@@ -26,7 +26,7 @@ import remarkGfm from "remark-gfm";
 import remarkParse from "remark-parse";
 import remarkStringify from "remark-stringify";
 import { unified } from "unified";
-import type { CardChild, CardElement } from "./cards";
+import { type CardChild, type CardElement, getChildrenArray } from "./cards";
 import type { AdapterPostableMessage } from "./types";
 
 // Alias for use within this file
@@ -564,8 +564,8 @@ export abstract class BaseFormatConverter implements FormatConverter {
       parts.push(card.subtitle);
     }
 
-    for (const child of card.children) {
-      const text = this.cardChildToFallbackText(child);
+    for (const child of getChildrenArray(card)) {
+      const text = this.cardChildToFallbackText(child as CardChild);
       if (text) {
         parts.push(text);
       }
@@ -582,8 +582,11 @@ export abstract class BaseFormatConverter implements FormatConverter {
       case "text":
         return child.content;
       case "fields":
-        return child.children
-          .map((f) => `**${f.label}**: ${f.value}`)
+        return getChildrenArray(child)
+          .map(
+            (f: unknown) =>
+              `**${(f as { label: string; value: string }).label}**: ${(f as { label: string; value: string }).value}`
+          )
           .join("\n");
       case "actions":
         // Actions are interactive-only — exclude from fallback text.
@@ -592,8 +595,8 @@ export abstract class BaseFormatConverter implements FormatConverter {
       case "table":
         return tableElementToAscii(child.headers, child.rows);
       case "section":
-        return child.children
-          .map((c) => this.cardChildToFallbackText(c))
+        return getChildrenArray(child)
+          .map((c: unknown) => this.cardChildToFallbackText(c as CardChild))
           .filter(Boolean)
           .join("\n");
       default:


### PR DESCRIPTION
Hello,

This PR fixes two related issues that showed up when using cards built with JSX or after serialization, and when nesting `Actions([...])` inside Card({ children: [...] }).

1. Runtime crash

For section and fields nodes, the fallback-text path assumed children was always an array and called `child.children.map(...)`. After JSX or serialization, children can be a single value or `undefined`, which led to `element.children.map` is not a function.

2. Type error when nesting Actions

Using the documented array form `Actions([Button(...), Button(...)])` inside `Card({ children: [...] })` caused a type error. The inner array was inferred as `CardChild[]`, so it didn’t match the strict action-children overload and also didn’t match `ContainerProps`, giving: `"Type 'ChatElement[]' has no properties in common with type 'ContainerProps'"`:

Essentially:

```ts
// No type errors, but runtime error
Actions({
  children: [
    Button({ id: "approve", label: "Approve", style: "primary" }),
    Button({ id: "reject", label: "Reject", style: "danger" }),
  ],
}),

// Type errors, but no runtime crash (and works as documented)
Actions([
    Button({ id: "approve", label: "Approve", style: "primary" }),
    Button({ id: "reject", label: "Reject", style: "danger" }),
]),
```
This PR does:

1. Introduces `getChildrenArray(node)`, which always returns an array: it keeps arrays as-is, wraps a single child in `[child]`, and returns `[]` when children is missing or null. It uses it everywhere we iterate over children in the fallback-text path (in both `cards.ts` and `markdown.ts`’s `BaseFormatConverter`), so we never call .map on a non-array.

2. Updates `ActionsComponent` so the array form is a single overload that accepts
`readonly CardChild[] | readonly ActionsChild[] | ActionsChild[]`. That way `Actions([...])` type-checks both on its own and when nested in `Card({ children: [...] })`, without adding overloads that would trigger the “unified type signatures” lint.


## Test plan

Added tests to PR.
