### PR TITLE
feat: add unstorage state adapter

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ See the [Getting Started guide](https://chat-sdk.dev/docs/getting-started) for a
 | `@chat-adapter/whatsapp` | [WhatsApp adapter](https://chat-sdk.dev/adapters/whatsapp) |
 | `@chat-adapter/state-redis` | [Redis state adapter](https://chat-sdk.dev/docs/state/redis) (production) |
 | `@chat-adapter/state-ioredis` | [ioredis state adapter](https://chat-sdk.dev/docs/state/ioredis) (alternative) |
+| `@chat-adapter/state-unstorage` | [Unstorage state adapter](https://chat-sdk.dev/docs/state/unstorage) (bring your own backend) |
 | `@chat-adapter/state-pg` | [PostgreSQL state adapter](https://chat-sdk.dev/docs/state/postgres) (production) |
 | `@chat-adapter/state-memory` | [In-memory state adapter](https://chat-sdk.dev/docs/state/memory) (development) |
 

--- a/apps/docs/adapters.json
+++ b/apps/docs/adapters.json
@@ -100,6 +100,16 @@
     "readme": "https://github.com/vercel/chat/tree/main/packages/state-ioredis"
   },
   {
+    "name": "Unstorage",
+    "slug": "unstorage",
+    "type": "state",
+    "description": "State adapter powered by unstorage so you can choose any unstorage-compatible backend.",
+    "packageName": "@chat-adapter/state-unstorage",
+    "icon": "memory",
+    "beta": true,
+    "readme": "https://github.com/vercel/chat/tree/main/packages/state-unstorage"
+  },
+  {
     "name": "PostgreSQL",
     "slug": "postgres",
     "type": "state",

--- a/apps/docs/content/docs/concurrency.mdx
+++ b/apps/docs/content/docs/concurrency.mdx
@@ -190,7 +190,7 @@ The `queue` and `debounce` strategies require three additional methods on your s
 | `dequeue(threadId)` | Pop the next (oldest) message from the queue. Returns `null` if empty. |
 | `queueDepth(threadId)` | Return the current number of queued messages. |
 
-All built-in state adapters (`@chat-adapter/state-memory`, `@chat-adapter/state-redis`, `@chat-adapter/state-ioredis`) implement these methods. The Redis adapters use Lua scripts for atomicity.
+All built-in state adapters (`@chat-adapter/state-memory`, `@chat-adapter/state-redis`, `@chat-adapter/state-ioredis`, `@chat-adapter/state-unstorage`) implement these methods. The Redis adapters use Lua scripts for atomicity. The unstorage adapter behavior depends on the underlying driver consistency guarantees.
 
 ## Observability
 

--- a/apps/docs/content/docs/index.mdx
+++ b/apps/docs/content/docs/index.mdx
@@ -87,5 +87,6 @@ The SDK is distributed as a set of packages you install based on your needs:
 | `@chat-adapter/whatsapp` | WhatsApp Business adapter |
 | `@chat-adapter/state-redis` | Redis state adapter (production) |
 | `@chat-adapter/state-ioredis` | ioredis state adapter (alternative) |
+| `@chat-adapter/state-unstorage` | Unstorage state adapter (bring your own backend) |
 | `@chat-adapter/state-pg` | PostgreSQL state adapter (production) |
 | `@chat-adapter/state-memory` | In-memory state adapter (development) |

--- a/apps/docs/content/docs/state.mdx
+++ b/apps/docs/content/docs/state.mdx
@@ -42,3 +42,28 @@ Note that force-releasing a lock does not cancel the previous handler — it con
 ### Caching
 
 State adapters provide key-value storage with TTL for thread state (`thread.setState()`), message deduplication, and other internal caching.
+
+## Unstorage adapter
+
+Use `@chat-adapter/state-unstorage` when you want one state adapter API with a pluggable backend via [unstorage](https://unstorage.unjs.io/):
+
+```typescript
+import { createUnstorageState } from "@chat-adapter/state-unstorage";
+import { createStorage } from "unstorage";
+import redisDriver from "unstorage/drivers/redis";
+
+const storage = createStorage({
+  driver: redisDriver({
+    url: process.env.REDIS_URL,
+    base: "chat-sdk",
+  }),
+});
+
+const chat = new Chat({
+  userName: "my-bot",
+  adapters: { slack },
+  state: createUnstorageState({ storage }),
+});
+```
+
+If you run multiple instances and need strict distributed atomicity, choose a backend with strong consistency guarantees.

--- a/packages/integration-tests/src/documentation-test-utils.ts
+++ b/packages/integration-tests/src/documentation-test-utils.ts
@@ -21,6 +21,7 @@ export const VALID_PACKAGE_README_IMPORTS = [
   "@chat-adapter/whatsapp",
   "@chat-adapter/state-redis",
   "@chat-adapter/state-ioredis",
+  "@chat-adapter/state-unstorage",
   "@chat-adapter/state-pg",
   "@chat-adapter/state-memory",
   "next/server",
@@ -28,6 +29,9 @@ export const VALID_PACKAGE_README_IMPORTS = [
   "ioredis",
   "pg",
   "postgres",
+  "unstorage",
+  "unstorage/drivers/memory",
+  "unstorage/drivers/redis",
 ];
 
 export const VALID_DOC_PACKAGES = [
@@ -42,6 +46,7 @@ export const VALID_DOC_PACKAGES = [
   "@chat-adapter/whatsapp",
   "@chat-adapter/state-redis",
   "@chat-adapter/state-ioredis",
+  "@chat-adapter/state-unstorage",
   "@chat-adapter/state-pg",
   "@chat-adapter/state-memory",
   "@chat-adapter/shared",
@@ -61,6 +66,9 @@ export const VALID_DOC_PACKAGES = [
   "ioredis",
   "pg",
   "postgres",
+  "unstorage",
+  "unstorage/drivers/memory",
+  "unstorage/drivers/redis",
   "tsup",
   "vitest",
   "vitest/config",
@@ -146,6 +154,9 @@ export function createTempProject(codeBlocks: string[]): string {
         ],
         "@chat-adapter/state-pg": [
           join(import.meta.dirname, "../../state-pg/src/index.ts"),
+        ],
+        "@chat-adapter/state-unstorage": [
+          join(import.meta.dirname, "../../state-unstorage/src/index.ts"),
         ],
         "@chat-adapter/state-memory": [
           join(import.meta.dirname, "../../state-memory/src/index.ts"),

--- a/packages/state-unstorage/CHANGELOG.md
+++ b/packages/state-unstorage/CHANGELOG.md
@@ -1,0 +1,5 @@
+# @chat-adapter/state-unstorage
+
+## 4.24.0
+
+- Initial release.

--- a/packages/state-unstorage/README.md
+++ b/packages/state-unstorage/README.md
@@ -1,0 +1,66 @@
+# @chat-adapter/state-unstorage
+
+[![npm version](https://img.shields.io/npm/v/@chat-adapter/state-unstorage)](https://www.npmjs.com/package/@chat-adapter/state-unstorage)
+[![npm downloads](https://img.shields.io/npm/dm/@chat-adapter/state-unstorage)](https://www.npmjs.com/package/@chat-adapter/state-unstorage)
+
+State adapter for [Chat SDK](https://chat-sdk.dev) built on top of [unstorage](https://unstorage.unjs.io/). It lets you use any unstorage-compatible backend behind the same Chat SDK state API.
+
+## Installation
+
+```bash
+pnpm add @chat-adapter/state-unstorage unstorage
+```
+
+## Usage
+
+```typescript
+import { Chat } from "chat";
+import { createUnstorageState } from "@chat-adapter/state-unstorage";
+import { createStorage } from "unstorage";
+import redisDriver from "unstorage/drivers/redis";
+
+const storage = createStorage({
+  driver: redisDriver({
+    base: "chat-sdk",
+    url: process.env.REDIS_URL,
+  }),
+});
+
+const bot = new Chat({
+  userName: "mybot",
+  adapters: { /* ... */ },
+  state: createUnstorageState({ storage }),
+});
+```
+
+You can also pass a driver directly:
+
+```typescript
+import memoryDriver from "unstorage/drivers/memory";
+
+const state = createUnstorageState({
+  driver: memoryDriver(),
+  keyPrefix: "my-bot",
+});
+```
+
+## Configuration
+
+| Option | Required | Description |
+|--------|----------|-------------|
+| `storage` | No | Existing unstorage instance |
+| `driver` | No | unstorage driver used to create an internal storage instance |
+| `keyPrefix` | No | Prefix for all keys (default: `"chat-sdk"`) |
+| `logger` | No | Logger instance (defaults to `ConsoleLogger("info")`) |
+
+`storage` and `driver` are mutually exclusive.
+
+## Compatibility
+
+- Implements the full Chat SDK `StateAdapter` surface (`locks`, `subscriptions`, `cache`, `lists`, and `queues`)
+- Works with any unstorage backend
+- Preserves key prefix namespacing across multiple adapters sharing the same backend
+
+## License
+
+MIT

--- a/packages/state-unstorage/package.json
+++ b/packages/state-unstorage/package.json
@@ -1,0 +1,55 @@
+{
+  "name": "@chat-adapter/state-unstorage",
+  "version": "4.24.0",
+  "description": "Unstorage-based state adapter for chat",
+  "type": "module",
+  "main": "./dist/index.js",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsup",
+    "dev": "tsup --watch",
+    "test": "vitest run --coverage",
+    "test:watch": "vitest",
+    "typecheck": "tsc --noEmit",
+    "clean": "rm -rf dist"
+  },
+  "dependencies": {
+    "chat": "workspace:*",
+    "unstorage": "^1.17.5"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/vercel/chat.git",
+    "directory": "packages/state-unstorage"
+  },
+  "homepage": "https://github.com/vercel/chat#readme",
+  "bugs": {
+    "url": "https://github.com/vercel/chat/issues"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "keywords": [
+    "chat",
+    "state",
+    "unstorage",
+    "production"
+  ],
+  "license": "MIT",
+  "devDependencies": {
+    "@types/node": "^25.3.2",
+    "tsup": "^8.5.1",
+    "typescript": "^5.9.3",
+    "vitest": "^4.0.18"
+  }
+}

--- a/packages/state-unstorage/src/index.test.ts
+++ b/packages/state-unstorage/src/index.test.ts
@@ -1,0 +1,465 @@
+import type { Logger } from "chat";
+import { createStorage } from "unstorage";
+import memoryDriver from "unstorage/drivers/memory";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  createUnstorageState,
+  type UnstorageStateAdapter,
+  UnstorageStateAdapter as UnstorageStateAdapterClass,
+} from "./index";
+
+const mockLogger: Logger = {
+  debug: vi.fn(),
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+};
+
+describe("UnstorageStateAdapter", () => {
+  describe("construction", () => {
+    it("should export createUnstorageState function", () => {
+      expect(typeof createUnstorageState).toBe("function");
+    });
+
+    it("should create an adapter instance", () => {
+      const adapter = createUnstorageState({ logger: mockLogger });
+      expect(adapter).toBeInstanceOf(UnstorageStateAdapterClass);
+    });
+
+    it("should accept an existing unstorage instance", () => {
+      const storage = createStorage({ driver: memoryDriver() });
+      const adapter = createUnstorageState({ storage, logger: mockLogger });
+
+      expect(adapter).toBeInstanceOf(UnstorageStateAdapterClass);
+      expect(adapter.getStorage()).toBe(storage);
+    });
+
+    it("should throw when both storage and driver are provided", () => {
+      const storage = createStorage({ driver: memoryDriver() });
+      expect(() =>
+        createUnstorageState({
+          storage,
+          driver: memoryDriver(),
+          logger: mockLogger,
+        })
+      ).toThrow("either storage or driver");
+    });
+
+    it("should not dispose injected storage on disconnect", async () => {
+      const storage = createStorage({ driver: memoryDriver() });
+      const disposeSpy = vi.spyOn(storage, "dispose");
+
+      const adapter = createUnstorageState({ storage, logger: mockLogger });
+      await adapter.connect();
+      await adapter.disconnect();
+
+      expect(disposeSpy).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("compatibility behavior", () => {
+    let adapter: UnstorageStateAdapter;
+
+    beforeEach(async () => {
+      adapter = createUnstorageState({
+        storage: createStorage({ driver: memoryDriver() }),
+        logger: mockLogger,
+      });
+      await adapter.connect();
+    });
+
+    describe("subscriptions", () => {
+      it("should subscribe to a thread", async () => {
+        await adapter.subscribe("slack:C123:1234.5678");
+        expect(await adapter.isSubscribed("slack:C123:1234.5678")).toBe(true);
+      });
+
+      it("should unsubscribe from a thread", async () => {
+        await adapter.subscribe("slack:C123:1234.5678");
+        await adapter.unsubscribe("slack:C123:1234.5678");
+        expect(await adapter.isSubscribed("slack:C123:1234.5678")).toBe(false);
+      });
+    });
+
+    describe("locking", () => {
+      it("should acquire a lock", async () => {
+        const lock = await adapter.acquireLock("thread1", 5000);
+        expect(lock).not.toBeNull();
+        expect(lock?.threadId).toBe("thread1");
+        expect(lock?.token).toBeTruthy();
+      });
+
+      it("should prevent double-locking", async () => {
+        const lock1 = await adapter.acquireLock("thread1", 5000);
+        const lock2 = await adapter.acquireLock("thread1", 5000);
+
+        expect(lock1).not.toBeNull();
+        expect(lock2).toBeNull();
+      });
+
+      it("should release a lock", async () => {
+        const lock = await adapter.acquireLock("thread1", 5000);
+        expect(lock).not.toBeNull();
+        await adapter.releaseLock(lock as NonNullable<typeof lock>);
+
+        const lock2 = await adapter.acquireLock("thread1", 5000);
+        expect(lock2).not.toBeNull();
+      });
+
+      it("should not release a lock with wrong token", async () => {
+        const lock = await adapter.acquireLock("thread1", 5000);
+
+        await adapter.releaseLock({
+          threadId: "thread1",
+          token: "fake-token",
+          expiresAt: Date.now() + 5000,
+        });
+
+        const lock2 = await adapter.acquireLock("thread1", 5000);
+        expect(lock2).toBeNull();
+
+        expect(lock).not.toBeNull();
+        await adapter.releaseLock(lock as NonNullable<typeof lock>);
+      });
+
+      it("should allow re-locking after expiry", async () => {
+        const lock1 = await adapter.acquireLock("thread1", 10);
+
+        await new Promise((resolve) => setTimeout(resolve, 20));
+
+        const lock2 = await adapter.acquireLock("thread1", 5000);
+        expect(lock2).not.toBeNull();
+        expect(lock2?.token).not.toBe(lock1?.token);
+      });
+
+      it("should extend a lock", async () => {
+        const lock = await adapter.acquireLock("thread1", 100);
+        expect(lock).not.toBeNull();
+
+        const extended = await adapter.extendLock(
+          lock as NonNullable<typeof lock>,
+          5000
+        );
+        expect(extended).toBe(true);
+
+        const lock2 = await adapter.acquireLock("thread1", 5000);
+        expect(lock2).toBeNull();
+      });
+
+      it("should force-release a lock regardless of token", async () => {
+        const lock = await adapter.acquireLock("thread1", 5000);
+        expect(lock).not.toBeNull();
+
+        await adapter.forceReleaseLock("thread1");
+
+        const lock2 = await adapter.acquireLock("thread1", 5000);
+        expect(lock2).not.toBeNull();
+        expect(lock2?.token).not.toBe(lock?.token);
+      });
+
+      it("should no-op when force-releasing a non-existent lock", async () => {
+        await expect(
+          adapter.forceReleaseLock("nonexistent")
+        ).resolves.toBeUndefined();
+      });
+
+      it("should not extend an expired lock", async () => {
+        const lock = await adapter.acquireLock("thread1", 10);
+        expect(lock).not.toBeNull();
+
+        await new Promise((resolve) => setTimeout(resolve, 20));
+
+        const extended = await adapter.extendLock(
+          lock as NonNullable<typeof lock>,
+          5000
+        );
+        expect(extended).toBe(false);
+      });
+    });
+
+    describe("setIfNotExists", () => {
+      it("should set a value when key does not exist", async () => {
+        const result = await adapter.setIfNotExists("key1", "value1");
+        expect(result).toBe(true);
+        expect(await adapter.get("key1")).toBe("value1");
+      });
+
+      it("should not overwrite an existing key", async () => {
+        await adapter.setIfNotExists("key1", "first");
+        const result = await adapter.setIfNotExists("key1", "second");
+        expect(result).toBe(false);
+        expect(await adapter.get("key1")).toBe("first");
+      });
+
+      it("should allow setting after TTL expiry", async () => {
+        await adapter.setIfNotExists("key1", "first", 10);
+        await new Promise((resolve) => setTimeout(resolve, 20));
+        const result = await adapter.setIfNotExists("key1", "second");
+        expect(result).toBe(true);
+        expect(await adapter.get("key1")).toBe("second");
+      });
+
+      it("should respect TTL on the new value", async () => {
+        await adapter.setIfNotExists("key1", "value", 10);
+        await new Promise((resolve) => setTimeout(resolve, 20));
+        expect(await adapter.get("key1")).toBeNull();
+      });
+    });
+
+    describe("appendToList / getList", () => {
+      it("should append and retrieve list items", async () => {
+        await adapter.appendToList("list1", { id: 1 });
+        await adapter.appendToList("list1", { id: 2 });
+
+        const result = await adapter.getList("list1");
+        expect(result).toEqual([{ id: 1 }, { id: 2 }]);
+      });
+
+      it("should return empty array for non-existent list", async () => {
+        const result = await adapter.getList("nonexistent");
+        expect(result).toEqual([]);
+      });
+
+      it("should trim to maxLength, keeping newest", async () => {
+        for (let i = 1; i <= 5; i++) {
+          await adapter.appendToList("list1", { id: i }, { maxLength: 3 });
+        }
+
+        const result = await adapter.getList("list1");
+        expect(result).toEqual([{ id: 3 }, { id: 4 }, { id: 5 }]);
+      });
+
+      it("should respect TTL on lists", async () => {
+        await adapter.appendToList("list1", { id: 1 }, { ttlMs: 10 });
+        await new Promise((resolve) => setTimeout(resolve, 20));
+
+        const result = await adapter.getList("list1");
+        expect(result).toEqual([]);
+      });
+
+      it("should refresh TTL on subsequent appends", async () => {
+        vi.useFakeTimers();
+
+        try {
+          await adapter.appendToList("list1", { id: 1 }, { ttlMs: 50 });
+          await vi.advanceTimersByTimeAsync(30);
+
+          await adapter.appendToList("list1", { id: 2 }, { ttlMs: 50 });
+
+          const result = await adapter.getList("list1");
+          expect(result).toEqual([{ id: 1 }, { id: 2 }]);
+        } finally {
+          vi.useRealTimers();
+        }
+      });
+
+      it("should keep lists isolated by key", async () => {
+        await adapter.appendToList("list-a", "a");
+        await adapter.appendToList("list-b", "b");
+
+        expect(await adapter.getList("list-a")).toEqual(["a"]);
+        expect(await adapter.getList("list-b")).toEqual(["b"]);
+      });
+
+      it("should start fresh after expired list", async () => {
+        await adapter.appendToList("list1", { id: 1 }, { ttlMs: 10 });
+        await new Promise((resolve) => setTimeout(resolve, 20));
+
+        await adapter.appendToList("list1", { id: 2 });
+        const result = await adapter.getList("list1");
+        expect(result).toEqual([{ id: 2 }]);
+      });
+    });
+
+    describe("enqueue / dequeue / queueDepth", () => {
+      it("should enqueue and dequeue a single entry", async () => {
+        const entry = {
+          message: { id: "m1", text: "hello" },
+          enqueuedAt: Date.now(),
+          expiresAt: Date.now() + 90000,
+        };
+        const depth = await adapter.enqueue("thread1", entry as never, 10);
+        expect(depth).toBe(1);
+
+        const result = await adapter.dequeue("thread1");
+        expect(result).toEqual(entry);
+      });
+
+      it("should return null when dequeuing from empty queue", async () => {
+        const result = await adapter.dequeue("thread1");
+        expect(result).toBeNull();
+      });
+
+      it("should return 0 depth for empty queue", async () => {
+        const depth = await adapter.queueDepth("thread1");
+        expect(depth).toBe(0);
+      });
+
+      it("should dequeue in FIFO order", async () => {
+        const entry1 = {
+          message: { id: "m1" },
+          enqueuedAt: 1000,
+          expiresAt: Date.now() + 90000,
+        };
+        const entry2 = {
+          message: { id: "m2" },
+          enqueuedAt: 2000,
+          expiresAt: Date.now() + 90000,
+        };
+        const entry3 = {
+          message: { id: "m3" },
+          enqueuedAt: 3000,
+          expiresAt: Date.now() + 90000,
+        };
+
+        await adapter.enqueue("thread1", entry1 as never, 10);
+        await adapter.enqueue("thread1", entry2 as never, 10);
+        await adapter.enqueue("thread1", entry3 as never, 10);
+
+        expect(await adapter.queueDepth("thread1")).toBe(3);
+
+        const r1 = await adapter.dequeue("thread1");
+        expect(r1?.message).toEqual({ id: "m1" });
+
+        const r2 = await adapter.dequeue("thread1");
+        expect(r2?.message).toEqual({ id: "m2" });
+
+        const r3 = await adapter.dequeue("thread1");
+        expect(r3?.message).toEqual({ id: "m3" });
+
+        expect(await adapter.dequeue("thread1")).toBeNull();
+        expect(await adapter.queueDepth("thread1")).toBe(0);
+      });
+
+      it("should trim to maxSize keeping newest entries", async () => {
+        for (let i = 1; i <= 5; i++) {
+          await adapter.enqueue(
+            "thread1",
+            {
+              message: { id: `m${i}` },
+              enqueuedAt: i * 1000,
+              expiresAt: Date.now() + 90000,
+            } as never,
+            3
+          );
+        }
+
+        expect(await adapter.queueDepth("thread1")).toBe(3);
+
+        const r1 = await adapter.dequeue("thread1");
+        expect(r1?.message).toEqual({ id: "m3" });
+
+        const r2 = await adapter.dequeue("thread1");
+        expect(r2?.message).toEqual({ id: "m4" });
+
+        const r3 = await adapter.dequeue("thread1");
+        expect(r3?.message).toEqual({ id: "m5" });
+      });
+
+      it("should handle maxSize of 1 (debounce behavior)", async () => {
+        await adapter.enqueue(
+          "thread1",
+          {
+            message: { id: "m1" },
+            enqueuedAt: 1000,
+            expiresAt: Date.now() + 90000,
+          } as never,
+          1
+        );
+        await adapter.enqueue(
+          "thread1",
+          {
+            message: { id: "m2" },
+            enqueuedAt: 2000,
+            expiresAt: Date.now() + 90000,
+          } as never,
+          1
+        );
+        await adapter.enqueue(
+          "thread1",
+          {
+            message: { id: "m3" },
+            enqueuedAt: 3000,
+            expiresAt: Date.now() + 90000,
+          } as never,
+          1
+        );
+
+        expect(await adapter.queueDepth("thread1")).toBe(1);
+        const result = await adapter.dequeue("thread1");
+        expect(result?.message).toEqual({ id: "m3" });
+      });
+
+      it("should keep queues isolated by thread", async () => {
+        await adapter.enqueue(
+          "thread-a",
+          {
+            message: { id: "a1" },
+            enqueuedAt: 1000,
+            expiresAt: Date.now() + 90000,
+          } as never,
+          10
+        );
+        await adapter.enqueue(
+          "thread-b",
+          {
+            message: { id: "b1" },
+            enqueuedAt: 1000,
+            expiresAt: Date.now() + 90000,
+          } as never,
+          10
+        );
+
+        expect(await adapter.queueDepth("thread-a")).toBe(1);
+        expect(await adapter.queueDepth("thread-b")).toBe(1);
+
+        const ra = await adapter.dequeue("thread-a");
+        expect(ra?.message).toEqual({ id: "a1" });
+
+        const rb = await adapter.dequeue("thread-b");
+        expect(rb?.message).toEqual({ id: "b1" });
+      });
+    });
+
+    describe("key prefix", () => {
+      it("should isolate state by keyPrefix", async () => {
+        const storage = createStorage({ driver: memoryDriver() });
+        const adapterA = createUnstorageState({
+          storage,
+          keyPrefix: "a",
+          logger: mockLogger,
+        });
+        const adapterB = createUnstorageState({
+          storage,
+          keyPrefix: "b",
+          logger: mockLogger,
+        });
+
+        await adapterA.connect();
+        await adapterB.connect();
+
+        await adapterA.set("k", "value-a");
+        await adapterB.set("k", "value-b");
+
+        expect(await adapterA.get("k")).toBe("value-a");
+        expect(await adapterB.get("k")).toBe("value-b");
+      });
+    });
+
+    describe("connection", () => {
+      it("should throw when not connected", async () => {
+        const newAdapter = createUnstorageState({ logger: mockLogger });
+        await expect(newAdapter.subscribe("test")).rejects.toThrow(
+          "not connected"
+        );
+      });
+
+      it("should reconnect successfully", async () => {
+        await adapter.disconnect();
+        await adapter.connect();
+        await adapter.subscribe("thread1");
+        expect(await adapter.isSubscribed("thread1")).toBe(true);
+      });
+    });
+  });
+});

--- a/packages/state-unstorage/src/index.ts
+++ b/packages/state-unstorage/src/index.ts
@@ -1,0 +1,621 @@
+import type { Lock, Logger, QueueEntry, StateAdapter } from "chat";
+import { ConsoleLogger } from "chat";
+import { createStorage, type Driver, type Storage } from "unstorage";
+
+interface LockRecord {
+  expiresAt: number;
+  token: string;
+}
+
+interface ValueRecord<T = unknown> {
+  expiresAt: number | null;
+  value: T;
+}
+
+interface ListRecord {
+  expiresAt: number | null;
+  items: unknown[];
+}
+
+interface QueueRecord {
+  expiresAt: number;
+  items: QueueEntry[];
+}
+
+interface MutexState {
+  locked: boolean;
+  waiters: Array<() => void>;
+}
+
+/**
+ * Options for creating an unstorage-backed state adapter.
+ */
+export interface UnstorageStateAdapterOptions {
+  /**
+   * Driver used to create an internal unstorage instance.
+   *
+   * If omitted, unstorage's default in-memory driver is used.
+   */
+  driver?: Driver;
+  /** Key prefix for all keys in storage (default: "chat-sdk") */
+  keyPrefix?: string;
+  /** Logger instance for diagnostics and error reporting */
+  logger?: Logger;
+  /**
+   * Existing unstorage instance.
+   *
+   * When provided, this adapter will not call `storage.dispose()` on disconnect.
+   */
+  storage?: Storage;
+}
+
+/**
+ * Factory options for `createUnstorageState`.
+ */
+export interface CreateUnstorageStateOptions
+  extends UnstorageStateAdapterOptions {}
+
+/**
+ * State adapter implementation built on top of unstorage.
+ *
+ * This adapter preserves the Chat SDK `StateAdapter` contract while delegating
+ * persistence to any unstorage-compatible backend.
+ */
+export class UnstorageStateAdapter implements StateAdapter {
+  private readonly keyPrefix: string;
+  private readonly logger: Logger;
+  private readonly ownsStorage: boolean;
+  private readonly mutexes = new Map<string, MutexState>();
+  private readonly storage: Storage;
+  private connected = false;
+  private connectPromise: Promise<void> | null = null;
+
+  constructor(options: UnstorageStateAdapterOptions = {}) {
+    if (options.storage && options.driver) {
+      throw new Error(
+        "Provide either storage or driver, not both, when creating UnstorageStateAdapter."
+      );
+    }
+
+    this.storage = options.storage ?? createStorage({ driver: options.driver });
+    this.ownsStorage = !options.storage;
+    this.keyPrefix = options.keyPrefix ?? "chat-sdk";
+    this.logger =
+      options.logger ?? new ConsoleLogger("info").child("unstorage");
+  }
+
+  /**
+   * Connect to the underlying storage backend.
+   */
+  async connect(): Promise<void> {
+    if (this.connected) {
+      return;
+    }
+
+    if (!this.connectPromise) {
+      this.connectPromise = Promise.resolve().then(() => {
+        this.connected = true;
+      });
+    }
+
+    await this.connectPromise;
+  }
+
+  /**
+   * Disconnect from the storage backend.
+   */
+  async disconnect(): Promise<void> {
+    if (!this.connected) {
+      return;
+    }
+
+    if (this.ownsStorage) {
+      await this.storage.dispose();
+    }
+
+    this.connected = false;
+    this.connectPromise = null;
+    this.mutexes.clear();
+  }
+
+  /**
+   * Subscribe to a thread.
+   */
+  async subscribe(threadId: string): Promise<void> {
+    this.ensureConnected();
+    await this.withMutex(this.subscriptionsSetKey(), async () => {
+      const subscriptions = await this.readSubscriptions();
+      if (!subscriptions.includes(threadId)) {
+        subscriptions.push(threadId);
+        await this.storage.setItem(this.subscriptionsSetKey(), subscriptions);
+      }
+    });
+  }
+
+  /**
+   * Unsubscribe from a thread.
+   */
+  async unsubscribe(threadId: string): Promise<void> {
+    this.ensureConnected();
+    await this.withMutex(this.subscriptionsSetKey(), async () => {
+      const subscriptions = await this.readSubscriptions();
+      const filtered = subscriptions.filter((id) => id !== threadId);
+      await this.storage.setItem(this.subscriptionsSetKey(), filtered);
+    });
+  }
+
+  /**
+   * Check whether a thread is currently subscribed.
+   */
+  async isSubscribed(threadId: string): Promise<boolean> {
+    this.ensureConnected();
+    const subscriptions = await this.readSubscriptions();
+    return subscriptions.includes(threadId);
+  }
+
+  /**
+   * Acquire a lock for a specific thread.
+   */
+  async acquireLock(threadId: string, ttlMs: number): Promise<Lock | null> {
+    this.ensureConnected();
+
+    const lockKey = this.key("lock", threadId);
+    return this.withMutex(lockKey, async () => {
+      const current = await this.readLock(lockKey);
+      if (current && current.expiresAt > Date.now()) {
+        return null;
+      }
+
+      const token = generateToken();
+      const expiresAt = Date.now() + ttlMs;
+
+      await this.storage.setItem<LockRecord>(lockKey, { token, expiresAt });
+
+      return {
+        threadId,
+        token,
+        expiresAt,
+      };
+    });
+  }
+
+  /**
+   * Force-release lock regardless of token ownership.
+   */
+  async forceReleaseLock(threadId: string): Promise<void> {
+    this.ensureConnected();
+    await this.storage.removeItem(this.key("lock", threadId));
+  }
+
+  /**
+   * Release lock if the token matches the current lock owner.
+   */
+  async releaseLock(lock: Lock): Promise<void> {
+    this.ensureConnected();
+
+    const lockKey = this.key("lock", lock.threadId);
+    await this.withMutex(lockKey, async () => {
+      const current = await this.readLock(lockKey);
+      if (current?.token === lock.token) {
+        await this.storage.removeItem(lockKey);
+      }
+    });
+  }
+
+  /**
+   * Extend lock TTL if token matches and lock is still active.
+   */
+  async extendLock(lock: Lock, ttlMs: number): Promise<boolean> {
+    this.ensureConnected();
+
+    const lockKey = this.key("lock", lock.threadId);
+    return this.withMutex(lockKey, async () => {
+      const current = await this.readLock(lockKey);
+      if (!current || current.token !== lock.token) {
+        return false;
+      }
+
+      if (current.expiresAt <= Date.now()) {
+        await this.storage.removeItem(lockKey);
+        return false;
+      }
+
+      await this.storage.setItem<LockRecord>(lockKey, {
+        token: current.token,
+        expiresAt: Date.now() + ttlMs,
+      });
+      return true;
+    });
+  }
+
+  /**
+   * Get cached value.
+   */
+  async get<T = unknown>(key: string): Promise<T | null> {
+    this.ensureConnected();
+
+    const cacheKey = this.key("cache", key);
+    const record = await this.readValueRecord<T>(cacheKey);
+
+    if (!record) {
+      return null;
+    }
+
+    if (record.expiresAt !== null && record.expiresAt <= Date.now()) {
+      await this.storage.removeItem(cacheKey);
+      return null;
+    }
+
+    return record.value;
+  }
+
+  /**
+   * Set cached value with optional TTL.
+   */
+  async set<T = unknown>(key: string, value: T, ttlMs?: number): Promise<void> {
+    this.ensureConnected();
+
+    const expiresAt = ttlMs ? Date.now() + ttlMs : null;
+    await this.storage.setItem<ValueRecord<T>>(this.key("cache", key), {
+      value,
+      expiresAt,
+    });
+  }
+
+  /**
+   * Atomically set cached value only if key does not already exist.
+   */
+  async setIfNotExists(
+    key: string,
+    value: unknown,
+    ttlMs?: number
+  ): Promise<boolean> {
+    this.ensureConnected();
+
+    const cacheKey = this.key("cache", key);
+    return this.withMutex(cacheKey, async () => {
+      const current = await this.readValueRecord(cacheKey);
+      if (
+        current &&
+        (current.expiresAt === null || current.expiresAt > Date.now())
+      ) {
+        return false;
+      }
+
+      await this.storage.setItem<ValueRecord>(cacheKey, {
+        value,
+        expiresAt: ttlMs ? Date.now() + ttlMs : null,
+      });
+      return true;
+    });
+  }
+
+  /**
+   * Delete cached value.
+   */
+  async delete(key: string): Promise<void> {
+    this.ensureConnected();
+    await this.storage.removeItem(this.key("cache", key));
+  }
+
+  /**
+   * Append value to a list, optionally trimming to max length and refreshing TTL.
+   */
+  async appendToList(
+    key: string,
+    value: unknown,
+    options?: { maxLength?: number; ttlMs?: number }
+  ): Promise<void> {
+    this.ensureConnected();
+
+    const listKey = this.key("list", key);
+    await this.withMutex(listKey, async () => {
+      const now = Date.now();
+      const current = await this.readListRecord(listKey);
+
+      const currentExpiresAt = current?.expiresAt ?? null;
+      const isExpired = currentExpiresAt !== null && currentExpiresAt <= now;
+
+      const items = isExpired ? [] : [...(current?.items ?? [])];
+      items.push(value);
+
+      const maxLength = options?.maxLength ?? 0;
+      const trimmedItems =
+        maxLength > 0 && items.length > maxLength
+          ? items.slice(items.length - maxLength)
+          : items;
+
+      let expiresAt: number | null;
+      if (options?.ttlMs !== undefined) {
+        expiresAt = options.ttlMs > 0 ? now + options.ttlMs : null;
+      } else if (isExpired) {
+        expiresAt = null;
+      } else {
+        expiresAt = currentExpiresAt;
+      }
+
+      await this.storage.setItem<ListRecord>(listKey, {
+        items: trimmedItems,
+        expiresAt,
+      });
+    });
+  }
+
+  /**
+   * Enqueue an entry and keep only newest `maxSize` entries.
+   */
+  async enqueue(
+    threadId: string,
+    entry: QueueEntry,
+    maxSize: number
+  ): Promise<number> {
+    this.ensureConnected();
+
+    const queueKey = this.key("queue", threadId);
+    return this.withMutex(queueKey, async () => {
+      const now = Date.now();
+      const current = await this.readQueueRecord(queueKey);
+
+      const isExpired = current ? current.expiresAt <= now : false;
+      const items = isExpired ? [] : [...(current?.items ?? [])];
+
+      items.push(entry);
+      if (maxSize > 0 && items.length > maxSize) {
+        items.splice(0, items.length - maxSize);
+      }
+
+      const ttlMs = Math.max(entry.expiresAt - now, 60_000);
+      await this.storage.setItem<QueueRecord>(queueKey, {
+        items,
+        expiresAt: now + ttlMs,
+      });
+
+      return items.length;
+    });
+  }
+
+  /**
+   * Dequeue the oldest queued entry for a thread.
+   */
+  async dequeue(threadId: string): Promise<QueueEntry | null> {
+    this.ensureConnected();
+
+    const queueKey = this.key("queue", threadId);
+    return this.withMutex(queueKey, async () => {
+      const now = Date.now();
+      const current = await this.readQueueRecord(queueKey);
+
+      if (!current || current.expiresAt <= now || current.items.length === 0) {
+        await this.storage.removeItem(queueKey);
+        return null;
+      }
+
+      const queueItems = current.items;
+      const [entry, ...rest] = queueItems;
+      if (!entry) {
+        return null;
+      }
+
+      if (rest.length === 0) {
+        await this.storage.removeItem(queueKey);
+      } else {
+        await this.storage.setItem<QueueRecord>(queueKey, {
+          items: rest,
+          expiresAt: current.expiresAt,
+        });
+      }
+
+      return entry;
+    });
+  }
+
+  /**
+   * Get current queue depth for a thread.
+   */
+  async queueDepth(threadId: string): Promise<number> {
+    this.ensureConnected();
+
+    const queueKey = this.key("queue", threadId);
+    const current = await this.readQueueRecord(queueKey);
+
+    if (!current) {
+      return 0;
+    }
+
+    if (current.expiresAt <= Date.now()) {
+      await this.storage.removeItem(queueKey);
+      return 0;
+    }
+
+    return current.items.length;
+  }
+
+  /**
+   * Read list values in insertion order.
+   */
+  async getList<T = unknown>(key: string): Promise<T[]> {
+    this.ensureConnected();
+
+    const listKey = this.key("list", key);
+    const record = await this.readListRecord(listKey);
+
+    if (!record) {
+      return [];
+    }
+
+    if (record.expiresAt !== null && record.expiresAt <= Date.now()) {
+      await this.storage.removeItem(listKey);
+      return [];
+    }
+
+    return record.items as T[];
+  }
+
+  /**
+   * Exposes underlying unstorage instance.
+   */
+  getStorage(): Storage {
+    return this.storage;
+  }
+
+  private key(
+    type: "cache" | "list" | "lock" | "queue" | "sub",
+    id: string
+  ): string {
+    return `${this.keyPrefix}:${type}:${id}`;
+  }
+
+  private subscriptionsSetKey(): string {
+    return `${this.keyPrefix}:subscriptions`;
+  }
+
+  private async readSubscriptions(): Promise<string[]> {
+    const raw = await this.storage.getItem<unknown>(this.subscriptionsSetKey());
+    if (!Array.isArray(raw)) {
+      return [];
+    }
+
+    return raw.filter((entry): entry is string => typeof entry === "string");
+  }
+
+  private async readLock(key: string): Promise<LockRecord | null> {
+    const raw = await this.storage.getItem<unknown>(key);
+    if (!isObject(raw)) {
+      return null;
+    }
+
+    const expiresAt = raw.expiresAt;
+    const token = raw.token;
+    if (typeof expiresAt !== "number" || typeof token !== "string") {
+      return null;
+    }
+
+    return { expiresAt, token };
+  }
+
+  private async readValueRecord<T = unknown>(
+    key: string
+  ): Promise<ValueRecord<T> | null> {
+    const raw = await this.storage.getItem<unknown>(key);
+    if (!(isObject(raw) && "value" in raw)) {
+      return null;
+    }
+
+    const expiresAt = raw.expiresAt;
+    if (expiresAt !== null && typeof expiresAt !== "number") {
+      return null;
+    }
+
+    return {
+      value: raw.value as T,
+      expiresAt: expiresAt ?? null,
+    };
+  }
+
+  private async readListRecord(key: string): Promise<ListRecord | null> {
+    const raw = await this.storage.getItem<unknown>(key);
+    if (!(isObject(raw) && Array.isArray(raw.items))) {
+      return null;
+    }
+
+    const expiresAt = raw.expiresAt;
+    if (
+      expiresAt !== null &&
+      expiresAt !== undefined &&
+      typeof expiresAt !== "number"
+    ) {
+      return null;
+    }
+
+    return {
+      items: raw.items,
+      expiresAt: expiresAt ?? null,
+    };
+  }
+
+  private async readQueueRecord(key: string): Promise<QueueRecord | null> {
+    const raw = await this.storage.getItem<unknown>(key);
+    if (!(isObject(raw) && Array.isArray(raw.items))) {
+      return null;
+    }
+
+    const expiresAt = raw.expiresAt;
+    if (typeof expiresAt !== "number") {
+      return null;
+    }
+
+    return {
+      items: raw.items as QueueEntry[],
+      expiresAt,
+    };
+  }
+
+  private ensureConnected(): void {
+    if (!this.connected) {
+      throw new Error(
+        "UnstorageStateAdapter is not connected. Call connect() first."
+      );
+    }
+  }
+
+  private async withMutex<T>(key: string, task: () => Promise<T>): Promise<T> {
+    const release = await this.acquireMutex(key);
+    try {
+      return await task();
+    } finally {
+      release();
+    }
+  }
+
+  private async acquireMutex(key: string): Promise<() => void> {
+    let state = this.mutexes.get(key);
+    if (!state) {
+      state = { locked: false, waiters: [] };
+      this.mutexes.set(key, state);
+    }
+
+    if (!state.locked) {
+      state.locked = true;
+      return () => this.releaseMutex(key);
+    }
+
+    await new Promise<void>((resolve) => {
+      state.waiters.push(resolve);
+    });
+
+    return () => this.releaseMutex(key);
+  }
+
+  private releaseMutex(key: string): void {
+    const state = this.mutexes.get(key);
+    if (!state) {
+      return;
+    }
+
+    const next = state.waiters.shift();
+    if (next) {
+      next();
+      return;
+    }
+
+    state.locked = false;
+    this.mutexes.delete(key);
+  }
+}
+
+function isObject(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object";
+}
+
+function generateToken(): string {
+  return `unstorage_${Date.now()}_${Math.random().toString(36).slice(2, 15)}`;
+}
+
+/**
+ * Create a new unstorage-backed state adapter.
+ */
+export function createUnstorageState(
+  options: CreateUnstorageStateOptions = {}
+): UnstorageStateAdapter {
+  return new UnstorageStateAdapter(options);
+}

--- a/packages/state-unstorage/src/index.ts
+++ b/packages/state-unstorage/src/index.ts
@@ -123,13 +123,7 @@ export class UnstorageStateAdapter implements StateAdapter {
    */
   async subscribe(threadId: string): Promise<void> {
     this.ensureConnected();
-    await this.withMutex(this.subscriptionsSetKey(), async () => {
-      const subscriptions = await this.readSubscriptions();
-      if (!subscriptions.includes(threadId)) {
-        subscriptions.push(threadId);
-        await this.storage.setItem(this.subscriptionsSetKey(), subscriptions);
-      }
-    });
+    await this.storage.setItem<boolean>(this.key("sub", threadId), true);
   }
 
   /**
@@ -137,11 +131,7 @@ export class UnstorageStateAdapter implements StateAdapter {
    */
   async unsubscribe(threadId: string): Promise<void> {
     this.ensureConnected();
-    await this.withMutex(this.subscriptionsSetKey(), async () => {
-      const subscriptions = await this.readSubscriptions();
-      const filtered = subscriptions.filter((id) => id !== threadId);
-      await this.storage.setItem(this.subscriptionsSetKey(), filtered);
-    });
+    await this.storage.removeItem(this.key("sub", threadId));
   }
 
   /**
@@ -149,8 +139,8 @@ export class UnstorageStateAdapter implements StateAdapter {
    */
   async isSubscribed(threadId: string): Promise<boolean> {
     this.ensureConnected();
-    const subscriptions = await this.readSubscriptions();
-    return subscriptions.includes(threadId);
+    const value = await this.storage.getItem(this.key("sub", threadId));
+    return value !== null && value !== undefined;
   }
 
   /**
@@ -463,19 +453,6 @@ export class UnstorageStateAdapter implements StateAdapter {
     id: string
   ): string {
     return `${this.keyPrefix}:${type}:${id}`;
-  }
-
-  private subscriptionsSetKey(): string {
-    return `${this.keyPrefix}:subscriptions`;
-  }
-
-  private async readSubscriptions(): Promise<string[]> {
-    const raw = await this.storage.getItem<unknown>(this.subscriptionsSetKey());
-    if (!Array.isArray(raw)) {
-      return [];
-    }
-
-    return raw.filter((entry): entry is string => typeof entry === "string");
   }
 
   private async readLock(key: string): Promise<LockRecord | null> {

--- a/packages/state-unstorage/tsconfig.json
+++ b/packages/state-unstorage/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "strictNullChecks": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist", "**/*.test.ts"]
+}

--- a/packages/state-unstorage/tsup.config.ts
+++ b/packages/state-unstorage/tsup.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from "tsup";
+
+export default defineConfig({
+  entry: ["src/index.ts"],
+  format: ["esm"],
+  dts: true,
+  clean: true,
+  sourcemap: false,
+  external: ["unstorage"],
+});

--- a/packages/state-unstorage/vitest.config.ts
+++ b/packages/state-unstorage/vitest.config.ts
@@ -1,0 +1,14 @@
+import { defineProject } from "vitest/config";
+
+export default defineProject({
+  test: {
+    globals: true,
+    environment: "node",
+    coverage: {
+      provider: "v8",
+      reporter: ["text", "json-summary"],
+      include: ["src/**/*.ts"],
+      exclude: ["src/**/*.test.ts"],
+    },
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -653,6 +653,28 @@ importers:
         specifier: ^4.0.18
         version: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@25.3.2)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)
 
+  packages/state-unstorage:
+    dependencies:
+      chat:
+        specifier: workspace:*
+        version: link:../chat
+      unstorage:
+        specifier: ^1.17.5
+        version: 1.17.5(ioredis@5.8.2)
+    devDependencies:
+      '@types/node':
+        specifier: ^25.3.2
+        version: 25.3.2
+      tsup:
+        specifier: ^8.5.1
+        version: 8.5.1(jiti@2.6.1)(postcss@8.5.6)(tsx@4.21.0)(typescript@5.9.3)
+      typescript:
+        specifier: ^5.9.3
+        version: 5.9.3
+      vitest:
+        specifier: ^4.0.18
+        version: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@25.3.2)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)
+
 packages:
 
   '@ai-sdk/gateway@2.0.39':
@@ -3054,6 +3076,10 @@ packages:
   any-promise@1.3.0:
     resolution: {integrity: sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==}
 
+  anymatch@3.1.3:
+    resolution: {integrity: sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==}
+    engines: {node: '>= 8'}
+
   argparse@1.0.10:
     resolution: {integrity: sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==}
 
@@ -3295,6 +3321,9 @@ packages:
     resolution: {integrity: sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==}
     engines: {node: '>= 0.6'}
 
+  cookie-es@1.2.3:
+    resolution: {integrity: sha512-lXVyvUvrNXblMqzIRrxHb57UUVmqsSWlxqt3XIjCkUP0wDAf6uicO6KMbEgYrMNtEvWgWHwe42CKxPu9MYAnWw==}
+
   cookie-signature@1.2.2:
     resolution: {integrity: sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==}
     engines: {node: '>=6.6.0'}
@@ -3316,6 +3345,9 @@ packages:
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
     engines: {node: '>= 8'}
+
+  crossws@0.3.5:
+    resolution: {integrity: sha512-ojKiDvcmByhwa8YYqbQI/hg7MEU0NC03+pSdEq4ZUnZR9xXpwk7E43SMNGkn+JxJGPFtNvQ48+vV2p+P1ml5PA==}
 
   cssesc@3.0.0:
     resolution: {integrity: sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==}
@@ -3513,6 +3545,9 @@ packages:
     resolution: {integrity: sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==}
     engines: {node: '>=0.10.0'}
 
+  defu@6.1.7:
+    resolution: {integrity: sha512-7z22QmUWiQ/2d0KkdYmANbRUVABpZ9SNYyH5vx6PZ+nE5bcC0l7uFvEfHlyld/HcGBFTL536ClDt3DEcSlEJAQ==}
+
   delaunator@5.0.1:
     resolution: {integrity: sha512-8nvh+XBe96aCESrGOqMp/84b13H9cdKbG5P2ejQCh4d4sK9RL4371qou9drQjMhvnPmhWl5hnmqbEE0fXr9Xnw==}
 
@@ -3531,6 +3566,9 @@ packages:
   dequal@2.0.3:
     resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
     engines: {node: '>=6'}
+
+  destr@2.0.5:
+    resolution: {integrity: sha512-ugFTXCtDZunbzasqBxrK93Ik/DRYsO6S/fedkWEMKqt04xZ4csmnmwGDBAb07QWNaGMAmnTIemsYZCksjATwsA==}
 
   detect-indent@6.1.0:
     resolution: {integrity: sha512-reYkTUJAZb9gUuZ2RvVCNhVHdg62RHnJ7WJl8ftMi4diZ6NWlciOzQN88pUhSELEwflJht4oQDv0F0BMlwaYtA==}
@@ -3965,6 +4003,9 @@ packages:
     resolution: {integrity: sha512-BL/Xd/T9baO6NFzoMpiMD7YUZ62R6viR5tp/MULVEnbYJXZA//kRNW7J0j1w/wXArgL0sCxhDfK5dczSKn3+cg==}
     engines: {node: '>= 10.x'}
 
+  h3@1.15.11:
+    resolution: {integrity: sha512-L3THSe2MPeBwgIZVSH5zLdBBU90TOxarvhK9d04IDY2AmVS8j2Jz2LIWtwsGOU3lu2I5jCN7FNvVfY2+XyF+mg==}
+
   hachure-fill@0.5.2:
     resolution: {integrity: sha512-3GKBOn+m2LX9iq+JC1064cSFprJY4jL1jCXTcpnfER5HYE2l/4EfWSGzkPa/ZDBmYI0ZOEj5VHV/eKnPGkHuOg==}
 
@@ -4105,6 +4146,9 @@ packages:
   ipaddr.js@1.9.1:
     resolution: {integrity: sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==}
     engines: {node: '>= 0.10'}
+
+  iron-webcrypto@1.2.1:
+    resolution: {integrity: sha512-feOM6FaSr6rEABp/eDfVseKyTMDt+KGpeB35SkVn9Tyn0CqvVsY3EwI0v5i8nMHyJnzCIQf7nsy3p41TPkJZhg==}
 
   is-alphabetical@2.0.1:
     resolution: {integrity: sha512-FWyyY60MeTNyeSRpkM2Iry0G9hpr7/9kD40mD/cGQEuilcZYS4okz8SN2Q6rLCJ8gbCt6fN+rC+6tMGS99LaxQ==}
@@ -4433,6 +4477,10 @@ packages:
 
   lru-cache@11.2.6:
     resolution: {integrity: sha512-ESL2CrkS/2wTPfuend7Zhkzo2u0daGJ/A2VucJOgQ/C48S/zB8MMeMHSGKYpXhIjbPxfuezITkaBH1wqv00DDQ==}
+    engines: {node: 20 || >=22}
+
+  lru-cache@11.3.2:
+    resolution: {integrity: sha512-wgWa6FWQ3QRRJbIjbsldRJZxdxYngT/dO0I5Ynmlnin8qy7tC6xYzbcJjtN4wHLXtkbVwHzk0C+OejVw1XM+DQ==}
     engines: {node: 20 || >=22}
 
   lru-cache@6.0.0:
@@ -4816,9 +4864,19 @@ packages:
     engines: {node: '>=10.5.0'}
     deprecated: Use your platform's native DOMException instead
 
+  node-fetch-native@1.6.7:
+    resolution: {integrity: sha512-g9yhqoedzIUm0nTnTqAQvueMPVOuIY16bqgAJJC8XOOubYFNwz6IER9qs0Gq2Xd0+CecCKFjtdDTMA4u4xG06Q==}
+
   node-fetch@3.3.2:
     resolution: {integrity: sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+
+  node-mock-http@1.0.4:
+    resolution: {integrity: sha512-8DY+kFsDkNXy1sJglUfuODx1/opAGJGyrTuFqEoN90oRc2Vk0ZbD4K2qmKXBBEhZQzdKHIVfEJpDU8Ak2NJEvQ==}
+
+  normalize-path@3.0.0:
+    resolution: {integrity: sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==}
+    engines: {node: '>=0.10.0'}
 
   npm-to-yarn@3.0.1:
     resolution: {integrity: sha512-tt6PvKu4WyzPwWUzy/hvPFqn+uwXO0K1ZHka8az3NnrhWJDmSqI8ncWq0fkL0k/lmmi5tAC11FXwXuh0rFbt1A==}
@@ -4839,6 +4897,9 @@ packages:
 
   obug@2.1.1:
     resolution: {integrity: sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==}
+
+  ofetch@1.5.1:
+    resolution: {integrity: sha512-2W4oUZlVaqAPAil6FUg/difl6YhqhUR7x2eZY4bQCko22UXg3hptq9KLQdqFClV+Wu85UX7hNtdGTngi/1BxcA==}
 
   on-finished@2.4.1:
     resolution: {integrity: sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==}
@@ -5097,6 +5158,9 @@ packages:
         optional: true
       '@types/react-dom':
         optional: true
+
+  radix3@1.1.2:
+    resolution: {integrity: sha512-b484I/7b8rDEdSDKckSSBA8knMpcdsXudlE/LNL639wFoHKwLbEkQFZHWEYwDC0wa0FKUcCY+GAF73Z7wxNVFA==}
 
   range-parser@1.2.1:
     resolution: {integrity: sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==}
@@ -5675,6 +5739,9 @@ packages:
   ufo@1.6.1:
     resolution: {integrity: sha512-9a4/uxlTWJ4+a5i0ooc1rU7C7YOw3wT+UGqdeNNHWnOF9qcMBgLRS+4IYUqbczewFx4mLEig6gawh7X6mFlEkA==}
 
+  ufo@1.6.3:
+    resolution: {integrity: sha512-yDJTmhydvl5lJzBmy/hyOAA0d+aqCBuwl818haVdYCRrWV84o7YyeVm4QlVHStqNrrJSTb6jKuFAVqAFsr+K3Q==}
+
   ultracite@7.2.4:
     resolution: {integrity: sha512-3b2g2pwZMDSd+PBK8pxYCjEoYaqVSgXD22HS22BxR8GfbmRXJ3VpNu5Z5lNywIxZXsJleWdpGPHibOPYr/xmKg==}
     hasBin: true
@@ -5683,6 +5750,9 @@ packages:
     peerDependenciesMeta:
       oxlint:
         optional: true
+
+  uncrypto@0.1.3:
+    resolution: {integrity: sha512-Ql87qFHB3s/De2ClA9e0gsnS6zXG27SkTiSJwjCc9MebbfapQfuPzumMIUMi38ezPZVNFcHI9sUIepeQfw8J8Q==}
 
   undici-types@7.18.2:
     resolution: {integrity: sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==}
@@ -5734,6 +5804,68 @@ packages:
   unpipe@1.0.0:
     resolution: {integrity: sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==}
     engines: {node: '>= 0.8'}
+
+  unstorage@1.17.5:
+    resolution: {integrity: sha512-0i3iqvRfx29hkNntHyQvJTpf5W9dQ9ZadSoRU8+xVlhVtT7jAX57fazYO9EHvcRCfBCyi5YRya7XCDOsbTgkPg==}
+    peerDependencies:
+      '@azure/app-configuration': ^1.8.0
+      '@azure/cosmos': ^4.2.0
+      '@azure/data-tables': ^13.3.0
+      '@azure/identity': ^4.6.0
+      '@azure/keyvault-secrets': ^4.9.0
+      '@azure/storage-blob': ^12.26.0
+      '@capacitor/preferences': ^6 || ^7 || ^8
+      '@deno/kv': '>=0.9.0'
+      '@netlify/blobs': ^6.5.0 || ^7.0.0 || ^8.1.0 || ^9.0.0 || ^10.0.0
+      '@planetscale/database': ^1.19.0
+      '@upstash/redis': ^1.34.3
+      '@vercel/blob': '>=0.27.1'
+      '@vercel/functions': ^2.2.12 || ^3.0.0
+      '@vercel/kv': ^1 || ^2 || ^3
+      aws4fetch: ^1.0.20
+      db0: '>=0.2.1'
+      idb-keyval: ^6.2.1
+      ioredis: ^5.4.2
+      uploadthing: ^7.4.4
+    peerDependenciesMeta:
+      '@azure/app-configuration':
+        optional: true
+      '@azure/cosmos':
+        optional: true
+      '@azure/data-tables':
+        optional: true
+      '@azure/identity':
+        optional: true
+      '@azure/keyvault-secrets':
+        optional: true
+      '@azure/storage-blob':
+        optional: true
+      '@capacitor/preferences':
+        optional: true
+      '@deno/kv':
+        optional: true
+      '@netlify/blobs':
+        optional: true
+      '@planetscale/database':
+        optional: true
+      '@upstash/redis':
+        optional: true
+      '@vercel/blob':
+        optional: true
+      '@vercel/functions':
+        optional: true
+      '@vercel/kv':
+        optional: true
+      aws4fetch:
+        optional: true
+      db0:
+        optional: true
+      idb-keyval:
+        optional: true
+      ioredis:
+        optional: true
+      uploadthing:
+        optional: true
 
   url-template@2.0.8:
     resolution: {integrity: sha512-XdVKMF4SJ0nP/O7XIPB0JwAEuT9lDIYnNsK8yGVe43y0AWoKeJNdv3ZNWh7ksJ6KqQFjOO6ox/VEitLnaVNufw==}
@@ -8335,6 +8467,11 @@ snapshots:
 
   any-promise@1.3.0: {}
 
+  anymatch@3.1.3:
+    dependencies:
+      normalize-path: 3.0.0
+      picomatch: 2.3.1
+
   argparse@1.0.10:
     dependencies:
       sprintf-js: 1.0.3
@@ -8553,6 +8690,8 @@ snapshots:
 
   content-type@1.0.5: {}
 
+  cookie-es@1.2.3: {}
+
   cookie-signature@1.2.2: {}
 
   cookie@0.7.2: {}
@@ -8575,6 +8714,10 @@ snapshots:
       path-key: 3.1.1
       shebang-command: 2.0.0
       which: 2.0.2
+
+  crossws@0.3.5:
+    dependencies:
+      uncrypto: 0.1.3
 
   cssesc@3.0.0: {}
 
@@ -8813,6 +8956,8 @@ snapshots:
 
   deepmerge@4.3.1: {}
 
+  defu@6.1.7: {}
+
   delaunator@5.0.1:
     dependencies:
       robust-predicates: 3.0.2
@@ -8824,6 +8969,8 @@ snapshots:
   depd@2.0.0: {}
 
   dequal@2.0.3: {}
+
+  destr@2.0.5: {}
 
   detect-indent@6.1.0: {}
 
@@ -9368,6 +9515,18 @@ snapshots:
 
   graphql@15.10.1: {}
 
+  h3@1.15.11:
+    dependencies:
+      cookie-es: 1.2.3
+      crossws: 0.3.5
+      defu: 6.1.7
+      destr: 2.0.5
+      iron-webcrypto: 1.2.1
+      node-mock-http: 1.0.4
+      radix3: 1.1.2
+      ufo: 1.6.3
+      uncrypto: 0.1.3
+
   hachure-fill@0.5.2: {}
 
   has-flag@4.0.0: {}
@@ -9607,6 +9766,8 @@ snapshots:
       - supports-color
 
   ipaddr.js@1.9.1: {}
+
+  iron-webcrypto@1.2.1: {}
 
   is-alphabetical@2.0.1: {}
 
@@ -9883,6 +10044,8 @@ snapshots:
   lru-cache@10.4.3: {}
 
   lru-cache@11.2.6: {}
+
+  lru-cache@11.3.2: {}
 
   lru-cache@6.0.0:
     dependencies:
@@ -10551,11 +10714,17 @@ snapshots:
 
   node-domexception@1.0.0: {}
 
+  node-fetch-native@1.6.7: {}
+
   node-fetch@3.3.2:
     dependencies:
       data-uri-to-buffer: 4.0.1
       fetch-blob: 3.2.0
       formdata-polyfill: 4.0.10
+
+  node-mock-http@1.0.4: {}
+
+  normalize-path@3.0.0: {}
 
   npm-to-yarn@3.0.1: {}
 
@@ -10570,6 +10739,12 @@ snapshots:
   object-inspect@1.13.4: {}
 
   obug@2.1.1: {}
+
+  ofetch@1.5.1:
+    dependencies:
+      destr: 2.0.5
+      node-fetch-native: 1.6.7
+      ufo: 1.6.3
 
   on-finished@2.4.1:
     dependencies:
@@ -10878,6 +11053,8 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.7
       '@types/react-dom': 19.2.3(@types/react@19.2.7)
+
+  radix3@1.1.2: {}
 
   range-parser@1.2.1: {}
 
@@ -11580,6 +11757,8 @@ snapshots:
 
   ufo@1.6.1: {}
 
+  ufo@1.6.3: {}
+
   ultracite@7.2.4:
     dependencies:
       '@clack/prompts': 1.0.1
@@ -11588,6 +11767,8 @@ snapshots:
       glob: 13.0.6
       jsonc-parser: 3.3.1
       nypm: 0.6.5
+
+  uncrypto@0.1.3: {}
 
   undici-types@7.18.2: {}
 
@@ -11653,6 +11834,19 @@ snapshots:
   universalify@0.1.2: {}
 
   unpipe@1.0.0: {}
+
+  unstorage@1.17.5(ioredis@5.8.2):
+    dependencies:
+      anymatch: 3.1.3
+      chokidar: 5.0.0
+      destr: 2.0.5
+      h3: 1.15.11
+      lru-cache: 11.3.2
+      node-fetch-native: 1.6.7
+      ofetch: 1.5.1
+      ufo: 1.6.3
+    optionalDependencies:
+      ioredis: 5.8.2
 
   url-template@2.0.8: {}
 

--- a/skills/chat/SKILL.md
+++ b/skills/chat/SKILL.md
@@ -171,6 +171,7 @@ await thread.post(
 |--------------|---------|---------|
 | Redis | `@chat-adapter/state-redis` | `createRedisState` |
 | ioredis | `@chat-adapter/state-ioredis` | `createIoRedisState` |
+| Unstorage | `@chat-adapter/state-unstorage` | `createUnstorageState` |
 | PostgreSQL | `@chat-adapter/state-pg` | `createPostgresState` |
 | Memory | `@chat-adapter/state-memory` | `createMemoryState` |
 

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -14,6 +14,7 @@ export default defineConfig({
       "packages/state-ioredis",
       "packages/state-memory",
       "packages/state-redis",
+      "packages/state-unstorage",
     ],
   },
 });


### PR DESCRIPTION
## Summary
- add a new `@chat-adapter/state-unstorage` package implementing the full `StateAdapter` surface on top of `unstorage`, with JSDoc for in-IDE docs
- include a comprehensive test suite mirroring state adapter compatibility scenarios (locks, cache, lists, queue, connection behavior) and switch subscriptions to per-key storage (`sub:<threadId>`) to avoid list RMW
- wire the new package into workspace/integration checks and update docs/catalog references across README, docs pages, adapters catalog, and chat skill table

## Validation
- `pnpm --filter @chat-adapter/state-unstorage test`
- `pnpm --filter @chat-adapter/state-unstorage build`
- `pnpm --filter @chat-adapter/integration-tests test`
- `pnpm validate`