### PR TITLE
feat: enhance task update structure with optional details field

### DIFF
--- a/.changeset/task-update-details.md
+++ b/.changeset/task-update-details.md
@@ -1,0 +1,5 @@
+---
+"chat": minor
+---
+
+Allow `task_update` streaming chunks to include optional `details` text for Slack task cards

--- a/apps/docs/content/docs/streaming.mdx
+++ b/apps/docs/content/docs/streaming.mdx
@@ -118,6 +118,7 @@ const stream = (async function* () {
     type: "task_update",
     id: "search-1",
     title: "Searching documents",
+    details: "Querying internal docs and ranking the best matches",
     status: "in_progress",
   } satisfies StreamChunk;
 
@@ -127,6 +128,7 @@ const stream = (async function* () {
     type: "task_update",
     id: "search-1",
     title: "Searching documents",
+    details: "Ranked 3 relevant results",
     status: "complete",
     output: "Found 3 results",
   } satisfies StreamChunk;
@@ -142,7 +144,7 @@ await thread.post(stream);
 | Type | Fields | Description |
 |------|--------|-------------|
 | `markdown_text` | `text` | Streamed text content |
-| `task_update` | `id`, `title`, `status`, `output?` | Tool/step progress cards (`pending`, `in_progress`, `complete`, `error`) |
+| `task_update` | `id`, `title`, `status`, `details?`, `output?` | Tool/step progress cards (`pending`, `in_progress`, `complete`, `error`) with optional extra task context |
 | `plan_update` | `title` | Plan title updates |
 
 ### Task display mode

--- a/packages/chat/src/thread.test.ts
+++ b/packages/chat/src/thread.test.ts
@@ -711,6 +711,7 @@ describe("ThreadImpl", () => {
           type: "task_update" as const,
           id: "tool-1",
           title: "Running bash",
+          details: "Installing dependencies",
           status: "in_progress",
         };
         yield "world";
@@ -718,6 +719,7 @@ describe("ThreadImpl", () => {
           type: "task_update" as const,
           id: "tool-1",
           title: "Running bash",
+          details: "Installed dependencies",
           status: "complete",
           output: "Done",
         };
@@ -732,11 +734,20 @@ describe("ThreadImpl", () => {
       expect(capturedChunks).toHaveLength(4);
       expect(capturedChunks[0]).toBe("Hello ");
       expect(capturedChunks[1]).toEqual(
-        expect.objectContaining({ type: "task_update", status: "in_progress" })
+        expect.objectContaining({
+          type: "task_update",
+          details: "Installing dependencies",
+          status: "in_progress",
+        })
       );
       expect(capturedChunks[2]).toBe("world");
       expect(capturedChunks[3]).toEqual(
-        expect.objectContaining({ type: "task_update", status: "complete" })
+        expect.objectContaining({
+          type: "task_update",
+          details: "Installed dependencies",
+          output: "Done",
+          status: "complete",
+        })
       );
 
       // Accumulated text should only include strings, not task_update chunks
@@ -785,6 +796,7 @@ describe("ThreadImpl", () => {
           type: "task_update" as const,
           id: "tool-1",
           title: "Running bash",
+          details: "Installing dependencies",
           status: "in_progress",
         };
         yield " World";

--- a/packages/chat/src/types.ts
+++ b/packages/chat/src/types.ts
@@ -518,6 +518,7 @@ export interface MarkdownTextChunk {
 }
 
 export interface TaskUpdateChunk {
+  details?: string;
   id: string;
   output?: string;
   status: "pending" | "in_progress" | "complete" | "error";
@@ -1186,10 +1187,7 @@ export type {
   UpdateTaskInput,
 } from "./plan";
 // Re-export PostableObject types from plan.ts for backwards compatibility
-export type {
-  PostableObject,
-  PostableObjectContext,
-} from "./postable-object";
+export type { PostableObject, PostableObjectContext } from "./postable-object";
 
 export interface ThreadInfo {
   channelId: string;


### PR DESCRIPTION
## Summary

- Added a `details` field to the `task_update` type for providing additional context in task updates.
- Updated relevant documentation and test cases to reflect the new field, improving clarity on task progress reporting.
