### PR TITLE
AI SDK Tool Approvals

### DIFF
--- a/packages/chat/src/approval-integration.test.ts
+++ b/packages/chat/src/approval-integration.test.ts
@@ -1,0 +1,1031 @@
+/**
+ * Integration tests for the approval system.
+ *
+ * These tests exercise the full flow across thread.requestApproval(),
+ * thread.runAgent(), and chat.handleApprovalAction().
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  type AgentLike,
+  type AgentResultLike,
+  ApprovalRegistry,
+  type ApprovalResponseHandler,
+  consumePendingApproval,
+} from "./approval";
+import { Chat } from "./chat";
+import { clearChatSingleton, setChatSingleton } from "./chat-singleton";
+import { createMockAdapter, createMockState, mockLogger } from "./mock-adapter";
+import { ThreadImpl } from "./thread";
+import type { ActionEvent, Adapter } from "./types";
+
+// ── Helpers ─────────────────────────────────────────────────────────────────
+
+function makeActionEvent(
+  actionId: string,
+  adapter: Adapter,
+  overrides?: Partial<Omit<ActionEvent, "thread" | "openModal">>
+): Omit<ActionEvent, "thread" | "openModal"> {
+  return {
+    actionId,
+    value: "",
+    user: {
+      userId: "U999",
+      userName: "reviewer",
+      fullName: "The Reviewer",
+      isBot: false,
+      isMe: false,
+    },
+    messageId: "msg-1",
+    threadId: "slack:C123:1234.5678",
+    adapter,
+    raw: {},
+    ...overrides,
+  };
+}
+
+/** Create a mock agent that returns the given results in sequence. */
+function createMockAgent(
+  results: AgentResultLike[]
+): AgentLike & { generateCalls: unknown[][] } {
+  let callIndex = 0;
+  const generateCalls: unknown[][] = [];
+
+  return {
+    generateCalls,
+    generate: vi.fn().mockImplementation(async (options: unknown) => {
+      generateCalls.push([options]);
+      const result = results[callIndex];
+      callIndex++;
+      return result;
+    }),
+  };
+}
+
+function noApprovalResult(): AgentResultLike {
+  return {
+    content: [{ type: "text", text: "Done" }],
+    response: { messages: [{ role: "assistant", content: "Done" }] },
+    text: "Done",
+  };
+}
+
+function approvalRequestResult(
+  toolCalls: Array<{
+    approvalId: string;
+    toolName: string;
+    toolCallId: string;
+    input: Record<string, unknown>;
+  }>
+): AgentResultLike {
+  return {
+    content: toolCalls.map((tc) => ({
+      type: "tool-approval-request",
+      approvalId: tc.approvalId,
+      toolCall: {
+        toolName: tc.toolName,
+        toolCallId: tc.toolCallId,
+        input: tc.input,
+      },
+    })),
+    response: {
+      messages: [{ role: "assistant", content: "needs approval" }],
+    },
+  };
+}
+
+// ============================================================================
+// thread.requestApproval()
+// ============================================================================
+
+describe("thread.requestApproval()", () => {
+  let mockAdapter: Adapter;
+  let mockState: ReturnType<typeof createMockState>;
+  let registry: ApprovalRegistry;
+  let thread: ThreadImpl;
+
+  beforeEach(() => {
+    mockAdapter = createMockAdapter();
+    mockState = createMockState();
+    registry = new ApprovalRegistry();
+
+    setChatSingleton({
+      _approvalRegistry: registry,
+      getAdapter: () => mockAdapter,
+      getState: () => mockState,
+    });
+
+    thread = new ThreadImpl({
+      id: "slack:C123:1234.5678",
+      adapter: mockAdapter,
+      channelId: "C123",
+      stateAdapter: mockState,
+    });
+  });
+
+  afterEach(() => {
+    clearChatSingleton();
+  });
+
+  /** Wait for the registry entry to appear, then resolve it. */
+  async function resolveWhenReady(
+    id: string,
+    approved: boolean,
+    extra?: { reason?: string }
+  ) {
+    while (!registry.has(id)) {
+      await new Promise((r) => setTimeout(r, 1));
+    }
+    registry.resolve(id, {
+      id,
+      approved,
+      ...extra,
+      user: {
+        userId: "U1",
+        userName: "alice",
+        fullName: "Alice",
+        isBot: false,
+        isMe: false,
+      },
+    });
+  }
+
+  it("should post a card and resolve when approved", async () => {
+    const [result] = await Promise.all([
+      thread.requestApproval({ id: "txn-1", title: "Transfer $500" }),
+      resolveWhenReady("txn-1", true),
+    ]);
+
+    expect(result.approved).toBe(true);
+    expect(result.id).toBe("txn-1");
+    expect(result.user.userName).toBe("alice");
+    expect(mockAdapter.postMessage).toHaveBeenCalledTimes(1);
+  });
+
+  it("should post a card and resolve when denied", async () => {
+    const [result] = await Promise.all([
+      thread.requestApproval({ id: "txn-2", title: "Delete Account" }),
+      resolveWhenReady("txn-2", false),
+    ]);
+
+    expect(result.approved).toBe(false);
+  });
+
+  it("should persist the approval in the state adapter", async () => {
+    const [result] = await Promise.all([
+      thread.requestApproval({
+        id: "persist-1",
+        title: "Persist Test",
+        fields: { key: "value" },
+        metadata: { context: "test" },
+      }),
+      (async () => {
+        // Wait for state to be persisted
+        while (!mockState.cache.has("pending-approval:persist-1")) {
+          await new Promise((r) => setTimeout(r, 1));
+        }
+        const stored = mockState.cache.get("pending-approval:persist-1") as any;
+        expect(stored.id).toBe("persist-1");
+        expect(stored.title).toBe("Persist Test");
+        expect(stored.fields).toEqual({ key: "value" });
+        expect(stored.metadata).toEqual({ context: "test" });
+        expect(stored.adapterName).toBe("slack");
+
+        // Now resolve so the promise completes
+        await resolveWhenReady("persist-1", true);
+      })(),
+    ]);
+
+    expect(result.approved).toBe(true);
+  });
+
+  it("should update the card after approval when updateCard is true", async () => {
+    await Promise.all([
+      thread.requestApproval({
+        id: "update-1",
+        title: "Update Test",
+        updateCard: true,
+      }),
+      resolveWhenReady("update-1", true),
+    ]);
+
+    expect(mockAdapter.editMessage).toHaveBeenCalledTimes(1);
+  });
+
+  it("should not update the card when updateCard is false", async () => {
+    await Promise.all([
+      thread.requestApproval({
+        id: "no-update-1",
+        title: "No Update Test",
+        updateCard: false,
+      }),
+      resolveWhenReady("no-update-1", true),
+    ]);
+
+    expect(mockAdapter.editMessage).not.toHaveBeenCalled();
+  });
+
+  it("should time out if no response within TTL", async () => {
+    vi.useFakeTimers();
+
+    const promise = thread.requestApproval({
+      id: "timeout-1",
+      title: "Timeout Test",
+      ttlMs: 5000,
+    });
+
+    // Flush the async work (post card, persist state, register)
+    await vi.advanceTimersByTimeAsync(1);
+
+    // Now advance past the TTL
+    vi.advanceTimersByTime(5001);
+
+    await expect(promise).rejects.toThrow("timed out");
+
+    vi.useRealTimers();
+  });
+
+  it("should register the approval in the in-memory registry", async () => {
+    const promise = thread.requestApproval({
+      id: "reg-1",
+      title: "Registry Test",
+    });
+
+    // Wait for the async work to complete
+    while (!registry.has("reg-1")) {
+      await new Promise((r) => setTimeout(r, 1));
+    }
+
+    expect(registry.has("reg-1")).toBe(true);
+
+    // Clean up
+    registry.resolve("reg-1", {
+      id: "reg-1",
+      approved: true,
+      user: {
+        userId: "U1",
+        userName: "alice",
+        fullName: "Alice",
+        isBot: false,
+        isMe: false,
+      },
+    });
+    await promise;
+  });
+
+  it("should survive card edit failure gracefully", async () => {
+    (mockAdapter.editMessage as ReturnType<typeof vi.fn>).mockRejectedValue(
+      new Error("Platform error")
+    );
+
+    const [result] = await Promise.all([
+      thread.requestApproval({
+        id: "edit-fail",
+        title: "Edit Fail",
+        updateCard: true,
+      }),
+      resolveWhenReady("edit-fail", true),
+    ]);
+
+    // Should not throw — edit failure is caught
+    expect(result.approved).toBe(true);
+  });
+
+  it("should include reason in the result when provided", async () => {
+    const [result] = await Promise.all([
+      thread.requestApproval({ id: "reason-1", title: "Reason Test" }),
+      resolveWhenReady("reason-1", false, { reason: "Too risky" }),
+    ]);
+
+    expect(result.reason).toBe("Too risky");
+  });
+
+  it("should register resolver and persist state before posting the card", async () => {
+    // Intercept postMessage to check state at the moment the card is posted,
+    // and resolve the approval inside the mock so it doesn't race.
+    let registryHadEntry = false;
+    let stateHadEntry = false;
+    (mockAdapter.postMessage as ReturnType<typeof vi.fn>).mockImplementation(
+      async () => {
+        registryHadEntry = registry.has("race-1");
+        stateHadEntry = mockState.cache.has("pending-approval:race-1");
+        // Resolve inside postMessage so it doesn't race with the poll
+        registry.resolve("race-1", {
+          id: "race-1",
+          approved: true,
+          user: {
+            userId: "U1",
+            userName: "alice",
+            fullName: "Alice",
+            isBot: false,
+            isMe: false,
+          },
+        });
+        return { id: "msg-1", threadId: undefined, raw: {} };
+      }
+    );
+
+    const result = await thread.requestApproval({
+      id: "race-1",
+      title: "Race Test",
+    });
+
+    expect(result.approved).toBe(true);
+    expect(registryHadEntry).toBe(true);
+    expect(stateHadEntry).toBe(true);
+  });
+
+  it("should throw before any side effects if singleton is missing", async () => {
+    clearChatSingleton();
+
+    await expect(
+      thread.requestApproval({ id: "no-singleton", title: "Fail" })
+    ).rejects.toThrow("No Chat singleton registered");
+
+    // No card should have been posted
+    expect(mockAdapter.postMessage).not.toHaveBeenCalled();
+    // No state should have been persisted
+    expect(mockState.cache.has("pending-approval:no-singleton")).toBe(false);
+  });
+
+  it("should clean up registry and persisted state if posting fails", async () => {
+    (mockAdapter.postMessage as ReturnType<typeof vi.fn>).mockRejectedValue(
+      new Error("Slack API error")
+    );
+
+    await expect(
+      thread.requestApproval({ id: "post-fail", title: "Post Fail" })
+    ).rejects.toThrow("Slack API error");
+
+    // Registry entry should be cleaned up
+    expect(registry.has("post-fail")).toBe(false);
+    // Persisted state should be cleaned up
+    expect(mockState.cache.has("pending-approval:post-fail")).toBe(false);
+  });
+});
+
+// ============================================================================
+// thread.runAgent()
+// ============================================================================
+
+describe("thread.runAgent()", () => {
+  let mockAdapter: Adapter;
+  let mockState: ReturnType<typeof createMockState>;
+  let registry: ApprovalRegistry;
+  let thread: ThreadImpl;
+
+  beforeEach(() => {
+    mockAdapter = createMockAdapter();
+    mockState = createMockState();
+    registry = new ApprovalRegistry();
+
+    setChatSingleton({
+      _approvalRegistry: registry,
+      getAdapter: () => mockAdapter,
+      getState: () => mockState,
+    });
+
+    thread = new ThreadImpl({
+      id: "slack:C123:1234.5678",
+      adapter: mockAdapter,
+      channelId: "C123",
+      stateAdapter: mockState,
+    });
+  });
+
+  afterEach(() => {
+    clearChatSingleton();
+  });
+
+  it("should return immediately when agent needs no approvals", async () => {
+    const agent = createMockAgent([noApprovalResult()]);
+
+    const result = await thread.runAgent(agent, { prompt: "hello" });
+
+    expect(agent.generate).toHaveBeenCalledTimes(1);
+    expect(result.text).toBe("Done");
+  });
+
+  it("should handle a single tool approval request", async () => {
+    const agent = createMockAgent([
+      approvalRequestResult([
+        {
+          approvalId: "ap-1",
+          toolName: "deleteFile",
+          toolCallId: "tc-1",
+          input: { path: "/tmp/file.txt" },
+        },
+      ]),
+      noApprovalResult(),
+    ]);
+
+    // Approve asynchronously when the registry entry appears
+    const approveWhenReady = async () => {
+      while (!registry.has("ap-1")) {
+        await new Promise((r) => setTimeout(r, 1));
+      }
+      registry.resolve("ap-1", {
+        id: "ap-1",
+        approved: true,
+        user: {
+          userId: "U1",
+          userName: "alice",
+          fullName: "Alice",
+          isBot: false,
+          isMe: false,
+        },
+      });
+    };
+
+    const [result] = await Promise.all([
+      thread.runAgent(agent, { prompt: "delete the file" }),
+      approveWhenReady(),
+    ]);
+
+    expect(agent.generate).toHaveBeenCalledTimes(2);
+    expect(result.text).toBe("Done");
+
+    // Second call should include a tool-role message with approval responses
+    const secondCallArgs = (agent.generate as ReturnType<typeof vi.fn>).mock
+      .calls[1][0];
+    const messages = secondCallArgs.messages;
+    const toolMessage = messages.find(
+      (m: { role?: string }) => m.role === "tool"
+    );
+    expect(toolMessage).toBeDefined();
+    expect(toolMessage.content).toEqual([
+      {
+        type: "tool-approval-response",
+        approvalId: "ap-1",
+        approved: true,
+      },
+    ]);
+  });
+
+  it("should handle multiple parallel approval requests", async () => {
+    const agent = createMockAgent([
+      approvalRequestResult([
+        {
+          approvalId: "ap-a",
+          toolName: "sendEmail",
+          toolCallId: "tc-a",
+          input: { to: "a@test.com" },
+        },
+        {
+          approvalId: "ap-b",
+          toolName: "transfer",
+          toolCallId: "tc-b",
+          input: { amount: 500 },
+        },
+      ]),
+      noApprovalResult(),
+    ]);
+
+    const approveAll = async () => {
+      while (!(registry.has("ap-a") && registry.has("ap-b"))) {
+        await new Promise((r) => setTimeout(r, 1));
+      }
+      registry.resolve("ap-a", {
+        id: "ap-a",
+        approved: true,
+        user: {
+          userId: "U1",
+          userName: "alice",
+          fullName: "Alice",
+          isBot: false,
+          isMe: false,
+        },
+      });
+      registry.resolve("ap-b", {
+        id: "ap-b",
+        approved: false,
+        user: {
+          userId: "U2",
+          userName: "bob",
+          fullName: "Bob",
+          isBot: false,
+          isMe: false,
+        },
+      });
+    };
+
+    const [result] = await Promise.all([
+      thread.runAgent(agent, { prompt: "do both" }),
+      approveAll(),
+    ]);
+
+    expect(result.text).toBe("Done");
+
+    // Check that both responses are wrapped in a single tool message
+    const secondCallArgs = (agent.generate as ReturnType<typeof vi.fn>).mock
+      .calls[1][0];
+    const toolMessage = secondCallArgs.messages.find(
+      (m: { role?: string }) => m.role === "tool"
+    );
+    expect(toolMessage.content).toHaveLength(2);
+    expect(toolMessage.content).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ approvalId: "ap-a", approved: true }),
+        expect.objectContaining({ approvalId: "ap-b", approved: false }),
+      ])
+    );
+  });
+
+  it("should handle multi-round approval loops", async () => {
+    const agent = createMockAgent([
+      // Round 1: one approval
+      approvalRequestResult([
+        {
+          approvalId: "r1",
+          toolName: "step1",
+          toolCallId: "tc-1",
+          input: {},
+        },
+      ]),
+      // Round 2: another approval
+      approvalRequestResult([
+        {
+          approvalId: "r2",
+          toolName: "step2",
+          toolCallId: "tc-2",
+          input: {},
+        },
+      ]),
+      // Round 3: done
+      noApprovalResult(),
+    ]);
+
+    const approveSequentially = async () => {
+      // Approve round 1
+      while (!registry.has("r1")) {
+        await new Promise((r) => setTimeout(r, 1));
+      }
+      registry.resolve("r1", {
+        id: "r1",
+        approved: true,
+        user: {
+          userId: "U1",
+          userName: "alice",
+          fullName: "Alice",
+          isBot: false,
+          isMe: false,
+        },
+      });
+      // Approve round 2
+      while (!registry.has("r2")) {
+        await new Promise((r) => setTimeout(r, 1));
+      }
+      registry.resolve("r2", {
+        id: "r2",
+        approved: true,
+        user: {
+          userId: "U1",
+          userName: "alice",
+          fullName: "Alice",
+          isBot: false,
+          isMe: false,
+        },
+      });
+    };
+
+    const [result] = await Promise.all([
+      thread.runAgent(agent, { prompt: "multi-step" }),
+      approveSequentially(),
+    ]);
+
+    expect(agent.generate).toHaveBeenCalledTimes(3);
+    expect(result.text).toBe("Done");
+  });
+
+  it("should use custom approvalCard callback", async () => {
+    const agent = createMockAgent([
+      approvalRequestResult([
+        {
+          approvalId: "custom-1",
+          toolName: "dangerousAction",
+          toolCallId: "tc-1",
+          input: { level: "high" },
+        },
+      ]),
+      noApprovalResult(),
+    ]);
+
+    const customCard = vi.fn().mockReturnValue({
+      title: "Custom Title",
+      description: "Custom description",
+      fields: { Level: "high" },
+    });
+
+    const approveWhenReady = async () => {
+      while (!registry.has("custom-1")) {
+        await new Promise((r) => setTimeout(r, 1));
+      }
+      registry.resolve("custom-1", {
+        id: "custom-1",
+        approved: true,
+        user: {
+          userId: "U1",
+          userName: "alice",
+          fullName: "Alice",
+          isBot: false,
+          isMe: false,
+        },
+      });
+    };
+
+    await Promise.all([
+      thread.runAgent(agent, {
+        prompt: "do it",
+        approvalCard: customCard,
+      }),
+      approveWhenReady(),
+    ]);
+
+    expect(customCard).toHaveBeenCalledWith({
+      toolName: "dangerousAction",
+      toolCallId: "tc-1",
+      input: { level: "high" },
+    });
+  });
+
+  it("should use default approvalCard when none is provided", async () => {
+    const agent = createMockAgent([
+      approvalRequestResult([
+        {
+          approvalId: "default-1",
+          toolName: "myTool",
+          toolCallId: "tc-1",
+          input: { foo: "bar" },
+        },
+      ]),
+      noApprovalResult(),
+    ]);
+
+    const approveWhenReady = async () => {
+      while (!registry.has("default-1")) {
+        await new Promise((r) => setTimeout(r, 1));
+      }
+      registry.resolve("default-1", {
+        id: "default-1",
+        approved: true,
+        user: {
+          userId: "U1",
+          userName: "alice",
+          fullName: "Alice",
+          isBot: false,
+          isMe: false,
+        },
+      });
+    };
+
+    await Promise.all([
+      thread.runAgent(agent, { prompt: "go" }),
+      approveWhenReady(),
+    ]);
+
+    // The posted card should have the default title format
+    const postedCard = (mockAdapter.postMessage as ReturnType<typeof vi.fn>)
+      .mock.calls[0][1];
+    expect(postedCard.title).toContain("myTool");
+  });
+
+  it("should forward reason in tool-approval-response when provided", async () => {
+    const agent = createMockAgent([
+      approvalRequestResult([
+        {
+          approvalId: "reason-1",
+          toolName: "riskyOp",
+          toolCallId: "tc-1",
+          input: {},
+        },
+      ]),
+      noApprovalResult(),
+    ]);
+
+    const denyWithReason = async () => {
+      while (!registry.has("reason-1")) {
+        await new Promise((r) => setTimeout(r, 1));
+      }
+      registry.resolve("reason-1", {
+        id: "reason-1",
+        approved: false,
+        reason: "Not authorized",
+        user: {
+          userId: "U1",
+          userName: "alice",
+          fullName: "Alice",
+          isBot: false,
+          isMe: false,
+        },
+      });
+    };
+
+    await Promise.all([
+      thread.runAgent(agent, { prompt: "try it" }),
+      denyWithReason(),
+    ]);
+
+    const secondCallArgs = (agent.generate as ReturnType<typeof vi.fn>).mock
+      .calls[1][0];
+    const toolMessage = secondCallArgs.messages.find(
+      (m: { role?: string }) => m.role === "tool"
+    );
+    expect(toolMessage.content[0]).toEqual({
+      type: "tool-approval-response",
+      approvalId: "reason-1",
+      approved: false,
+      reason: "Not authorized",
+    });
+  });
+
+  it("should not include reason field when it is undefined", async () => {
+    const agent = createMockAgent([
+      approvalRequestResult([
+        {
+          approvalId: "no-reason",
+          toolName: "tool",
+          toolCallId: "tc-1",
+          input: {},
+        },
+      ]),
+      noApprovalResult(),
+    ]);
+
+    const approve = async () => {
+      while (!registry.has("no-reason")) {
+        await new Promise((r) => setTimeout(r, 1));
+      }
+      registry.resolve("no-reason", {
+        id: "no-reason",
+        approved: true,
+        user: {
+          userId: "U1",
+          userName: "alice",
+          fullName: "Alice",
+          isBot: false,
+          isMe: false,
+        },
+      });
+    };
+
+    await Promise.all([thread.runAgent(agent, { prompt: "go" }), approve()]);
+
+    const secondCallArgs = (agent.generate as ReturnType<typeof vi.fn>).mock
+      .calls[1][0];
+    const toolMessage = secondCallArgs.messages.find(
+      (m: { role?: string }) => m.role === "tool"
+    );
+    // reason should not be present as a key
+    expect(toolMessage.content[0]).toEqual({
+      type: "tool-approval-response",
+      approvalId: "no-reason",
+      approved: true,
+    });
+    expect("reason" in toolMessage.content[0]).toBe(false);
+  });
+
+  it("should pass through extra agent options", async () => {
+    const agent = createMockAgent([noApprovalResult()]);
+
+    await thread.runAgent(agent, {
+      prompt: "hello",
+      temperature: 0.5,
+      maxTokens: 100,
+    });
+
+    const callArgs = (agent.generate as ReturnType<typeof vi.fn>).mock
+      .calls[0][0];
+    expect(callArgs.temperature).toBe(0.5);
+    expect(callArgs.maxTokens).toBe(100);
+  });
+
+  it("should include assistant response messages when resuming", async () => {
+    const assistantMessages = [
+      { role: "assistant", content: "I need to call deleteFile" },
+      {
+        role: "assistant",
+        content: [{ type: "tool-call", toolCallId: "tc-1" }],
+      },
+    ];
+
+    const agent = createMockAgent([
+      {
+        content: [
+          {
+            type: "tool-approval-request",
+            approvalId: "msg-test",
+            toolCall: {
+              toolName: "deleteFile",
+              toolCallId: "tc-1",
+              input: {},
+            },
+          },
+        ],
+        response: { messages: assistantMessages },
+      },
+      noApprovalResult(),
+    ]);
+
+    const approve = async () => {
+      while (!registry.has("msg-test")) {
+        await new Promise((r) => setTimeout(r, 1));
+      }
+      registry.resolve("msg-test", {
+        id: "msg-test",
+        approved: true,
+        user: {
+          userId: "U1",
+          userName: "alice",
+          fullName: "Alice",
+          isBot: false,
+          isMe: false,
+        },
+      });
+    };
+
+    await Promise.all([
+      thread.runAgent(agent, { prompt: "delete it" }),
+      approve(),
+    ]);
+
+    const secondCallArgs = (agent.generate as ReturnType<typeof vi.fn>).mock
+      .calls[1][0];
+
+    // Messages should contain: assistant messages + tool-role approval response
+    expect(secondCallArgs.messages).toHaveLength(3);
+    expect(secondCallArgs.messages[0]).toBe(assistantMessages[0]);
+    expect(secondCallArgs.messages[1]).toBe(assistantMessages[1]);
+    expect(secondCallArgs.messages[2].role).toBe("tool");
+  });
+});
+
+// ============================================================================
+// chat.handleApprovalAction() (via processAction)
+// ============================================================================
+
+describe("chat.handleApprovalAction()", () => {
+  let chat: Chat<{ slack: Adapter }>;
+  let mockAdapter: Adapter;
+  let mockState: ReturnType<typeof createMockState>;
+
+  beforeEach(async () => {
+    mockAdapter = createMockAdapter("slack");
+    mockState = createMockState();
+
+    chat = new Chat({
+      userName: "testbot",
+      adapters: { slack: mockAdapter },
+      state: mockState,
+      logger: mockLogger,
+    });
+
+    // Initialize via webhook
+    await chat.webhooks.slack(
+      new Request("http://test.com", { method: "POST" })
+    );
+  });
+
+  it("should resolve in-memory promise on approval action", async () => {
+    // Register an in-memory approval
+    const promise = chat._approvalRegistry.register("mem-1", 60000);
+
+    // Simulate button click
+    chat.processAction(
+      makeActionEvent("__approval:mem-1:approve", mockAdapter)
+    );
+    await new Promise((r) => setTimeout(r, 10));
+
+    const result = await promise;
+    expect(result.approved).toBe(true);
+    expect(result.id).toBe("mem-1");
+    expect(result.user.userName).toBe("reviewer");
+  });
+
+  it("should resolve in-memory promise on deny action", async () => {
+    const promise = chat._approvalRegistry.register("mem-2", 60000);
+
+    chat.processAction(makeActionEvent("__approval:mem-2:deny", mockAdapter));
+    await new Promise((r) => setTimeout(r, 10));
+
+    const result = await promise;
+    expect(result.approved).toBe(false);
+  });
+
+  it("should not propagate approval actions to user onAction handlers", async () => {
+    const userHandler = vi.fn();
+    chat.onAction(userHandler);
+
+    chat._approvalRegistry.register("intercept-1", 60000);
+
+    chat.processAction(
+      makeActionEvent("__approval:intercept-1:approve", mockAdapter)
+    );
+    await new Promise((r) => setTimeout(r, 10));
+
+    // User handler should NOT be called — approval actions are intercepted
+    expect(userHandler).not.toHaveBeenCalled();
+  });
+
+  it("should call onApprovalResponse handler on restart recovery path", async () => {
+    const handler: ApprovalResponseHandler = vi.fn();
+    chat.onApprovalResponse(handler);
+
+    // Simulate persisted approval (as if server restarted — no in-memory promise)
+    mockState.cache.set("pending-approval:restart-1", {
+      id: "restart-1",
+      title: "Restart Test",
+      metadata: { context: "recovery" },
+      adapterName: "slack",
+      createdAt: new Date().toISOString(),
+      thread: {
+        _type: "chat:Thread",
+        id: "slack:C123:1234.5678",
+        channelId: "C123",
+        isDM: false,
+        adapterName: "slack",
+      },
+      updateCard: false,
+      sentMessage: undefined,
+    });
+
+    chat.processAction(
+      makeActionEvent("__approval:restart-1:approve", mockAdapter)
+    );
+    await new Promise((r) => setTimeout(r, 10));
+
+    expect(handler).toHaveBeenCalledTimes(1);
+    const event = (handler as ReturnType<typeof vi.fn>).mock.calls[0][0];
+    expect(event.id).toBe("restart-1");
+    expect(event.approved).toBe(true);
+    expect(event.metadata).toEqual({ context: "recovery" });
+  });
+
+  it("should consume stored approval on click (prevents double-processing)", async () => {
+    mockState.cache.set("pending-approval:double-1", {
+      id: "double-1",
+      title: "Double Click Test",
+      adapterName: "slack",
+      createdAt: new Date().toISOString(),
+      thread: {
+        _type: "chat:Thread",
+        id: "slack:C123:1234.5678",
+        channelId: "C123",
+        isDM: false,
+        adapterName: "slack",
+      },
+      updateCard: false,
+    });
+
+    chat.processAction(
+      makeActionEvent("__approval:double-1:approve", mockAdapter)
+    );
+    await new Promise((r) => setTimeout(r, 10));
+
+    // Stored approval should be consumed (deleted)
+    const remaining = await consumePendingApproval(mockState, "double-1");
+    expect(remaining).toBeNull();
+  });
+
+  it("should post expiry message when approval is expired and no handler registered", async () => {
+    // No stored approval, no in-memory promise — it's expired
+    chat.processAction(
+      makeActionEvent("__approval:expired-1:approve", mockAdapter)
+    );
+    await new Promise((r) => setTimeout(r, 10));
+
+    // Should have posted an expiry message
+    expect(mockAdapter.postMessage).toHaveBeenCalled();
+    const postedText = (mockAdapter.postMessage as ReturnType<typeof vi.fn>)
+      .mock.calls[0][1];
+    expect(postedText).toContain("expired");
+  });
+
+  it("should attach metadata from stored approval to the in-memory result", async () => {
+    // Persist approval with metadata
+    mockState.cache.set("pending-approval:meta-1", {
+      id: "meta-1",
+      title: "Meta Test",
+      metadata: { toolName: "transfer", amount: 500 },
+      adapterName: "slack",
+      createdAt: new Date().toISOString(),
+      thread: {
+        _type: "chat:Thread",
+        id: "slack:C123:1234.5678",
+        channelId: "C123",
+        isDM: false,
+        adapterName: "slack",
+      },
+      updateCard: false,
+    });
+
+    // Also register in-memory (happy path where stored metadata is attached)
+    const promise = chat._approvalRegistry.register("meta-1", 60000);
+
+    chat.processAction(
+      makeActionEvent("__approval:meta-1:approve", mockAdapter)
+    );
+    await new Promise((r) => setTimeout(r, 10));
+
+    const result = await promise;
+    expect(result.metadata).toEqual({ toolName: "transfer", amount: 500 });
+  });
+});

--- a/packages/chat/src/approval.test.ts
+++ b/packages/chat/src/approval.test.ts
@@ -1,0 +1,743 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  APPROVAL_PREFIX,
+  ApprovalRegistry,
+  type ApprovalResult,
+  buildApprovalCard,
+  buildExpiredCard,
+  buildResolvedCard,
+  consumePendingApproval,
+  defaultApprovalCard,
+  isApprovalActionId,
+  parseApprovalAction,
+  type StoredApproval,
+  storePendingApproval,
+} from "./approval";
+import type { Author } from "./types";
+
+// ── Helpers ─────────────────────────────────────────────────────────────────
+
+const makeUser = (overrides?: Partial<Author>): Author => ({
+  userId: "u1",
+  userName: "alice",
+  fullName: "Alice",
+  isBot: false,
+  isMe: false,
+  ...overrides,
+});
+
+const makeResult = (
+  id: string,
+  approved: boolean,
+  overrides?: Partial<ApprovalResult>
+): ApprovalResult => ({
+  id,
+  approved,
+  user: makeUser(),
+  ...overrides,
+});
+
+const makeStoredApproval = (
+  overrides?: Partial<StoredApproval>
+): StoredApproval => ({
+  id: "test-123",
+  title: "Test",
+  adapterName: "slack",
+  createdAt: new Date().toISOString(),
+  thread: {} as StoredApproval["thread"],
+  updateCard: true,
+  ...overrides,
+});
+
+// ============================================================================
+// buildApprovalCard
+// ============================================================================
+
+describe("buildApprovalCard", () => {
+  it("should build a card with approve and deny buttons", () => {
+    const card = buildApprovalCard({
+      id: "test-123",
+      title: "Test Approval",
+    });
+
+    expect(card.type).toBe("card");
+    expect(card.title).toBe("Test Approval");
+
+    const actions = card.children.find((c) => c.type === "actions");
+    expect(actions).toBeDefined();
+    if (actions?.type === "actions") {
+      expect(actions.children).toHaveLength(2);
+      const [approve, deny] = actions.children;
+      expect(approve).toMatchObject({
+        type: "button",
+        id: `${APPROVAL_PREFIX}:test-123:approve`,
+        label: "Approve",
+        style: "primary",
+      });
+      expect(deny).toMatchObject({
+        type: "button",
+        id: `${APPROVAL_PREFIX}:test-123:deny`,
+        label: "Deny",
+        style: "danger",
+      });
+    }
+  });
+
+  it("should include description text", () => {
+    const card = buildApprovalCard({
+      id: "test",
+      title: "Test",
+      description: "Please review this action.",
+    });
+
+    const textChild = card.children.find(
+      (c) => c.type === "text" && c.content === "Please review this action."
+    );
+    expect(textChild).toBeDefined();
+  });
+
+  it("should include fields", () => {
+    const card = buildApprovalCard({
+      id: "test",
+      title: "Test",
+      fields: { Amount: "$500", To: "acct_123" },
+    });
+
+    const fieldsChild = card.children.find((c) => c.type === "fields");
+    expect(fieldsChild).toBeDefined();
+    if (fieldsChild?.type === "fields") {
+      expect(fieldsChild.children).toHaveLength(2);
+      expect(fieldsChild.children[0]).toMatchObject({
+        type: "field",
+        label: "Amount",
+        value: "$500",
+      });
+      expect(fieldsChild.children[1]).toMatchObject({
+        type: "field",
+        label: "To",
+        value: "acct_123",
+      });
+    }
+  });
+
+  it("should support custom button labels", () => {
+    const card = buildApprovalCard({
+      id: "test",
+      title: "Test",
+      approveLabel: "Yes, Delete",
+      denyLabel: "Cancel",
+    });
+
+    const actions = card.children.find((c) => c.type === "actions");
+    if (actions?.type === "actions") {
+      expect(actions.children[0]).toMatchObject({ label: "Yes, Delete" });
+      expect(actions.children[1]).toMatchObject({ label: "Cancel" });
+    }
+  });
+
+  it("should include custom children before the buttons", () => {
+    const card = buildApprovalCard({
+      id: "test",
+      title: "Test",
+      children: [{ type: "text", content: "Custom content" }],
+    });
+
+    const customText = card.children.find(
+      (c) => c.type === "text" && c.content === "Custom content"
+    );
+    expect(customText).toBeDefined();
+    if (!customText) {
+      throw new Error("expected customText");
+    }
+
+    // Custom content should come before divider+actions
+    const customIdx = card.children.indexOf(customText);
+    const dividerIdx = card.children.findIndex((c) => c.type === "divider");
+    expect(customIdx).toBeLessThan(dividerIdx);
+  });
+
+  it("should build a minimal card with only title and no optional fields", () => {
+    const card = buildApprovalCard({ id: "minimal", title: "Minimal" });
+
+    // Should only have divider + actions (no description, no fields, no children)
+    expect(card.children).toHaveLength(2);
+    expect(card.children[0].type).toBe("divider");
+    expect(card.children[1].type).toBe("actions");
+  });
+
+  it("should skip fields when the fields object is empty", () => {
+    const card = buildApprovalCard({
+      id: "empty-fields",
+      title: "Test",
+      fields: {},
+    });
+
+    const fieldsChild = card.children.find((c) => c.type === "fields");
+    expect(fieldsChild).toBeUndefined();
+  });
+
+  it("should include description, fields, and children in the correct order", () => {
+    const card = buildApprovalCard({
+      id: "ordering",
+      title: "Ordering Test",
+      description: "Desc",
+      fields: { Key: "Val" },
+      children: [{ type: "text", content: "Extra" }],
+    });
+
+    const types = card.children.map((c) => c.type);
+    // description (text), fields, custom child (text), divider, actions
+    expect(types).toEqual(["text", "fields", "text", "divider", "actions"]);
+  });
+
+  it("should handle multiple custom children", () => {
+    const card = buildApprovalCard({
+      id: "multi",
+      title: "Multi",
+      children: [
+        { type: "text", content: "First" },
+        { type: "text", content: "Second" },
+        { type: "text", content: "Third" },
+      ],
+    });
+
+    const textChildren = card.children.filter(
+      (c) =>
+        c.type === "text" && ["First", "Second", "Third"].includes(c.content)
+    );
+    expect(textChildren).toHaveLength(3);
+  });
+});
+
+// ============================================================================
+// buildResolvedCard
+// ============================================================================
+
+describe("buildResolvedCard", () => {
+  const user = makeUser({ userName: "sarah", fullName: "Sarah Connor" });
+
+  it("should build an approved card", () => {
+    const card = buildResolvedCard("Transfer Money", true, user);
+    expect(card.title).toBe("✅ Approved — Transfer Money");
+    const textChild = card.children.find((c) => c.type === "text");
+    expect(textChild).toBeDefined();
+    if (textChild?.type === "text") {
+      expect(textChild.content).toContain("sarah");
+    }
+  });
+
+  it("should build a denied card", () => {
+    const card = buildResolvedCard("Transfer Money", false, user);
+    expect(card.title).toBe("❌ Denied — Transfer Money");
+  });
+
+  it("should include fields if provided", () => {
+    const card = buildResolvedCard("Test", true, user, {
+      Amount: "$500",
+    });
+    const fieldsChild = card.children.find((c) => c.type === "fields");
+    expect(fieldsChild).toBeDefined();
+  });
+
+  it("should fall back to fullName when userName is missing", () => {
+    const noUserName = makeUser({
+      userName: undefined,
+      fullName: "John Doe",
+    });
+    const card = buildResolvedCard("Test", true, noUserName);
+    const textChild = card.children.find((c) => c.type === "text");
+    if (textChild?.type === "text") {
+      expect(textChild.content).toContain("John Doe");
+    }
+  });
+
+  it("should fall back to 'a user' when both names are missing", () => {
+    const anonymous = makeUser({
+      userName: undefined,
+      fullName: undefined,
+    });
+    const card = buildResolvedCard("Test", true, anonymous);
+    const textChild = card.children.find((c) => c.type === "text");
+    if (textChild?.type === "text") {
+      expect(textChild.content).toContain("a user");
+    }
+  });
+
+  it("should not include fields section when fields object is empty", () => {
+    const card = buildResolvedCard("Test", true, user, {});
+    const fieldsChild = card.children.find((c) => c.type === "fields");
+    expect(fieldsChild).toBeUndefined();
+  });
+
+  it("should not include fields section when fields is undefined", () => {
+    const card = buildResolvedCard("Test", false, user, undefined);
+    expect(card.children).toHaveLength(1); // only the status text
+  });
+});
+
+// ============================================================================
+// buildExpiredCard
+// ============================================================================
+
+describe("buildExpiredCard", () => {
+  it("should build an expired card", () => {
+    const card = buildExpiredCard("Transfer Money");
+    expect(card.title).toBe("⏰ Expired — Transfer Money");
+    expect(card.children).toHaveLength(1);
+  });
+
+  it("should contain an expiry message in the card body", () => {
+    const card = buildExpiredCard("Something");
+    const textChild = card.children[0];
+    if (textChild.type === "text") {
+      expect(textChild.content).toContain("expired");
+    }
+  });
+});
+
+// ============================================================================
+// parseApprovalAction
+// ============================================================================
+
+describe("parseApprovalAction", () => {
+  it("should parse an approve action", () => {
+    const result = parseApprovalAction("__approval:txn_123:approve");
+    expect(result).toEqual({ id: "txn_123", approved: true });
+  });
+
+  it("should parse a deny action", () => {
+    const result = parseApprovalAction("__approval:txn_123:deny");
+    expect(result).toEqual({ id: "txn_123", approved: false });
+  });
+
+  it("should return null for non-approval actions", () => {
+    expect(parseApprovalAction("hello")).toBeNull();
+    expect(parseApprovalAction("approve")).toBeNull();
+    expect(parseApprovalAction("__approval")).toBeNull();
+    expect(parseApprovalAction("__approval:id")).toBeNull();
+    expect(parseApprovalAction("__approval:id:unknown")).toBeNull();
+  });
+
+  it("should return null for empty string", () => {
+    expect(parseApprovalAction("")).toBeNull();
+  });
+
+  it("should return null when there are too many colon-separated segments", () => {
+    // An ID containing a colon produces 4+ segments
+    expect(parseApprovalAction("__approval:a:b:approve")).toBeNull();
+  });
+
+  it("should return null for prefix-only with trailing colon", () => {
+    expect(parseApprovalAction("__approval:")).toBeNull();
+  });
+
+  it("should handle IDs with special characters (no colons)", () => {
+    const result = parseApprovalAction("__approval:id-with_chars.123:approve");
+    expect(result).toEqual({ id: "id-with_chars.123", approved: true });
+  });
+});
+
+// ============================================================================
+// isApprovalActionId
+// ============================================================================
+
+describe("isApprovalActionId", () => {
+  it("should return true for approval actions", () => {
+    expect(isApprovalActionId("__approval:id:approve")).toBe(true);
+    expect(isApprovalActionId("__approval:id:deny")).toBe(true);
+    expect(isApprovalActionId("__approval:anything")).toBe(true);
+  });
+
+  it("should return false for non-approval actions", () => {
+    expect(isApprovalActionId("hello")).toBe(false);
+    expect(isApprovalActionId("approve")).toBe(false);
+    expect(isApprovalActionId("")).toBe(false);
+  });
+
+  it("should return false for similar-looking prefixes", () => {
+    expect(isApprovalActionId("__approvalx:id:approve")).toBe(false);
+    expect(isApprovalActionId("__APPROVAL:id:approve")).toBe(false);
+    expect(isApprovalActionId("_approval:id:approve")).toBe(false);
+  });
+
+  it("should return true for prefix with only a colon (no ID)", () => {
+    // Starts with `__approval:` — isApprovalActionId only checks prefix
+    expect(isApprovalActionId("__approval:")).toBe(true);
+  });
+});
+
+// ============================================================================
+// State Persistence Helpers
+// ============================================================================
+
+describe("storePendingApproval / consumePendingApproval", () => {
+  const mockStateAdapter = {
+    get: vi.fn(),
+    set: vi.fn(),
+    delete: vi.fn(),
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("should store an approval in the state adapter", async () => {
+    const approval = makeStoredApproval();
+
+    await storePendingApproval(mockStateAdapter as any, approval, 60000);
+
+    expect(mockStateAdapter.set).toHaveBeenCalledWith(
+      "pending-approval:test-123",
+      approval,
+      60000
+    );
+  });
+
+  it("should consume and delete an approval", async () => {
+    const stored = makeStoredApproval();
+    mockStateAdapter.get.mockResolvedValue(stored);
+
+    const result = await consumePendingApproval(
+      mockStateAdapter as any,
+      "test-123"
+    );
+
+    expect(result).toBe(stored);
+    expect(mockStateAdapter.get).toHaveBeenCalledWith(
+      "pending-approval:test-123"
+    );
+    expect(mockStateAdapter.delete).toHaveBeenCalledWith(
+      "pending-approval:test-123"
+    );
+  });
+
+  it("should return null for missing approval", async () => {
+    mockStateAdapter.get.mockResolvedValue(null);
+
+    const result = await consumePendingApproval(
+      mockStateAdapter as any,
+      "missing"
+    );
+
+    expect(result).toBeNull();
+    expect(mockStateAdapter.delete).not.toHaveBeenCalled();
+  });
+
+  it("should use the default TTL when none is provided", async () => {
+    const approval = makeStoredApproval();
+
+    await storePendingApproval(mockStateAdapter as any, approval);
+
+    // Default is 24 hours
+    expect(mockStateAdapter.set).toHaveBeenCalledWith(
+      "pending-approval:test-123",
+      approval,
+      86_400_000
+    );
+  });
+
+  it("should preserve metadata in stored approval", async () => {
+    const approval = makeStoredApproval({
+      metadata: { toolName: "transfer", args: { amount: 500 } },
+    });
+    mockStateAdapter.get.mockResolvedValue(approval);
+
+    const result = await consumePendingApproval(
+      mockStateAdapter as any,
+      "test-123"
+    );
+
+    expect(result?.metadata).toEqual({
+      toolName: "transfer",
+      args: { amount: 500 },
+    });
+  });
+
+  it("should use the correct key prefix for different IDs", async () => {
+    const approval1 = makeStoredApproval({ id: "abc" });
+    const approval2 = makeStoredApproval({ id: "xyz" });
+
+    await storePendingApproval(mockStateAdapter as any, approval1, 1000);
+    await storePendingApproval(mockStateAdapter as any, approval2, 1000);
+
+    expect(mockStateAdapter.set).toHaveBeenCalledWith(
+      "pending-approval:abc",
+      expect.anything(),
+      1000
+    );
+    expect(mockStateAdapter.set).toHaveBeenCalledWith(
+      "pending-approval:xyz",
+      expect.anything(),
+      1000
+    );
+  });
+});
+
+// ============================================================================
+// ApprovalRegistry
+// ============================================================================
+
+describe("ApprovalRegistry", () => {
+  let registry: ApprovalRegistry;
+
+  beforeEach(() => {
+    registry = new ApprovalRegistry();
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("should register and resolve an approval", async () => {
+    const promise = registry.register("test-1", 60000);
+    const result = makeResult("test-1", true);
+
+    const resolved = registry.resolve("test-1", result);
+    expect(resolved).toBe(true);
+
+    const value = await promise;
+    expect(value).toEqual(result);
+  });
+
+  it("should return false when resolving a non-existent approval", () => {
+    const result = registry.resolve(
+      "non-existent",
+      makeResult("non-existent", true)
+    );
+    expect(result).toBe(false);
+  });
+
+  it("should time out pending approvals", async () => {
+    const promise = registry.register("test-timeout", 5000);
+
+    vi.advanceTimersByTime(5001);
+
+    await expect(promise).rejects.toThrow(
+      'Approval request "test-timeout" timed out'
+    );
+    expect(registry.has("test-timeout")).toBe(false);
+  });
+
+  it("should track pending approvals with has()", () => {
+    registry.register("test-has", 60000);
+    expect(registry.has("test-has")).toBe(true);
+    expect(registry.has("non-existent")).toBe(false);
+  });
+
+  it("should remove pending approvals", () => {
+    registry.register("test-remove", 60000);
+    expect(registry.has("test-remove")).toBe(true);
+
+    registry.remove("test-remove");
+    expect(registry.has("test-remove")).toBe(false);
+  });
+
+  it("should replace existing entry for same ID", async () => {
+    registry.register("dup", 60000);
+    const promise2 = registry.register("dup", 60000);
+
+    const result = makeResult("dup", true);
+    registry.resolve("dup", result);
+    const value = await promise2;
+    expect(value.approved).toBe(true);
+  });
+
+  it("should clear timeout on resolve", () => {
+    registry.register("test-clear", 60000);
+
+    registry.resolve("test-clear", makeResult("test-clear", false));
+
+    // Advancing time should not cause issues
+    vi.advanceTimersByTime(120000);
+    expect(registry.has("test-clear")).toBe(false);
+  });
+
+  it("should resolve with denied result", async () => {
+    const promise = registry.register("deny-test", 60000);
+    const result = makeResult("deny-test", false);
+
+    registry.resolve("deny-test", result);
+
+    const value = await promise;
+    expect(value.approved).toBe(false);
+  });
+
+  it("should include metadata in resolved result", async () => {
+    const promise = registry.register("meta-test", 60000);
+    const result = makeResult("meta-test", true, {
+      metadata: { toolName: "send", args: {} },
+    });
+
+    registry.resolve("meta-test", result);
+
+    const value = await promise;
+    expect(value.metadata).toEqual({ toolName: "send", args: {} });
+  });
+
+  it("should include reason in resolved result", async () => {
+    const promise = registry.register("reason-test", 60000);
+    const result = makeResult("reason-test", false, {
+      reason: "Too risky",
+    });
+
+    registry.resolve("reason-test", result);
+
+    const value = await promise;
+    expect(value.reason).toBe("Too risky");
+  });
+
+  it("should not time out when ttlMs is 0", async () => {
+    const promise = registry.register("no-timeout", 0);
+
+    // Advance a lot of time
+    vi.advanceTimersByTime(999_999);
+
+    // Should still be pending
+    expect(registry.has("no-timeout")).toBe(true);
+
+    // Can still resolve
+    registry.resolve("no-timeout", makeResult("no-timeout", true));
+    const value = await promise;
+    expect(value.approved).toBe(true);
+  });
+
+  it("should handle removing a non-existent entry gracefully", () => {
+    // Should not throw
+    expect(() => registry.remove("does-not-exist")).not.toThrow();
+  });
+
+  it("should manage multiple independent approvals concurrently", async () => {
+    const p1 = registry.register("a", 60000);
+    const p2 = registry.register("b", 60000);
+    const p3 = registry.register("c", 60000);
+
+    expect(registry.has("a")).toBe(true);
+    expect(registry.has("b")).toBe(true);
+    expect(registry.has("c")).toBe(true);
+
+    registry.resolve("b", makeResult("b", false));
+    registry.resolve("a", makeResult("a", true));
+    registry.resolve("c", makeResult("c", true));
+
+    const [v1, v2, v3] = await Promise.all([p1, p2, p3]);
+    expect(v1.approved).toBe(true);
+    expect(v2.approved).toBe(false);
+    expect(v3.approved).toBe(true);
+  });
+
+  it("should not resolve after timeout has fired", async () => {
+    const promise = registry.register("late", 1000);
+
+    vi.advanceTimersByTime(1001);
+
+    // Promise rejected
+    await expect(promise).rejects.toThrow("timed out");
+
+    // Attempting to resolve returns false (entry already cleaned up)
+    const resolved = registry.resolve("late", makeResult("late", true));
+    expect(resolved).toBe(false);
+  });
+
+  it("should clear timeout on remove", () => {
+    registry.register("remove-timer", 5000);
+    registry.remove("remove-timer");
+
+    // Advancing past original timeout should not cause unhandled rejection
+    vi.advanceTimersByTime(10000);
+    expect(registry.has("remove-timer")).toBe(false);
+  });
+
+  it("should remove entry that has no timer (ttlMs=0)", () => {
+    registry.register("no-timer", 0);
+    expect(registry.has("no-timer")).toBe(true);
+
+    registry.remove("no-timer");
+    expect(registry.has("no-timer")).toBe(false);
+  });
+});
+
+// ============================================================================
+// defaultApprovalCard
+// ============================================================================
+
+describe("defaultApprovalCard", () => {
+  it("should build card options from a tool call", () => {
+    const result = defaultApprovalCard({
+      toolName: "transferMoney",
+      toolCallId: "tc_123",
+      input: { amount: 500, to: "acct_456" },
+    });
+
+    expect(result.title).toBe("🔒 transferMoney");
+    expect(result.fields).toEqual({
+      amount: "500",
+      to: "acct_456",
+    });
+  });
+
+  it("should handle null and undefined values", () => {
+    const result = defaultApprovalCard({
+      toolName: "test",
+      toolCallId: "tc_1",
+      input: { a: null, b: undefined },
+    });
+
+    expect(result.fields).toEqual({ a: "—", b: "—" });
+  });
+
+  it("should stringify nested objects", () => {
+    const result = defaultApprovalCard({
+      toolName: "test",
+      toolCallId: "tc_1",
+      input: { config: { nested: true } },
+    });
+
+    expect(result.fields?.config).toBe('{"nested":true}');
+  });
+
+  it("should handle empty input", () => {
+    const result = defaultApprovalCard({
+      toolName: "noop",
+      toolCallId: "tc_1",
+      input: {},
+    });
+
+    expect(result.title).toBe("🔒 noop");
+    expect(result.fields).toEqual({});
+  });
+
+  it("should stringify arrays in input", () => {
+    const result = defaultApprovalCard({
+      toolName: "test",
+      toolCallId: "tc_1",
+      input: { items: [1, 2, 3] },
+    });
+
+    expect(result.fields?.items).toBe("[1,2,3]");
+  });
+
+  it("should convert boolean values to strings", () => {
+    const result = defaultApprovalCard({
+      toolName: "test",
+      toolCallId: "tc_1",
+      input: { dryRun: true, force: false },
+    });
+
+    expect(result.fields).toEqual({ dryRun: "true", force: "false" });
+  });
+
+  it("should convert numeric values to strings", () => {
+    const result = defaultApprovalCard({
+      toolName: "test",
+      toolCallId: "tc_1",
+      input: { count: 0, amount: 99.99, negative: -5 },
+    });
+
+    expect(result.fields).toEqual({
+      count: "0",
+      amount: "99.99",
+      negative: "-5",
+    });
+  });
+});

--- a/packages/chat/src/approval.test.ts
+++ b/packages/chat/src/approval.test.ts
@@ -322,9 +322,19 @@ describe("parseApprovalAction", () => {
     expect(parseApprovalAction("")).toBeNull();
   });
 
-  it("should return null when there are too many colon-separated segments", () => {
-    // An ID containing a colon produces 4+ segments
-    expect(parseApprovalAction("__approval:a:b:approve")).toBeNull();
+  it("should handle IDs containing colons", () => {
+    const result = parseApprovalAction("__approval:a:b:approve");
+    expect(result).toEqual({ id: "a:b", approved: true });
+  });
+
+  it("should handle IDs with multiple colons", () => {
+    const result = parseApprovalAction("__approval:tool:call:abc_123:deny");
+    expect(result).toEqual({ id: "tool:call:abc_123", approved: false });
+  });
+
+  it("should handle an ID that is only a colon", () => {
+    const result = parseApprovalAction("__approval:::approve");
+    expect(result).toEqual({ id: ":", approved: true });
   });
 
   it("should return null for prefix-only with trailing colon", () => {

--- a/packages/chat/src/approval.ts
+++ b/packages/chat/src/approval.ts
@@ -1,0 +1,525 @@
+/**
+ * Human-in-the-loop approval system for Chat SDK.
+ *
+ * Provides `thread.requestApproval()` (Layer 1) and `thread.runAgent()` (Layer 2):
+ *
+ * **Layer 1 — `requestApproval()`**
+ * Posts a rich approval Card with Approve/Deny buttons, persists the pending
+ * approval in the StateAdapter (survives server restarts), and returns a Promise
+ * that resolves when the user clicks a button.
+ *
+ * **Layer 2 — `runAgent()`**
+ * Runs an AI SDK agent, automatically handles `needsApproval` tool calls by
+ * posting approval cards via `requestApproval()`, and resumes the agent with
+ * the user's decision. Loops until the agent finishes.
+ *
+ * @example Layer 1 — `requestApproval()`
+ * ```tsx
+ * const { approved, user } = await thread.requestApproval({
+ *   title: "Transfer Money",
+ *   fields: { Amount: "$500", To: "acct_123" },
+ * });
+ * ```
+ *
+ * @example Layer 2 — `runAgent()`
+ * ```tsx
+ * const result = await thread.runAgent(agent, {
+ *   prompt: history,
+ *   approvalCard: (toolCall) => ({
+ *     title: `🔒 Confirm ${toolCall.toolName}`,
+ *     fields: toolCall.input,
+ *   }),
+ * });
+ * await thread.post(result.fullStream);
+ * ```
+ *
+ * @module
+ */
+
+import type { CardChild, CardElement } from "./cards";
+import { Actions, Button, Card, Divider, Field, Fields, Text } from "./cards";
+import type { SerializedMessage } from "./message";
+import type { SerializedThread } from "./thread";
+import type { ActionEvent, Author, StateAdapter } from "./types";
+
+// ============================================================================
+// Constants
+// ============================================================================
+
+/** Prefix for approval action IDs on buttons */
+export const APPROVAL_PREFIX = "__approval";
+
+/** Key prefix for pending approvals in the StateAdapter */
+const APPROVAL_STATE_KEY_PREFIX = "pending-approval:";
+
+/** Default TTL for pending approvals (24 hours) */
+const DEFAULT_APPROVAL_TTL_MS = 24 * 60 * 60 * 1000;
+
+// ============================================================================
+// Types — requestApproval (Layer 1)
+// ============================================================================
+
+/** Options for building an approval card */
+export interface ApprovalCardOptions {
+  /** Custom approve button label @default "Approve" */
+  approveLabel?: string;
+  /** Additional card children inserted before the action buttons */
+  children?: CardChild[];
+  /** Custom deny button label @default "Deny" */
+  denyLabel?: string;
+  /** Optional description text shown below the title */
+  description?: string;
+  /** Key-value fields to display (e.g. `{ Amount: "$500", To: "acct_123" }`) */
+  fields?: Record<string, string>;
+  /** Unique ID for this approval (typically toolCallId or a UUID) */
+  id: string;
+  /** Card title */
+  title: string;
+}
+
+/** Full options for `thread.requestApproval()` */
+export interface RequestApprovalOptions extends ApprovalCardOptions {
+  /**
+   * Arbitrary metadata to persist alongside the approval.
+   * Useful for storing context needed to resume agent execution after a restart.
+   *
+   * @example
+   * ```ts
+   * await thread.requestApproval({
+   *   id: toolCall.toolCallId,
+   *   title: "Transfer Money",
+   *   metadata: { toolName: "transferMoney", args: toolCall.args, history },
+   * });
+   * ```
+   */
+  metadata?: Record<string, unknown>;
+  /**
+   * TTL for the pending approval in the state adapter.
+   * After this time the approval is considered expired.
+   * @default 86_400_000 (24 hours)
+   */
+  ttlMs?: number;
+  /**
+   * Update the card after the user responds to show the decision.
+   * @default true
+   */
+  updateCard?: boolean;
+}
+
+/** Result returned when a user responds to an approval card */
+export interface ApprovalResult {
+  /** Whether the user approved or denied */
+  approved: boolean;
+  /** The approval ID (matches the `id` passed to `requestApproval`) */
+  id: string;
+  /** The metadata passed to `requestApproval` (if any) */
+  metadata?: Record<string, unknown>;
+  /** Optional reason for the decision (forwarded to AI SDK as `reason` on tool-approval-response) */
+  reason?: string;
+  /** The user who responded */
+  user: Author;
+}
+
+// ============================================================================
+// Types — onApprovalResponse (restart recovery)
+// ============================================================================
+
+/**
+ * Event emitted when an approval response arrives after a server restart.
+ * The in-memory promise from `requestApproval()` is gone, so this handler
+ * gives the developer a chance to resume the agent or workflow.
+ */
+export interface ApprovalResponseEvent {
+  /** Whether the user approved */
+  approved: boolean;
+  /** The full action event from the platform */
+  event: ActionEvent;
+  /** The approval ID */
+  id: string;
+  /** The metadata stored with the original `requestApproval()` call */
+  metadata?: Record<string, unknown>;
+  /** The user who clicked the button */
+  user: Author;
+}
+
+/** Handler for approval responses that arrive after a server restart */
+export type ApprovalResponseHandler = (
+  event: ApprovalResponseEvent
+) => void | Promise<void>;
+
+// ============================================================================
+// Types — runAgent (Layer 2)
+// ============================================================================
+
+/**
+ * Callback to customize the approval card for a specific tool call.
+ * Return the card options (title, fields, description, etc.).
+ */
+export type ApprovalCardCallback = (toolCall: {
+  input: Record<string, unknown>;
+  toolCallId: string;
+  toolName: string;
+}) => Omit<ApprovalCardOptions, "id">;
+
+/**
+ * Options for `thread.runAgent()`.
+ */
+export interface RunAgentOptions {
+  /**
+   * Customize the approval card for each tool call that needs approval.
+   * Receives the tool call and returns card options.
+   *
+   * @default Generates a card with the tool name as title and args as fields.
+   *
+   * @example
+   * ```ts
+   * approvalCard: (toolCall) => ({
+   *   title: `Confirm ${toolCall.toolName}`,
+   *   description: "This action requires your approval.",
+   *   fields: { Amount: toolCall.input.amount },
+   * })
+   * ```
+   */
+  approvalCard?: ApprovalCardCallback;
+  /** Conversation history / prompt to send to the agent */
+  prompt: unknown;
+  /**
+   * Additional options passed through to `agent.generate()`.
+   */
+  [key: string]: unknown;
+}
+
+/**
+ * Minimal agent interface for `thread.runAgent()`.
+ * Compatible with AI SDK's `ToolLoopAgent` without importing it.
+ */
+export interface AgentLike {
+  generate(options: {
+    messages?: unknown[];
+    prompt?: unknown;
+    [key: string]: unknown;
+  }): Promise<AgentResultLike>;
+}
+
+/**
+ * Minimal agent result interface.
+ * Compatible with AI SDK's `generate()` result shape.
+ */
+export interface AgentResultLike {
+  /** Content parts — may include `tool-approval-request` parts */
+  content: Array<{ type: string; [key: string]: unknown }>;
+  /** The full stream for streaming to the client */
+  fullStream?: AsyncIterable<unknown>;
+  /** The response messages for resuming the agent */
+  response: { messages: unknown[] };
+  /** The final text output */
+  text?: string | Promise<string>;
+  [key: string]: unknown;
+}
+
+// ============================================================================
+// Types — State Persistence
+// ============================================================================
+
+/** Internal state persisted in the StateAdapter for each pending approval */
+export interface StoredApproval {
+  /** Adapter name for rehydration */
+  adapterName: string;
+  /** Timestamp when the approval was created */
+  createdAt: string;
+  /** Key-value fields from the card (for card update after restart) */
+  fields?: Record<string, string>;
+  /** The approval ID */
+  id: string;
+  /** Developer-supplied metadata */
+  metadata?: Record<string, unknown>;
+  /** Serialized SentMessage for updating the card after restart */
+  sentMessage?: SerializedMessage;
+  /** Serialized thread for rehydration after restart */
+  thread: SerializedThread;
+  /** Card title (for card update after restart) */
+  title: string;
+  /** Whether to update the card after the decision */
+  updateCard: boolean;
+}
+
+// ============================================================================
+// Card Builders
+// ============================================================================
+
+/**
+ * Build an approval card element.
+ *
+ * Uses deterministic action IDs (`__approval:{id}:approve` / `__approval:{id}:deny`)
+ * so the Chat SDK can automatically intercept button clicks without any
+ * manual `onAction` registration.
+ */
+export function buildApprovalCard(options: ApprovalCardOptions): CardElement {
+  const children: CardChild[] = [];
+
+  if (options.description) {
+    children.push(Text(options.description));
+  }
+
+  if (options.fields && Object.keys(options.fields).length > 0) {
+    children.push(
+      Fields(
+        Object.entries(options.fields).map(([label, value]) =>
+          Field({ label, value: String(value) })
+        )
+      )
+    );
+  }
+
+  if (options.children) {
+    children.push(...options.children);
+  }
+
+  children.push(Divider());
+  children.push(
+    Actions([
+      Button({
+        id: `${APPROVAL_PREFIX}:${options.id}:approve`,
+        label: options.approveLabel ?? "Approve",
+        style: "primary",
+      }),
+      Button({
+        id: `${APPROVAL_PREFIX}:${options.id}:deny`,
+        label: options.denyLabel ?? "Deny",
+        style: "danger",
+      }),
+    ])
+  );
+
+  return Card({ title: options.title, children });
+}
+
+/**
+ * Build a card to replace the approval card after the user responds.
+ */
+export function buildResolvedCard(
+  title: string,
+  approved: boolean,
+  user: Author,
+  fields?: Record<string, string>
+): CardElement {
+  const status = approved ? "✅ Approved" : "❌ Denied";
+  const userName = user.userName ?? user.fullName ?? "a user";
+  const children: CardChild[] = [Text(`${status} by ${userName}`)];
+
+  if (fields && Object.keys(fields).length > 0) {
+    children.push(
+      Fields(
+        Object.entries(fields).map(([label, value]) =>
+          Field({ label, value: String(value) })
+        )
+      )
+    );
+  }
+
+  return Card({ title: `${status} — ${title}`, children });
+}
+
+/**
+ * Build a card for when an approval request has expired.
+ */
+export function buildExpiredCard(title: string): CardElement {
+  return Card({
+    title: `⏰ Expired — ${title}`,
+    children: [Text("This approval request has expired. Please try again.")],
+  });
+}
+
+// ============================================================================
+// Action ID Parsing
+// ============================================================================
+
+/**
+ * Check if an action ID matches the approval pattern and extract the decision.
+ * Returns `null` if the action ID is not an approval action.
+ *
+ * @example
+ * ```ts
+ * parseApprovalAction("__approval:txn_123:approve")
+ * // => { id: "txn_123", approved: true }
+ *
+ * parseApprovalAction("some_other_action")
+ * // => null
+ * ```
+ */
+export function parseApprovalAction(
+  actionId: string
+): { id: string; approved: boolean } | null {
+  if (!actionId.startsWith(`${APPROVAL_PREFIX}:`)) {
+    return null;
+  }
+  const parts = actionId.split(":");
+  if (parts.length !== 3) {
+    return null;
+  }
+  const [, id, decision] = parts;
+  if (decision !== "approve" && decision !== "deny") {
+    return null;
+  }
+  return { id, approved: decision === "approve" };
+}
+
+/**
+ * Quick boolean check: is this action ID an approval action?
+ */
+export function isApprovalActionId(actionId: string): boolean {
+  return actionId.startsWith(`${APPROVAL_PREFIX}:`);
+}
+
+// ============================================================================
+// State Persistence Helpers
+// ============================================================================
+
+function approvalStateKey(id: string): string {
+  return `${APPROVAL_STATE_KEY_PREFIX}${id}`;
+}
+
+/**
+ * Persist a pending approval in the state adapter.
+ */
+export async function storePendingApproval(
+  stateAdapter: StateAdapter,
+  approval: StoredApproval,
+  ttlMs: number = DEFAULT_APPROVAL_TTL_MS
+): Promise<void> {
+  await stateAdapter.set(approvalStateKey(approval.id), approval, ttlMs);
+}
+
+/**
+ * Retrieve and delete a pending approval from the state adapter.
+ * Returns `null` if not found (expired or already consumed).
+ * The delete-on-read prevents double-processing from double-clicks.
+ */
+export async function consumePendingApproval(
+  stateAdapter: StateAdapter,
+  id: string
+): Promise<StoredApproval | null> {
+  const key = approvalStateKey(id);
+  const stored = await stateAdapter.get<StoredApproval>(key);
+  if (stored) {
+    await stateAdapter.delete(key);
+  }
+  return stored;
+}
+
+// ============================================================================
+// In-Memory Promise Registry
+// ============================================================================
+
+/**
+ * Registry for in-memory approval promise resolvers.
+ *
+ * When `thread.requestApproval()` is called, it registers a resolver here.
+ * When the button click arrives in the same process, we resolve the promise
+ * directly — no state adapter round-trip needed.
+ *
+ * If the server restarted between posting the card and the button click,
+ * this map is empty and the Chat class falls back to the `onApprovalResponse`
+ * handler using the persisted `StoredApproval`.
+ */
+export class ApprovalRegistry {
+  private readonly pending = new Map<
+    string,
+    {
+      resolve: (result: ApprovalResult) => void;
+      reject: (error: Error) => void;
+      timer?: ReturnType<typeof setTimeout>;
+    }
+  >();
+
+  /**
+   * Register a pending approval and return a Promise that resolves
+   * when the user clicks Approve or Deny (in the same process).
+   */
+  register(id: string, ttlMs: number): Promise<ApprovalResult> {
+    // Clean up any existing entry for the same ID
+    this.remove(id);
+
+    return new Promise<ApprovalResult>((resolve, reject) => {
+      const timer =
+        ttlMs > 0
+          ? setTimeout(() => {
+              this.pending.delete(id);
+              reject(new Error(`Approval request "${id}" timed out`));
+            }, ttlMs)
+          : undefined;
+
+      this.pending.set(id, { resolve, reject, timer });
+    });
+  }
+
+  /**
+   * Resolve a pending approval. Returns `true` if the promise was found
+   * and resolved (same process), `false` if not found (restart case).
+   */
+  resolve(id: string, result: ApprovalResult): boolean {
+    const entry = this.pending.get(id);
+    if (!entry) {
+      return false;
+    }
+
+    if (entry.timer) {
+      clearTimeout(entry.timer);
+    }
+    this.pending.delete(id);
+    entry.resolve(result);
+    return true;
+  }
+
+  /**
+   * Remove a pending approval without resolving it.
+   */
+  remove(id: string): void {
+    const entry = this.pending.get(id);
+    if (entry) {
+      if (entry.timer) {
+        clearTimeout(entry.timer);
+      }
+      this.pending.delete(id);
+    }
+  }
+
+  /**
+   * Check if an approval is pending in memory.
+   */
+  has(id: string): boolean {
+    return this.pending.has(id);
+  }
+}
+
+// ============================================================================
+// Default Approval Card Builder
+// ============================================================================
+
+/**
+ * Default `approvalCard` callback used by `thread.runAgent()` when
+ * the developer doesn't provide a custom one.
+ *
+ * Uses the tool name as title and stringifies the input as fields.
+ */
+export function defaultApprovalCard(toolCall: {
+  input: Record<string, unknown>;
+  toolCallId: string;
+  toolName: string;
+}): Omit<ApprovalCardOptions, "id"> {
+  const fields: Record<string, string> = {};
+  for (const [key, value] of Object.entries(toolCall.input)) {
+    if (value === null || value === undefined) {
+      fields[key] = "—";
+    } else if (typeof value === "object") {
+      fields[key] = JSON.stringify(value);
+    } else {
+      fields[key] = String(value);
+    }
+  }
+
+  return {
+    title: `🔒 ${toolCall.toolName}`,
+    fields,
+  };
+}

--- a/packages/chat/src/approval.ts
+++ b/packages/chat/src/approval.ts
@@ -350,14 +350,19 @@ export function buildExpiredCard(title: string): CardElement {
 export function parseApprovalAction(
   actionId: string
 ): { id: string; approved: boolean } | null {
-  if (!actionId.startsWith(`${APPROVAL_PREFIX}:`)) {
+  const prefix = `${APPROVAL_PREFIX}:`;
+  if (!actionId.startsWith(prefix)) {
     return null;
   }
-  const parts = actionId.split(":");
-  if (parts.length !== 3) {
+  // Extract decision from the last segment, ID is everything in between.
+  // This supports IDs containing colons (e.g. "tool:call_abc").
+  const rest = actionId.slice(prefix.length);
+  const lastColon = rest.lastIndexOf(":");
+  if (lastColon === -1 || lastColon === 0) {
     return null;
   }
-  const [, id, decision] = parts;
+  const id = rest.slice(0, lastColon);
+  const decision = rest.slice(lastColon + 1);
   if (decision !== "approve" && decision !== "deny") {
     return null;
   }

--- a/packages/chat/src/chat-singleton.ts
+++ b/packages/chat/src/chat-singleton.ts
@@ -2,12 +2,15 @@
  * Singleton holder for Chat instance.
  * Separate module to avoid circular dependency between chat.ts and thread.ts.
  */
+import type { ApprovalRegistry } from "./approval";
 import type { Adapter, StateAdapter } from "./types";
 
 /**
  * Interface for the Chat singleton to avoid importing the full Chat class.
  */
 export interface ChatSingleton {
+  /** Get the approval registry for in-memory promise resolution */
+  readonly _approvalRegistry: ApprovalRegistry;
   getAdapter(name: string): Adapter | undefined;
   getState(): StateAdapter;
 }

--- a/packages/chat/src/chat.ts
+++ b/packages/chat/src/chat.ts
@@ -1,3 +1,12 @@
+import {
+  ApprovalRegistry,
+  type ApprovalResponseHandler,
+  type ApprovalResult,
+  buildResolvedCard,
+  consumePendingApproval,
+  isApprovalActionId,
+  parseApprovalAction,
+} from "./approval";
 import { ChannelImpl, type SerializedChannel } from "./channel";
 import {
   getChatSingleton,
@@ -188,6 +197,11 @@ export class Chat<
   private readonly _dedupeTtlMs: number;
   private readonly _onLockConflict: ChatConfig["onLockConflict"];
   private readonly _messageHistory: MessageHistoryCache;
+
+  /** In-memory registry for pending approval promises */
+  readonly _approvalRegistry = new ApprovalRegistry();
+  /** User-registered handler for approval responses after server restart */
+  private _approvalResponseHandler?: ApprovalResponseHandler;
 
   private readonly mentionHandlers: MentionHandler<TState>[] = [];
   private readonly directMessageHandlers: DirectMessageHandler<TState>[] = [];
@@ -538,6 +552,36 @@ export class Chat<
       this.actionHandlers.push({ actionIds, handler });
       this.logger.debug("Registered action handler", { actionIds });
     }
+  }
+
+  /**
+   * Register a handler for approval responses that arrive after a server restart.
+   *
+   * In the normal flow, `thread.requestApproval()` returns a Promise that resolves
+   * when the user clicks Approve or Deny. But if the server restarts before that
+   * happens, the Promise is lost. This handler is called instead, with the full
+   * context from the original `requestApproval()` call (including metadata).
+   *
+   * @example
+   * ```ts
+   * bot.onApprovalResponse(async ({ id, approved, metadata, event }) => {
+   *   if (!metadata || !event.thread) return;
+   *
+   *   const { toolCallId, history } = metadata;
+   *   const resumed = await agent.generate({
+   *     messages: [...history, {
+   *       type: "tool-approval-response",
+   *       approvalId: id,
+   *       approved,
+   *     }],
+   *   });
+   *   await event.thread.post(resumed.fullStream);
+   * });
+   * ```
+   */
+  onApprovalResponse(handler: ApprovalResponseHandler): void {
+    this._approvalResponseHandler = handler;
+    this.logger.debug("Registered approval response handler");
   }
 
   onModalSubmit(handler: ModalSubmitHandler): void;
@@ -1247,6 +1291,14 @@ export class Chat<
       },
     };
 
+    // ─── Approval interception (runs BEFORE user-registered handlers) ───
+    // Actions with the __approval: prefix are owned by the approval system.
+    // They are intercepted here and NOT propagated to user onAction handlers.
+    if (isApprovalActionId(event.actionId)) {
+      await this.handleApprovalAction(fullEvent);
+      return;
+    }
+
     // Run matching handlers
     this.logger.debug("Checking action handlers", {
       handlerCount: this.actionHandlers.length,
@@ -1267,6 +1319,104 @@ export class Chat<
           actionId: event.actionId,
         });
         await handler(fullEvent);
+      }
+    }
+  }
+
+  /**
+   * Handle an approval button click.
+   *
+   * 1. Parse the action ID to get the approval ID and decision
+   * 2. Consume the persisted approval from the state adapter (prevents double-clicks)
+   * 3. Try to resolve the in-memory promise (same process — happy path)
+   * 4. If no promise found (server restarted), call onApprovalResponse handler
+   * 5. Update the original card to show the decision
+   */
+  private async handleApprovalAction(event: ActionEvent): Promise<void> {
+    const parsed = parseApprovalAction(event.actionId);
+    if (!parsed) {
+      return;
+    }
+
+    const { id, approved } = parsed;
+
+    this.logger.debug("Handling approval action", {
+      id,
+      approved,
+      user: event.user.userName,
+    });
+
+    // Consume from state adapter (also prevents double-clicks)
+    const stored = await consumePendingApproval(this._stateAdapter, id);
+
+    const result: ApprovalResult = {
+      id,
+      approved,
+      user: event.user,
+      metadata: stored?.metadata,
+    };
+
+    // Try in-memory first (same process, happy path)
+    const resolvedInMemory = this._approvalRegistry.resolve(id, result);
+
+    if (resolvedInMemory) {
+      // The promise in requestApproval() was resolved — it handles the card update
+      this.logger.debug("Approval resolved in-memory", { id, approved });
+      return;
+    }
+
+    // ── Restart recovery path ──
+    // The in-memory promise is gone (server restarted), but the state adapter
+    // had the persisted approval data.
+    this.logger.info("Approval resolved via state adapter (restart recovery)", {
+      id,
+      approved,
+    });
+
+    // Update the original card to show the decision
+    if (stored?.updateCard && stored.sentMessage && event.thread) {
+      try {
+        const resolvedCard = buildResolvedCard(
+          stored.title,
+          approved,
+          event.user,
+          stored.fields
+        );
+        const thread = event.thread as ThreadImpl<TState>;
+        const message = Message.fromJSON(stored.sentMessage);
+        const sentMessage = thread.createSentMessageFromMessage(message);
+        await sentMessage.edit(resolvedCard);
+      } catch (err) {
+        this.logger.warn("Failed to update approval card after restart", {
+          id,
+          error: err,
+        });
+      }
+    }
+
+    // Call the user's restart recovery handler
+    if (this._approvalResponseHandler) {
+      await this._approvalResponseHandler({
+        id,
+        approved,
+        user: event.user,
+        event,
+        metadata: stored?.metadata,
+      });
+    } else if (!stored) {
+      // No stored approval AND no in-memory promise — must have expired
+      this.logger.warn(
+        "Approval action received but no pending approval found (expired?)",
+        { id }
+      );
+      if (event.thread) {
+        try {
+          await event.thread.post(
+            "This approval request has expired. Please try again."
+          );
+        } catch {
+          // Best effort
+        }
       }
     }
   }

--- a/packages/chat/src/index.ts
+++ b/packages/chat/src/index.ts
@@ -10,6 +10,24 @@ export {
   type AiUserMessage,
   toAiMessages,
 } from "./ai";
+export type {
+  AgentLike,
+  AgentResultLike,
+  ApprovalCardCallback,
+  ApprovalCardOptions,
+  ApprovalResponseEvent,
+  ApprovalResponseHandler,
+  ApprovalResult,
+  RequestApprovalOptions,
+  RunAgentOptions,
+} from "./approval";
+// Approval system
+export {
+  buildApprovalCard,
+  defaultApprovalCard,
+  isApprovalActionId,
+  parseApprovalAction,
+} from "./approval";
 export {
   ChannelImpl,
   deriveChannelId,

--- a/packages/chat/src/thread.ts
+++ b/packages/chat/src/thread.ts
@@ -1,5 +1,17 @@
 import { WORKFLOW_DESERIALIZE, WORKFLOW_SERIALIZE } from "@workflow/serde";
 import type { Root } from "mdast";
+import {
+  type AgentLike,
+  type AgentResultLike,
+  type ApprovalResult,
+  buildApprovalCard,
+  buildResolvedCard,
+  defaultApprovalCard,
+  type RequestApprovalOptions,
+  type RunAgentOptions,
+  type StoredApproval,
+  storePendingApproval,
+} from "./approval";
 import { cardToFallbackText } from "./cards";
 import { ChannelImpl, deriveChannelId } from "./channel";
 import { getChatSingleton } from "./chat-singleton";
@@ -707,6 +719,227 @@ export class ThreadImpl<TState = Record<string, unknown>>
 
   mentionUser(userId: string): string {
     return `<@${userId}>`;
+  }
+
+  // ===========================================================================
+  // Approval System
+  // ===========================================================================
+
+  /**
+   * Post an approval card and wait for the user to approve or deny.
+   *
+   * This method:
+   * 1. Builds and posts a Card with Approve/Deny buttons
+   * 2. Persists the approval state in the StateAdapter (survives restarts)
+   * 3. Returns a Promise that resolves when the user clicks a button
+   * 4. Automatically updates the card to show the decision
+   *
+   * If the server restarts before the user responds, the Promise is lost
+   * but the persisted state remains. Register `bot.onApprovalResponse()`
+   * to handle approvals that arrive after a restart.
+   *
+   * @example Basic usage
+   * ```tsx
+   * const { approved, user } = await thread.requestApproval({
+   *   id: "transfer-123",
+   *   title: "🔒 Transfer Money",
+   *   fields: { Amount: "$500", To: "acct_123" },
+   * });
+   *
+   * if (approved) {
+   *   await transferMoney(500, "acct_123");
+   * }
+   * ```
+   *
+   * @example With AI SDK tool calls
+   * ```tsx
+   * const { approved } = await thread.requestApproval({
+   *   id: toolCall.toolCallId,
+   *   title: `🔒 ${toolCall.toolName}`,
+   *   fields: toolCall.args,
+   *   metadata: { toolCall, history },
+   * });
+   * ```
+   */
+  async requestApproval(
+    options: RequestApprovalOptions
+  ): Promise<ApprovalResult> {
+    const {
+      id,
+      title,
+      description,
+      fields,
+      children,
+      approveLabel,
+      denyLabel,
+      ttlMs = 24 * 60 * 60 * 1000,
+      updateCard = true,
+      metadata,
+    } = options;
+
+    // 1. Validate singleton early — fail before any side effects
+    const chat = getChatSingleton();
+
+    // 2. Register in-memory resolver BEFORE posting the card, so that
+    //    if the user clicks immediately the handler finds the promise.
+    const promise = chat._approvalRegistry.register(id, ttlMs);
+
+    // 3. Persist to state adapter BEFORE posting. The record starts
+    //    without sentMessage so restart-recovery works even if the
+    //    process dies after posting but before the second write.
+    const startTime = Date.now();
+    const storedApproval: StoredApproval = {
+      id,
+      title,
+      fields,
+      metadata,
+      thread: this.toJSON(),
+      adapterName: this.adapter.name,
+      createdAt: new Date(startTime).toISOString(),
+      updateCard,
+    };
+    await storePendingApproval(this._stateAdapter, storedApproval, ttlMs);
+
+    // 4. Build and post the approval card. If posting fails, clean up
+    //    the registry entry and persisted state.
+    const card = buildApprovalCard({
+      id,
+      title,
+      description,
+      fields,
+      children,
+      approveLabel,
+      denyLabel,
+    });
+    let sentMessage: Awaited<ReturnType<typeof this.post>>;
+    try {
+      sentMessage = await this.post(card);
+    } catch (err) {
+      chat._approvalRegistry.remove(id);
+      await this._stateAdapter.delete(`pending-approval:${id}`);
+      throw err;
+    }
+
+    // 5. Update persisted record with sentMessage for card editing on restart.
+    //    Use remaining TTL so the expiry matches the caller's original intent.
+    //    If the process dies here, recovery still works — just can't edit the card.
+    const remainingTtl = Math.max(0, ttlMs - (Date.now() - startTime));
+    await storePendingApproval(
+      this._stateAdapter,
+      { ...storedApproval, sentMessage: sentMessage.toJSON() },
+      remainingTtl
+    );
+
+    // 5. When resolved, update the card to show the decision
+    return promise.then(async (result) => {
+      if (updateCard) {
+        try {
+          await sentMessage.edit(
+            buildResolvedCard(title, result.approved, result.user, fields)
+          );
+        } catch {
+          // Some platforms don't support editing — that's fine
+        }
+      }
+      return result;
+    });
+  }
+
+  /**
+   * Run an AI SDK agent with automatic human-in-the-loop approval handling.
+   *
+   * This method:
+   * 1. Calls `agent.generate()` with the provided prompt
+   * 2. Checks if any tool calls need approval (`tool-approval-request` parts)
+   * 3. Posts an approval card for each via `requestApproval()`
+   * 4. Resumes the agent with the user's decisions
+   * 5. Repeats until the agent finishes (no more approval requests)
+   *
+   * @param agent - An AI SDK agent (e.g. `ToolLoopAgent`) or any object with a
+   *   compatible `generate()` method.
+   * @param options - Prompt, approval card callback, and any extra agent options.
+   * @returns The final agent result (call `.fullStream` to stream or `.text` to get text).
+   *
+   * @example Minimal
+   * ```tsx
+   * const result = await thread.runAgent(agent, { prompt: history });
+   * await thread.post(result.fullStream);
+   * ```
+   *
+   * @example With custom approval cards
+   * ```tsx
+   * const result = await thread.runAgent(agent, {
+   *   prompt: history,
+   *   approvalCard: (toolCall) => ({
+   *     title: `🔒 Confirm ${toolCall.toolName}`,
+   *     fields: toolCall.input,
+   *   }),
+   * });
+   * await thread.post(result.fullStream);
+   * ```
+   */
+  async runAgent(
+    agent: AgentLike,
+    options: RunAgentOptions
+  ): Promise<AgentResultLike> {
+    const { approvalCard, prompt, ...agentOptions } = options;
+    const cardBuilder = approvalCard ?? defaultApprovalCard;
+
+    // Initial agent call
+    let result = await agent.generate({ prompt, ...agentOptions });
+
+    // Loop: keep resolving approvals until the agent finishes
+    while (true) {
+      // Find all tool-approval-request parts in the result
+      const approvalRequests = result.content.filter(
+        (
+          part
+        ): part is {
+          type: "tool-approval-request";
+          approvalId: string;
+          toolCall: {
+            toolName: string;
+            toolCallId: string;
+            input: Record<string, unknown>;
+          };
+        } => part.type === "tool-approval-request"
+      );
+
+      // No approvals needed — agent is done
+      if (approvalRequests.length === 0) {
+        break;
+      }
+
+      // Request approval for each tool call (in parallel)
+      const responses = await Promise.all(
+        approvalRequests.map(async (part) => {
+          const cardOpts = cardBuilder(part.toolCall);
+
+          const { approved, reason } = await this.requestApproval({
+            id: part.approvalId,
+            ...cardOpts,
+          });
+
+          return {
+            type: "tool-approval-response" as const,
+            approvalId: part.approvalId,
+            approved,
+            ...(reason !== undefined && { reason }),
+          };
+        })
+      );
+
+      // Resume the agent with approval responses wrapped in a tool-role message
+      result = await agent.generate({
+        messages: [
+          ...result.response.messages,
+          { role: "tool" as const, content: responses },
+        ],
+        ...agentOptions,
+      });
+    }
+
+    return result;
   }
 
   /**

--- a/packages/chat/src/types.ts
+++ b/packages/chat/src/types.ts
@@ -3,6 +3,13 @@
  */
 
 import type { Root } from "mdast";
+import type {
+  AgentLike,
+  AgentResultLike,
+  ApprovalResult,
+  RequestApprovalOptions,
+  RunAgentOptions,
+} from "./approval";
 import type { CardElement } from "./cards";
 import type { SerializedChannel } from "./channel";
 import type { ChatElement } from "./jsx-runtime";
@@ -926,6 +933,48 @@ export interface Thread<TState = Record<string, unknown>, TRawMessage = unknown>
    * Fetches the latest 50 messages and updates `recentMessages`.
    */
   refresh(): Promise<void>;
+
+  /**
+   * Post an approval card and wait for the user to approve or deny.
+   *
+   * Posts a Card with Approve/Deny buttons, persists the pending approval
+   * in the StateAdapter (survives server restarts), and returns a Promise
+   * that resolves when the user clicks a button.
+   *
+   * @example
+   * ```tsx
+   * const { approved, user } = await thread.requestApproval({
+   *   id: "transfer-123",
+   *   title: "🔒 Transfer Money",
+   *   fields: { Amount: "$500", To: "acct_123" },
+   * });
+   * ```
+   */
+  requestApproval(options: RequestApprovalOptions): Promise<ApprovalResult>;
+
+  /**
+   * Run an AI SDK agent with automatic human-in-the-loop approval handling.
+   *
+   * Calls the agent, checks for `needsApproval` tool calls, posts approval
+   * cards via `requestApproval()`, resumes the agent with the user's decisions,
+   * and loops until the agent finishes.
+   *
+   * @example
+   * ```tsx
+   * const result = await thread.runAgent(agent, {
+   *   prompt: history,
+   *   approvalCard: (toolCall) => ({
+   *     title: `🔒 Confirm ${toolCall.toolName}`,
+   *     fields: toolCall.input,
+   *   }),
+   * });
+   * await thread.post(result.fullStream);
+   * ```
+   */
+  runAgent(
+    agent: AgentLike,
+    options: RunAgentOptions
+  ): Promise<AgentResultLike>;
 
   /**
    * Show typing indicator in the thread.


### PR DESCRIPTION
**What**

- Adds `thread.requestApproval()` — posts a Card with Approve/Deny buttons, persists the pending approval in the StateAdapter, and returns a Promise that resolves when the user clicks
- Adds `thread.runAgent()` — runs an AI SDK agent in a loop, intercepts `tool-approval-request` content parts, posts approval cards, and resumes the agent with `tool-approval-response` messages in a tool-role message
- Supports `needsApproval` tools from AI SDK 6
- Exports card builders (`buildApprovalCard`, `buildResolvedCard`) and helpers (`isApprovalActionId`, `parseApprovalAction`) for custom usage

**Reliability**

- Singleton validated before any side effects — fails fast if `registerSingleton()` wasn't called
- Registry and state persisted before posting the card to prevent race conditions on fast clicks
- Registry and state cleaned up if posting the card fails
- Second state write uses remaining TTL to prevent expiry drift on slow posts
- Approval actions (`__approval:*`) intercepted before user `onAction` handlers
- Restart recovery via `bot.onApprovalResponse()` for approvals that arrive after a server restart

**Examples**

Standalone approval:
```ts
const { approved, user } = await thread.requestApproval({
  id: "transfer-123",
  title: "Transfer Money",
  fields: { Amount: "$500", To: "acct_123" },
});

if (approved) {
  await transferMoney(500, "acct_123");
}
```

With an AI SDK agent:
```ts
const result = await thread.runAgent(agent, {
  prompt: history,
  approvalCard: (toolCall) => ({
    title: `Confirm ${toolCall.toolName}`,
    fields: toolCall.input,
  }),
});
const text = await result.text;
await thread.post(text);
```

**Tests**

- 87 tests across `approval.test.ts` (58 unit) and `approval-integration.test.ts` (29 integration)
- Covers card builders, registry, state persistence, `requestApproval()`, `runAgent()`, and `handleApprovalAction()`