### PR TITLE
fix(slack): enrich link previews with unfurl metadata from attachments

### DIFF
--- a/.changeset/full-clowns-scream.md
+++ b/.changeset/full-clowns-scream.md
@@ -1,0 +1,5 @@
+---
+"@chat-adapter/slack": patch
+---
+
+enrich link previews with title, description, and image from Slack unfurl attachments

--- a/packages/adapter-slack/src/index.test.ts
+++ b/packages/adapter-slack/src/index.test.ts
@@ -6863,3 +6863,240 @@ describe("getUser", () => {
     expect(usersInfoMock).not.toHaveBeenCalled();
   });
 });
+describe("link unfurl enrichment", () => {
+  const secret = "test-signing-secret";
+
+  it("should enrich links with metadata from attachments", async () => {
+    const state = createMockState();
+    const chatInstance = createMockChatInstance(state);
+    const adapter = createSlackAdapter({
+      botToken: "xoxb-test-token",
+      signingSecret: secret,
+      logger: mockLogger,
+    });
+    await adapter.initialize(chatInstance);
+
+    const body = JSON.stringify({
+      type: "event_callback",
+      event: {
+        type: "message",
+        channel: "C123",
+        ts: "1234567890.123456",
+        text: "Check out <https://example.com/article>",
+        user: "U_USER",
+        blocks: [
+          {
+            type: "rich_text",
+            elements: [
+              {
+                type: "rich_text_section",
+                elements: [
+                  { type: "text", text: "Check out " },
+                  { type: "link", url: "https://example.com/article" },
+                ],
+              },
+            ],
+          },
+        ],
+        attachments: [
+          {
+            from_url: "https://example.com/article",
+            title: "Example Article",
+            text: "An interesting article about testing",
+            image_url: "https://example.com/og-image.png",
+            service_name: "Example",
+          },
+        ],
+      },
+    });
+
+    const request = createWebhookRequest(body, secret);
+    await adapter.handleWebhook(request);
+
+    expect(chatInstance.processMessage).toHaveBeenCalled();
+    const factory = (chatInstance.processMessage as ReturnType<typeof vi.fn>)
+      .mock.calls[0][2] as () => Promise<{
+      links: Array<{
+        url: string;
+        title?: string;
+        description?: string;
+        imageUrl?: string;
+        siteName?: string;
+      }>;
+    }>;
+    const msg = await factory();
+
+    expect(msg.links).toHaveLength(1);
+    expect(msg.links[0].url).toBe("https://example.com/article");
+    expect(msg.links[0].title).toBe("Example Article");
+    expect(msg.links[0].description).toBe(
+      "An interesting article about testing"
+    );
+    expect(msg.links[0].imageUrl).toBe("https://example.com/og-image.png");
+    expect(msg.links[0].siteName).toBe("Example");
+  });
+
+  it("should extract links from attachments even without blocks", async () => {
+    const state = createMockState();
+    const chatInstance = createMockChatInstance(state);
+    const adapter = createSlackAdapter({
+      botToken: "xoxb-test-token",
+      signingSecret: secret,
+      logger: mockLogger,
+    });
+    await adapter.initialize(chatInstance);
+
+    const body = JSON.stringify({
+      type: "event_callback",
+      event: {
+        type: "message",
+        channel: "C123",
+        ts: "1234567890.123456",
+        text: "https://github.com/vercel/chat",
+        user: "U_USER",
+        attachments: [
+          {
+            from_url: "https://github.com/vercel/chat",
+            title: "vercel/chat",
+            text: "Chat SDK for building bots",
+            service_name: "GitHub",
+            service_icon: "https://github.githubassets.com/favicon.ico",
+          },
+        ],
+      },
+    });
+
+    const request = createWebhookRequest(body, secret);
+    await adapter.handleWebhook(request);
+
+    const factory = (chatInstance.processMessage as ReturnType<typeof vi.fn>)
+      .mock.calls[0][2] as () => Promise<{
+      links: Array<{ url: string; title?: string; siteName?: string }>;
+    }>;
+    const msg = await factory();
+
+    expect(msg.links).toHaveLength(1);
+    expect(msg.links[0].title).toBe("vercel/chat");
+    expect(msg.links[0].siteName).toBe("GitHub");
+  });
+
+  it("should return bare links when no attachments present", async () => {
+    const state = createMockState();
+    const chatInstance = createMockChatInstance(state);
+    const adapter = createSlackAdapter({
+      botToken: "xoxb-test-token",
+      signingSecret: secret,
+      logger: mockLogger,
+    });
+    await adapter.initialize(chatInstance);
+
+    const body = JSON.stringify({
+      type: "event_callback",
+      event: {
+        type: "message",
+        channel: "C123",
+        ts: "1234567890.123456",
+        text: "Check out <https://example.com>",
+        user: "U_USER",
+        blocks: [
+          {
+            type: "rich_text",
+            elements: [
+              {
+                type: "rich_text_section",
+                elements: [{ type: "link", url: "https://example.com" }],
+              },
+            ],
+          },
+        ],
+      },
+    });
+
+    const request = createWebhookRequest(body, secret);
+    await adapter.handleWebhook(request);
+
+    const factory = (chatInstance.processMessage as ReturnType<typeof vi.fn>)
+      .mock.calls[0][2] as () => Promise<{
+      links: Array<{ url: string; title?: string }>;
+    }>;
+    const msg = await factory();
+
+    expect(msg.links).toHaveLength(1);
+    expect(msg.links[0].url).toBe("https://example.com");
+    expect(msg.links[0].title).toBeUndefined();
+  });
+
+  it("should not re-dispatch message_changed as a new message", async () => {
+    const state = createMockState();
+    const chatInstance = createMockChatInstance(state);
+    const adapter = createSlackAdapter({
+      botToken: "xoxb-test-token",
+      signingSecret: secret,
+      logger: mockLogger,
+    });
+    await adapter.initialize(chatInstance);
+
+    const body = JSON.stringify({
+      type: "event_callback",
+      event: {
+        type: "message",
+        subtype: "message_changed",
+        hidden: true,
+        channel: "C123",
+        ts: "1234567891.000000",
+        message: {
+          type: "message",
+          user: "U_USER",
+          text: "https://example.com",
+          ts: "1234567890.123456",
+          attachments: [
+            {
+              from_url: "https://example.com",
+              title: "Example Site",
+              text: "Welcome to Example",
+            },
+          ],
+        },
+      },
+    });
+
+    const request = createWebhookRequest(body, secret);
+    await adapter.handleWebhook(request);
+
+    expect(chatInstance.processMessage).not.toHaveBeenCalled();
+  });
+
+  it("should ignore message_changed without unfurl attachments", async () => {
+    const state = createMockState();
+    const chatInstance = createMockChatInstance(state);
+    const adapter = createSlackAdapter({
+      botToken: "xoxb-test-token",
+      signingSecret: secret,
+      logger: mockLogger,
+    });
+    await adapter.initialize(chatInstance);
+
+    const body = JSON.stringify({
+      type: "event_callback",
+      event: {
+        type: "message",
+        subtype: "message_changed",
+        hidden: true,
+        channel: "C123",
+        ts: "1234567891.000000",
+        message: {
+          type: "message",
+          user: "U_USER",
+          text: "edited text",
+          ts: "1234567890.123456",
+          edited: { user: "U_USER", ts: "1234567891.000000" },
+        },
+      },
+    });
+
+    const request = createWebhookRequest(body, secret);
+    await adapter.handleWebhook(request);
+
+    expect(chatInstance.processMessage).not.toHaveBeenCalled();
+  });
+});

--- a/packages/adapter-slack/src/index.test.ts
+++ b/packages/adapter-slack/src/index.test.ts
@@ -7026,6 +7026,60 @@ describe("link unfurl enrichment", () => {
     expect(msg.links[0].title).toBeUndefined();
   });
 
+  it("should match unfurl metadata with trailing slash differences", async () => {
+    const state = createMockState();
+    const chatInstance = createMockChatInstance(state);
+    const adapter = createSlackAdapter({
+      botToken: "xoxb-test-token",
+      signingSecret: secret,
+      logger: mockLogger,
+    });
+    await adapter.initialize(chatInstance);
+
+    const body = JSON.stringify({
+      type: "event_callback",
+      event: {
+        type: "message",
+        channel: "C123",
+        ts: "1234567890.123456",
+        text: "<https://example.com>",
+        user: "U_USER",
+        blocks: [
+          {
+            type: "rich_text",
+            elements: [
+              {
+                type: "rich_text_section",
+                elements: [{ type: "link", url: "https://example.com" }],
+              },
+            ],
+          },
+        ],
+        attachments: [
+          {
+            from_url: "https://example.com/",
+            title: "Example",
+            text: "Welcome",
+          },
+        ],
+      },
+    });
+
+    const request = createWebhookRequest(body, secret);
+    await adapter.handleWebhook(request);
+
+    const factory = (chatInstance.processMessage as ReturnType<typeof vi.fn>)
+      .mock.calls[0][2] as () => Promise<{
+      links: Array<{ url: string; title?: string }>;
+    }>;
+    const msg = await factory();
+
+    const mainLink = msg.links.find(
+      (l: { url: string }) => l.url === "https://example.com"
+    );
+    expect(mainLink?.title).toBe("Example");
+  });
+
   it("should not re-dispatch message_changed as a new message", async () => {
     const state = createMockState();
     const chatInstance = createMockChatInstance(state);

--- a/packages/adapter-slack/src/index.ts
+++ b/packages/adapter-slack/src/index.ts
@@ -102,6 +102,7 @@ function findNextMention(text: string): number {
  * The timestamp in the URL has no dot (e.g., p1234567890123456).
  * Supports optional query parameters (e.g., ?thread_ts=...&cid=...).
  */
+const TRAILING_SLASH_PATTERN = /\/$/;
 const SLACK_MESSAGE_URL_PATTERN =
   /^https?:\/\/[^/]+\.slack\.com\/archives\/([A-Z0-9]+)\/p(\d+)(?:\?.*)?$/;
 
@@ -2565,7 +2566,10 @@ export class SlackAdapter implements Adapter<SlackThreadId, unknown> {
 
     return [...urls].map((url) => {
       const preview = this.createLinkPreview(url);
-      const unfurl = unfurls.get(url);
+      const unfurl =
+        unfurls.get(url) ||
+        unfurls.get(url.replace(TRAILING_SLASH_PATTERN, "")) ||
+        unfurls.get(`${url}/`);
       if (unfurl) {
         return { ...preview, ...unfurl };
       }

--- a/packages/adapter-slack/src/index.ts
+++ b/packages/adapter-slack/src/index.ts
@@ -2076,6 +2076,40 @@ export class SlackAdapter implements Adapter<SlackThreadId, unknown> {
       ts: inner.ts,
       attachmentCount: inner.attachments?.length,
     });
+
+    if (!(this.chat && inner.ts && inner.attachments)) {
+      return;
+    }
+
+    const unfurls: Record<
+      string,
+      {
+        title?: string;
+        description?: string;
+        imageUrl?: string;
+        siteName?: string;
+      }
+    > = {};
+    for (const att of inner.attachments) {
+      const attUrl = att.from_url || att.original_url;
+      if (attUrl && (att.title || att.text)) {
+        unfurls[attUrl] = {
+          title: att.title,
+          description: att.text,
+          imageUrl: att.image_url || att.thumb_url,
+          siteName: att.service_name,
+        };
+      }
+    }
+
+    if (Object.keys(unfurls).length > 0) {
+      this.chat
+        .getState()
+        .set(`slack:unfurls:${inner.ts}`, unfurls, 60 * 60 * 1000)
+        .catch((error) => {
+          this.logger.error("Failed to cache unfurl metadata", { error });
+        });
+    }
   }
 
   /**
@@ -2686,8 +2720,55 @@ export class SlackAdapter implements Adapter<SlackThreadId, unknown> {
       attachments: (event.files || []).map((file) =>
         this.createAttachment(file, event.team_id ?? event.team)
       ),
-      links: this.extractLinks(event),
+      links: await this.enrichLinks(this.extractLinks(event), event.ts),
     });
+  }
+
+  private async enrichLinks(
+    links: LinkPreview[],
+    messageTs?: string
+  ): Promise<LinkPreview[]> {
+    if (!(this.chat && messageTs) || links.length === 0) {
+      return links;
+    }
+
+    const allHaveMetadata = links.every((l) => l.title || l.fetchMessage);
+    if (allHaveMetadata) {
+      return links;
+    }
+
+    try {
+      const stored = await this.chat.getState().get<
+        Record<
+          string,
+          {
+            title?: string;
+            description?: string;
+            imageUrl?: string;
+            siteName?: string;
+          }
+        >
+      >(`slack:unfurls:${messageTs}`);
+      if (!stored) {
+        return links;
+      }
+
+      return links.map((link) => {
+        if (link.title) {
+          return link;
+        }
+        const unfurl =
+          stored[link.url] ||
+          stored[link.url.replace(TRAILING_SLASH_PATTERN, "")] ||
+          stored[`${link.url}/`];
+        if (unfurl) {
+          return { ...link, ...unfurl };
+        }
+        return link;
+      });
+    } catch {
+      return links;
+    }
   }
 
   /**

--- a/packages/adapter-slack/src/index.ts
+++ b/packages/adapter-slack/src/index.ts
@@ -220,6 +220,19 @@ export interface SlackThreadId {
 
 /** Slack event payload (raw message format) */
 export interface SlackEvent {
+  /** Legacy attachments (unfurl previews, app unfurls, etc.) */
+  attachments?: Array<{
+    from_url?: string;
+    image_url?: string;
+    is_msg_unfurl?: boolean;
+    original_url?: string;
+    service_icon?: string;
+    service_name?: string;
+    text?: string;
+    thumb_url?: string;
+    title?: string;
+    title_link?: string;
+  }>;
   /** Rich text blocks containing structured elements (links, mentions, etc.) */
   blocks?: Array<{
     type: string;
@@ -246,8 +259,12 @@ export interface SlackEvent {
     original_w?: number;
     original_h?: number;
   }>;
+  /** Hidden flag on message_changed events (true for unfurl-only updates) */
+  hidden?: boolean;
   /** Timestamp of the latest reply (present on thread parent messages) */
   latest_reply?: string;
+  /** Inner message on message_changed events */
+  message?: SlackEvent;
   /** Number of replies in the thread (present on thread parent messages) */
   reply_count?: number;
   subtype?: string;
@@ -1965,7 +1982,6 @@ export class SlackAdapter implements Adapter<SlackThreadId, unknown> {
     // Allow through: bot_message, file_share, thread_broadcast, me_message, and
     // any other content-carrying subtypes. Chat class handles isMe filtering.
     const ignoredSubtypes = new Set([
-      "message_changed",
       "message_deleted",
       "message_replied",
       "channel_join",
@@ -1985,6 +2001,11 @@ export class SlackAdapter implements Adapter<SlackThreadId, unknown> {
       "ekm_access_denied",
       "tombstone",
     ]);
+
+    if (event.subtype === "message_changed") {
+      this.handleMessageChanged(event, options);
+      return;
+    }
 
     if (event.subtype && ignoredSubtypes.has(event.subtype)) {
       this.logger.debug("Ignoring message subtype", {
@@ -2030,6 +2051,30 @@ export class SlackAdapter implements Adapter<SlackThreadId, unknown> {
     };
 
     this.chat.processMessage(this, threadId, factory, options);
+  }
+
+  private handleMessageChanged(
+    event: SlackEvent,
+    _options?: WebhookOptions
+  ): void {
+    const inner = event.message;
+    if (!(inner && event.channel)) {
+      return;
+    }
+
+    const hasUnfurlAttachments = inner.attachments?.some(
+      (att) => att.from_url || att.original_url
+    );
+    if (!hasUnfurlAttachments) {
+      this.logger.debug("Ignoring message_changed without unfurl data");
+      return;
+    }
+
+    this.logger.debug("Processing message_changed for link unfurls", {
+      channel: event.channel,
+      ts: inner.ts,
+      attachmentCount: inner.attachments?.length,
+    });
   }
 
   /**
@@ -2487,14 +2532,45 @@ export class SlackAdapter implements Adapter<SlackThreadId, unknown> {
     if (urls.size === 0 && event.text) {
       const urlPattern = /<(https?:\/\/[^>]+)>/g;
       for (const match of event.text.matchAll(urlPattern)) {
-        // Strip optional "|label" suffix (Slack format: <url|label>)
         const raw = match[1] as string;
         const pipeIdx = raw.indexOf("|");
         urls.add(pipeIdx >= 0 ? raw.slice(0, pipeIdx) : raw);
       }
     }
 
-    return [...urls].map((url) => this.createLinkPreview(url));
+    // Build unfurl metadata index from legacy attachments
+    const unfurls = new Map<
+      string,
+      {
+        title?: string;
+        description?: string;
+        imageUrl?: string;
+        siteName?: string;
+      }
+    >();
+    if (event.attachments) {
+      for (const att of event.attachments) {
+        const attUrl = att.from_url || att.original_url;
+        if (attUrl && (att.title || att.text)) {
+          unfurls.set(attUrl, {
+            title: att.title,
+            description: att.text,
+            imageUrl: att.image_url || att.thumb_url,
+            siteName: att.service_name,
+          });
+          urls.add(attUrl);
+        }
+      }
+    }
+
+    return [...urls].map((url) => {
+      const preview = this.createLinkPreview(url);
+      const unfurl = unfurls.get(url);
+      if (unfurl) {
+        return { ...preview, ...unfurl };
+      }
+      return preview;
+    });
   }
 
   /**

--- a/packages/adapter-slack/src/index.ts
+++ b/packages/adapter-slack/src/index.ts
@@ -103,6 +103,15 @@ function findNextMention(text: string): number {
  * Supports optional query parameters (e.g., ?thread_ts=...&cid=...).
  */
 const TRAILING_SLASH_PATTERN = /\/$/;
+const UNFURL_WAIT_MS = 2000;
+const UNFURL_POLL_MS = 150;
+
+interface SlackUnfurl {
+  description?: string;
+  imageUrl?: string;
+  siteName?: string;
+  title?: string;
+}
 const SLACK_MESSAGE_URL_PATTERN =
   /^https?:\/\/[^/]+\.slack\.com\/archives\/([A-Z0-9]+)\/p(\d+)(?:\?.*)?$/;
 
@@ -2737,38 +2746,42 @@ export class SlackAdapter implements Adapter<SlackThreadId, unknown> {
       return links;
     }
 
-    try {
-      const stored = await this.chat.getState().get<
-        Record<
-          string,
-          {
-            title?: string;
-            description?: string;
-            imageUrl?: string;
-            siteName?: string;
-          }
-        >
-      >(`slack:unfurls:${messageTs}`);
-      if (!stored) {
+    // slack delivers unfurled attachments via a separate message_changed event
+    // that lands ~100-2000ms after the original event. poll briefly so the
+    // handler sees enriched links instead of bare urls.
+    const deadline = Date.now() + UNFURL_WAIT_MS;
+    const state = this.chat.getState();
+    let stored: Record<string, SlackUnfurl> | null = null;
+    while (true) {
+      try {
+        stored = await state.get<Record<string, SlackUnfurl>>(
+          `slack:unfurls:${messageTs}`
+        );
+      } catch {
         return links;
       }
-
-      return links.map((link) => {
-        if (link.title) {
-          return link;
-        }
-        const unfurl =
-          stored[link.url] ||
-          stored[link.url.replace(TRAILING_SLASH_PATTERN, "")] ||
-          stored[`${link.url}/`];
-        if (unfurl) {
-          return { ...link, ...unfurl };
-        }
-        return link;
-      });
-    } catch {
+      if (stored || Date.now() >= deadline) {
+        break;
+      }
+      await new Promise((resolve) => setTimeout(resolve, UNFURL_POLL_MS));
+    }
+    if (!stored) {
       return links;
     }
+
+    return links.map((link) => {
+      if (link.title) {
+        return link;
+      }
+      const unfurl =
+        stored[link.url] ||
+        stored[link.url.replace(TRAILING_SLASH_PATTERN, "")] ||
+        stored[`${link.url}/`];
+      if (unfurl) {
+        return { ...link, ...unfurl };
+      }
+      return link;
+    });
   }
 
   /**


### PR DESCRIPTION
## summary

- add `attachments` field to `SlackEvent` interface for legacy unfurl data
- enrich `LinkPreview` objects with title, description, imageUrl, and siteName from Slack's attachment metadata
- selectively handle `message_changed` events for unfurl updates instead of blanket-ignoring them
- links fetched via `conversations.replies` / `conversations.history` now include full OG metadata for `toAiMessages`