### PR TITLE
fix(slack): preserve email addresses in @mention regex

### DIFF
--- a/.changeset/slack-mention-regex-email-addresses.md
+++ b/.changeset/slack-mention-regex-email-addresses.md
@@ -1,0 +1,5 @@
+---
+"@chat-adapter/slack": patch
+---
+
+Fix `@mention` rewrite regex so email addresses (e.g. `user@example.com`) and `<mailto:…>` links are no longer mangled into broken Slack user mentions. The lookbehind now excludes any word character before `@`, which also means mentions immediately following a word character (e.g. `prefix@user`) are no longer rewritten — a bare `@user` still converts as before.

--- a/packages/adapter-slack/src/markdown.test.ts
+++ b/packages/adapter-slack/src/markdown.test.ts
@@ -110,6 +110,42 @@ describe("SlackMarkdownConverter", () => {
     it("should not double-wrap mentions via fromMarkdown", () => {
       expect(converter.fromMarkdown("Hey <@U12345>")).toBe("Hey <@U12345>");
     });
+
+    it("should not mangle email addresses in plain strings", () => {
+      expect(
+        converter.renderPostable("Contact user@example.com for help")
+      ).toBe("Contact user@example.com for help");
+    });
+
+    it("should not mangle email addresses in markdown input", () => {
+      // GFM auto-link turns the email into a mailto link; key point is the
+      // `@example` is not rewritten as a `<@example>` Slack mention.
+      expect(
+        converter.renderPostable({
+          markdown: "Contact user@example.com for help",
+        })
+      ).toBe("Contact <mailto:user@example.com|user@example.com> for help");
+    });
+
+    it("should not mangle mailto links in plain strings", () => {
+      expect(converter.renderPostable("Email <mailto:user@example.com>")).toBe(
+        "Email <mailto:user@example.com>"
+      );
+    });
+
+    it("should not mangle email addresses inside markdown link text", () => {
+      expect(
+        converter.fromMarkdown(
+          "Email [user@example.com](mailto:user@example.com)"
+        )
+      ).toBe("Email <mailto:user@example.com|user@example.com>");
+    });
+
+    it("should still convert mentions adjacent to non-word punctuation", () => {
+      expect(converter.renderPostable("(cc @george, @anne)")).toBe(
+        "(cc <@george>, <@anne>)"
+      );
+    });
   });
 
   describe("toPlainText", () => {

--- a/packages/adapter-slack/src/markdown.ts
+++ b/packages/adapter-slack/src/markdown.ts
@@ -33,13 +33,18 @@ import {
 } from "chat";
 import type { SlackBlock } from "./cards";
 
+// Match bare @mentions (e.g. "@george") to rewrite as Slack's `<@george>`.
+// The lookbehind excludes `<` (already-formatted mentions like `<@U123>`) and
+// any word character, so email addresses like `user@example.com` are left alone.
+const BARE_MENTION_REGEX = /(?<![<\w])@(\w+)/g;
+
 export class SlackFormatConverter extends BaseFormatConverter {
   /**
    * Convert @mentions to Slack format in plain text.
    * @name → <@name>
    */
   private convertMentionsToSlack(text: string): string {
-    return text.replace(/(?<!<)@(\w+)/g, "<@$1>");
+    return text.replace(BARE_MENTION_REGEX, "<@$1>");
   }
 
   /**
@@ -170,7 +175,7 @@ export class SlackFormatConverter extends BaseFormatConverter {
 
     if (isTextNode(node)) {
       // Convert @mentions to Slack format <@mention>
-      return node.value.replace(/(?<!<)@(\w+)/g, "<@$1>");
+      return node.value.replace(BARE_MENTION_REGEX, "<@$1>");
     }
 
     if (isStrongNode(node)) {


### PR DESCRIPTION
- Extend `@mention` rewrite lookbehind from `(?<!<)` to `(?<![<\w])` so `user@example.com` and `<mailto:…>` links are no longer mangled into broken Slack mentions
- Extract the regex into a shared `BARE_MENTION_REGEX` const so the two call sites in `markdown.ts` can't drift
- Add five tests covering plain-string emails, markdown emails (GFM auto-link), mailto links, email-in-link-text, and mentions adjacent to punctuation

Fixes #392