### PR TITLE
fix(state-memory): use crypto.randomUUID() for lock token generation

### DIFF
--- a/packages/state-memory/src/index.ts
+++ b/packages/state-memory/src/index.ts
@@ -1,3 +1,4 @@
+import crypto from "node:crypto";
 import type { Lock, QueueEntry, StateAdapter } from "chat";
 
 interface MemoryLock extends Lock {
@@ -305,7 +306,7 @@ export class MemoryStateAdapter implements StateAdapter {
 }
 
 function generateToken(): string {
-  return `mem_${Date.now()}_${Math.random().toString(36).substring(2, 15)}`;
+  return `mem_${crypto.randomUUID()}`;
 }
 
 export function createMemoryState(): MemoryStateAdapter {


### PR DESCRIPTION
## Summary

This PR replaces insecure lock token generation in `MemoryStateAdapter` with `crypto.randomUUID()`.

## What changed

* removed `Math.random()` / `Date.now()`-based token generation
* added `node:crypto` import
* updated token creation to use `crypto.randomUUID()`
* preserved the existing `mem_` token prefix format

## Why

The previous implementation used non-cryptographic randomness for lock tokens, which made generated values more predictable than necessary. Even though this adapter is primarily used for development and testing, stronger token generation reduces the risk of accidental collisions or predictable lock values.

## Impact

* improves token unpredictability and uniqueness
* aligns token generation with safer platform primitives
* preserves existing behavior and token format expectations

## Verification

* confirmed `Math.random()`-based generation was fully removed
* verified tokens now follow the expected `mem_<UUID>` format
* checked that the change is consistent with secure token-generation patterns elsewhere in the codebase
