### PR TITLE
chore: downgrade linear changeset from major to minor

### DIFF
--- a/.changeset/dirty-masks-bathe.md
+++ b/.changeset/dirty-masks-bathe.md
@@ -1,5 +1,5 @@
 ---
-"@chat-adapter/linear": major
+"@chat-adapter/linear": minor
 ---
 
 Add multi-tenant support in the Linear adapter using `clientId` / `clientSecret`.


### PR DESCRIPTION
## summary

downgrades the linear adapter changeset from major to minor per malte's guidance - adapter changes should not be breaking changes