### PR TITLE
[gchat] [bug] render markdown links with proper Google Chat custom link syntax

### DIFF
--- a/.changeset/gchat-link-labels.md
+++ b/.changeset/gchat-link-labels.md
@@ -1,0 +1,5 @@
+---
+"@chat-adapter/gchat": patch
+---
+
+Preserve custom link labels in Google Chat text messages by rendering Markdown links with Google Chat's supported `<url|text>` syntax.

--- a/packages/adapter-gchat/src/markdown.test.ts
+++ b/packages/adapter-gchat/src/markdown.test.ts
@@ -43,10 +43,10 @@ describe("GoogleChatFormatConverter", () => {
       expect(result).toContain("https://example.com");
     });
 
-    it("should output 'text (url)' when link text differs", () => {
+    it("should output Google Chat custom link syntax when link text differs", () => {
       const ast = converter.toAst("[click here](https://example.com)");
       const result = converter.fromAst(ast);
-      expect(result).toContain("click here (https://example.com)");
+      expect(result).toContain("<https://example.com|click here>");
     });
 
     it("should handle blockquotes", () => {

--- a/packages/adapter-gchat/src/markdown.ts
+++ b/packages/adapter-gchat/src/markdown.ts
@@ -106,16 +106,14 @@ export class GoogleChatFormatConverter extends BaseFormatConverter {
     }
 
     if (isLinkNode(node)) {
-      // Google Chat auto-detects links, so we just output the URL
+      // Google Chat supports custom link labels using <url|text> syntax.
       const linkText = getNodeChildren(node)
         .map((child) => this.nodeToGChat(child))
         .join("");
-      // If link text matches URL, just output URL
       if (linkText === node.url) {
         return node.url;
       }
-      // Otherwise output "text (url)"
-      return `${linkText} (${node.url})`;
+      return `<${node.url}|${linkText}>`;
     }
 
     if (isBlockquoteNode(node)) {

--- a/packages/integration-tests/src/gchat.test.ts
+++ b/packages/integration-tests/src/gchat.test.ts
@@ -415,6 +415,32 @@ describe("Google Chat Integration", () => {
       expect(sent.text).toContain("`code`");
     });
 
+    it("should preserve custom link labels in posted messages", async () => {
+      chat.onNewMention(async (thread) => {
+        await thread.post({
+          markdown: "[Click here](https://example.com)",
+        });
+      });
+
+      const event = createGoogleChatEvent({
+        text: `@${GCHAT_BOT_NAME} link test`,
+        messageName: `${TEST_SPACE_NAME}/messages/msg-001`,
+        spaceName: TEST_SPACE_NAME,
+        threadName: TEST_THREAD_NAME,
+        senderId: "users/user-123",
+        senderName: "John Doe",
+        hasBotMention: true,
+      });
+
+      await chat.webhooks.gchat(createGoogleChatWebhookRequest(event), {
+        waitUntil: tracker.waitUntil,
+      });
+      await tracker.waitForAll();
+
+      const sent = mockChatApi.sentMessages[0];
+      expect(sent.text).toBe("<https://example.com|Click here>");
+    });
+
     it("should pass @mentions through as-is in posted messages", async () => {
       chat.onNewMention(async (thread) => {
         await thread.post("Hey @john, check this out!");


### PR DESCRIPTION
Fix Google Chat markdown link rendering so labeled links preserve their custom text instead of degrading to `text (url)`.
Render markdown links using Google Chat’s supported <url|text> syntax in @chat-adapter/gchat.

Before/after:
<img width="876" height="273" alt="image" src="https://github.com/user-attachments/assets/4e4b109a-143f-4888-af83-b88b126cbb19" />
