### PR TITLE
ci: use npm trusted publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,6 +13,7 @@ concurrency: ${{ github.workflow }}-${{ github.ref }}
 permissions:
   contents: write
   pull-requests: write
+  id-token: write
 
 jobs:
   release:
@@ -27,7 +28,8 @@ jobs:
 
       - uses: actions/setup-node@v6
         with:
-          node-version: 20
+          node-version: "24"
+          registry-url: "https://registry.npmjs.org"
           cache: "pnpm"
 
       - run: pnpm install --frozen-lockfile
@@ -43,7 +45,6 @@ jobs:
           publish: pnpm changeset publish
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Deploy to Vercel
         if: steps.changesets.outputs.published == 'true'


### PR DESCRIPTION
Switch the release workflow from `NPM_TOKEN` to npm trusted publishing via OIDC.