### PR TITLE
Add Liveblocks vendor official adapter

### DIFF
--- a/apps/docs/adapters.json
+++ b/apps/docs/adapters.json
@@ -194,6 +194,17 @@
     "readme": "https://github.com/rama-adi/chat-adapter-baileys"
   },
   {
+    "name": "Liveblocks",
+    "slug": "liveblocks",
+    "type": "platform",
+    "community": true,
+    "description": "Liveblocks Comments adapter for building conversational bots on top of Liveblocks rooms, threads, and comments.",
+    "packageName": "@liveblocks/chat-sdk-adapter",
+    "author": "Liveblocks",
+    "readme": "https://github.com/liveblocks/liveblocks/tree/main/packages/liveblocks-chat-sdk-adapter",
+    "vendorOfficial": true
+  },
+  {
     "name": "Instagram",
     "slug": "instagram",
     "type": "platform",

--- a/apps/docs/app/[lang]/(home)/adapters/[slug]/page.tsx
+++ b/apps/docs/app/[lang]/(home)/adapters/[slug]/page.tsx
@@ -7,6 +7,8 @@ import adapters from "@/adapters.json";
 import { ReadmeContent } from "../components/readme-content";
 
 const LOCAL_PACKAGE_PATTERN = /github\.com\/vercel\/chat\/tree\/[^/]+\/(.+)/;
+const GITHUB_SUBPATH_PATTERN =
+  /github\.com\/([^/]+)\/([^/]+)\/tree\/([^/]+)\/(.+)/;
 const GITHUB_REPO_PATTERN = /github\.com\/([^/]+)\/([^/]+)/;
 
 const getAdapter = (slug: string) => adapters.find((a) => a.slug === slug);
@@ -20,6 +22,19 @@ const getReadme = async (repoUrl: string): Promise<string | undefined> => {
       return await readFile(filePath, "utf-8");
     } catch {
       return undefined;
+    }
+  }
+
+  const subpathMatch = repoUrl.match(GITHUB_SUBPATH_PATTERN);
+  if (subpathMatch) {
+    const [, owner, repo, ref, path] = subpathMatch;
+    const url = `https://api.github.com/repos/${owner}/${repo}/readme/${path}?ref=${ref}`;
+    const response = await fetch(url, {
+      headers: { Accept: "application/vnd.github.raw+json" },
+      next: { revalidate: 3600 },
+    });
+    if (response.ok) {
+      return response.text();
     }
   }
 

--- a/skills/chat/SKILL.md
+++ b/skills/chat/SKILL.md
@@ -183,6 +183,7 @@ await thread.post(
 - `@resend/chat-sdk-adapter`
 - `@zernio/chat-sdk-adapter`
 - `chat-adapter-baileys`
+- `@liveblocks/chat-sdk-adapter`
 
 ### Coming-soon platform entries
 


### PR DESCRIPTION
- Adds Liveblocks as a vendor official platform adapter to the adapters directory
- Fixes `getReadme` to support GitHub monorepo subpaths (Liveblocks package lives at `liveblocks/liveblocks/packages/liveblocks-chat-sdk-adapter`)
- Updates SKILL.md community adapter list

## Adapter entry

```json
{
  "name": "Liveblocks",
  "slug": "liveblocks",
  "type": "platform",
  "community": true,
  "description": "Liveblocks Comments adapter for building conversational bots on top of Liveblocks rooms, threads, and comments.",
  "packageName": "@liveblocks/chat-sdk-adapter",
  "author": "Liveblocks",
  "readme": "https://github.com/liveblocks/liveblocks/tree/main/packages/liveblocks-chat-sdk-adapter",
  "vendorOfficial": true
}
```

## Vendor official qualifications

| Requirement | Status |
|---|---|
| Published under vendor scope | `@liveblocks/chat-sdk-adapter` |
| GitHub in vendor org | [liveblocks/liveblocks](https://github.com/liveblocks/liveblocks/tree/main/packages/liveblocks-chat-sdk-adapter) |
| Docs on vendor site | [liveblocks.io/docs/api-reference/liveblocks-chat-sdk-adapter](https://liveblocks.io/docs/api-reference/liveblocks-chat-sdk-adapter) |