### PR TITLE
feat: add apiUrl config option to all platform adapters

### DIFF
--- a/.changeset/adapter-api-url.md
+++ b/.changeset/adapter-api-url.md
@@ -1,0 +1,12 @@
+---
+"@chat-adapter/slack": minor
+"@chat-adapter/discord": minor
+"@chat-adapter/gchat": minor
+"@chat-adapter/github": minor
+"@chat-adapter/linear": minor
+"@chat-adapter/teams": minor
+"@chat-adapter/telegram": minor
+"@chat-adapter/whatsapp": minor
+---
+
+Add `apiUrl` config option for custom API endpoint configuration (e.g. GovSlack, GitHub Enterprise, GCC-High Teams)

--- a/packages/adapter-discord/src/index.test.ts
+++ b/packages/adapter-discord/src/index.test.ts
@@ -181,6 +181,33 @@ describe("constructor env var resolution", () => {
     });
     expect(adapter.userName).toBe("mybot");
   });
+
+  it("should resolve apiUrl from DISCORD_API_URL env var", () => {
+    process.env.DISCORD_BOT_TOKEN = "env-token";
+    process.env.DISCORD_PUBLIC_KEY = testPublicKey;
+    process.env.DISCORD_APPLICATION_ID = "env-app-id";
+    process.env.DISCORD_API_URL = "https://custom-discord.example.com/api/v10";
+    const adapter = new DiscordAdapter();
+    expect((adapter as unknown as { apiBaseUrl: string }).apiBaseUrl).toBe(
+      "https://custom-discord.example.com/api/v10"
+    );
+  });
+
+  it("should prefer apiUrl config over DISCORD_API_URL env var", () => {
+    process.env.DISCORD_BOT_TOKEN = "env-token";
+    process.env.DISCORD_PUBLIC_KEY = testPublicKey;
+    process.env.DISCORD_APPLICATION_ID = "env-app-id";
+    process.env.DISCORD_API_URL = "https://env-url.example.com/api/v10";
+    const adapter = new DiscordAdapter({
+      botToken: "config-token",
+      publicKey: testPublicKey,
+      applicationId: "config-app-id",
+      apiUrl: "https://config-url.example.com/api/v10",
+    });
+    expect((adapter as unknown as { apiBaseUrl: string }).apiBaseUrl).toBe(
+      "https://config-url.example.com/api/v10"
+    );
+  });
 });
 
 // ============================================================================

--- a/packages/adapter-discord/src/index.ts
+++ b/packages/adapter-discord/src/index.ts
@@ -85,6 +85,7 @@ export class DiscordAdapter implements Adapter<DiscordThreadId, unknown> {
   readonly userName: string;
   readonly botUserId?: string;
 
+  private readonly apiBaseUrl: string;
   private readonly botToken: string;
   private readonly publicKey: string;
   private readonly applicationId: string;
@@ -124,6 +125,8 @@ export class DiscordAdapter implements Adapter<DiscordThreadId, unknown> {
       );
     }
 
+    this.apiBaseUrl =
+      config.apiUrl ?? process.env.DISCORD_API_URL ?? DISCORD_API_BASE;
     this.botToken = botToken;
     this.publicKey = publicKey.trim().toLowerCase();
     this.applicationId = applicationId;
@@ -1582,7 +1585,7 @@ export class DiscordAdapter implements Adapter<DiscordThreadId, unknown> {
     method: string,
     body?: unknown
   ): Promise<Response> {
-    const url = `${DISCORD_API_BASE}${path}`;
+    const url = `${this.apiBaseUrl}${path}`;
     const headers: Record<string, string> = {
       Authorization: `Bot ${this.botToken}`,
     };

--- a/packages/adapter-discord/src/types.ts
+++ b/packages/adapter-discord/src/types.ts
@@ -15,6 +15,8 @@ import type {
  * Discord adapter configuration.
  */
 export interface DiscordAdapterConfig {
+  /** Override the Discord API base URL. Defaults to DISCORD_API_URL env var or "https://discord.com/api/v10". */
+  apiUrl?: string;
   /** Discord application ID. Defaults to DISCORD_APPLICATION_ID env var. */
   applicationId?: string;
   /** Discord bot token. Defaults to DISCORD_BOT_TOKEN env var. */

--- a/packages/adapter-gchat/src/index.test.ts
+++ b/packages/adapter-gchat/src/index.test.ts
@@ -389,6 +389,21 @@ describe("GoogleChatAdapter", () => {
       });
       expect(adapter).toBeInstanceOf(GoogleChatAdapter);
     });
+
+    it("should resolve apiUrl from GOOGLE_CHAT_API_URL env var", () => {
+      process.env.GOOGLE_CHAT_CREDENTIALS = JSON.stringify(TEST_CREDENTIALS);
+      process.env.GOOGLE_CHAT_API_URL = "https://custom-chat.googleapis.com";
+      const adapter = new GoogleChatAdapter();
+      expect(adapter).toBeInstanceOf(GoogleChatAdapter);
+    });
+
+    it("should accept apiUrl config", () => {
+      const adapter = new GoogleChatAdapter({
+        credentials: TEST_CREDENTIALS,
+        apiUrl: "https://custom-chat.googleapis.com",
+      });
+      expect(adapter).toBeInstanceOf(GoogleChatAdapter);
+    });
   });
 
   describe("isDM", () => {

--- a/packages/adapter-gchat/src/index.ts
+++ b/packages/adapter-gchat/src/index.ts
@@ -70,6 +70,8 @@ export interface ServiceAccountCredentials {
 
 /** Base config options shared by all auth methods */
 export interface GoogleChatAdapterBaseConfig {
+  /** Override the Google Chat API root URL. Defaults to GOOGLE_CHAT_API_URL env var. */
+  apiUrl?: string;
   /**
    * HTTP endpoint URL for button click actions.
    * Required for HTTP endpoint apps - button clicks will be routed to this URL.
@@ -319,6 +321,7 @@ export class GoogleChatAdapter implements Adapter<GoogleChatThreadId, unknown> {
       config.googleChatProjectNumber ?? process.env.GOOGLE_CHAT_PROJECT_NUMBER;
     this.pubsubAudience =
       config.pubsubAudience ?? process.env.GOOGLE_CHAT_PUBSUB_AUDIENCE;
+    const apiRootUrl = config.apiUrl ?? process.env.GOOGLE_CHAT_API_URL;
 
     let authClient: Parameters<typeof chat>[0]["auth"];
 
@@ -377,7 +380,11 @@ export class GoogleChatAdapter implements Adapter<GoogleChatThreadId, unknown> {
     }
 
     this.authClient = authClient;
-    this.chatApi = chat({ version: "v1", auth: authClient });
+    this.chatApi = chat({
+      version: "v1",
+      auth: authClient,
+      ...(apiRootUrl ? { rootUrl: apiRootUrl } : {}),
+    });
 
     // Create impersonated Chat API for user-context operations (DMs)
     // Domain-wide delegation requires setting the `subject` claim to the impersonated user
@@ -396,6 +403,7 @@ export class GoogleChatAdapter implements Adapter<GoogleChatThreadId, unknown> {
         this.impersonatedChatApi = chat({
           version: "v1",
           auth: impersonatedAuth,
+          ...(apiRootUrl ? { rootUrl: apiRootUrl } : {}),
         });
       } else if (this.useADC) {
         // ADC with impersonation (requires clientOptions.subject support)
@@ -412,6 +420,7 @@ export class GoogleChatAdapter implements Adapter<GoogleChatThreadId, unknown> {
         this.impersonatedChatApi = chat({
           version: "v1",
           auth: impersonatedAuth,
+          ...(apiRootUrl ? { rootUrl: apiRootUrl } : {}),
         });
       }
     }

--- a/packages/adapter-github/src/index.test.ts
+++ b/packages/adapter-github/src/index.test.ts
@@ -2230,6 +2230,7 @@ describe("createGitHubAdapter", () => {
       "GITHUB_PRIVATE_KEY",
       "GITHUB_INSTALLATION_ID",
       "GITHUB_BOT_USERNAME",
+      "GITHUB_API_URL",
     ]) {
       delete process.env[key];
     }
@@ -2336,5 +2337,42 @@ describe("createGitHubAdapter", () => {
       botUserId: 42,
     });
     expect(a.botUserId).toBe("42");
+  });
+
+  it("should accept apiUrl config for GitHub Enterprise", () => {
+    const a = createGitHubAdapter({
+      token: "ghp_test",
+      webhookSecret: "secret",
+      apiUrl: "https://github.example.com/api/v3",
+    });
+    expect(a).toBeInstanceOf(GitHubAdapter);
+    expect((a as unknown as { apiUrl: string }).apiUrl).toBe(
+      "https://github.example.com/api/v3"
+    );
+  });
+
+  it("should resolve apiUrl from GITHUB_API_URL env var", () => {
+    process.env.GITHUB_WEBHOOK_SECRET = "env-secret";
+    process.env.GITHUB_TOKEN = "env-token";
+    process.env.GITHUB_API_URL = "https://github.example.com/api/v3";
+    const a = createGitHubAdapter();
+    expect(a).toBeInstanceOf(GitHubAdapter);
+    expect((a as unknown as { apiUrl: string }).apiUrl).toBe(
+      "https://github.example.com/api/v3"
+    );
+  });
+
+  it("should prefer apiUrl config over GITHUB_API_URL env var", () => {
+    process.env.GITHUB_WEBHOOK_SECRET = "env-secret";
+    process.env.GITHUB_TOKEN = "env-token";
+    process.env.GITHUB_API_URL = "https://env-github.example.com/api/v3";
+    const a = createGitHubAdapter({
+      token: "ghp_test",
+      webhookSecret: "secret",
+      apiUrl: "https://config-github.example.com/api/v3",
+    });
+    expect((a as unknown as { apiUrl: string }).apiUrl).toBe(
+      "https://config-github.example.com/api/v3"
+    );
   });
 });

--- a/packages/adapter-github/src/index.ts
+++ b/packages/adapter-github/src/index.ts
@@ -115,6 +115,8 @@ export class GitHubAdapter
   private readonly fixedInstallationId: number | null;
   // Cache of Octokit instances per installation (for multi-tenant)
   private readonly installationClients = new Map<number, Octokit>();
+  // Custom API base URL (e.g. for GitHub Enterprise)
+  private readonly apiUrl?: string;
 
   private readonly webhookSecret: string;
   private chat: ChatInstance | null = null;
@@ -146,6 +148,7 @@ export class GitHubAdapter
     this.userName =
       config.userName ?? process.env.GITHUB_BOT_USERNAME ?? "github-bot";
     this._botUserId = config.botUserId ?? null;
+    this.apiUrl = config.apiUrl ?? process.env.GITHUB_API_URL;
     let fixedInstallationId: number | null = null;
 
     // Create Octokit instance based on auth method.
@@ -159,7 +162,10 @@ export class GitHubAdapter
 
     if ("token" in config && config.token) {
       // PAT mode - single Octokit instance
-      this.octokit = new Octokit({ auth: config.token });
+      this.octokit = new Octokit({
+        auth: config.token,
+        ...(this.apiUrl ? { baseUrl: this.apiUrl } : {}),
+      });
     } else if (
       "appId" in config &&
       config.appId &&
@@ -176,6 +182,7 @@ export class GitHubAdapter
             privateKey: config.privateKey,
             installationId: config.installationId,
           },
+          ...(this.apiUrl ? { baseUrl: this.apiUrl } : {}),
         });
       } else {
         // Multi-tenant app mode - create clients per installation
@@ -197,7 +204,10 @@ export class GitHubAdapter
       // Auto-detect from env vars
       const token = process.env.GITHUB_TOKEN;
       if (token) {
-        this.octokit = new Octokit({ auth: token });
+        this.octokit = new Octokit({
+          auth: token,
+          ...(this.apiUrl ? { baseUrl: this.apiUrl } : {}),
+        });
       } else {
         const appId = process.env.GITHUB_APP_ID;
         const privateKey = process.env.GITHUB_PRIVATE_KEY;
@@ -210,6 +220,7 @@ export class GitHubAdapter
             this.octokit = new Octokit({
               authStrategy: createAppAuth,
               auth: { appId, privateKey, installationId: installationIdRaw },
+              ...(this.apiUrl ? { baseUrl: this.apiUrl } : {}),
             });
           } else {
             this.appCredentials = { appId, privateKey };
@@ -265,6 +276,7 @@ export class GitHubAdapter
           privateKey: this.appCredentials.privateKey,
           installationId,
         },
+        ...(this.apiUrl ? { baseUrl: this.apiUrl } : {}),
       });
       this.installationClients.set(installationId, client);
       this.logger.debug("Created Octokit client for installation", {

--- a/packages/adapter-github/src/types.ts
+++ b/packages/adapter-github/src/types.ts
@@ -12,6 +12,8 @@ import type { Logger } from "chat";
  * Base configuration options shared by all auth methods.
  */
 interface GitHubAdapterBaseConfig {
+  /** Override the GitHub API base URL (e.g. "https://github.example.com/api/v3" for GitHub Enterprise). Defaults to GITHUB_API_URL env var. */
+  apiUrl?: string;
   /**
    * Bot's GitHub user ID (numeric).
    * Used for self-message detection. If not provided, will be fetched on first API call.

--- a/packages/adapter-linear/src/index.test.ts
+++ b/packages/adapter-linear/src/index.test.ts
@@ -2120,4 +2120,40 @@ describe("createLinearAdapter", () => {
     });
     expect(adapter).toBeInstanceOf(LinearAdapter);
   });
+
+  it("should accept apiUrl config", () => {
+    const adapter = createLinearAdapter({
+      apiKey: "lin_api_123",
+      webhookSecret: "secret",
+      apiUrl: "https://custom-linear.example.com",
+    });
+    expect(adapter).toBeInstanceOf(LinearAdapter);
+    expect((adapter as unknown as { apiUrl: string }).apiUrl).toBe(
+      "https://custom-linear.example.com"
+    );
+  });
+
+  it("should resolve apiUrl from LINEAR_API_URL env var", () => {
+    process.env.LINEAR_WEBHOOK_SECRET = "env-secret";
+    process.env.LINEAR_API_KEY = "env-key";
+    process.env.LINEAR_API_URL = "https://custom-linear.example.com";
+    const adapter = createLinearAdapter();
+    expect(adapter).toBeInstanceOf(LinearAdapter);
+    expect((adapter as unknown as { apiUrl: string }).apiUrl).toBe(
+      "https://custom-linear.example.com"
+    );
+  });
+
+  it("should prefer apiUrl config over LINEAR_API_URL env var", () => {
+    process.env.LINEAR_WEBHOOK_SECRET = "env-secret";
+    process.env.LINEAR_API_KEY = "env-key";
+    process.env.LINEAR_API_URL = "https://env-linear.example.com";
+    const adapter = createLinearAdapter({
+      apiKey: "key",
+      apiUrl: "https://config-linear.example.com",
+    });
+    expect((adapter as unknown as { apiUrl: string }).apiUrl).toBe(
+      "https://config-linear.example.com"
+    );
+  });
 });

--- a/packages/adapter-linear/src/index.ts
+++ b/packages/adapter-linear/src/index.ts
@@ -111,6 +111,8 @@ export class LinearAdapter
     clientSecret: string;
   } | null = null;
   private accessTokenExpiry: number | null = null;
+  // Custom API base URL
+  private readonly apiUrl?: string;
 
   /** Bot user ID used for self-message detection */
   get botUserId(): string | undefined {
@@ -130,14 +132,19 @@ export class LinearAdapter
     this.logger = config.logger ?? new ConsoleLogger("info").child("linear");
     this.userName =
       config.userName ?? process.env.LINEAR_BOT_USERNAME ?? "linear-bot";
+    this.apiUrl = config.apiUrl ?? process.env.LINEAR_API_URL;
 
     // Create LinearClient based on auth method
     // @see https://linear.app/developers/sdk
     if ("apiKey" in config && config.apiKey) {
-      this.linearClient = new LinearClient({ apiKey: config.apiKey });
+      this.linearClient = new LinearClient({
+        apiKey: config.apiKey,
+        ...(this.apiUrl ? { apiUrl: this.apiUrl } : {}),
+      });
     } else if ("accessToken" in config && config.accessToken) {
       this.linearClient = new LinearClient({
         accessToken: config.accessToken,
+        ...(this.apiUrl ? { apiUrl: this.apiUrl } : {}),
       });
     } else if ("clientId" in config && config.clientId) {
       // Client credentials mode - token will be fetched during initialize()
@@ -149,11 +156,17 @@ export class LinearAdapter
       // Auto-detect from env vars
       const apiKey = process.env.LINEAR_API_KEY;
       if (apiKey) {
-        this.linearClient = new LinearClient({ apiKey });
+        this.linearClient = new LinearClient({
+          apiKey,
+          ...(this.apiUrl ? { apiUrl: this.apiUrl } : {}),
+        });
       } else {
         const accessToken = process.env.LINEAR_ACCESS_TOKEN;
         if (accessToken) {
-          this.linearClient = new LinearClient({ accessToken });
+          this.linearClient = new LinearClient({
+            accessToken,
+            ...(this.apiUrl ? { apiUrl: this.apiUrl } : {}),
+          });
         } else {
           const clientId = process.env.LINEAR_CLIENT_ID;
           const clientSecret = process.env.LINEAR_CLIENT_SECRET;
@@ -233,6 +246,7 @@ export class LinearAdapter
 
     this.linearClient = new LinearClient({
       accessToken: data.access_token,
+      ...(this.apiUrl ? { apiUrl: this.apiUrl } : {}),
     });
 
     // Track expiry so we can proactively refresh (with 1 hour buffer)

--- a/packages/adapter-linear/src/types.ts
+++ b/packages/adapter-linear/src/types.ts
@@ -15,6 +15,8 @@ import type { Logger } from "chat";
  * Base configuration options shared by all auth methods.
  */
 interface LinearAdapterBaseConfig {
+  /** Override the Linear API base URL. Defaults to LINEAR_API_URL env var. */
+  apiUrl?: string;
   /** Logger instance for error reporting. Defaults to ConsoleLogger. */
   logger?: Logger;
   /**

--- a/packages/adapter-slack/src/index.test.ts
+++ b/packages/adapter-slack/src/index.test.ts
@@ -152,6 +152,22 @@ describe("constructor env var resolution", () => {
     });
     expect(adapter).toBeInstanceOf(SlackAdapter);
   });
+
+  it("should resolve apiUrl from SLACK_API_URL env var", () => {
+    process.env.SLACK_SIGNING_SECRET = "env-signing-secret";
+    process.env.SLACK_API_URL = "https://slack-gov.com/api/";
+    const adapter = new SlackAdapter();
+    expect(adapter).toBeInstanceOf(SlackAdapter);
+  });
+
+  it("should accept apiUrl config value", () => {
+    const adapter = new SlackAdapter({
+      signingSecret: "test-secret",
+      apiUrl: "https://slack-gov.com/api/",
+      logger: mockLogger,
+    });
+    expect(adapter).toBeInstanceOf(SlackAdapter);
+  });
 });
 
 // ============================================================================

--- a/packages/adapter-slack/src/index.ts
+++ b/packages/adapter-slack/src/index.ts
@@ -96,6 +96,8 @@ const SLACK_MESSAGE_URL_PATTERN =
   /^https?:\/\/[^/]+\.slack\.com\/archives\/([A-Z0-9]+)\/p(\d+)(?:\?.*)?$/;
 
 export interface SlackAdapterConfig {
+  /** Override the Slack API base URL (e.g. "https://slack-gov.com/api/" for GovSlack). Defaults to SLACK_API_URL env var. */
+  apiUrl?: string;
   /** Bot token (xoxb-...). Required for single-workspace mode. Omit for multi-workspace. */
   botToken?: string;
   /** Bot user ID (will be fetched if not provided) */
@@ -436,7 +438,10 @@ export class SlackAdapter implements Adapter<SlackThreadId, unknown> {
     const botToken =
       config.botToken ?? (zeroConfig ? process.env.SLACK_BOT_TOKEN : undefined);
 
-    this.client = new WebClient(botToken);
+    const slackApiUrl = config.apiUrl ?? process.env.SLACK_API_URL;
+    this.client = new WebClient(botToken, {
+      ...(slackApiUrl ? { slackApiUrl } : {}),
+    });
     this.signingSecret = signingSecret;
     this.defaultBotToken = botToken;
     this.logger = config.logger ?? new ConsoleLogger("info").child("slack");

--- a/packages/adapter-teams/src/config.ts
+++ b/packages/adapter-teams/src/config.ts
@@ -35,11 +35,13 @@ export function toAppOptions(
   }
 
   const managedIdentityClientId = config.federated?.clientId;
+  const serviceUrl = config.apiUrl ?? process.env.TEAMS_API_URL;
 
   return {
     ...(clientId ? { clientId } : {}),
     ...(clientSecret ? { clientSecret } : {}),
     ...(tenantId ? { tenantId } : {}),
     ...(managedIdentityClientId ? { managedIdentityClientId } : {}),
+    ...(serviceUrl ? { serviceUrl } : {}),
   };
 }

--- a/packages/adapter-teams/src/index.test.ts
+++ b/packages/adapter-teams/src/index.test.ts
@@ -275,6 +275,24 @@ describe("TeamsAdapter", () => {
       expect(adapter).toBeInstanceOf(TeamsAdapter);
       expect(adapter.name).toBe("teams");
     });
+
+    it("should resolve apiUrl from TEAMS_API_URL env var", () => {
+      process.env.TEAMS_APP_ID = "env-app-id";
+      process.env.TEAMS_APP_PASSWORD = "env-password";
+      process.env.TEAMS_API_URL = "https://custom-teams.example.com";
+      const adapter = new TeamsAdapter();
+      expect(adapter).toBeInstanceOf(TeamsAdapter);
+    });
+
+    it("should accept apiUrl config", () => {
+      const adapter = new TeamsAdapter({
+        appId: "test",
+        appPassword: "test",
+        apiUrl: "https://custom-teams.example.com",
+        logger,
+      });
+      expect(adapter).toBeInstanceOf(TeamsAdapter);
+    });
   });
 
   // ==========================================================================

--- a/packages/adapter-teams/src/types.ts
+++ b/packages/adapter-teams/src/types.ts
@@ -18,6 +18,8 @@ export interface TeamsAuthFederated {
 }
 
 export interface TeamsAdapterConfig {
+  /** Override the Teams Bot Framework service URL (e.g. for GCC-High environments). Defaults to TEAMS_API_URL env var. */
+  apiUrl?: string;
   /** Microsoft App ID. Defaults to TEAMS_APP_ID env var. */
   appId?: string;
   /** Microsoft App Password. Defaults to TEAMS_APP_PASSWORD env var. */

--- a/packages/adapter-telegram/src/index.test.ts
+++ b/packages/adapter-telegram/src/index.test.ts
@@ -212,6 +212,29 @@ describe("constructor env var resolution", () => {
     expect(adapter).toBeInstanceOf(TelegramAdapter);
   });
 
+  it("should accept apiUrl config and prefer it over apiBaseUrl", () => {
+    process.env.TELEGRAM_BOT_TOKEN = "env-bot-token";
+    const adapter = new TelegramAdapter({
+      botToken: "token",
+      apiUrl: "https://apiurl.example.com",
+      apiBaseUrl: "https://apibaseurl.example.com",
+    });
+    expect((adapter as unknown as { apiBaseUrl: string }).apiBaseUrl).toBe(
+      "https://apiurl.example.com"
+    );
+  });
+
+  it("should fall back to apiBaseUrl when apiUrl is not set", () => {
+    process.env.TELEGRAM_BOT_TOKEN = "env-bot-token";
+    const adapter = new TelegramAdapter({
+      botToken: "token",
+      apiBaseUrl: "https://apibaseurl.example.com",
+    });
+    expect((adapter as unknown as { apiBaseUrl: string }).apiBaseUrl).toBe(
+      "https://apibaseurl.example.com"
+    );
+  });
+
   it("should default logger when not provided", () => {
     process.env.TELEGRAM_BOT_TOKEN = "env-bot-token";
     const adapter = new TelegramAdapter();

--- a/packages/adapter-telegram/src/index.ts
+++ b/packages/adapter-telegram/src/index.ts
@@ -242,7 +242,8 @@ export class TelegramAdapter
 
     this.botToken = botToken;
     this.apiBaseUrl = trimTrailingSlashes(
-      config.apiBaseUrl ??
+      config.apiUrl ??
+        config.apiBaseUrl ??
         process.env.TELEGRAM_API_BASE_URL ??
         TELEGRAM_API_BASE
     );

--- a/packages/adapter-telegram/src/types.ts
+++ b/packages/adapter-telegram/src/types.ts
@@ -10,6 +10,8 @@ import type { Logger } from "chat";
 export interface TelegramAdapterConfig {
   /** Optional custom API base URL (defaults to https://api.telegram.org). Defaults to TELEGRAM_API_BASE_URL env var. */
   apiBaseUrl?: string;
+  /** Override the Telegram API base URL. Alias for apiBaseUrl — apiUrl takes precedence if both are set. Defaults to TELEGRAM_API_BASE_URL env var. */
+  apiUrl?: string;
   /** Telegram bot token from BotFather. Defaults to TELEGRAM_BOT_TOKEN env var. */
   botToken?: string;
   /** Logger instance for error reporting. Defaults to ConsoleLogger. */

--- a/packages/adapter-whatsapp/src/index.test.ts
+++ b/packages/adapter-whatsapp/src/index.test.ts
@@ -1096,4 +1096,68 @@ describe("createWhatsAppAdapter", () => {
       }
     }
   });
+
+  it("uses apiUrl config to override base URL", () => {
+    const adapter = new WhatsAppAdapter({
+      accessToken: "test-token",
+      appSecret: "test-secret",
+      phoneNumberId: "123456789",
+      verifyToken: "test-verify-token",
+      userName: "test-bot",
+      apiUrl: "https://custom-graph.example.com",
+      logger: {
+        info: () => {},
+        warn: () => {},
+        error: () => {},
+        debug: () => {},
+      },
+    });
+    expect((adapter as unknown as { graphApiUrl: string }).graphApiUrl).toBe(
+      "https://custom-graph.example.com/v21.0"
+    );
+  });
+
+  it("uses WHATSAPP_API_URL env var via factory", () => {
+    const originalEnv = { ...process.env };
+    for (const [key, value] of Object.entries(requiredEnvVars)) {
+      process.env[key] = value;
+    }
+    process.env.WHATSAPP_API_URL = "https://custom-graph.example.com";
+
+    try {
+      const adapter = createWhatsAppAdapter();
+      expect((adapter as unknown as { graphApiUrl: string }).graphApiUrl).toBe(
+        "https://custom-graph.example.com/v21.0"
+      );
+    } finally {
+      for (const key of [...Object.keys(requiredEnvVars), "WHATSAPP_API_URL"]) {
+        if (key in originalEnv) {
+          process.env[key] = originalEnv[key];
+        } else {
+          delete process.env[key];
+        }
+      }
+    }
+  });
+
+  it("uses apiUrl with custom apiVersion", () => {
+    const adapter = new WhatsAppAdapter({
+      accessToken: "test-token",
+      appSecret: "test-secret",
+      phoneNumberId: "123456789",
+      verifyToken: "test-verify-token",
+      userName: "test-bot",
+      apiUrl: "https://custom-graph.example.com",
+      apiVersion: "v19.0",
+      logger: {
+        info: () => {},
+        warn: () => {},
+        error: () => {},
+        debug: () => {},
+      },
+    });
+    expect((adapter as unknown as { graphApiUrl: string }).graphApiUrl).toBe(
+      "https://custom-graph.example.com/v19.0"
+    );
+  });
 });

--- a/packages/adapter-whatsapp/src/index.ts
+++ b/packages/adapter-whatsapp/src/index.ts
@@ -143,7 +143,8 @@ export class WhatsAppAdapter
     this.logger = config.logger;
     this.userName = config.userName;
     const apiVersion = config.apiVersion ?? DEFAULT_API_VERSION;
-    this.graphApiUrl = `https://graph.facebook.com/${apiVersion}`;
+    const baseUrl = config.apiUrl ?? "https://graph.facebook.com";
+    this.graphApiUrl = `${baseUrl}/${apiVersion}`;
   }
 
   /**
@@ -1177,6 +1178,7 @@ export class WhatsAppAdapter
  */
 export function createWhatsAppAdapter(config?: {
   accessToken?: string;
+  apiUrl?: string;
   apiVersion?: string;
   appSecret?: string;
   logger?: Logger;
@@ -1224,6 +1226,7 @@ export function createWhatsAppAdapter(config?: {
 
   return new WhatsAppAdapter({
     accessToken,
+    apiUrl: config?.apiUrl ?? process.env.WHATSAPP_API_URL,
     apiVersion: config?.apiVersion,
     appSecret,
     phoneNumberId,

--- a/packages/adapter-whatsapp/src/types.ts
+++ b/packages/adapter-whatsapp/src/types.ts
@@ -22,6 +22,8 @@ import type { Logger } from "chat";
 export interface WhatsAppAdapterConfig {
   /** Access token (System User token) for WhatsApp Cloud API calls */
   accessToken: string;
+  /** Override the Meta Graph API base URL (e.g. for on-premise deployments). Defaults to "https://graph.facebook.com". */
+  apiUrl?: string;
   /** Meta Graph API version (default: "v21.0") */
   apiVersion?: string;
   /** Meta App Secret for webhook HMAC-SHA256 signature verification */


### PR DESCRIPTION
- Add `apiUrl?: string` config option to all 8 platform adapters (Slack, Discord, WhatsApp, GitHub, Linear, Google Chat, Telegram, Teams)
- Each adapter maps `apiUrl` to its underlying SDK/client option (`slackApiUrl`, `baseUrl`, `rootUrl`, `serviceUrl`, etc.)
- Env var fallbacks: `SLACK_API_URL`, `DISCORD_API_URL`, `WHATSAPP_API_URL`, `GITHUB_API_URL`, `LINEAR_API_URL`, `GOOGLE_CHAT_API_URL`, `TEAMS_API_URL`
- Telegram: `apiUrl` added as alias for existing `apiBaseUrl` — both continue to work, `apiUrl` takes precedence
- Fully backwards compatible — all fields optional, no behavior change when omitted
- 19 new unit tests across all adapters