### PR TITLE
Add AI agent detection via @vercel/agent-readability

### DIFF
--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -17,6 +17,7 @@
     "@streamdown/code": "^1.0.3",
     "@streamdown/math": "^1.0.2",
     "@streamdown/mermaid": "^1.0.2",
+    "@vercel/agent-readability": "^0.2.1",
     "@vercel/analytics": "^1.6.1",
     "@vercel/speed-insights": "^1.3.1",
     "ai": "^5.0.106",

--- a/apps/docs/proxy.ts
+++ b/apps/docs/proxy.ts
@@ -7,6 +7,7 @@ import {
 } from "next/server";
 import { i18n } from "@/lib/geistdocs/i18n";
 import { trackMdRequest } from "@/lib/geistdocs/md-tracking";
+import { generateNotFoundMarkdown, isAIAgent } from "@vercel/agent-readability";
 
 const { rewrite: rewriteLLM } = rewritePath(
   "/docs/*path",
@@ -56,6 +57,39 @@ const proxy = (request: NextRequest, context: NextFetchEvent) => {
       return NextResponse.rewrite(new URL(result, request.nextUrl));
     }
   }
+
+  // AI agent detection — rewrite docs pages to markdown for agents
+  if (
+    (pathname === "/docs" || pathname.startsWith("/docs/")) &&
+    !pathname.includes("/llms.mdx/")
+  ) {
+    const agentResult = isAIAgent(request);
+    if (agentResult.detected && !isMarkdownPreferred(request)) {
+      const result =
+        pathname === "/docs"
+          ? `/${i18n.defaultLanguage}/llms.mdx`
+          : rewriteLLM(pathname);
+
+      if (result) {
+        context.waitUntil(
+          trackMdRequest({
+            path: pathname,
+            userAgent: request.headers.get("user-agent"),
+            referer: request.headers.get("referer"),
+            acceptHeader: request.headers.get("accept"),
+            requestType: "agent-rewrite",
+            detectionMethod: agentResult.method,
+          })
+        );
+        return NextResponse.rewrite(new URL(result, request.nextUrl));
+      }
+      // Agent requested a non-existent docs URL
+      return new NextResponse(generateNotFoundMarkdown(pathname), {
+        headers: { "Content-Type": "text/markdown; charset=utf-8" },
+      });
+    }
+  }
+
 
   // Handle Accept header content negotiation and track the request
   if (isMarkdownPreferred(request)) {


### PR DESCRIPTION
## Summary
- Adds `@vercel/agent-readability` package for AI agent detection in middleware
- Detected agents get markdown responses instead of HTML for better AI consumption
- Non-existent docs URLs return helpful not-found markdown with discovery links
- Accept header content negotiation continues to work as before

Matches the geistdocs template (vercel/geistdocs#58). Uses the same shared package as vercel/front#65649.

## Test plan
- [ ] AI agent hitting a valid docs URL gets markdown rewrite
- [ ] AI agent hitting a non-existent docs URL gets not-found markdown
- [ ] Normal browser requests unaffected
- [ ] Build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)