### PR TITLE
feat(examples): add emulated variant of telegram-chat reference bot

### DIFF
--- a/examples/telegram-chat/package.json
+++ b/examples/telegram-chat/package.json
@@ -5,12 +5,15 @@
   "type": "module",
   "scripts": {
     "start": "tsx src/index.ts",
+    "start:emulated": "tsx src/index.emulated.ts",
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
     "@chat-adapter/state-memory": "workspace:*",
     "@chat-adapter/telegram": "workspace:*",
-    "chat": "workspace:*"
+    "@emulators/telegram": "^0.4.1",
+    "chat": "workspace:*",
+    "emulate": "^0.4.1"
   },
   "devDependencies": {
     "@types/node": "^22.10.2",

--- a/examples/telegram-chat/src/bot.ts
+++ b/examples/telegram-chat/src/bot.ts
@@ -1,0 +1,163 @@
+/**
+ * Shared bot wiring: registers the menu + demo handlers on a fresh Chat,
+ * initializes it, and returns the Chat instance. Used by both the real-bot
+ * entry (src/index.ts) and the emulator entry (src/index.emulated.ts) —
+ * everything except where the adapter points is identical.
+ */
+
+import { createMemoryState } from "@chat-adapter/state-memory";
+import { createTelegramAdapter } from "@chat-adapter/telegram";
+import { type ActionEvent, Chat, type Logger, type Thread } from "chat";
+import { APPROVAL_DEMO_ID, buildDecidedCard, CARD_DEMOS } from "./demos/cards";
+import { MARKDOWN_DEMOS } from "./demos/markdown";
+import { MEDIA_DEMOS, type MediaDemoChat } from "./demos/media";
+import { decode } from "./lib/callbacks";
+import { postMainMenu, postMenu } from "./menu";
+
+export interface StartBotConfig {
+  botToken: string;
+  userName: string;
+  /** Override the Telegram API host (e.g. the emulate.dev Telegram emulator). */
+  apiBaseUrl?: string;
+  logger?: Logger;
+}
+
+export const defaultLogger: Logger = (() => {
+  const l: Logger = {
+    debug: (msg, meta) => console.debug(`[debug] ${msg}`, meta ?? ""),
+    info: (msg, meta) => console.log(`[info] ${msg}`, meta ?? ""),
+    warn: (msg, meta) => console.warn(`[warn] ${msg}`, meta ?? ""),
+    error: (msg, meta) => console.error(`[error] ${msg}`, meta ?? ""),
+    child: () => l,
+  };
+  return l;
+})();
+
+export async function startBot(config: StartBotConfig): Promise<Chat> {
+  const logger = config.logger ?? defaultLogger;
+
+  const state = createMemoryState();
+  const telegram = createTelegramAdapter({
+    botToken: config.botToken,
+    apiBaseUrl: config.apiBaseUrl,
+    mode: "polling",
+    userName: config.userName,
+    logger,
+  });
+
+  const chat = new Chat({
+    userName: config.userName,
+    adapters: { telegram },
+    state,
+    logger,
+  });
+
+  type DemoRunner = (thread: Thread<unknown>) => Promise<void>;
+  const demos = new Map<string, { label: string; run: DemoRunner }>();
+  for (const demo of MARKDOWN_DEMOS) {
+    demos.set(demo.id, { label: demo.label, run: demo.run });
+  }
+  for (const demo of CARD_DEMOS) {
+    demos.set(demo.id, { label: demo.label, run: demo.run });
+  }
+  const mediaDemoChat: MediaDemoChat = {
+    onSubscribedMessage: (handler) => chat.onSubscribedMessage(handler),
+  };
+  for (const demo of MEDIA_DEMOS) {
+    demos.set(demo.id, {
+      label: demo.label,
+      run: (thread) => demo.run(thread, mediaDemoChat),
+    });
+  }
+
+  // Any DM text opens the main menu. Telegram DMs route every message as a
+  // mention because the bot is the only other participant in the chat.
+  chat.onNewMention(async (thread, message) => {
+    console.log(`[bot] incoming text: ${message.text}`);
+    try {
+      await postMainMenu(thread);
+    } catch (err) {
+      console.error("[bot] failed to post main menu", err);
+    }
+  });
+
+  chat.onAction(async (event) => {
+    const parsed = decode(event.actionId);
+    if (!parsed) {
+      console.warn(`[bot] unknown callback_data: ${event.actionId}`);
+      return;
+    }
+    const thread = event.thread;
+    if (!thread) {
+      console.warn(`[bot] action ${event.actionId} received with no thread`);
+      return;
+    }
+
+    if (parsed.kind === "nav") {
+      await postMenu(thread, parsed.menu);
+      return;
+    }
+    if (parsed.kind === "run") {
+      const demo = demos.get(parsed.demo);
+      if (!demo) {
+        await thread.post(`❌ Unknown demo: ${parsed.demo}`);
+        return;
+      }
+      try {
+        await demo.run(thread);
+      } catch (err) {
+        console.error(`[bot] demo ${parsed.demo} failed`, err);
+        await thread.post(
+          `❌ ${demo.label} — ${(err as Error).message ?? String(err)}`
+        );
+      }
+      return;
+    }
+    if (parsed.kind === "act") {
+      await handleAction(parsed.demo, parsed.arg, event);
+    }
+  });
+
+  await chat.initialize();
+  return chat;
+}
+
+async function handleAction(
+  demo: string,
+  arg: string,
+  event: ActionEvent
+): Promise<void> {
+  const thread = event.thread;
+  if (!thread) {
+    return;
+  }
+  if (demo === APPROVAL_DEMO_ID && (arg === "approve" || arg === "reject")) {
+    try {
+      const card = buildDecidedCard(
+        arg,
+        event.user.userName || event.user.fullName,
+        new Date()
+      );
+      await event.adapter.editMessage(event.threadId, event.messageId, {
+        card,
+      });
+    } catch (err) {
+      console.error("[bot] approval edit failed", err);
+      await thread.post(
+        `❌ Approval update — ${(err as Error).message ?? String(err)}`
+      );
+    }
+    return;
+  }
+  // Size-probe: Telegram rejects the oversize button at post time, so a
+  // click on the acceptable one just reports success.
+  if (demo === "card.size") {
+    await thread.post(
+      arg === "ok"
+        ? "✅ Small payload delivered successfully."
+        : `ℹ️ Unexpected action: ${arg}`
+    );
+    return;
+  }
+  console.warn(`[bot] unhandled action ${demo}:${arg}`);
+}

--- a/examples/telegram-chat/src/index.emulated.ts
+++ b/examples/telegram-chat/src/index.emulated.ts
@@ -1,0 +1,164 @@
+/**
+ * Emulated variant of telegram-chat. Boots a local emulate.dev Telegram
+ * emulator, mints a bot + user + private chat via its test-control plane,
+ * hands the bot off to the shared startBot() wiring with apiBaseUrl pointed
+ * at the emulator, then drives a scripted interaction so you can watch the
+ * demo react without a real BotFather bot.
+ */
+
+import {
+  createTelegramTestClient,
+  type TestMessage,
+} from "@emulators/telegram/test";
+import { createEmulator } from "emulate";
+import { startBot } from "./bot";
+
+const EMU_PORT = Number(process.env.EMULATE_TELEGRAM_PORT ?? 4007);
+const BOT_USERNAME = "telegramchatdemobot";
+
+console.log(`[boot] starting Telegram emulator on :${EMU_PORT}…`);
+const emu = await createEmulator({ service: "telegram", port: EMU_PORT });
+console.log(`[boot] emulator ready at ${emu.url}`);
+
+const tg = createTelegramTestClient(emu.url);
+const bot = await tg.createBot({
+  username: BOT_USERNAME,
+  first_name: "Telegram Chat Demo",
+});
+const user = await tg.createUser({
+  first_name: "Alice",
+  username: "alice_tester",
+});
+const dm = await tg.createPrivateChat({ botId: bot.bot_id, userId: user.id });
+console.log(
+  `[boot] bot=${bot.username} (id=${bot.bot_id}) user=${user.id} chat=${dm.id}`
+);
+
+console.log("[boot] initializing chat…");
+await startBot({
+  botToken: bot.token,
+  userName: bot.username,
+  apiBaseUrl: emu.url,
+});
+console.log(`[boot] polling updates via ${emu.url}`);
+
+const delay = (ms: number): Promise<void> =>
+  new Promise((resolve) => {
+    setTimeout(resolve, ms);
+  });
+
+interface InlineKeyboardButton {
+  text: string;
+  callback_data?: string;
+  url?: string;
+}
+interface InlineReplyMarkup {
+  inline_keyboard?: InlineKeyboardButton[][];
+}
+
+function dumpMessage(index: number, msg: TestMessage): void {
+  const body = msg.text ?? msg.caption ?? "<no text>";
+  const preview = body.replace(/\n/g, " ").slice(0, 160);
+  console.log(`  [#${index}] msg_id=${msg.message_id} ${preview}`);
+  const markup = msg.reply_markup as InlineReplyMarkup | undefined;
+  for (const row of markup?.inline_keyboard ?? []) {
+    for (const btn of row) {
+      const ref = btn.callback_data
+        ? `callback_data="${btn.callback_data}"`
+        : btn.url
+          ? `url="${btn.url}"`
+          : "";
+      console.log(`       • ${btn.text} ${ref}`);
+    }
+  }
+}
+
+function findButton(
+  msg: TestMessage | undefined,
+  predicate: (btn: InlineKeyboardButton) => boolean
+): InlineKeyboardButton | undefined {
+  const markup = msg?.reply_markup as InlineReplyMarkup | undefined;
+  for (const row of markup?.inline_keyboard ?? []) {
+    for (const btn of row) {
+      if (predicate(btn)) {
+        return btn;
+      }
+    }
+  }
+  return undefined;
+}
+
+async function drive(): Promise<void> {
+  console.log('\n[drive] user sends "hi bot" to trigger the main menu…');
+  await tg.sendUserMessage({ chatId: dm.id, userId: user.id, text: "hi bot" });
+  await delay(1500);
+
+  let bots = await tg.getSentMessages({ chatId: dm.id });
+  console.log(`[drive] bot has sent ${bots.length} message(s):`);
+  bots.forEach((m, i) => dumpMessage(i, m));
+
+  const mainMenu = bots.at(-1);
+  const textBtn = findButton(mainMenu, (b) =>
+    b.text.toLowerCase().includes("text")
+  );
+  if (!(textBtn?.callback_data && mainMenu)) {
+    console.warn("[drive] could not find a Text & Markdown button; stopping");
+    return;
+  }
+
+  console.log(`\n[drive] clicking "${textBtn.text}"…`);
+  await tg.clickInlineButton({
+    chatId: dm.id,
+    userId: user.id,
+    messageId: mainMenu.message_id,
+    callbackData: textBtn.callback_data,
+  });
+  await delay(1500);
+
+  bots = await tg.getSentMessages({ chatId: dm.id });
+  console.log(`[drive] bot has sent ${bots.length} total; latest:`);
+  const latest = bots.at(-1);
+  if (latest) {
+    dumpMessage(bots.length - 1, latest);
+  }
+
+  const firstDemoBtn = findButton(
+    latest,
+    (b) => b.callback_data?.includes('"run:') ?? false
+  );
+  if (firstDemoBtn?.callback_data && latest) {
+    console.log(`\n[drive] running demo via "${firstDemoBtn.text}"…`);
+    await tg.clickInlineButton({
+      chatId: dm.id,
+      userId: user.id,
+      messageId: latest.message_id,
+      callbackData: firstDemoBtn.callback_data,
+    });
+    await delay(2000);
+    bots = await tg.getSentMessages({ chatId: dm.id });
+    console.log(`[drive] final bot-sent count: ${bots.length}`);
+    const demoMsg = bots.at(-1);
+    if (demoMsg) {
+      dumpMessage(bots.length - 1, demoMsg);
+    }
+  }
+}
+
+await drive();
+
+console.log("\n[done] scripted interaction complete.");
+console.log(
+  "[done] polling is still active — Ctrl-C to stop the emulator and exit."
+);
+
+const shutdown = async (): Promise<void> => {
+  console.log("\n[boot] shutting down…");
+  try {
+    await emu.close();
+  } catch (err) {
+    console.error("[boot] emulator close failed", err);
+  }
+  process.exit(0);
+};
+process.on("SIGINT", shutdown);
+process.on("SIGTERM", shutdown);

--- a/examples/telegram-chat/src/index.ts
+++ b/examples/telegram-chat/src/index.ts
@@ -1,19 +1,11 @@
 /**
  * telegram-chat — reference bot for the Chat SDK's Telegram adapter.
  *
- * Boots a polling-mode Telegram adapter, wires mention and action handlers,
- * routes both to the menu state machine in menu.tsx. Stateless beyond the
- * reactions demo, which briefly subscribes and self-unsubscribes.
+ * Boots a polling-mode Telegram adapter against the real Bot API using a
+ * BotFather token, then delegates all wiring to startBot() in ./bot.
  */
 
-import { createMemoryState } from "@chat-adapter/state-memory";
-import { createTelegramAdapter } from "@chat-adapter/telegram";
-import { type ActionEvent, Chat, type Logger, type Thread } from "chat";
-import { APPROVAL_DEMO_ID, buildDecidedCard, CARD_DEMOS } from "./demos/cards";
-import { MARKDOWN_DEMOS } from "./demos/markdown";
-import { MEDIA_DEMOS, type MediaDemoChat } from "./demos/media";
-import { decode } from "./lib/callbacks";
-import { postMainMenu, postMenu } from "./menu";
+import { startBot } from "./bot";
 
 const TELEGRAM_BOT_TOKEN = process.env.TELEGRAM_BOT_TOKEN;
 if (!TELEGRAM_BOT_TOKEN) {
@@ -25,153 +17,8 @@ if (!TELEGRAM_BOT_TOKEN) {
 
 const BOT_USERNAME = process.env.TELEGRAM_BOT_USERNAME ?? "telegramchatdemobot";
 
-const logger: Logger = {
-  debug: (msg, meta) => console.debug(`[debug] ${msg}`, meta ?? ""),
-  info: (msg, meta) => console.log(`[info] ${msg}`, meta ?? ""),
-  warn: (msg, meta) => console.warn(`[warn] ${msg}`, meta ?? ""),
-  error: (msg, meta) => console.error(`[error] ${msg}`, meta ?? ""),
-  child: () => logger,
-};
-
-const state = createMemoryState();
-const telegram = createTelegramAdapter({
-  botToken: TELEGRAM_BOT_TOKEN,
-  mode: "polling",
-  userName: BOT_USERNAME,
-  logger,
-});
-
-const chat = new Chat({
-  userName: BOT_USERNAME,
-  adapters: { telegram },
-  state,
-  logger,
-});
-
-type DemoRunner = (thread: Thread<unknown>) => Promise<void>;
-
-const DEMO_LOOKUP = new Map<string, { label: string; run: DemoRunner }>();
-
-for (const demo of MARKDOWN_DEMOS) {
-  DEMO_LOOKUP.set(demo.id, { label: demo.label, run: demo.run });
-}
-for (const demo of CARD_DEMOS) {
-  DEMO_LOOKUP.set(demo.id, { label: demo.label, run: demo.run });
-}
-
-const mediaDemoChat: MediaDemoChat = {
-  onSubscribedMessage: (handler) => chat.onSubscribedMessage(handler),
-};
-for (const demo of MEDIA_DEMOS) {
-  DEMO_LOOKUP.set(demo.id, {
-    label: demo.label,
-    run: (thread) => demo.run(thread, mediaDemoChat),
-  });
-}
-
-// Any DM text opens the main menu. Telegram DMs route every message as a
-// mention because the bot is the only other participant in the chat.
-chat.onNewMention(async (thread, message) => {
-  console.log(`[bot] incoming text: ${message.text}`);
-  try {
-    await postMainMenu(thread);
-  } catch (err) {
-    console.error("[bot] failed to post main menu", err);
-  }
-});
-
-// The reactions demo registers its own short-lived onSubscribedMessage
-// handler and unsubscribes as soon as it fires or times out. No global
-// subscribed-message handler is needed here.
-
-// All button callbacks route through here.
-chat.onAction(async (event) => {
-  const raw = event.actionId;
-  const parsed = decode(raw);
-  if (!parsed) {
-    console.warn(`[bot] unknown callback_data: ${raw}`);
-    return;
-  }
-
-  const thread = event.thread;
-  if (!thread) {
-    console.warn(`[bot] action ${raw} received with no thread`);
-    return;
-  }
-
-  if (parsed.kind === "nav") {
-    await postMenu(thread, parsed.menu);
-    return;
-  }
-
-  if (parsed.kind === "run") {
-    const demo = DEMO_LOOKUP.get(parsed.demo);
-    if (!demo) {
-      await thread.post(`❌ Unknown demo: ${parsed.demo}`);
-      return;
-    }
-    try {
-      await demo.run(thread);
-    } catch (err) {
-      console.error(`[bot] demo ${parsed.demo} failed`, err);
-      await thread.post(
-        `❌ ${demo.label} — ${(err as Error).message ?? String(err)}`
-      );
-    }
-    return;
-  }
-
-  if (parsed.kind === "act") {
-    await handleAction(parsed.demo, parsed.arg, event);
-    return;
-  }
-});
-
-async function handleAction(
-  demo: string,
-  arg: string,
-  event: ActionEvent
-): Promise<void> {
-  const thread = event.thread;
-  if (!thread) {
-    return;
-  }
-
-  if (demo === APPROVAL_DEMO_ID && (arg === "approve" || arg === "reject")) {
-    try {
-      const card = buildDecidedCard(
-        arg,
-        event.user.userName || event.user.fullName,
-        new Date()
-      );
-      await event.adapter.editMessage(event.threadId, event.messageId, {
-        card,
-      });
-    } catch (err) {
-      console.error("[bot] approval edit failed", err);
-      await thread.post(
-        `❌ Approval update — ${(err as Error).message ?? String(err)}`
-      );
-    }
-    return;
-  }
-
-  // Size-probe: Telegram rejects the oversize button at post time, so a
-  // click on the acceptable one just reports success.
-  if (demo === "card.size") {
-    await thread.post(
-      arg === "ok"
-        ? "✅ Small payload delivered successfully."
-        : `ℹ️ Unexpected action: ${arg}`
-    );
-    return;
-  }
-
-  console.warn(`[bot] unhandled action ${demo}:${arg}`);
-}
-
 console.log("[boot] initializing chat…");
-await chat.initialize();
+await startBot({ botToken: TELEGRAM_BOT_TOKEN, userName: BOT_USERNAME });
 console.log(
   `[boot] polling for messages. DM @${BOT_USERNAME} any text to open the menu.`
 );


### PR DESCRIPTION
Follow-up to #407. Adds a second entry point for the `telegram-chat` example that runs against a local [emulate.dev](https://emulate.dev/) Telegram emulator — same bot wiring, different `apiBaseUrl`.

Extracts `src/bot.ts` with `startBot({ botToken, userName, apiBaseUrl?, logger? })` so `index.ts` (real bot) and the new `index.emulated.ts` share all handler registration, demo lookup, and `chat.initialize()`. `index.ts` drops from 183 → 29 lines; the emulated entry adds the three-step scripted drive (simulated DM → menu click → demo click) and asserts via `getSentMessages()`.

The Telegram adapter already accepts `apiBaseUrl`, so nothing in `@chat-adapter/telegram` changes.

## Dependency

Blocked on [vercel-labs/emulate#75](https://github.com/vercel-labs/emulate/pull/75), which adds the Telegram emulator and publishes `emulate` + `@emulators/telegram` to npm. `pnpm-lock.yaml` is intentionally not committed — integrity hashes will be generated against the real tarballs on first `pnpm install` post-release.

## Test plan

Once upstream is released:

- [ ] `pnpm install`
- [ ] `pnpm --filter example-telegram-chat typecheck`
- [ ] `pnpm --filter example-telegram-chat start:emulated` — bot sends exactly 3 messages: main menu (`msg_id=2`, 3 nav buttons), Text & Markdown sub-menu (`msg_id=3`, 12 buttons), `"Hello, this is plain text. No formatting."` (`msg_id=4`)
- [ ] Real-bot path unchanged: `TELEGRAM_BOT_TOKEN=... pnpm --filter example-telegram-chat start`