### PR TITLE
Add webhook verification to GChat

### DIFF
--- a/.changeset/few-cows-search.md
+++ b/.changeset/few-cows-search.md
@@ -1,0 +1,5 @@
+---
+"@chat-adapter/gchat": patch
+---
+
+Introduce optional gchat signature verification

--- a/packages/adapter-gchat/README.md
+++ b/packages/adapter-gchat/README.md
@@ -161,6 +161,8 @@ All options are auto-detected from environment variables when not provided.
 | `credentials` | No* | Service account credentials JSON. Auto-detected from `GOOGLE_CHAT_CREDENTIALS` |
 | `useApplicationDefaultCredentials` | No | Use Application Default Credentials. Auto-detected from `GOOGLE_CHAT_USE_ADC` |
 | `pubsubTopic` | No | Pub/Sub topic for Workspace Events. Auto-detected from `GOOGLE_CHAT_PUBSUB_TOPIC` |
+| `pubsubAudience` | No | Expected JWT audience for Pub/Sub webhook verification. Auto-detected from `GOOGLE_CHAT_PUBSUB_AUDIENCE` |
+| `googleChatProjectNumber` | No | GCP project number for direct webhook JWT verification. Auto-detected from `GOOGLE_CHAT_PROJECT_NUMBER` |
 | `impersonateUser` | No | User email for domain-wide delegation. Auto-detected from `GOOGLE_CHAT_IMPERSONATE_USER` |
 | `auth` | No | Custom auth object (advanced) |
 | `logger` | No | Logger instance (defaults to `ConsoleLogger("info")`) |
@@ -175,7 +177,48 @@ GOOGLE_CHAT_CREDENTIALS={"type":"service_account",...}
 # Optional: for receiving all messages
 GOOGLE_CHAT_PUBSUB_TOPIC=projects/your-project/topics/chat-events
 GOOGLE_CHAT_IMPERSONATE_USER=admin@yourdomain.com
+
+# Optional: webhook verification (recommended for production)
+GOOGLE_CHAT_PROJECT_NUMBER=123456789          # For direct webhook JWT verification
+GOOGLE_CHAT_PUBSUB_AUDIENCE=https://your-domain.com/api/webhooks/gchat  # For Pub/Sub JWT verification
 ```
+
+## Webhook verification
+
+The adapter supports JWT verification for both webhook types. When configured, the adapter validates the `Authorization: Bearer <JWT>` header on incoming requests using Google's public keys. Requests with missing or invalid tokens are rejected with HTTP 401.
+
+Verification is opt-in — when the config options are not set, webhooks are accepted without signature checks (for backward compatibility and development).
+
+### Direct webhooks (Google Chat API)
+
+Google Chat sends a signed JWT with every webhook request. The JWT audience (`aud` claim) is your GCP project number.
+
+```typescript
+createGoogleChatAdapter({
+  googleChatProjectNumber: "123456789",
+});
+```
+
+Find your project number in the [GCP Console dashboard](https://console.cloud.google.com/home/dashboard) (it's different from the project ID).
+
+### Pub/Sub push messages
+
+Google Cloud Pub/Sub sends a signed OIDC JWT with push deliveries. The JWT audience is whatever you configured on the push subscription.
+
+```typescript
+createGoogleChatAdapter({
+  pubsubAudience: "https://your-domain.com/api/webhooks/gchat",
+});
+```
+
+To enable authenticated push on your Pub/Sub subscription:
+
+1. Go to **Pub/Sub** then **Subscriptions**
+2. Edit your push subscription
+3. Enable **Authentication**
+4. Select a service account with the **Service Account Token Creator** role
+5. Set the **Audience** to your webhook URL
+6. Use the same URL as `GOOGLE_CHAT_PUBSUB_AUDIENCE`
 
 ## Features
 
@@ -236,6 +279,13 @@ GOOGLE_CHAT_IMPERSONATE_USER=admin@yourdomain.com
 Fetching message history requires domain-wide delegation with the `impersonateUser` config option set. The impersonated user must have access to the spaces you want to read from. See the [Pub/Sub setup](#4-enable-domain-wide-delegation) above for configuring delegation and OAuth scopes.
 
 ## Troubleshooting
+
+### 401 Unauthorized on webhooks
+
+- For direct webhooks: verify `GOOGLE_CHAT_PROJECT_NUMBER` matches your GCP project number (not project ID)
+- For Pub/Sub: verify `GOOGLE_CHAT_PUBSUB_AUDIENCE` matches the audience configured on your push subscription
+- Check that authentication is enabled on your Pub/Sub push subscription
+- Ensure the service account used for push authentication has the **Service Account Token Creator** role
 
 ### No webhook received
 

--- a/packages/adapter-gchat/src/index.test.ts
+++ b/packages/adapter-gchat/src/index.test.ts
@@ -1,4 +1,5 @@
 import { AdapterRateLimitError } from "@chat-adapter/shared";
+import { auth } from "@googleapis/chat";
 import type { ChatInstance, Lock, Logger, StateAdapter } from "chat";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
@@ -151,6 +152,8 @@ async function createInitializedAdapter(opts?: {
   pubsubTopic?: string;
   userName?: string;
   endpointUrl?: string;
+  googleChatProjectNumber?: string;
+  pubsubAudience?: string;
 }) {
   const adapter = createGoogleChatAdapter({
     credentials: TEST_CREDENTIALS,
@@ -158,6 +161,8 @@ async function createInitializedAdapter(opts?: {
     pubsubTopic: opts?.pubsubTopic,
     userName: opts?.userName,
     endpointUrl: opts?.endpointUrl,
+    googleChatProjectNumber: opts?.googleChatProjectNumber,
+    pubsubAudience: opts?.pubsubAudience,
   });
   const mockState = createMockStateAdapter();
   const mockChat = createMockChatInstance(mockState);
@@ -2702,6 +2707,289 @@ describe("GoogleChatAdapter", () => {
         displayName: "Bob Wilson",
         email: undefined,
       });
+    });
+  });
+
+  describe("webhook verification", () => {
+    let verifyIdTokenSpy: ReturnType<typeof vi.spyOn>;
+
+    beforeEach(() => {
+      verifyIdTokenSpy = vi
+        .spyOn(auth.OAuth2.prototype, "verifyIdToken")
+        .mockRejectedValue(new Error("Invalid token"));
+    });
+
+    afterEach(() => {
+      verifyIdTokenSpy.mockRestore();
+    });
+
+    it("should reject direct webhook without Authorization header when project number is configured", async () => {
+      const { adapter } = await createInitializedAdapter({
+        googleChatProjectNumber: "123456789",
+      });
+
+      const event = makeMessageEvent({ messageText: "Hello" });
+      const request = new Request("https://example.com/webhook", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify(event),
+      });
+
+      const response = await adapter.handleWebhook(request);
+      expect(response.status).toBe(401);
+      // Should not even call verifyIdToken — no Bearer token present
+      expect(verifyIdTokenSpy).not.toHaveBeenCalled();
+    });
+
+    it("should reject direct webhook with invalid Bearer token when project number is configured", async () => {
+      const { adapter } = await createInitializedAdapter({
+        googleChatProjectNumber: "123456789",
+      });
+
+      const event = makeMessageEvent({ messageText: "Hello" });
+      const request = new Request("https://example.com/webhook", {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          authorization: "Bearer invalid-token",
+        },
+        body: JSON.stringify(event),
+      });
+
+      const response = await adapter.handleWebhook(request);
+      expect(response.status).toBe(401);
+      expect(verifyIdTokenSpy).toHaveBeenCalledWith({
+        idToken: "invalid-token",
+        audience: "123456789",
+      });
+    });
+
+    it("should allow direct webhook with valid Bearer token when project number is configured", async () => {
+      verifyIdTokenSpy.mockResolvedValue({
+        getPayload: () => ({
+          iss: "chat@system.gserviceaccount.com",
+          aud: "123456789",
+          email: "chat@system.gserviceaccount.com",
+        }),
+      });
+
+      const { adapter } = await createInitializedAdapter({
+        googleChatProjectNumber: "123456789",
+      });
+
+      const event = makeMessageEvent({ messageText: "Hello" });
+      const request = new Request("https://example.com/webhook", {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          authorization: "Bearer valid-google-jwt",
+        },
+        body: JSON.stringify(event),
+      });
+
+      const response = await adapter.handleWebhook(request);
+      expect(response.status).toBe(200);
+      expect(verifyIdTokenSpy).toHaveBeenCalledWith({
+        idToken: "valid-google-jwt",
+        audience: "123456789",
+      });
+    });
+
+    it("should allow direct webhook without verification when project number is not configured and warn once", async () => {
+      const { adapter } = await createInitializedAdapter();
+
+      const event = makeMessageEvent({ messageText: "Hello" });
+      const request1 = new Request("https://example.com/webhook", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify(event),
+      });
+      const request2 = new Request("https://example.com/webhook", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify(event),
+      });
+
+      const response1 = await adapter.handleWebhook(request1);
+      expect(response1.status).toBe(200);
+      expect(verifyIdTokenSpy).not.toHaveBeenCalled();
+      expect(mockLogger.warn).toHaveBeenCalledWith(
+        expect.stringContaining("GOOGLE_CHAT_PROJECT_NUMBER")
+      );
+
+      // Second call should not warn again
+      (mockLogger.warn as ReturnType<typeof vi.fn>).mockClear();
+      await adapter.handleWebhook(request2);
+      expect(mockLogger.warn).not.toHaveBeenCalledWith(
+        expect.stringContaining("GOOGLE_CHAT_PROJECT_NUMBER")
+      );
+    });
+
+    it("should reject Pub/Sub webhook without Authorization header when pubsubAudience is configured", async () => {
+      const { adapter } = await createInitializedAdapter({
+        pubsubAudience: "https://example.com/webhook/pubsub",
+      });
+
+      const pubsubMessage = makePubSubPushMessage({
+        message: {
+          name: "spaces/ABC123/messages/msg1",
+          text: "Hello",
+          sender: { name: "users/100", displayName: "User", type: "HUMAN" },
+          createTime: new Date().toISOString(),
+        },
+      });
+
+      const request = new Request("https://example.com/webhook", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify(pubsubMessage),
+      });
+
+      const response = await adapter.handleWebhook(request);
+      expect(response.status).toBe(401);
+    });
+
+    it("should allow Pub/Sub webhook without verification when pubsubAudience is not configured and warn once", async () => {
+      const { adapter } = await createInitializedAdapter();
+
+      const makePubSubRequest = () => {
+        const pubsubMessage = makePubSubPushMessage({
+          message: {
+            name: "spaces/ABC123/messages/msg1",
+            text: "Hello",
+            sender: { name: "users/100", displayName: "User", type: "HUMAN" },
+            createTime: new Date().toISOString(),
+          },
+        });
+        return new Request("https://example.com/webhook", {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify(pubsubMessage),
+        });
+      };
+
+      const response1 = await adapter.handleWebhook(makePubSubRequest());
+      expect(response1.status).toBe(200);
+      expect(verifyIdTokenSpy).not.toHaveBeenCalled();
+      expect(mockLogger.warn).toHaveBeenCalledWith(
+        expect.stringContaining("GOOGLE_CHAT_PUBSUB_AUDIENCE")
+      );
+
+      // Second call should not warn again
+      (mockLogger.warn as ReturnType<typeof vi.fn>).mockClear();
+      await adapter.handleWebhook(makePubSubRequest());
+      expect(mockLogger.warn).not.toHaveBeenCalledWith(
+        expect.stringContaining("GOOGLE_CHAT_PUBSUB_AUDIENCE")
+      );
+    });
+
+    it("should reject Pub/Sub webhook with invalid token when pubsubAudience is configured", async () => {
+      const { adapter } = await createInitializedAdapter({
+        pubsubAudience: "https://example.com/webhook/pubsub",
+      });
+
+      const pubsubMessage = makePubSubPushMessage({
+        message: {
+          name: "spaces/ABC123/messages/msg1",
+          text: "Hello",
+          sender: { name: "users/100", displayName: "User", type: "HUMAN" },
+          createTime: new Date().toISOString(),
+        },
+      });
+
+      const request = new Request("https://example.com/webhook", {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          authorization: "Bearer bad-token",
+        },
+        body: JSON.stringify(pubsubMessage),
+      });
+
+      const response = await adapter.handleWebhook(request);
+      expect(response.status).toBe(401);
+      expect(verifyIdTokenSpy).toHaveBeenCalledWith({
+        idToken: "bad-token",
+        audience: "https://example.com/webhook/pubsub",
+      });
+    });
+
+    it("should allow Pub/Sub webhook with valid token when pubsubAudience is configured", async () => {
+      verifyIdTokenSpy.mockResolvedValue({
+        getPayload: () => ({
+          iss: "accounts.google.com",
+          aud: "https://example.com/webhook/pubsub",
+          email: "pubsub@my-project.iam.gserviceaccount.com",
+        }),
+      });
+
+      const { adapter } = await createInitializedAdapter({
+        pubsubAudience: "https://example.com/webhook/pubsub",
+      });
+
+      const pubsubMessage = makePubSubPushMessage({
+        message: {
+          name: "spaces/ABC123/messages/msg1",
+          text: "Hello",
+          sender: { name: "users/100", displayName: "User", type: "HUMAN" },
+          createTime: new Date().toISOString(),
+        },
+      });
+
+      const request = new Request("https://example.com/webhook", {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          authorization: "Bearer valid-pubsub-jwt",
+        },
+        body: JSON.stringify(pubsubMessage),
+      });
+
+      const response = await adapter.handleWebhook(request);
+      expect(response.status).toBe(200);
+    });
+
+    it("should reject request with non-Bearer Authorization scheme", async () => {
+      const { adapter } = await createInitializedAdapter({
+        googleChatProjectNumber: "123456789",
+      });
+
+      const event = makeMessageEvent({ messageText: "Hello" });
+      const request = new Request("https://example.com/webhook", {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          authorization: "Basic dXNlcjpwYXNz",
+        },
+        body: JSON.stringify(event),
+      });
+
+      const response = await adapter.handleWebhook(request);
+      expect(response.status).toBe(401);
+      expect(verifyIdTokenSpy).not.toHaveBeenCalled();
+    });
+
+    it("should reject when verifyIdToken returns no payload", async () => {
+      verifyIdTokenSpy.mockResolvedValue({
+        getPayload: () => undefined,
+      });
+
+      const { adapter } = await createInitializedAdapter({
+        googleChatProjectNumber: "123456789",
+      });
+
+      const event = makeMessageEvent({ messageText: "Hello" });
+      const request = new Request("https://example.com/webhook", {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          authorization: "Bearer token-no-payload",
+        },
+        body: JSON.stringify(event),
+      });
+
+      const response = await adapter.handleWebhook(request);
+      expect(response.status).toBe(401);
     });
   });
 });

--- a/packages/adapter-gchat/src/index.ts
+++ b/packages/adapter-gchat/src/index.ts
@@ -77,6 +77,13 @@ export interface GoogleChatAdapterBaseConfig {
    */
   endpointUrl?: string;
   /**
+   * Google Cloud project number for verifying direct webhook JWTs.
+   * When set, the adapter verifies the Bearer token on incoming Google Chat webhooks
+   * by checking the JWT audience matches this project number.
+   * Defaults to GOOGLE_CHAT_PROJECT_NUMBER env var.
+   */
+  googleChatProjectNumber?: string;
+  /**
    * User email to impersonate for Workspace Events API calls.
    * Required when using domain-wide delegation.
    * This user must have access to the Chat spaces you want to subscribe to.
@@ -85,6 +92,13 @@ export interface GoogleChatAdapterBaseConfig {
   impersonateUser?: string;
   /** Logger instance for error reporting. Defaults to ConsoleLogger. */
   logger?: Logger;
+  /**
+   * Expected audience for Pub/Sub push message JWT verification.
+   * Typically the push endpoint URL configured in your Pub/Sub subscription.
+   * When set, the adapter verifies the Authorization Bearer token on Pub/Sub messages.
+   * Defaults to GOOGLE_CHAT_PUBSUB_AUDIENCE env var.
+   */
+  pubsubAudience?: string;
   /**
    * Pub/Sub topic for receiving all messages via Workspace Events.
    * When set, the adapter will automatically create subscriptions when added to a space.
@@ -277,6 +291,15 @@ export class GoogleChatAdapter implements Adapter<GoogleChatThreadId, unknown> {
   private readonly impersonatedChatApi?: chat_v1.Chat;
   /** HTTP endpoint URL for button click actions */
   private endpointUrl?: string;
+  /** Google Cloud project number for verifying direct webhook JWTs */
+  private readonly googleChatProjectNumber?: string;
+  /** Expected audience for Pub/Sub push message JWT verification */
+  private readonly pubsubAudience?: string;
+  /** OAuth2 client for verifying Google-signed JWTs */
+  private readonly oauth2Client = new auth.OAuth2();
+  /** Track whether we've already warned about missing verification config */
+  private warnedNoWebhookVerification = false;
+  private warnedNoPubsubVerification = false;
   /** User info cache for display name lookups - initialized later in initialize() */
   private userInfoCache: UserInfoCache;
 
@@ -292,6 +315,10 @@ export class GoogleChatAdapter implements Adapter<GoogleChatThreadId, unknown> {
     this.impersonateUser =
       config.impersonateUser ?? process.env.GOOGLE_CHAT_IMPERSONATE_USER;
     this.endpointUrl = config.endpointUrl;
+    this.googleChatProjectNumber =
+      config.googleChatProjectNumber ?? process.env.GOOGLE_CHAT_PROJECT_NUMBER;
+    this.pubsubAudience =
+      config.pubsubAudience ?? process.env.GOOGLE_CHAT_PUBSUB_AUDIENCE;
 
     let authClient: Parameters<typeof chat>[0]["auth"];
 
@@ -628,6 +655,47 @@ export class GoogleChatAdapter implements Adapter<GoogleChatThreadId, unknown> {
     return null;
   }
 
+  /**
+   * Verify a Google-signed JWT Bearer token from the Authorization header.
+   * Used for both direct Google Chat webhooks and Pub/Sub push messages.
+   *
+   * @param request - The incoming HTTP request
+   * @param expectedAudience - The expected audience claim in the JWT
+   * @returns true if verification succeeds or is not configured
+   */
+  private async verifyBearerToken(
+    request: Request,
+    expectedAudience: string
+  ): Promise<boolean> {
+    const authHeader = request.headers.get("authorization");
+    if (!authHeader?.startsWith("Bearer ")) {
+      this.logger.warn("Missing or invalid Authorization header");
+      return false;
+    }
+
+    const token = authHeader.slice(7);
+    try {
+      const ticket = await this.oauth2Client.verifyIdToken({
+        idToken: token,
+        audience: expectedAudience,
+      });
+      const payload = ticket.getPayload();
+      if (!payload) {
+        this.logger.warn("JWT verification returned no payload");
+        return false;
+      }
+      this.logger.debug("JWT verified", {
+        iss: payload.iss,
+        aud: payload.aud,
+        email: payload.email,
+      });
+      return true;
+    } catch (error) {
+      this.logger.warn("JWT verification failed", { error });
+      return false;
+    }
+  }
+
   async handleWebhook(
     request: Request,
     options?: WebhookOptions
@@ -660,7 +728,38 @@ export class GoogleChatAdapter implements Adapter<GoogleChatThreadId, unknown> {
     // Check if this is a Pub/Sub push message (from Workspace Events subscription)
     const maybePubSub = parsed as PubSubPushMessage;
     if (maybePubSub.message?.data && maybePubSub.subscription) {
+      // Verify Pub/Sub JWT if audience is configured
+      if (this.pubsubAudience) {
+        const valid = await this.verifyBearerToken(
+          request,
+          this.pubsubAudience
+        );
+        if (!valid) {
+          return new Response("Unauthorized", { status: 401 });
+        }
+      } else if (!this.warnedNoPubsubVerification) {
+        this.warnedNoPubsubVerification = true;
+        this.logger.warn(
+          "Pub/Sub webhook verification is disabled. Set GOOGLE_CHAT_PUBSUB_AUDIENCE or pubsubAudience to verify incoming requests."
+        );
+      }
       return this.handlePubSubMessage(maybePubSub, options);
+    }
+
+    // Verify direct Google Chat webhook JWT if project number is configured
+    if (this.googleChatProjectNumber) {
+      const valid = await this.verifyBearerToken(
+        request,
+        this.googleChatProjectNumber
+      );
+      if (!valid) {
+        return new Response("Unauthorized", { status: 401 });
+      }
+    } else if (!this.warnedNoWebhookVerification) {
+      this.warnedNoWebhookVerification = true;
+      this.logger.warn(
+        "Google Chat webhook verification is disabled. Set GOOGLE_CHAT_PROJECT_NUMBER or googleChatProjectNumber to verify incoming requests."
+      );
     }
 
     // Otherwise, treat as a direct Google Chat webhook event
@@ -2548,7 +2647,6 @@ export {
   listSpaceSubscriptions,
   type PubSubPushMessage,
   type SpaceSubscriptionResult,
-  verifyPubSubRequest,
   type WorkspaceEventNotification,
   type WorkspaceEventsAuthOptions,
 } from "./workspace-events";

--- a/packages/adapter-gchat/src/workspace-events.test.ts
+++ b/packages/adapter-gchat/src/workspace-events.test.ts
@@ -5,7 +5,6 @@ import {
   decodePubSubMessage,
   deleteSpaceSubscription,
   listSpaceSubscriptions,
-  verifyPubSubRequest,
 } from "./workspace-events";
 
 vi.mock("@googleapis/workspaceevents", () => ({
@@ -85,39 +84,6 @@ describe("decodePubSubMessage", () => {
     const result = decodePubSubMessage(push);
     expect(result.reaction?.name).toBe("spaces/ABC/messages/123/reactions/456");
     expect(result.reaction?.emoji?.unicode).toBe("\u{1F44D}");
-  });
-});
-
-describe("verifyPubSubRequest", () => {
-  it("should reject non-POST requests", () => {
-    const req = new Request("https://example.com/webhook", {
-      method: "GET",
-    });
-    expect(verifyPubSubRequest(req)).toBe(false);
-  });
-
-  it("should reject wrong content-type", () => {
-    const req = new Request("https://example.com/webhook", {
-      method: "POST",
-      headers: { "content-type": "text/plain" },
-    });
-    expect(verifyPubSubRequest(req)).toBe(false);
-  });
-
-  it("should accept valid POST with JSON content-type", () => {
-    const req = new Request("https://example.com/webhook", {
-      method: "POST",
-      headers: { "content-type": "application/json" },
-    });
-    expect(verifyPubSubRequest(req)).toBe(true);
-  });
-
-  it("should accept application/json with charset", () => {
-    const req = new Request("https://example.com/webhook", {
-      method: "POST",
-      headers: { "content-type": "application/json; charset=utf-8" },
-    });
-    expect(verifyPubSubRequest(req)).toBe(true);
   });
 });
 

--- a/packages/adapter-gchat/src/workspace-events.ts
+++ b/packages/adapter-gchat/src/workspace-events.ts
@@ -318,32 +318,3 @@ export function decodePubSubMessage(
     reaction: payload.reaction,
   };
 }
-
-/**
- * Verify a Pub/Sub push message is authentic.
- * In production, you should verify the JWT token in the Authorization header.
- *
- * @see https://cloud.google.com/pubsub/docs/authenticate-push-subscriptions
- */
-export function verifyPubSubRequest(
-  request: Request,
-  _expectedAudience?: string
-): boolean {
-  // Basic check - Pub/Sub always sends POST with specific content type
-  if (request.method !== "POST") {
-    return false;
-  }
-
-  const contentType = request.headers.get("content-type");
-  if (!contentType?.includes("application/json")) {
-    return false;
-  }
-
-  // For full verification, you would:
-  // 1. Extract the Bearer token from Authorization header
-  // 2. Verify it's a valid Google-signed JWT
-  // 3. Check the audience matches your endpoint
-  // This requires additional setup - see Google's docs
-
-  return true;
-}

--- a/packages/adapter-telegram/src/index.ts
+++ b/packages/adapter-telegram/src/index.ts
@@ -1,3 +1,4 @@
+import { timingSafeEqual } from "node:crypto";
 import {
   AdapterRateLimitError,
   AuthenticationError,
@@ -194,6 +195,7 @@ export class TelegramAdapter
   private readonly botToken: string;
   private readonly apiBaseUrl: string;
   private readonly secretToken?: string;
+  private warnedNoVerification = false;
   private readonly logger: Logger;
   private readonly formatConverter = new TelegramFormatConverter();
   private readonly messageCache = new Map<
@@ -313,12 +315,28 @@ export class TelegramAdapter
   ): Promise<Response> {
     if (this.secretToken) {
       const headerToken = request.headers.get(TELEGRAM_SECRET_TOKEN_HEADER);
-      if (headerToken !== this.secretToken) {
+      let valid = false;
+      try {
+        valid =
+          !!headerToken &&
+          timingSafeEqual(
+            Buffer.from(headerToken),
+            Buffer.from(this.secretToken)
+          );
+      } catch {
+        // Length mismatch throws — treat as invalid
+      }
+      if (!valid) {
         this.logger.warn(
           "Telegram webhook rejected due to invalid secret token"
         );
         return new Response("Invalid secret token", { status: 401 });
       }
+    } else if (!this.warnedNoVerification) {
+      this.warnedNoVerification = true;
+      this.logger.warn(
+        "Telegram webhook verification is disabled. Set TELEGRAM_WEBHOOK_SECRET_TOKEN or secretToken to verify incoming requests."
+      );
     }
 
     let update: TelegramUpdate;


### PR DESCRIPTION
- Issues a warning if required env vars are not present (also for telegram)
- Makes telegram use a time-safe verifier

