### PR TITLE
fix(chat): guard fallback streaming against empty content

### DIFF
--- a/.changeset/small-glasses-cough.md
+++ b/.changeset/small-glasses-cough.md
@@ -1,0 +1,5 @@
+---
+"chat": patch
+---
+
+guard fallback streaming against empty post and edit calls

--- a/packages/chat/src/thread.test.ts
+++ b/packages/chat/src/thread.test.ts
@@ -320,12 +320,8 @@ describe("ThreadImpl", () => {
         "slack:C123:1234.5678",
         "..."
       );
-      // Should edit with empty string wrapped as markdown (final content)
-      expect(mockAdapter.editMessage).toHaveBeenLastCalledWith(
-        "slack:C123:1234.5678",
-        "msg-1",
-        { markdown: "" }
-      );
+      // Should not edit with empty content
+      expect(mockAdapter.editMessage).not.toHaveBeenCalled();
     });
 
     it("should support disabling the placeholder for fallback streaming", async () => {
@@ -367,13 +363,79 @@ describe("ThreadImpl", () => {
       const textStream = createTextStream([]);
       await threadNoPlaceholder.post(textStream);
 
-      // Should still post a message (empty) even with no chunks, wrapped as markdown
+      // Should post a non-empty fallback since stream must return a SentMessage
       expect(mockAdapter.postMessage).toHaveBeenCalledWith(
         "slack:C123:1234.5678",
-        { markdown: "" }
+        { markdown: " " }
       );
-      // No edit needed since post content matches accumulated
       expect(mockAdapter.editMessage).not.toHaveBeenCalled();
+    });
+
+    it("should not post empty content when table is buffered with null placeholder", async () => {
+      mockAdapter.stream = undefined;
+
+      const threadNoPlaceholder = new ThreadImpl({
+        id: "slack:C123:1234.5678",
+        adapter: mockAdapter,
+        channelId: "C123",
+        stateAdapter: mockState,
+        fallbackStreamingPlaceholderText: null,
+      });
+
+      const textStream = createTextStream([
+        "| A | B |\n",
+        "|---|---|\n",
+        "| 1 | 2 |\n",
+      ]);
+      await threadNoPlaceholder.post(textStream);
+
+      const postCalls = (mockAdapter.postMessage as ReturnType<typeof vi.fn>)
+        .mock.calls;
+      for (const call of postCalls) {
+        const content = call[1];
+        if (typeof content === "object" && "markdown" in content) {
+          expect(content.markdown.trim().length).toBeGreaterThan(0);
+        }
+      }
+    });
+
+    it("should not edit placeholder to empty during LLM warm-up", async () => {
+      mockAdapter.stream = undefined;
+      const editFn = mockAdapter.editMessage as ReturnType<typeof vi.fn>;
+
+      const textStream = createTextStream(["Hello world"]);
+      await thread.post(textStream);
+
+      for (const call of editFn.mock.calls) {
+        const content = call[2];
+        if (typeof content === "object" && "markdown" in content) {
+          expect(content.markdown.trim().length).toBeGreaterThan(0);
+        }
+      }
+    });
+
+    it("should not post empty content during streaming with whitespace chunks", async () => {
+      mockAdapter.stream = undefined;
+
+      const threadNoPlaceholder = new ThreadImpl({
+        id: "slack:C123:1234.5678",
+        adapter: mockAdapter,
+        channelId: "C123",
+        stateAdapter: mockState,
+        fallbackStreamingPlaceholderText: null,
+      });
+
+      const textStream = createTextStream(["  ", "\n", "  \n"]);
+      await threadNoPlaceholder.post(textStream);
+
+      const postCalls = (mockAdapter.postMessage as ReturnType<typeof vi.fn>)
+        .mock.calls;
+      for (const call of postCalls) {
+        const content = call[1];
+        if (typeof content === "object" && "markdown" in content) {
+          expect(content.markdown.length).toBeGreaterThan(0);
+        }
+      }
     });
 
     it("should preserve newlines in streamed text (native path)", async () => {

--- a/packages/chat/src/thread.ts
+++ b/packages/chat/src/thread.ts
@@ -645,7 +645,7 @@ export class ThreadImpl<TState = Record<string, unknown>>
       }
 
       const content = renderer.render();
-      if (content !== lastEditContent) {
+      if (content.trim() && content !== lastEditContent) {
         try {
           await this.adapter.editMessage(threadIdForEdits, msg.id, {
             markdown: content,
@@ -671,12 +671,14 @@ export class ThreadImpl<TState = Record<string, unknown>>
         renderer.push(chunk);
         if (!msg) {
           const content = renderer.render();
-          msg = await this.adapter.postMessage(this.id, {
-            markdown: content,
-          });
-          threadIdForEdits = msg.threadId || this.id;
-          lastEditContent = content;
-          scheduleNextEdit();
+          if (content.trim()) {
+            msg = await this.adapter.postMessage(this.id, {
+              markdown: content,
+            });
+            threadIdForEdits = msg.threadId || this.id;
+            lastEditContent = content;
+            scheduleNextEdit();
+          }
         }
       }
     } finally {
@@ -697,13 +699,13 @@ export class ThreadImpl<TState = Record<string, unknown>>
 
     if (!msg) {
       msg = await this.adapter.postMessage(this.id, {
-        markdown: accumulated,
+        markdown: accumulated.trim() ? accumulated : " ",
       });
       threadIdForEdits = msg.threadId || this.id;
       lastEditContent = accumulated;
     }
 
-    if (finalContent !== lastEditContent) {
+    if (finalContent.trim() && finalContent !== lastEditContent) {
       await this.adapter.editMessage(threadIdForEdits, msg.id, {
         markdown: accumulated,
       });


### PR DESCRIPTION
## summary

fallback streaming (post+edit) can send empty content to platform APIs that reject it (Telegram requires 1-4096 characters for both sendMessage and editMessageText)

three guards added to fallbackStream:
- skip intermediate edits when renderer returns empty (e.g. table buffering, LLM warm-up)
- skip first post when placeholder is null and renderer has no committable content yet
- skip final edit when accumulated content is empty

closes #276
closes #350