### PR TITLE
docs(adapters): add Telnyx as vendor-official SMS/MMS adapter

### DIFF
--- a/apps/docs/adapters.json
+++ b/apps/docs/adapters.json
@@ -173,6 +173,17 @@
     "vendorOfficial": true
   },
   {
+    "name": "Telnyx",
+    "slug": "telnyx",
+    "type": "platform",
+    "community": true,
+    "description": "Bidirectional SMS/MMS adapter for Chat SDK with Ed25519-verified webhooks, automatic MMS upgrade, and dedicated messaging profile support via Telnyx.",
+    "packageName": "@telnyx/chat-sdk-adapter",
+    "author": "Telnyx",
+    "readme": "https://github.com/team-telnyx/telnyx-chat-sdk-adapter",
+    "vendorOfficial": true
+  },
+  {
     "name": "Zernio",
     "slug": "zernio",
     "type": "platform",


### PR DESCRIPTION
## Summary

Adds `@telnyx/chat-sdk-adapter` as a **vendor-official** entry under the platform adapters list. The package is authored and maintained by Telnyx in [team-telnyx/telnyx-chat-sdk-adapter](https://github.com/team-telnyx/telnyx-chat-sdk-adapter), and `v0.1.0` is [live on npm](https://www.npmjs.com/package/@telnyx/chat-sdk-adapter) as of today.


## Vendor-official criteria (per the [building guide](https://chat-sdk.dev/docs/contributing/building))

- [x] **Continued maintenance** — owned by Telnyx's team
- [x] **GitHub hosting in official vendor-owned org** — `team-telnyx/telnyx-chat-sdk-adapter`
- [x] **Documentation in primary vendor docs** — Mintlify page coming in a follow-up PR to the Telnyx developer docs

## Adapter capabilities

- Bidirectional SMS/MMS via the Telnyx Messaging API
- Ed25519-verified webhooks with a 300-second replay window (validated against real Telnyx webhook deliveries during development)
- Automatic MMS upgrade when posted messages have attachments with public URLs
- Rate-limit handling (`429` → `AdapterRateLimitError` with `Retry-After`)
- Structured error parsing (`AuthenticationError` surfaces Telnyx error codes)
- Dedicated messaging profile support via `messagingProfileId`
- Attribution tags (`vercel-chat-sdk`, `vercel-chat-sdk:<version>`) and `User-Agent` for ecosystem observability

## Test plan

- [x] JSON validates (verified locally with `python3 -c "import json; json.load(open('apps/docs/adapters.json'))"`)
- [ ] Reviewer: adapter card renders on the `/docs/adapters` page in the vendor-official group (needs Vercel preview deploy authorization)