### PR TITLE
Fix typo: Committment → Commitment

### DIFF
--- a/apps/docs/content/docs/contributing/building.mdx
+++ b/apps/docs/content/docs/contributing/building.mdx
@@ -31,7 +31,7 @@ Chat SDK ships with Vercel-maintained adapters for Slack, Teams, Google Chat, Di
 
 #### Qualifications for vendor official tier
 
-- Committment for continued maintenance of the adapter.
+- Commitment for continued maintenance of the adapter.
 - GitHub hosting in official vendor-owned org.
 - Documentation of the adapter in primary vendor docs.
 - Announcement of the adapter in blog post or changelog and social media.


### PR DESCRIPTION
  ## Summary
  Fixed typo in the contributing guide: "Committment" → "Commitment"

  ## Type
  Documentation fix

  ## Files changed
  - `apps/docs/content/docs/contributing/building.mdx`