### PR TITLE
fix(slack): add streaming keepalive to prevent session timeout

### DIFF
--- a/.changeset/slack-streaming-keepalive.md
+++ b/.changeset/slack-streaming-keepalive.md
@@ -1,0 +1,9 @@
+---
+"@chat-adapter/slack": patch
+---
+
+Add streaming keepalive to prevent `message_not_in_streaming_state` errors
+
+Slack's streaming API expires the session after ~5 minutes of inactivity. When the upstream `textStream` iterable pauses for extended periods (e.g. during long-running agent tool calls), the session expires and all subsequent `append` or `stop` calls fail with `message_not_in_streaming_state`.
+
+The fix races each chunk from the text stream against a 2-minute keepalive timer. If no chunk arrives within 2 minutes, a zero-width-space is appended to keep the Slack session alive. No chunks are ever dropped — the same pending promise is re-raced after each keepalive.

--- a/packages/adapter-slack/src/index.ts
+++ b/packages/adapter-slack/src/index.ts
@@ -3019,7 +3019,34 @@ export class SlackAdapter implements Adapter<SlackThreadId, unknown> {
       lastAppended = committable;
     };
 
-    for await (const chunk of textStream) {
+    // Race each chunk against a keepalive timer. Slack expires the streaming
+    // session after ~5 min of inactivity; we send a zero-width-space append
+    // every 2 min to keep it alive during long-running agent turns.
+    const KEEPALIVE_MS = 120_000;
+    const iter = textStream[Symbol.asyncIterator]();
+    let pending: Promise<IteratorResult<string | StreamChunk>> | null = null;
+
+    // eslint-disable-next-line no-constant-condition
+    while (true) {
+      if (!pending) pending = iter.next();
+
+      const raced = await Promise.race([
+        pending.then((r) => ({ kind: "value" as const, result: r })),
+        new Promise<{ kind: "keepalive" }>((r) =>
+          setTimeout(() => r({ kind: "keepalive" }), KEEPALIVE_MS)
+        ),
+      ]);
+
+      if (raced.kind === "keepalive") {
+        // Send an invisible append to keep the Slack streaming session alive
+        await flushMarkdownDelta("\u200B");
+        continue;
+      }
+
+      pending = null;
+      if (raced.result.done) break;
+
+      const chunk = raced.result.value;
       if (typeof chunk === "string") {
         await pushTextAndFlush(chunk);
       } else if (chunk.type === "markdown_text") {


### PR DESCRIPTION
## Problem

Slack's streaming API expires the session after ~5 minutes of inactivity. When the `textStream` iterable pauses for extended periods — which is common during long-running agent tool calls, multi-step reasoning, or external API waits — the session expires silently. All subsequent `streamer.append()` or `streamer.stop()` calls then fail with:

```
Error: An API error occurred: message_not_in_streaming_state
```

This is fatal: the SDK's `sendStructuredChunk` catch handler disables structured chunks for the rest of the stream, and if text streaming also fails, the entire response is lost. The user sees only an error message.

Currently the SDK has **no keepalive or heartbeat mechanism** — the `for await` loop in `stream()` simply blocks waiting for the next chunk with no timeout awareness.

## Fix

Replace the `for await` loop with a `Promise.race` pattern that races each `iter.next()` against a **2-minute keepalive timer** (well under Slack's ~5-minute TTL). If no chunk arrives within 2 minutes, a zero-width space (`\u200B`) is appended via the existing `flushMarkdownDelta` helper to keep the session alive.

The same pending iterator promise is re-raced after each keepalive, so **no chunks are ever dropped or duplicated**.

### Before

```
for await (const chunk of textStream) { ... }
```

### After

```
while (true) {
  if (!pending) pending = iter.next();
  const raced = await Promise.race([
    pending.then(r => ({ kind: 'value', result: r })),
    new Promise(r => setTimeout(() => r({ kind: 'keepalive' }), 120_000)),
  ]);
  if (raced.kind === 'keepalive') {
    await flushMarkdownDelta('\u200B');  // invisible keepalive
    continue;
  }
  pending = null;
  if (raced.result.done) break;
  // ... process chunk as before
}
```

## Testing

- `pnpm --filter @chat-adapter/slack build` ✅
- `pnpm --filter @chat-adapter/slack typecheck` ✅
- `pnpm --filter @chat-adapter/slack test` — 296/297 pass (1 pre-existing network-dependent failure unrelated to this change)
