### PR TITLE
feat(chat): add thread.getParticipants()

### DIFF
--- a/.changeset/thread-get-participants.md
+++ b/.changeset/thread-get-participants.md
@@ -1,0 +1,5 @@
+---
+"chat": minor
+---
+
+Add `thread.getParticipants()` to get unique human participants in a thread

--- a/apps/docs/content/docs/api/thread.mdx
+++ b/apps/docs/content/docs/api/thread.mdx
@@ -114,6 +114,28 @@ await scheduled.cancel();
 Streaming and file uploads are not supported in scheduled messages.
 </Callout>
 
+## getParticipants
+
+Get the unique human participants in a thread. Returns deduplicated authors, excluding all bots. Useful for subscribing only to 1:1 conversations and unsubscribing when others join.
+
+```typescript
+const participants = await thread.getParticipants();
+
+// Subscribe only when one person is talking to the bot
+if (participants.length === 1) {
+  await thread.subscribe();
+}
+
+// Unsubscribe when the thread becomes a group conversation
+if (participants.length > 1) {
+  await thread.unsubscribe();
+}
+```
+
+<Callout type="warn">
+  Each call fetches the full message history to find all participants. On threads with long history this makes multiple API calls to the platform. Consider checking `message.author` against a known set before calling `getParticipants()` on every incoming message.
+</Callout>
+
 ## subscribe / unsubscribe
 
 Manage thread subscriptions. Subscribed threads route all messages to `onSubscribedMessage` handlers.

--- a/apps/docs/content/docs/threads-messages-channels.mdx
+++ b/apps/docs/content/docs/threads-messages-channels.mdx
@@ -40,6 +40,33 @@ await thread.unsubscribe();
 const subscribed = await thread.isSubscribed();
 ```
 
+### Participants
+
+Get the unique human participants in a thread. Returns deduplicated authors, excluding all bots. Useful for deciding whether to subscribe based on how many humans are in the conversation.
+
+```typescript title="lib/bot.ts" lineNumbers
+bot.onNewMention(async (thread) => {
+  const participants = await thread.getParticipants();
+  if (participants.length === 1) {
+    await thread.subscribe();
+    await thread.post("I'm here to help!");
+  }
+});
+
+bot.onSubscribedMessage(async (thread) => {
+  const participants = await thread.getParticipants();
+  if (participants.length > 1) {
+    await thread.unsubscribe();
+    return;
+  }
+  // respond...
+});
+```
+
+<Callout type="warn">
+  Each call fetches the full message history to find all participants. On threads with long history this makes multiple API calls to the platform. Consider checking `message.author` against a known set before calling `getParticipants()` on every incoming message.
+</Callout>
+
 ### Typing indicator
 
 ```typescript title="lib/bot.ts"

--- a/packages/chat/src/thread.test.ts
+++ b/packages/chat/src/thread.test.ts
@@ -2711,4 +2711,156 @@ describe("ThreadImpl", () => {
       expect(cancel2).not.toHaveBeenCalled();
     });
   });
+
+  describe("getParticipants", () => {
+    it("should return unique non-bot authors from messages", async () => {
+      const mockAdapter = createMockAdapter();
+      const mockState = createMockState();
+
+      const msg1 = createTestMessage("1", "Hello", {
+        author: {
+          userId: "U1",
+          userName: "alice",
+          fullName: "Alice",
+          isBot: false,
+          isMe: false,
+        },
+      });
+      const msg2 = createTestMessage("2", "Hi", {
+        author: {
+          userId: "U2",
+          userName: "bob",
+          fullName: "Bob",
+          isBot: false,
+          isMe: false,
+        },
+      });
+      const msg3 = createTestMessage("3", "Hello again", {
+        author: {
+          userId: "U1",
+          userName: "alice",
+          fullName: "Alice",
+          isBot: false,
+          isMe: false,
+        },
+      });
+
+      mockAdapter.fetchMessages = vi
+        .fn()
+        .mockResolvedValue({ messages: [msg1, msg2, msg3], nextCursor: null });
+
+      const thread = new ThreadImpl({
+        id: "slack:C123:1234.5678",
+        adapter: mockAdapter,
+        channelId: "C123",
+        stateAdapter: mockState,
+      });
+
+      const participants = await thread.getParticipants();
+      expect(participants).toHaveLength(2);
+      expect(participants.map((p) => p.userId)).toEqual(
+        expect.arrayContaining(["U1", "U2"])
+      );
+    });
+
+    it("should exclude bot messages", async () => {
+      const mockAdapter = createMockAdapter();
+      const mockState = createMockState();
+
+      const humanMsg = createTestMessage("1", "Hello", {
+        author: {
+          userId: "U1",
+          userName: "alice",
+          fullName: "Alice",
+          isBot: false,
+          isMe: false,
+        },
+      });
+      const botMsg = createTestMessage("2", "Hi there!", {
+        author: {
+          userId: "B1",
+          userName: "bot",
+          fullName: "Bot",
+          isBot: true,
+          isMe: true,
+        },
+      });
+
+      mockAdapter.fetchMessages = vi
+        .fn()
+        .mockResolvedValue({ messages: [humanMsg, botMsg], nextCursor: null });
+
+      const thread = new ThreadImpl({
+        id: "slack:C123:1234.5678",
+        adapter: mockAdapter,
+        channelId: "C123",
+        stateAdapter: mockState,
+      });
+
+      const participants = await thread.getParticipants();
+      expect(participants).toHaveLength(1);
+      expect(participants[0].userId).toBe("U1");
+    });
+
+    it("should return empty array for thread with only bot messages", async () => {
+      const mockAdapter = createMockAdapter();
+      const mockState = createMockState();
+
+      mockAdapter.fetchMessages = vi.fn().mockResolvedValue({
+        messages: [
+          createTestMessage("1", "Bot message", {
+            author: {
+              userId: "B1",
+              userName: "bot",
+              fullName: "Bot",
+              isBot: true,
+              isMe: true,
+            },
+          }),
+        ],
+        nextCursor: null,
+      });
+
+      const thread = new ThreadImpl({
+        id: "slack:C123:1234.5678",
+        adapter: mockAdapter,
+        channelId: "C123",
+        stateAdapter: mockState,
+      });
+
+      const participants = await thread.getParticipants();
+      expect(participants).toHaveLength(0);
+    });
+
+    it("should include currentMessage author", async () => {
+      const mockAdapter = createMockAdapter();
+      const mockState = createMockState();
+
+      const currentMsg = createTestMessage("1", "Hey bot", {
+        author: {
+          userId: "U1",
+          userName: "alice",
+          fullName: "Alice",
+          isBot: false,
+          isMe: false,
+        },
+      });
+
+      mockAdapter.fetchMessages = vi
+        .fn()
+        .mockResolvedValue({ messages: [], nextCursor: null });
+
+      const thread = new ThreadImpl({
+        id: "slack:C123:1234.5678",
+        adapter: mockAdapter,
+        channelId: "C123",
+        stateAdapter: mockState,
+        currentMessage: currentMsg,
+      });
+
+      const participants = await thread.getParticipants();
+      expect(participants).toHaveLength(1);
+      expect(participants[0].userId).toBe("U1");
+    });
+  });
 });

--- a/packages/chat/src/thread.test.ts
+++ b/packages/chat/src/thread.test.ts
@@ -2776,7 +2776,7 @@ describe("ThreadImpl", () => {
           isMe: false,
         },
       });
-      const botMsg = createTestMessage("2", "Hi there!", {
+      const selfBotMsg = createTestMessage("2", "Hi there!", {
         author: {
           userId: "B1",
           userName: "bot",
@@ -2785,10 +2785,20 @@ describe("ThreadImpl", () => {
           isMe: true,
         },
       });
+      const thirdPartyBotMsg = createTestMessage("3", "Notification", {
+        author: {
+          userId: "B2",
+          userName: "jira-bot",
+          fullName: "Jira Bot",
+          isBot: true,
+          isMe: false,
+        },
+      });
 
-      mockAdapter.fetchMessages = vi
-        .fn()
-        .mockResolvedValue({ messages: [humanMsg, botMsg], nextCursor: null });
+      mockAdapter.fetchMessages = vi.fn().mockResolvedValue({
+        messages: [humanMsg, selfBotMsg, thirdPartyBotMsg],
+        nextCursor: null,
+      });
 
       const thread = new ThreadImpl({
         id: "slack:C123:1234.5678",

--- a/packages/chat/src/thread.ts
+++ b/packages/chat/src/thread.ts
@@ -360,13 +360,21 @@ export class ThreadImpl<TState = Record<string, unknown>>
     const seen = new Map<string, Author>();
 
     // Include the current message author if available
-    if (this._currentMessage && !this._currentMessage.author.isMe) {
+    if (
+      this._currentMessage &&
+      !this._currentMessage.author.isMe &&
+      !this._currentMessage.author.isBot
+    ) {
       seen.set(this._currentMessage.author.userId, this._currentMessage.author);
     }
 
-    // Scan all messages for unique non-bot authors
+    // Scan all messages for unique human authors
     for await (const message of this.allMessages) {
-      if (message.author.isMe || seen.has(message.author.userId)) {
+      if (
+        message.author.isMe ||
+        message.author.isBot ||
+        seen.has(message.author.userId)
+      ) {
         continue;
       }
       seen.set(message.author.userId, message.author);

--- a/packages/chat/src/thread.ts
+++ b/packages/chat/src/thread.ts
@@ -356,6 +356,25 @@ export class ThreadImpl<TState = Record<string, unknown>>
     };
   }
 
+  async getParticipants(): Promise<Author[]> {
+    const seen = new Map<string, Author>();
+
+    // Include the current message author if available
+    if (this._currentMessage && !this._currentMessage.author.isMe) {
+      seen.set(this._currentMessage.author.userId, this._currentMessage.author);
+    }
+
+    // Scan all messages for unique non-bot authors
+    for await (const message of this.allMessages) {
+      if (message.author.isMe || seen.has(message.author.userId)) {
+        continue;
+      }
+      seen.set(message.author.userId, message.author);
+    }
+
+    return [...seen.values()];
+  }
+
   async isSubscribed(): Promise<boolean> {
     // Short-circuit if we know we're in a subscribed context
     if (this._isSubscribedContext) {

--- a/packages/chat/src/types.ts
+++ b/packages/chat/src/types.ts
@@ -1026,6 +1026,41 @@ export interface Thread<TState = Record<string, unknown>, TRawMessage = unknown>
   ): SentMessage<TRawMessage>;
 
   /**
+   * Get the unique human participants in this thread.
+   *
+   * Scans all messages in the thread and returns deduplicated authors,
+   * excluding the bot itself. Useful for deciding whether to subscribe
+   * based on how many humans are participating — subscribe when it's a
+   * 1:1 conversation, unsubscribe when others join so humans can talk
+   * without the bot replying to every message.
+   *
+   * @returns Array of unique non-bot authors
+   *
+   * @example
+   * ```typescript
+   * // Subscribe only when one person is talking to the bot
+   * bot.onNewMention(async (thread, message) => {
+   *   const participants = await thread.getParticipants();
+   *   if (participants.length === 1) {
+   *     await thread.subscribe();
+   *     await thread.post("I'm here to help!");
+   *   }
+   * });
+   *
+   * // Unsubscribe when the thread becomes a group conversation
+   * bot.onSubscribedMessage(async (thread, message) => {
+   *   const participants = await thread.getParticipants();
+   *   if (participants.length > 1) {
+   *     await thread.unsubscribe();
+   *     return;
+   *   }
+   *   await thread.post("Still here to help!");
+   * });
+   * ```
+   */
+  getParticipants(): Promise<Author[]>;
+
+  /**
    * Check if this thread is currently subscribed.
    *
    * In subscribed message handlers, this is optimized to return true immediately


### PR DESCRIPTION
- Add `thread.getParticipants()` method that returns unique human participants in a thread
- Scans message history, deduplicates by user ID, excludes the bot itself
- Includes the current message author even if message history hasn't been fetched yet
- 4 unit tests covering deduplication, bot exclusion, empty threads, and currentMessage inclusion

Use case: subscribe only to 1:1 conversations, unsubscribe when others join so humans can chat without the bot replying to every message.

```typescript
bot.onNewMention(async (thread) => {
  const participants = await thread.getParticipants();
  if (participants.length === 1) {
    await thread.subscribe();
    await thread.post("I'm here to help!");
  }
});

bot.onSubscribedMessage(async (thread) => {
  const participants = await thread.getParticipants();
  if (participants.length > 1) {
    await thread.unsubscribe();
    return;
  }
  // respond...
});
```