### PR TITLE
fix(gchat): clear cards when editing a message to text

### DIFF
--- a/.changeset/gchat-clear-cards-on-text-edit.md
+++ b/.changeset/gchat-clear-cards-on-text-edit.md
@@ -1,0 +1,5 @@
+---
+"@chat-adapter/gchat": patch
+---
+
+Clear cardsV2 when editing a message to plain text so old cards don't persist underneath the new text

--- a/packages/adapter-gchat/src/index.test.ts
+++ b/packages/adapter-gchat/src/index.test.ts
@@ -1384,7 +1384,7 @@ describe("GoogleChatAdapter", () => {
   });
 
   describe("editMessage", () => {
-    it("should call chatApi.spaces.messages.update for text", async () => {
+    it("should update text and clear cards when editing to text", async () => {
       const { adapter } = await createInitializedAdapter();
       const threadId = adapter.encodeThreadId({
         spaceName: "spaces/ABC123",
@@ -1406,9 +1406,10 @@ describe("GoogleChatAdapter", () => {
       expect(mockUpdate).toHaveBeenCalledWith(
         expect.objectContaining({
           name: "spaces/ABC123/messages/msg1",
-          updateMask: "text",
+          updateMask: "text,cardsV2",
           requestBody: expect.objectContaining({
             text: expect.any(String),
+            cardsV2: [],
           }),
         })
       );

--- a/packages/adapter-gchat/src/index.ts
+++ b/packages/adapter-gchat/src/index.ts
@@ -1565,9 +1565,10 @@ export class GoogleChatAdapter implements Adapter<GoogleChatThreadId, unknown> {
 
       const response = await this.chatApi.spaces.messages.update({
         name: messageId,
-        updateMask: "text",
+        updateMask: "text,cardsV2",
         requestBody: {
           text,
+          cardsV2: [],
         },
       });
 


### PR DESCRIPTION
Update the Google Chat adapter so text edits also clear cardsV2.

Google Chat keeps previously attached cards when a message is updated with updateMask: "text" only.
That causes card-based messages edited to plain text to keep rendering the old card underneath the new text.

This change updates the text edit path in editMessage() to send:

```
updateMask: "text,cardsV2"
requestBody: { text, cardsV2: [] }
```

This allows a single in-place edit to convert a card message into a plain text message cleanly.