### PR TITLE
feat: add Mattermost adapter to community adapters in docs

### DIFF
--- a/apps/docs/adapters.json
+++ b/apps/docs/adapters.json
@@ -225,6 +225,16 @@
     "readme": "https://github.com/buiducnhat/chat-adapter-zalo"
   },
   {
+    "name": "Mattermost",
+    "slug": "mattermost",
+    "type": "platform",
+    "community": true,
+    "description": "Mattermost adapter for Chat SDK with support for posts, reactions, and slash commands.",
+    "packageName": "chat-adapter-mattermost",
+    "author": "thiagoferolla",
+    "readme": "https://github.com/thiagoferolla/chat-adapter-mattermost"
+  },
+  {
     "name": "Instagram",
     "slug": "instagram",
     "type": "platform",

--- a/apps/docs/app/[lang]/(home)/adapters/for/[messenger]/page.tsx
+++ b/apps/docs/app/[lang]/(home)/adapters/for/[messenger]/page.tsx
@@ -157,6 +157,13 @@ const messengerConfig: Record<
     adapterSlugs: ["zalo"],
     keywords: ["zalo"],
   },
+  mattermost: {
+    name: "Mattermost",
+    description:
+      "Build bots for Mattermost with Chat SDK. Browse official and community adapters that support Mattermost integration.",
+    adapterSlugs: ["mattermost"],
+    keywords: ["mattermost"],
+  },
 };
 
 const getMessengerAdapters = (messengerSlug: string) => {

--- a/apps/docs/app/[lang]/(home)/adapters/page.tsx
+++ b/apps/docs/app/[lang]/(home)/adapters/page.tsx
@@ -29,6 +29,7 @@ const messengerLinks = [
   { name: "Webex", slug: "webex" },
   { name: "Google Chat", slug: "google-chat" },
   { name: "Zalo", slug: "zalo" },
+  { name: "Mattermost", slug: "mattermost" },
 ];
 
 const AdaptersPage = () => (

--- a/skills/chat/SKILL.md
+++ b/skills/chat/SKILL.md
@@ -186,6 +186,7 @@ await thread.post(
 - `@liveblocks/chat-sdk-adapter`
 - `chat-adapter-sendblue`
 - `chat-adapter-zalo`
+- `chat-adapter-mattermost`
 
 ### Coming-soon platform entries
 


### PR DESCRIPTION
## Summary

<!-- What does this PR do? -->
[Mattermost](https://mattermost.com/) is an open-source Slack alternative

This PR updates the docs to add Mattermost adapter into the community adapters section. This PR is for doc updates only, the adapter lives in [https://github.com/thiagoferolla/chat-adapter-mattermost](https://github.com/thiagoferolla/chat-adapter-mattermost)

Files updated:
- `apps/docs/adapters.json`
- `apps/docs/app/[lang]/(home)/adapters/for/[messenger]/page.tsx`
- `apps/docs/app/[lang]/(home)/adapters/page.tsx`
- `skills/chat/SKILL.md`

## Test plan
- [x] `pnpm build` — all packages build cleanly
- [x] `pnpm --filter docs build` — docs app builds without errors
- [x] `pnpm -w run check` — lint/format passes
- [x] Manual: visit `/adapters` and confirm Mattermost card appears in the grid, community section
