### PR TITLE
feat(docs): add Resources page powered by Edge Config

### DIFF
--- a/apps/docs/app/[lang]/(home)/resources/components/resource-card.tsx
+++ b/apps/docs/app/[lang]/(home)/resources/components/resource-card.tsx
@@ -1,0 +1,59 @@
+import { ArrowUpRightIcon } from "lucide-react";
+import { Badge } from "@/components/ui/badge";
+import {
+  Card,
+  CardDescription,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+
+export interface Resource {
+  description: string;
+  href: string;
+  title: string;
+  type: "guide" | "template";
+}
+
+const typeLabel: Record<Resource["type"], string> = {
+  guide: "Guide",
+  template: "Template",
+};
+
+export const ResourceCard = ({ title, description, href, type }: Resource) => {
+  const isExternal = href.startsWith("http");
+
+  return (
+    <a
+      className="no-underline"
+      href={href}
+      {...(isExternal ? { target: "_blank", rel: "noopener noreferrer" } : {})}
+    >
+      <Card className="group h-full gap-0 overflow-hidden py-0 shadow-none transition-colors hover:bg-accent/50">
+        <CardHeader className="flex h-full flex-col gap-3 p-6!">
+          <Badge className="w-fit" variant="secondary">
+            {typeLabel[type]}
+          </Badge>
+          <CardTitle className="text-balance font-medium leading-snug">
+            {title}
+          </CardTitle>
+          <CardDescription className="line-clamp-2">
+            {description}
+          </CardDescription>
+        </CardHeader>
+        <CardFooter className="border-t bg-sidebar px-6! py-4! transition-colors group-hover:bg-secondary">
+          <span className="flex items-center gap-1.5 text-muted-foreground text-xs">
+            {isExternal ? (
+              <>
+                <ArrowUpRightIcon className="size-3" />
+                {new URL(href).hostname}
+              </>
+            ) : (
+              "Read more"
+            )}
+          </span>
+        </CardFooter>
+      </Card>
+    </a>
+  );
+};

--- a/apps/docs/app/[lang]/(home)/resources/page.tsx
+++ b/apps/docs/app/[lang]/(home)/resources/page.tsx
@@ -15,7 +15,11 @@ const getResources = async (): Promise<Resource[]> => {
   if (process.env.NODE_ENV === "development") {
     return localData.resources as Resource[];
   }
-  return (await get<Resource[]>("resources")) ?? [];
+  try {
+    return (await get<Resource[]>("resources")) ?? [];
+  } catch {
+    return [];
+  }
 };
 
 const ResourcesPage = async () => {

--- a/apps/docs/app/[lang]/(home)/resources/page.tsx
+++ b/apps/docs/app/[lang]/(home)/resources/page.tsx
@@ -1,0 +1,75 @@
+import { get } from "@vercel/edge-config";
+import type { Metadata } from "next";
+import localData from "@/resources-edge-config.json";
+import { type Resource, ResourceCard } from "./components/resource-card";
+
+export const revalidate = 86400;
+
+export const metadata: Metadata = {
+  title: "Resources",
+  description:
+    "Guides, templates, and examples to help you build with Chat SDK.",
+};
+
+const getResources = async (): Promise<Resource[]> => {
+  if (process.env.NODE_ENV === "development") {
+    return localData.resources as Resource[];
+  }
+  return (await get<Resource[]>("resources")) ?? [];
+};
+
+const ResourcesPage = async () => {
+  const resources = await getResources();
+
+  const jsonLd = {
+    "@context": "https://schema.org",
+    "@type": "CollectionPage",
+    name: "Resources",
+    description:
+      "Guides, templates, and examples to help you build with Chat SDK.",
+    mainEntity: {
+      "@type": "ItemList",
+      itemListElement: resources.map((resource, index) => ({
+        "@type": "ListItem",
+        position: index + 1,
+        name: resource.title,
+        description: resource.description,
+        url: resource.href,
+      })),
+    },
+  };
+
+  return (
+    <div className="container mx-auto max-w-5xl">
+      <script
+        // biome-ignore lint/security/noDangerouslySetInnerHtml: Next.js recommended pattern for JSON-LD
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
+        type="application/ld+json"
+      />
+      <section className="mt-(--fd-nav-height) space-y-4 px-4 pt-16 pb-8 sm:pt-24">
+        <h1 className="text-balance font-semibold text-[40px] leading-[1.1] tracking-tight sm:text-5xl">
+          Resources
+        </h1>
+        <p className="max-w-2xl text-lg text-muted-foreground leading-relaxed">
+          Guides, templates, and examples to help you build with Chat SDK.
+        </p>
+      </section>
+
+      <section className="px-4 pb-16">
+        {resources && resources.length > 0 ? (
+          <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+            {resources.map((resource) => (
+              <ResourceCard key={resource.href} {...resource} />
+            ))}
+          </div>
+        ) : (
+          <p className="py-12 text-center text-muted-foreground">
+            No resources available yet. Check back soon.
+          </p>
+        )}
+      </section>
+    </div>
+  );
+};
+
+export default ResourcesPage;

--- a/apps/docs/app/[lang]/(home)/resources/page.tsx
+++ b/apps/docs/app/[lang]/(home)/resources/page.tsx
@@ -17,6 +17,9 @@ export const metadata: Metadata = {
     "ai agent",
     "vercel",
   ],
+  twitter: {
+    card: "summary_large_image",
+  },
 };
 
 const getResources = async (): Promise<Resource[]> => {

--- a/apps/docs/app/[lang]/(home)/resources/page.tsx
+++ b/apps/docs/app/[lang]/(home)/resources/page.tsx
@@ -9,6 +9,14 @@ export const metadata: Metadata = {
   title: "Resources",
   description:
     "Guides, templates, and examples to help you build with Chat SDK.",
+  keywords: [
+    "chat sdk",
+    "guides",
+    "templates",
+    "slack bot",
+    "ai agent",
+    "vercel",
+  ],
 };
 
 const getResources = async (): Promise<Resource[]> => {

--- a/apps/docs/geistdocs.tsx
+++ b/apps/docs/geistdocs.tsx
@@ -21,6 +21,10 @@ export const nav = [
     href: "/adapters",
   },
   {
+    label: "Resources",
+    href: "/resources",
+  },
+  {
     label: "Guides",
     href: "/docs/guides/slack-nextjs",
   },

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -18,6 +18,7 @@
     "@streamdown/math": "^1.0.2",
     "@streamdown/mermaid": "^1.0.2",
     "@vercel/analytics": "^1.6.1",
+    "@vercel/edge-config": "^1.4.3",
     "@vercel/speed-insights": "^1.3.1",
     "ai": "^5.0.106",
     "class-variance-authority": "^0.7.1",

--- a/apps/docs/resources-edge-config.json
+++ b/apps/docs/resources-edge-config.json
@@ -1,0 +1,40 @@
+{
+  "resources": [
+    {
+      "title": "How to build an AI agent for Slack with Chat SDK and AI SDK",
+      "description": "Build a Slack AI agent using Chat SDK, AI SDK's ToolLoopAgent, and Vercel AI Gateway. Covers project setup, tool definitions, streaming responses, deployment to Vercel, and scaling tool selection with toolpick.",
+      "href": "https://vercel.com/kb/guide/how-to-build-an-ai-agent-for-slack-with-chat-sdk-and-ai-sdk",
+      "type": "guide"
+    },
+    {
+      "title": "Run and track deploys from Slack",
+      "description": "Build a Slack deploy bot with Chat SDK and Vercel Workflow. Dispatch GitHub Actions from a slash command, gate production behind approval, poll for completion, and notify Linear and GitHub when the run finishes.",
+      "href": "https://vercel.com/kb/guide/run-and-track-deploys-from-slack",
+      "type": "guide"
+    },
+    {
+      "title": "Triage form submissions with Chat SDK",
+      "description": "Build a Slack bot that triages form submissions with interactive cards. Forward, edit, or mark as spam without leaving Slack. Built with Chat SDK, Hono, and Resend.",
+      "href": "https://vercel.com/kb/guide/triage-form-submissions-with-chat-sdk",
+      "type": "guide"
+    },
+    {
+      "title": "Chat SDK Liveblocks Bot",
+      "description": "Build a bot that you can engage with inside Liveblocks.",
+      "href": "https://vercel.com/templates/next.js/chat-sdk-liveblocks-bot",
+      "type": "template"
+    },
+    {
+      "title": "Knowledge Agent",
+      "description": "Open source file-system and knowledge based agent template. Build AI agents that stay up to date with your knowledge base.",
+      "href": "https://vercel.com/templates/nuxt/chat-sdk-knowledge-agent",
+      "type": "template"
+    },
+    {
+      "title": "Community Agent",
+      "description": "Open source AI-powered Slack community management bot with a built-in Next.js admin panel. Uses Chat SDK, AI SDK, and Vercel Workflow.",
+      "href": "https://vercel.com/templates/next.js/chat-sdk-community-agent",
+      "type": "template"
+    }
+  ]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -59,6 +59,9 @@ importers:
       '@vercel/analytics':
         specifier: ^1.6.1
         version: 1.6.1(next@16.2.3(@opentelemetry/api@1.9.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)
+      '@vercel/edge-config':
+        specifier: ^1.4.3
+        version: 1.4.3(@opentelemetry/api@1.9.0)(next@16.2.3(@opentelemetry/api@1.9.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))
       '@vercel/speed-insights':
         specifier: ^1.3.1
         version: 1.3.1(next@16.2.3(@opentelemetry/api@1.9.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)
@@ -2917,6 +2920,21 @@ packages:
       vue:
         optional: true
       vue-router:
+        optional: true
+
+  '@vercel/edge-config-fs@0.1.0':
+    resolution: {integrity: sha512-NRIBwfcS0bUoUbRWlNGetqjvLSwgYH/BqKqDN7vK1g32p7dN96k0712COgaz6VFizAm9b0g6IG6hR6+hc0KCPg==}
+
+  '@vercel/edge-config@1.4.3':
+    resolution: {integrity: sha512-8vTDATodRrH49wMzKEjZ8/5H2qs1aPkD0uRK585f/Fx4YN2wfHfY/3td9OFrh+gdnCq07z8A5f0hoY6xhBcPkg==}
+    engines: {node: '>=14.6'}
+    peerDependencies:
+      '@opentelemetry/api': ^1.7.0
+      next: '>=1'
+    peerDependenciesMeta:
+      '@opentelemetry/api':
+        optional: true
+      next:
         optional: true
 
   '@vercel/oidc@3.0.5':
@@ -8216,6 +8234,15 @@ snapshots:
     optionalDependencies:
       next: 16.2.3(@opentelemetry/api@1.9.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       react: 19.2.3
+
+  '@vercel/edge-config-fs@0.1.0': {}
+
+  '@vercel/edge-config@1.4.3(@opentelemetry/api@1.9.0)(next@16.2.3(@opentelemetry/api@1.9.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))':
+    dependencies:
+      '@vercel/edge-config-fs': 0.1.0
+    optionalDependencies:
+      '@opentelemetry/api': 1.9.0
+      next: 16.2.3(@opentelemetry/api@1.9.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
 
   '@vercel/oidc@3.0.5': {}
 

--- a/turbo.json
+++ b/turbo.json
@@ -15,7 +15,8 @@
     "WHATSAPP_PHONE_NUMBER_ID",
     "WHATSAPP_VERIFY_TOKEN",
     "BOT_USERNAME",
-    "REDIS_URL"
+    "REDIS_URL",
+    "EDGE_CONFIG"
   ],
   "tasks": {
     "build": {


### PR DESCRIPTION
- Add a `/resources` page displaying guides and templates in a responsive 3-column card grid
- Data is fetched from Vercel Edge Config in production, with a local JSON fallback for development (`resources-edge-config.json`)
- Includes `CollectionPage` + `ItemList` JSON-LD structured data for SEO
- Page revalidates daily (ISR with `revalidate = 86400`)
- Adds "Resources" link to the top navigation bar

<img width="1344" height="873" alt="chat-sdk-resources-page" src="https://github.com/user-attachments/assets/3c337b2b-6384-4b3c-b2ca-5d33714565ca" />
