### PR TITLE
chore: add changeset for #415 (Teams SDK 2.0.8)

### DIFF
--- a/.changeset/teams-sdk-2.0.8.md
+++ b/.changeset/teams-sdk-2.0.8.md
@@ -1,0 +1,5 @@
+---
+'@chat-adapter/teams': patch
+---
+
+Bump Microsoft Teams SDK to 2.0.8 and switch to standard `User-Agent` header


### PR DESCRIPTION
Adds the missing changeset for #415, which bumped `@microsoft/teams.*` from 2.0.6 → 2.0.8 and switched the custom `X-User-Agent` header to the standard `User-Agent`.