### PR TITLE
fix(docs): replace thread.stream() with adapter.stream() in streaming docs

### DIFF
--- a/apps/docs/content/docs/streaming.mdx
+++ b/apps/docs/content/docs/streaming.mdx
@@ -149,11 +149,14 @@ await thread.post(stream);
 
 ### Task display mode
 
-Control how `task_update` chunks render in Slack by passing `taskDisplayMode` in stream options:
+Control how `task_update` chunks render in Slack by passing `taskDisplayMode` via the adapter's streaming API. These options are currently only available through `adapter.stream()` directly:
 
 ```typescript
-await thread.stream(stream, {
-  taskDisplayMode: "plan", // Group all tasks into a single plan block
+const raw = message.raw as { team_id?: string; team?: string };
+await thread.adapter.stream(thread.id, stream, {
+  recipientUserId: message.author.userId,
+  recipientTeamId: raw.team_id ?? raw.team,
+  taskDisplayMode: "plan",
 });
 ```
 
@@ -169,7 +172,10 @@ Adapters without structured chunk support extract text from `markdown_text` chun
 When streaming in Slack, you can attach Block Kit elements to the final message using `stopBlocks`. This is useful for adding action buttons after a streamed response completes:
 
 ```typescript title="lib/bot.ts" lineNumbers
-await thread.stream(textStream, {
+const raw = message.raw as { team_id?: string; team?: string };
+await thread.adapter.stream(thread.id, textStream, {
+  recipientUserId: message.author.userId,
+  recipientTeamId: raw.team_id ?? raw.team,
   stopBlocks: [
     {
       type: "actions",

--- a/apps/docs/public/.well-known/agent-skills/chat-sdk/SKILL.md
+++ b/apps/docs/public/.well-known/agent-skills/chat-sdk/SKILL.md
@@ -100,7 +100,7 @@ Read `node_modules/chat/docs/handling-events.mdx`, `node_modules/chat/docs/actio
 
 ## Streaming
 
-Pass any `AsyncIterable<string>` to `thread.post()` or `thread.stream()`. For AI SDK, prefer `result.fullStream` over `result.textStream` when available so step boundaries are preserved.
+Pass any `AsyncIterable<string>` to `thread.post()`. For AI SDK, prefer `result.fullStream` over `result.textStream` when available so step boundaries are preserved.
 
 ```typescript
 import { ToolLoopAgent } from "ai";
@@ -176,6 +176,7 @@ await thread.post(
 - `@liveblocks/chat-sdk-adapter`
 - `chat-adapter-sendblue`
 - `chat-adapter-zalo`
+- `chat-adapter-mattermost`
 
 ### Coming-soon platform entries
 

--- a/apps/docs/public/AGENTS.md
+++ b/apps/docs/public/AGENTS.md
@@ -100,7 +100,7 @@ Read `node_modules/chat/docs/handling-events.mdx`, `node_modules/chat/docs/actio
 
 ## Streaming
 
-Pass any `AsyncIterable<string>` to `thread.post()` or `thread.stream()`. For AI SDK, prefer `result.fullStream` over `result.textStream` when available so step boundaries are preserved.
+Pass any `AsyncIterable<string>` to `thread.post()`. For AI SDK, prefer `result.fullStream` over `result.textStream` when available so step boundaries are preserved.
 
 ```typescript
 import { ToolLoopAgent } from "ai";
@@ -176,6 +176,7 @@ await thread.post(
 - `@liveblocks/chat-sdk-adapter`
 - `chat-adapter-sendblue`
 - `chat-adapter-zalo`
+- `chat-adapter-mattermost`
 
 ### Coming-soon platform entries
 

--- a/packages/adapter-slack/README.md
+++ b/packages/adapter-slack/README.md
@@ -320,7 +320,10 @@ settings:
 When streaming in an assistant thread, you can attach Block Kit elements to the final message:
 
 ```typescript
-await thread.stream(textStream, {
+const raw = message.raw as { team_id?: string; team?: string };
+await thread.adapter.stream(thread.id, textStream, {
+  recipientUserId: message.author.userId,
+  recipientTeamId: raw.team_id ?? raw.team,
   stopBlocks: [
     { type: "actions", elements: [{ type: "button", text: { type: "plain_text", text: "Retry" }, action_id: "retry" }] },
   ],

--- a/skills/chat/SKILL.md
+++ b/skills/chat/SKILL.md
@@ -100,7 +100,7 @@ Read `node_modules/chat/docs/handling-events.mdx`, `node_modules/chat/docs/actio
 
 ## Streaming
 
-Pass any `AsyncIterable<string>` to `thread.post()` or `thread.stream()`. For AI SDK, prefer `result.fullStream` over `result.textStream` when available so step boundaries are preserved.
+Pass any `AsyncIterable<string>` to `thread.post()`. For AI SDK, prefer `result.fullStream` over `result.textStream` when available so step boundaries are preserved.
 
 ```typescript
 import { ToolLoopAgent } from "ai";


### PR DESCRIPTION
## summary

`thread.stream()` doesn't exist - docs referenced an API that was never implemented. updates all streaming examples to use `adapter.stream()` directly with the required `recipientUserId` and `recipientTeamId` fields, matching what users actually need to do today