### PR TITLE
perf(markdown): cache unified processors for parse and stringify

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-06-25 - Unified/Remark Processor Bottleneck
+**Learning:** Instantiating `unified()` processors with plugins (`remarkParse`, `remarkGfm`, `remarkStringify`) on every call is a significant performance bottleneck in high-throughput parsing/stringifying scenarios.
+**Action:** Always cache the processor instance at the module level (using static instance for parsing and a Map based on options for stringifying) rather than recreating them per call.

--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,3 +1,0 @@
-## 2024-06-25 - Unified/Remark Processor Bottleneck
-**Learning:** Instantiating `unified()` processors with plugins (`remarkParse`, `remarkGfm`, `remarkStringify`) on every call is a significant performance bottleneck in high-throughput parsing/stringifying scenarios.
-**Action:** Always cache the processor instance at the module level (using static instance for parsing and a Map based on options for stringifying) rather than recreating them per call.

--- a/packages/chat/src/markdown.ts
+++ b/packages/chat/src/markdown.ts
@@ -255,12 +255,17 @@ export function getNodeValue(node: Content): string {
 }
 
 /**
+ * Cached processor for parsing markdown to avoid recreating on each call.
+ * This improves performance significantly for high-throughput scenarios.
+ */
+const cachedParseProcessor = unified().use(remarkParse).use(remarkGfm);
+
+/**
  * Parse markdown string into an AST.
  * Supports GFM (GitHub Flavored Markdown) for strikethrough, tables, etc.
  */
 export function parseMarkdown(markdown: string): Root {
-  const processor = unified().use(remarkParse).use(remarkGfm);
-  return processor.parse(markdown);
+  return cachedParseProcessor.parse(markdown);
 }
 
 /**
@@ -274,14 +279,27 @@ export interface StringifyOptions {
 }
 
 /**
+ * Cache for stringify processors to avoid recreating them for the same options.
+ */
+const stringifyProcessorsCache = new Map<string, any>();
+
+/**
  * Stringify an AST back to markdown.
  */
 export function stringifyMarkdown(
   ast: Root,
   options?: StringifyOptions
 ): string {
-  const processor = unified().use(remarkStringify, options).use(remarkGfm);
-  return processor.stringify(ast);
+  // Use a string key based on options to cache the processor
+  const cacheKey = options ? JSON.stringify(options) : "default";
+
+  let processor = stringifyProcessorsCache.get(cacheKey);
+  if (!processor) {
+    processor = unified().use(remarkStringify, options).use(remarkGfm);
+    stringifyProcessorsCache.set(cacheKey, processor);
+  }
+
+  return String(processor.stringify(ast));
 }
 
 /**


### PR DESCRIPTION
## Summary

This PR improves markdown processing performance by caching the `unified` processors used in `packages/chat/src/markdown.ts` instead of recreating them on every call.

## What changed

* cached the `unified` processor for markdown parsing
* cached the `unified` processor for markdown stringifying
* reused the cached processors across repeated `parseMarkdown` and `stringifyMarkdown` calls

## Why

Previously, the `unified().use(...)` pipeline was instantiated repeatedly for every parse and stringify operation. That setup work is relatively expensive and adds unnecessary overhead in higher-throughput paths.

## Impact

* reduces repeated processor construction overhead
* improves performance for frequent markdown parse/stringify calls
* preserves existing behavior while making repeated operations more efficient

## Measurement

* validated with a simple Node benchmark comparing per-call processor creation vs cached reuse
* observed lower total duration with equivalent output behavior
* expected improvement is most noticeable in workloads with repeated markdown processing

## Verification

* confirmed parsing and stringifying still produce equivalent results
* reviewed the change to ensure processor setup is reused safely
