### PR TITLE
fix(github): correctly trigger removeReaction in multi-tenant mode

### DIFF
--- a/.changeset/fix-github-remove-reaction-multi-tenant.md
+++ b/.changeset/fix-github-remove-reaction-multi-tenant.md
@@ -1,0 +1,5 @@
+---
+"@chat-adapter/github": patch
+---
+
+Fix `removeReaction` in multi-tenant mode by lazily detecting `botUserId` via the per-installation octokit client when it wasn't set during `initialize()`

--- a/packages/adapter-github/src/index.test.ts
+++ b/packages/adapter-github/src/index.test.ts
@@ -1105,6 +1105,31 @@ describe("GitHubAdapter", () => {
 
       expect(mockReactionsDeleteForIssueComment).not.toHaveBeenCalled();
     });
+
+    it("should lazily detect botUserId when not set", async () => {
+      const detectedBotId = 42;
+
+      mockUsersGetAuthenticated.mockResolvedValueOnce({
+        data: { id: detectedBotId, login: "test-bot[bot]" },
+      });
+      mockReactionsListForIssueComment.mockResolvedValueOnce({
+        data: [
+          { id: 70, content: "eyes", user: { id: detectedBotId } },
+          { id: 71, content: "eyes", user: { id: 999 } },
+        ],
+      });
+      mockReactionsDeleteForIssueComment.mockResolvedValueOnce({});
+
+      await adapter.removeReaction("github:acme/app:42", "100", "eyes");
+
+      expect(mockUsersGetAuthenticated).toHaveBeenCalled();
+      expect(mockReactionsDeleteForIssueComment).toHaveBeenCalledWith({
+        owner: "acme",
+        repo: "app",
+        comment_id: 100,
+        reaction_id: 70,
+      });
+    });
   });
 
   describe("emojiToGitHubReaction (via addReaction)", () => {

--- a/packages/adapter-github/src/index.ts
+++ b/packages/adapter-github/src/index.ts
@@ -865,6 +865,16 @@ export class GitHubAdapter
 
     const octokit = await this.getOctokitForThread(owner, repo);
 
+    // Multi-tenant mode has no global octokit, so initialize() can't detect _botUserId
+    if (!this._botUserId) {
+      try {
+        const { data: user } = await octokit.users.getAuthenticated();
+        this._botUserId = user.id;
+      } catch {
+        this.logger.warn("Could not detect bot user ID for reaction removal");
+      }
+    }
+
     // List reactions to find the one to delete
     const reactions = reviewCommentId
       ? (


### PR DESCRIPTION
In multi-tenant mode (GitHub App without a fixed `installationId`), `initialize()` skips `_botUserId` auto-detection because there's no global octokit client. This leaves `_botUserId` as `null`, so `removeReaction` never finds a matching reaction to delete — the `reactions.find()` filter always fails.

Fixes this by lazily detecting `_botUserId` via `users.getAuthenticated()` on the per-installation octokit client that `removeReaction` already has available. The result is cached, so subsequent calls skip the extra API call.