### PR TITLE
[chat] enable updating task blocks by ID, rather than only most recent

### DIFF
--- a/.changeset/update-task-by-id.md
+++ b/.changeset/update-task-by-id.md
@@ -1,0 +1,5 @@
+---
+"chat": minor
+---
+
+Allow `plan.updateTask()` to target a specific task by ID via `{ id: taskId }` instead of always updating the last in_progress task

--- a/packages/chat/src/plan.ts
+++ b/packages/chat/src/plan.ts
@@ -53,6 +53,8 @@ export interface AddTaskOptions {
 export type UpdateTaskInput =
   | PlanContent
   | {
+      /** Task ID to update. If omitted, updates the last in_progress task. */
+      id?: string;
       /** Task output/results. */
       output?: PlanContent;
       /** Optional status override. */
@@ -224,13 +226,22 @@ export class Plan implements PostableObject<PlanModel> {
       return null;
     }
     let current: PlanModelTask | undefined;
-    for (let i = this._model.tasks.length - 1; i >= 0; i--) {
-      if (this._model.tasks[i].status === "in_progress") {
-        current = this._model.tasks[i];
-        break;
+    if (
+      typeof update === "object" &&
+      update !== null &&
+      "id" in update &&
+      update.id
+    ) {
+      current = this._model.tasks.find((t) => t.id === update.id);
+    } else {
+      for (let i = this._model.tasks.length - 1; i >= 0; i--) {
+        if (this._model.tasks[i].status === "in_progress") {
+          current = this._model.tasks[i];
+          break;
+        }
       }
+      current ??= this._model.tasks.at(-1);
     }
-    current ??= this._model.tasks.at(-1);
 
     if (!current) {
       return null;

--- a/packages/chat/src/thread.test.ts
+++ b/packages/chat/src/thread.test.ts
@@ -1484,6 +1484,75 @@ describe("ThreadImpl", () => {
       expect(mockEditObject).toHaveBeenCalled();
     });
 
+    it("should update a specific task by ID", async () => {
+      const mockPostObject = vi.fn().mockResolvedValue({
+        id: "plan-msg-1",
+        threadId: "slack:C123:1234.5678",
+      });
+      const mockEditObject = vi.fn().mockResolvedValue(undefined);
+      mockAdapter.postObject = mockPostObject;
+      mockAdapter.editObject = mockEditObject;
+
+      const plan = new Plan({ initialMessage: "Start" });
+      await thread.post(plan);
+      const task1 = await plan.addTask({ title: "Step 1" });
+      const task2 = await plan.addTask({ title: "Step 2" });
+
+      const updated = await plan.updateTask({
+        id: task1?.id,
+        output: "Step 1 result",
+        status: "complete",
+      });
+
+      expect(updated).not.toBeNull();
+      expect(updated?.id).toBe(task1?.id);
+      expect(updated?.status).toBe("complete");
+
+      const step2 = plan.tasks.find((t) => t.id === task2?.id);
+      expect(step2?.status).toBe("in_progress");
+    });
+
+    it("should return null when updating by non-existent ID", async () => {
+      const mockPostObject = vi.fn().mockResolvedValue({
+        id: "plan-msg-1",
+        threadId: "slack:C123:1234.5678",
+      });
+      const mockEditObject = vi.fn().mockResolvedValue(undefined);
+      mockAdapter.postObject = mockPostObject;
+      mockAdapter.editObject = mockEditObject;
+
+      const plan = new Plan({ initialMessage: "Start" });
+      await thread.post(plan);
+      await plan.addTask({ title: "Step 1" });
+
+      const updated = await plan.updateTask({
+        id: "non-existent-id",
+        output: "nope",
+      });
+
+      expect(updated).toBeNull();
+    });
+
+    it("should still update last in_progress task when no ID provided", async () => {
+      const mockPostObject = vi.fn().mockResolvedValue({
+        id: "plan-msg-1",
+        threadId: "slack:C123:1234.5678",
+      });
+      const mockEditObject = vi.fn().mockResolvedValue(undefined);
+      mockAdapter.postObject = mockPostObject;
+      mockAdapter.editObject = mockEditObject;
+
+      const plan = new Plan({ initialMessage: "Start" });
+      await thread.post(plan);
+      await plan.addTask({ title: "Step 1" });
+      await plan.addTask({ title: "Step 2" });
+
+      const updated = await plan.updateTask("Some output");
+
+      expect(updated).not.toBeNull();
+      expect(updated?.title).toBe("Step 2");
+    });
+
     it("should complete plan and mark tasks done", async () => {
       const mockPostObject = vi.fn().mockResolvedValue({
         id: "plan-msg-1",


### PR DESCRIPTION
Minor feature gap with the current `plan.updateTask()` – only allows you to update the latest task instead of any posted task by ID. 