### PR TITLE
docs: fix incorrect reference to c.executionCtx.waitUntil

### DIFF
--- a/apps/docs/content/docs/guides/code-review-hono.mdx
+++ b/apps/docs/content/docs/guides/code-review-hono.mdx
@@ -23,7 +23,7 @@ Scaffold a new Hono project and install dependencies:
 ```sh title="Terminal"
 pnpm create hono my-review-bot
 cd my-review-bot
-pnpm add @octokit/rest @vercel/sandbox ai bash-tool chat @chat-adapter/github @chat-adapter/state-redis
+pnpm add @octokit/rest @vercel/functions @vercel/sandbox ai bash-tool chat @chat-adapter/github @chat-adapter/state-redis
 ```
 
 <Callout type="info">
@@ -198,6 +198,7 @@ Create the Hono app with a single webhook route that delegates to Chat SDK:
 
 ```typescript title="src/index.ts" lineNumbers
 import { Hono } from "hono";
+import { waitUntil } from "@vercel/functions";
 import { bot } from "./bot";
 
 const app = new Hono();
@@ -208,15 +209,13 @@ app.post("/api/webhooks/github", async (c) => {
     return c.text("GitHub adapter not configured", 404);
   }
 
-  return handler(c.req.raw, {
-    waitUntil: (task) => c.executionCtx.waitUntil(task),
-  });
+  return handler(c.req.raw, { waitUntil });
 });
 
 export default app;
 ```
 
-Chat SDK's GitHub adapter handles signature verification, event parsing, and routing internally. The `waitUntil` option ensures the review completes after the HTTP response is sent.
+Chat SDK's GitHub adapter handles signature verification, event parsing, and routing internally. The `waitUntil` option ensures the review completes after the HTTP response is sent — required on serverless platforms where the function would otherwise terminate before your handlers finish.
 
 ## Test locally
 


### PR DESCRIPTION
## Why?

The Hono guide recommends `c.executionCtx.waitUntil(task)` to handle background processing, but Hono's Vercel adapter never passes an `ExecutionContext` to `app.fetch()`. This causes a runtime error on Vercel:

```
  Error: This context has no ExecutionContext
      at get executionCtx (file:///var/task/_libs/hono.mjs:625:14)
```

Closes #248 

## What changed?

- Add `@vercel/functions` to the install command
- Import `waitUntil` from `@vercel/functions` instead of accessing it through Hono's `c.executionCtx`

## Test plan

- Deploy a Hono app to Vercel using the updated pattern and confirm `waitUntil` works without throwing (tested on [purduehackers/wack-hacker](https://github.com/purduehackers/wack-hacker/commit/a722674ea19dcea39b8f1eb6df179b64183b3ebe) and [the deployment](https://vercel.com/purdue-hackers/wack-hacker/5o1rAGWQ2nBfcf4bFefLxZkJHXvo/logs) reads that it was fixed)