### PR TITLE
docs: add Kapso WhatsApp community adapter

### DIFF
--- a/apps/docs/adapters.json
+++ b/apps/docs/adapters.json
@@ -183,6 +183,16 @@
     "readme": "https://github.com/rama-adi/chat-adapter-baileys"
   },
   {
+    "name": "Kapso WhatsApp",
+    "slug": "kapso",
+    "type": "platform",
+    "community": true,
+    "description": "WhatsApp adapter for Chat SDK via Kapso.",
+    "packageName": "@luicho/kapso-chat-sdk",
+    "author": "luicho9",
+    "readme": "https://github.com/luicho9/kapso-chat-sdk"
+  },
+  {
     "name": "Instagram",
     "slug": "instagram",
     "type": "platform",


### PR DESCRIPTION
## Summary

Adds [`@luicho/kapso-chat-sdk`](https://github.com/luicho9/kapso-chat-sdk) to the community adapters catalog.

This is a WhatsApp adapter for Chat SDK that integrates via [Kapso](https://kapso.ai) webhooks and history APIs. It supports:

- Sending and receiving WhatsApp messages (text + media)
- Webhook signature verification
- Message history via `fetchMessages()` / `fetchThread()`
- Reactions, read receipts, and interactive reply buttons
- Auto-config from environment variables

Published on npm as [`@luicho/kapso-chat-sdk`](https://www.npmjs.com/package/@luicho/kapso-chat-sdk). The repo includes 5 working examples (echo bot, support bot, interactive menu, media handling, AI reply).

## Test plan

- Ran the docs dev server locally (`pnpm --filter docs dev`)
- Verified the **Kapso WhatsApp** card appears in the Community section on `/adapters`
- Verified the detail page at `/adapters/kapso` renders the README from GitHub
