### PR TITLE
fix(slack): add clear modal response_action for view_submission

### DIFF
--- a/.changeset/pink-places-matter.md
+++ b/.changeset/pink-places-matter.md
@@ -1,0 +1,6 @@
+---
+"@chat-adapter/slack": patch
+"chat": patch
+---
+
+Added response_action "clear"

--- a/packages/adapter-slack/src/index.test.ts
+++ b/packages/adapter-slack/src/index.test.ts
@@ -621,6 +621,39 @@ describe("handleWebhook - interactive payloads", () => {
     expect(response.status).toBe(200);
   });
 
+  it("returns response_action: clear when handler returns action: clear", async () => {
+    const clearAdapter = createSlackAdapter({
+      botToken: "xoxb-test-token",
+      signingSecret: secret,
+      logger: mockLogger,
+    });
+    const mockChat = {
+      processModalSubmit: vi.fn().mockResolvedValue({ action: "clear" }),
+    } as unknown as ChatInstance;
+    (clearAdapter as unknown as { chat: ChatInstance }).chat = mockChat;
+
+    const payload = JSON.stringify({
+      type: "view_submission",
+      trigger_id: "trigger123",
+      user: { id: "U123", username: "testuser", name: "Test User" },
+      view: {
+        id: "V123",
+        callback_id: "feedback_form",
+        private_metadata: "",
+        state: { values: {} },
+      },
+    });
+    const body = `payload=${encodeURIComponent(payload)}`;
+    const request = createWebhookRequest(body, secret, {
+      contentType: "application/x-www-form-urlencoded",
+    });
+
+    const response = await clearAdapter.handleWebhook(request);
+    expect(response.status).toBe(200);
+    expect(response.headers.get("content-type")).toBe("application/json");
+    expect(await response.json()).toEqual({ response_action: "clear" });
+  });
+
   it("handles view_closed payload", async () => {
     const payload = JSON.stringify({
       type: "view_closed",

--- a/packages/adapter-slack/src/index.ts
+++ b/packages/adapter-slack/src/index.ts
@@ -1228,6 +1228,8 @@ export class SlackAdapter implements Adapter<SlackThreadId, unknown> {
     switch (response.action) {
       case "close":
         return {};
+      case "clear":
+        return { response_action: "clear" };
       case "errors":
         return { response_action: "errors", errors: response.errors };
       case "update": {

--- a/packages/chat/src/index.ts
+++ b/packages/chat/src/index.ts
@@ -327,6 +327,7 @@ export type {
   MessageMetadata,
   ModalCloseEvent,
   ModalCloseHandler,
+  ModalClearResponse,
   ModalCloseResponse,
   ModalErrorsResponse,
   ModalPushResponse,

--- a/packages/chat/src/types.ts
+++ b/packages/chat/src/types.ts
@@ -2076,8 +2076,13 @@ export interface ModalCloseResponse {
   action: "close";
 }
 
+export interface ModalClearResponse {
+  action: "clear";
+}
+
 export type ModalResponse =
   | ModalCloseResponse
+  | ModalClearResponse
   | ModalErrorsResponse
   | ModalUpdateResponse
   | ModalPushResponse;


### PR DESCRIPTION
  ## Summary

  - Adds a fifth `ModalClearResponse` variant (`{ action: "clear" }`) to the SDK's `ModalResponse` union, bringing the abstraction to parity with Slack's five documented `view_submission` response semantics.
  - Wires it through the Slack adapter's `modalResponseToSlack` translator to emit `{ response_action: "clear" }`, which dismisses the entire modal stack (vs. `"close"` / empty body, which only closes the submitted view).

  
  Per the [official Slack modals docs](https://docs.slack.dev/surfaces/modals.md), `view_submission` supports 5 response shapes and only 4 were implemented
  
## Test plan

 `pnpm validate` 16/16 pass

Closes #400 