### PR TITLE
feat(chat): add chat.thread() for creating thread handles

### DIFF
--- a/.changeset/thread-handle.md
+++ b/.changeset/thread-handle.md
@@ -1,0 +1,5 @@
+---
+"chat": minor
+---
+
+Add `chat.thread(threadId)` method to create Thread handles outside of webhook contexts

--- a/apps/docs/content/docs/api/chat.mdx
+++ b/apps/docs/content/docs/api/chat.mdx
@@ -443,6 +443,15 @@ await dm.post("Hello via DM!");
 const dm = await bot.openDM(message.author);
 ```
 
+### thread
+
+Get a Thread handle by its thread ID. Useful for posting to threads outside of webhook contexts (e.g. cron jobs, external triggers).
+
+```typescript
+const thread = bot.thread("slack:C123ABC:1234567890.123456");
+await thread.post("Hello from a cron job!");
+```
+
 ### channel
 
 Get a Channel by its channel ID.

--- a/apps/docs/content/docs/api/thread.mdx
+++ b/apps/docs/content/docs/api/thread.mdx
@@ -4,7 +4,7 @@ description: Represents a conversation thread with methods for posting, subscrib
 type: reference
 ---
 
-A `Thread` is provided to your event handlers and represents a conversation thread on any platform. You don't create threads directly — they come from handler callbacks or `chat.openDM()`.
+A `Thread` is provided to your event handlers and represents a conversation thread on any platform. You can also create thread handles directly using `chat.thread()` or `chat.openDM()`.
 
 ## Properties
 

--- a/packages/chat/src/chat.test.ts
+++ b/packages/chat/src/chat.test.ts
@@ -1423,6 +1423,33 @@ describe("Chat", () => {
     });
   });
 
+  describe("thread", () => {
+    it("should return a Thread handle for a valid thread ID", () => {
+      const thread = chat.thread("slack:C123:1234.5678");
+      expect(thread).toBeDefined();
+      expect(thread.id).toBe("slack:C123:1234.5678");
+    });
+
+    it("should allow posting to a thread handle", async () => {
+      const thread = chat.thread("slack:C123:1234.5678");
+      await thread.post("Hello from outside a webhook!");
+      expect(mockAdapter.postMessage).toHaveBeenCalledWith(
+        "slack:C123:1234.5678",
+        "Hello from outside a webhook!"
+      );
+    });
+
+    it("should throw for an invalid thread ID", () => {
+      expect(() => chat.thread("")).toThrow("Invalid thread ID");
+    });
+
+    it("should throw for an unknown adapter prefix", () => {
+      expect(() => chat.thread("unknown:C123:1234.5678")).toThrow(
+        'Adapter "unknown" not found'
+      );
+    });
+  });
+
   describe("isDM", () => {
     it("should return true for DM threads", async () => {
       const thread = await chat.openDM("U123456");

--- a/packages/chat/src/chat.ts
+++ b/packages/chat/src/chat.ts
@@ -1576,6 +1576,40 @@ export class Chat<
   }
 
   /**
+   * Get a Thread handle by its thread ID.
+   *
+   * The adapter is automatically inferred from the thread ID prefix.
+   *
+   * @param threadId - Full thread ID (e.g., "slack:C123ABC:1234567890.123456")
+   * @returns A Thread that can be used to post messages, subscribe, etc.
+   *
+   * @example
+   * ```typescript
+   * const thread = chat.thread("slack:C123ABC:1234567890.123456");
+   * await thread.post("Hello from outside a webhook!");
+   * ```
+   */
+  thread(threadId: string): Thread<TState> {
+    const adapterName = threadId.split(":")[0];
+    if (!adapterName) {
+      throw new ChatError(
+        `Invalid thread ID: ${threadId}`,
+        "INVALID_THREAD_ID"
+      );
+    }
+
+    const adapter = this.adapters.get(adapterName);
+    if (!adapter) {
+      throw new ChatError(
+        `Adapter "${adapterName}" not found for thread ID "${threadId}"`,
+        "ADAPTER_NOT_FOUND"
+      );
+    }
+
+    return this.createThread(adapter, threadId, {} as Message, false);
+  }
+
+  /**
    * Infer which adapter to use based on the userId format.
    */
   private inferAdapterFromUserId(userId: string): Adapter {


### PR DESCRIPTION
- Add `chat.thread(threadId)` method to create a Thread handle from a thread ID outside of webhook contexts
- Adapter is inferred from the thread ID prefix (e.g. `slack:`, `teams:`, `gchat:`)
- Enables proactive messaging to existing threads (cron jobs, external triggers, etc.)
- This was the missing piece for the "Using the adapter outside webhooks" docs example — `getInstallation()` and `withBotToken()` already exist

```typescript
const install = await slackAdapter.getInstallation(teamId);
if (!install) throw new Error("Workspace not installed");

await slackAdapter.withBotToken(install.botToken, async () => {
  const thread = chat.thread("slack:C12345:1234567890.123456");
  await thread.post("Hello from a cron job!");
});
```

- 4 new unit tests
- Changeset: minor bump on `chat`

Closes #148