### PR TITLE
feat: support govslack

### DIFF
--- a/packages/adapter-slack/src/index.ts
+++ b/packages/adapter-slack/src/index.ts
@@ -118,10 +118,10 @@ export interface SlackAdapterConfig {
   logger?: Logger;
   /** Signing secret for webhook verification. Defaults to SLACK_SIGNING_SECRET env var. */
   signingSecret?: string;
-  /** Override bot username (optional) */
-  userName?: string;
   /** Override the Slack API base URL (e.g. 'https://slack-gov.com/api/' for GovSlack) */
   slackApiUrl?: "https://slack.com/api/" | "https://slack-gov.com/api/";
+  /** Override bot username (optional) */
+  userName?: string;
 }
 
 export interface SlackOAuthCallbackOptions {

--- a/packages/adapter-slack/src/index.ts
+++ b/packages/adapter-slack/src/index.ts
@@ -120,6 +120,8 @@ export interface SlackAdapterConfig {
   signingSecret?: string;
   /** Override bot username (optional) */
   userName?: string;
+  /** Override the Slack API base URL (e.g. 'https://slack-gov.com/api/' for GovSlack) */
+  slackApiUrl?: "https://slack.com/api/" | "https://slack-gov.com/api/";
 }
 
 export interface SlackOAuthCallbackOptions {
@@ -436,7 +438,7 @@ export class SlackAdapter implements Adapter<SlackThreadId, unknown> {
     const botToken =
       config.botToken ?? (zeroConfig ? process.env.SLACK_BOT_TOKEN : undefined);
 
-    this.client = new WebClient(botToken);
+    this.client = new WebClient(botToken, { slackApiUrl: config.slackApiUrl });
     this.signingSecret = signingSecret;
     this.defaultBotToken = botToken;
     this.logger = config.logger ?? new ConsoleLogger("info").child("slack");


### PR DESCRIPTION
## Summary
- allow the slack API URL to be configured in order to support usage of the chat SDK in a govslack environment

## Test plan
- we run a patched version of this package currently :) 
