### PR TITLE
[slack] [bug] preserve self mentions in multi-workspace installs

### DIFF
--- a/.changeset/slack-multi-workspace-self-mention.md
+++ b/.changeset/slack-multi-workspace-self-mention.md
@@ -1,0 +1,5 @@
+---
+"@chat-adapter/slack": patch
+---
+
+Fix self-mention detection in multi-workspace installs by using the request-scoped bot user ID instead of the adapter-level default

--- a/packages/adapter-slack/src/index.test.ts
+++ b/packages/adapter-slack/src/index.test.ts
@@ -3628,6 +3628,18 @@ describe("error handling", () => {
 
 describe("resolveInlineMentions", () => {
   const secret = "test-signing-secret";
+  interface AdapterWithMentionContext {
+    requestContext: {
+      run<T>(
+        store: { token: string; botUserId?: string },
+        callback: () => Promise<T>
+      ): Promise<T>;
+    };
+    resolveInlineMentions(
+      text: string,
+      skipSelfMention: boolean
+    ): Promise<string>;
+  }
 
   it("resolves user mentions in incoming messages via webhook", async () => {
     const state = createMockState();
@@ -3729,6 +3741,41 @@ describe("resolveInlineMentions", () => {
 
     // Bot mention should NOT be resolved (kept as-is for mention detection)
     expect(message.text).toContain("@U_BOT");
+  });
+
+  it("skips request-scoped self mention resolution in multi-workspace mode", async () => {
+    const state = createMockState();
+    const chatInstance = createMockChatInstance(state);
+    const adapter = createSlackAdapter({
+      signingSecret: secret,
+      logger: mockLogger,
+    });
+    await adapter.initialize(chatInstance);
+
+    const usersInfoMock = vi.fn().mockResolvedValue({
+      ok: true,
+      user: {
+        name: "workspacebot",
+        real_name: "Workspace Bot",
+        profile: {
+          display_name: "Workspace Bot",
+          real_name: "Workspace Bot",
+        },
+      },
+    });
+    mockClientMethod(adapter, "users.info", usersInfoMock);
+
+    const mentionAdapter = adapter as unknown as AdapterWithMentionContext;
+    const result = await mentionAdapter.requestContext.run(
+      {
+        token: "xoxb-multi-token",
+        botUserId: "U_BOT_MULTI",
+      },
+      () => mentionAdapter.resolveInlineMentions("<@U_BOT_MULTI> help me", true)
+    );
+
+    expect(result).toBe("<@U_BOT_MULTI> help me");
+    expect(usersInfoMock).not.toHaveBeenCalled();
   });
 
   it("resolves bare channel mentions in incoming messages", async () => {

--- a/packages/adapter-slack/src/index.ts
+++ b/packages/adapter-slack/src/index.ts
@@ -1705,8 +1705,10 @@ export class SlackAdapter implements Adapter<SlackThreadId, unknown> {
    *
    * @param skipSelfMention - When true, skips the bot's own user ID so that
    *   mention detection (which looks for @botUserId in the text) continues to
-   *   work. Set to false when parsing historical/channel messages where mention
-   *   detection doesn't apply.
+   *   work. Uses the effective request-scoped bot user ID in multi-workspace
+   *   mode, not only the adapter's default bot user ID. Set to false when
+   *   parsing historical/channel messages where mention detection doesn't
+   *   apply.
    */
   private async resolveInlineMentions(
     text: string,
@@ -1743,8 +1745,9 @@ export class SlackAdapter implements Adapter<SlackThreadId, unknown> {
 
     // Don't resolve the bot's own mention when processing incoming webhooks —
     // detectMention needs @botUserId in the text
-    if (skipSelfMention && this._botUserId) {
-      userIds.delete(this._botUserId);
+    const currentBotUserId = this.botUserId;
+    if (skipSelfMention && currentBotUserId) {
+      userIds.delete(currentBotUserId);
     }
     if (userIds.size === 0 && channelIds.size === 0) {
       return text;

--- a/packages/integration-tests/src/replay-multi-workspace-slack.test.ts
+++ b/packages/integration-tests/src/replay-multi-workspace-slack.test.ts
@@ -112,6 +112,84 @@ describe("Slack Multi-Workspace Replay Tests", () => {
     );
   });
 
+  it("should skip bot self lookup for plain message mentions in multi-workspace installs", async () => {
+    mockClient.users.info.mockImplementation(async ({ user }) => {
+      if (user === team1.mention.event.user) {
+        return {
+          ok: true,
+          user: {
+            id: user,
+            name: "sender-one",
+            real_name: "Sender One",
+            profile: {
+              display_name: "Sender One",
+              real_name: "Sender One",
+            },
+          },
+        };
+      }
+
+      if (user === team1.botUserId) {
+        return {
+          ok: true,
+          user: {
+            id: user,
+            name: "workspacebot",
+            real_name: "Workspace Bot",
+            profile: {
+              display_name: "Workspace Bot",
+              real_name: "Workspace Bot",
+            },
+          },
+        };
+      }
+
+      return {
+        ok: true,
+        user: {
+          id: user,
+          name: "unknown",
+          real_name: "Unknown User",
+        },
+      };
+    });
+
+    const plainMessageMention = {
+      type: "event_callback",
+      team_id: team1.teamId,
+      event_id: "Ev-multi-message-mention",
+      event_time: 1770677999,
+      event: {
+        type: "message",
+        user: team1.mention.event.user,
+        text: `<@${team1.botUserId}> hello from a plain message`,
+        ts: "1770677999.000001",
+        thread_ts: "1770677999.000001",
+        team: team1.teamId,
+        channel: team1.mention.event.channel,
+      },
+    };
+
+    await chat.webhooks.slack(
+      createSignedSlackRequest(JSON.stringify(plainMessageMention)),
+      { waitUntil: tracker.waitUntil }
+    );
+    await tracker.waitForAll();
+
+    expect(capturedMention).not.toBeNull();
+    expect(capturedMention?.message.text).toBe(
+      `@${team1.botUserId} hello from a plain message`
+    );
+    expect(mockClient.users.info).not.toHaveBeenCalledWith(
+      expect.objectContaining({ user: team1.botUserId })
+    );
+    expect(mockClient.chat.postMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        token: "xoxb-multi-workspace-token",
+      })
+    );
+  });
+
   it("should reject webhook when no installation exists for team", async () => {
     // Delete the installation
     await adapter.deleteInstallation(team1.teamId);


### PR DESCRIPTION
## Summary
In multi-workspace Slack installs, the adapter was only preserving self mentions with the adapter-level `_botUserId`. For OAuth-installed workspaces, the active bot identity is request-scoped, so `<@BOT_USER_ID>` could be rewritten before mention detection ran.

This change makes self-mention preservation use the effective request-scoped `botUserId`, so plain Slack `message` events still trigger `onNewMention()` correctly in multi-workspace installs.

## What changed
- use `this.botUserId` instead of only `_botUserId` in `resolveInlineMentions()`
- add a unit regression for request-scoped multi-workspace bot identity
- add a replay regression covering a plain `message` event with a bot self mention

`this.botUserId` already falls back to `_botUserId` when there is no request-scoped context, so single-workspace behavior stays the same.

## Note
The core bug affects plain Slack `message` events that rely on fallback mention detection. `app_mention` events are already marked as mentions separately.