### PR TITLE
fix(chat): honor concurrency.maxConcurrent in the concurrent strategy

### DIFF
--- a/.changeset/fix-max-concurrent.md
+++ b/.changeset/fix-max-concurrent.md
@@ -1,0 +1,5 @@
+---
+'chat': patch
+---
+
+fix(chat): honor `concurrency.maxConcurrent` in the `concurrent` strategy. The cap was documented but never applied, so handlers dispatched unbounded. Also warns when `maxConcurrent` is paired with a non-`concurrent` strategy (previously ignored silently) and throws on `maxConcurrent < 1` to prevent a deadlock.

--- a/packages/chat/src/chat.test.ts
+++ b/packages/chat/src/chat.test.ts
@@ -3211,6 +3211,139 @@ describe("Chat", () => {
       // Lock methods should not have been called by concurrent strategy
       // (the pre-acquire above is manual)
     });
+
+    it("should cap in-flight handlers at maxConcurrent per thread", async () => {
+      const state = createMockState();
+      const adapter = createMockAdapter("slack");
+
+      const chat = new Chat({
+        userName: "testbot",
+        adapters: { slack: adapter },
+        state,
+        logger: mockLogger,
+        concurrency: { strategy: "concurrent", maxConcurrent: 2 },
+      });
+
+      await chat.webhooks.slack(
+        new Request("http://test.com", { method: "POST" })
+      );
+
+      let inFlight = 0;
+      let peakInFlight = 0;
+      const releases: Array<() => void> = [];
+
+      chat.onNewMention(async () => {
+        inFlight++;
+        peakInFlight = Math.max(peakInFlight, inFlight);
+        await new Promise<void>((resolve) => {
+          releases.push(resolve);
+        });
+        inFlight--;
+      });
+
+      const threadId = "slack:C123:1234.5678";
+      const pending = Array.from({ length: 5 }, (_, i) =>
+        chat.handleIncomingMessage(
+          adapter,
+          threadId,
+          createTestMessage(`msg-mc-${i}`, "Hey @slack-bot")
+        )
+      );
+
+      // Let the first wave of handlers start.
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      expect(inFlight).toBe(2);
+
+      // Drain each slot one at a time and assert cap holds.
+      while (releases.length > 0) {
+        const release = releases.shift();
+        release?.();
+        await new Promise((resolve) => setTimeout(resolve, 0));
+        expect(inFlight).toBeLessThanOrEqual(2);
+      }
+
+      await Promise.all(pending);
+      expect(peakInFlight).toBe(2);
+    });
+
+    it("should track slots per thread independently", async () => {
+      const state = createMockState();
+      const adapter = createMockAdapter("slack");
+
+      const chat = new Chat({
+        userName: "testbot",
+        adapters: { slack: adapter },
+        state,
+        logger: mockLogger,
+        concurrency: { strategy: "concurrent", maxConcurrent: 1 },
+      });
+
+      await chat.webhooks.slack(
+        new Request("http://test.com", { method: "POST" })
+      );
+
+      const releases: Array<() => void> = [];
+      const handler = vi.fn().mockImplementation(
+        () =>
+          new Promise<void>((resolve) => {
+            releases.push(resolve);
+          })
+      );
+      chat.onNewMention(handler);
+
+      const pendingA = chat.handleIncomingMessage(
+        adapter,
+        "slack:C123:thread-A",
+        createTestMessage("msg-a", "Hey @slack-bot")
+      );
+      const pendingB = chat.handleIncomingMessage(
+        adapter,
+        "slack:C123:thread-B",
+        createTestMessage("msg-b", "Hey @slack-bot")
+      );
+
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      // Both threads dispatch immediately because they are independent.
+      expect(handler).toHaveBeenCalledTimes(2);
+
+      for (const release of releases) {
+        release();
+      }
+      await Promise.all([pendingA, pendingB]);
+    });
+
+    it("should warn when maxConcurrent is set with a non-concurrent strategy", () => {
+      const state = createMockState();
+      const adapter = createMockAdapter("slack");
+
+      new Chat({
+        userName: "testbot",
+        adapters: { slack: adapter },
+        state,
+        logger: mockLogger,
+        concurrency: { strategy: "queue", maxConcurrent: 2 },
+      });
+
+      expect(mockLogger.warn).toHaveBeenCalledWith(
+        expect.stringContaining("maxConcurrent has no effect when strategy is")
+      );
+    });
+
+    it("should throw when maxConcurrent is less than 1", () => {
+      const state = createMockState();
+      const adapter = createMockAdapter("slack");
+
+      expect(
+        () =>
+          new Chat({
+            userName: "testbot",
+            adapters: { slack: adapter },
+            state,
+            logger: mockLogger,
+            concurrency: { strategy: "concurrent", maxConcurrent: 0 },
+          })
+      ).toThrow("maxConcurrent must be >= 1");
+    });
   });
 
   describe("lockScope", () => {

--- a/packages/chat/src/chat.ts
+++ b/packages/chat/src/chat.ts
@@ -214,6 +214,10 @@ export class Chat<
   private readonly _concurrencyConfig: Required<
     Omit<ConcurrencyConfig, "strategy">
   >;
+  private readonly _concurrentSlots = new Map<
+    string,
+    { inFlight: number; waiters: Array<() => void> }
+  >();
   private readonly _lockScope: ChatConfig["lockScope"];
 
   private readonly mentionHandlers: MentionHandler<TState>[] = [];
@@ -259,6 +263,13 @@ export class Chat<
     this._onLockConflict = config.onLockConflict;
     this._lockScope = config.lockScope;
 
+    // Initialize logger first so concurrency parsing can warn on misconfig
+    if (typeof config.logger === "string") {
+      this.logger = new ConsoleLogger(config.logger as LogLevel);
+    } else {
+      this.logger = config.logger || new ConsoleLogger("info");
+    }
+
     // Parse concurrency config — new `concurrency` option takes precedence over deprecated `onLockConflict`
     const concurrency = config.concurrency;
     if (concurrency) {
@@ -272,6 +283,22 @@ export class Chat<
           queueEntryTtlMs: 90_000,
         };
       } else {
+        if (
+          concurrency.maxConcurrent !== undefined &&
+          concurrency.maxConcurrent < 1
+        ) {
+          throw new Error(
+            `concurrency.maxConcurrent must be >= 1 (got ${concurrency.maxConcurrent})`
+          );
+        }
+        if (
+          concurrency.maxConcurrent !== undefined &&
+          concurrency.strategy !== "concurrent"
+        ) {
+          this.logger.warn(
+            `concurrency.maxConcurrent has no effect when strategy is "${concurrency.strategy}" — it only applies to the "concurrent" strategy.`
+          );
+        }
         this._concurrencyStrategy = concurrency.strategy;
         this._concurrencyConfig = {
           debounceMs: concurrency.debounceMs ?? 1500,
@@ -296,13 +323,6 @@ export class Chat<
       this._stateAdapter,
       config.messageHistory
     );
-
-    // Initialize logger
-    if (typeof config.logger === "string") {
-      this.logger = new ConsoleLogger(config.logger as LogLevel);
-    } else {
-      this.logger = config.logger || new ConsoleLogger("info");
-    }
 
     // Register adapters and create webhook handlers
     const webhooks = {} as Record<string, WebhookHandler>;
@@ -2108,14 +2128,62 @@ export class Chat<
   }
 
   /**
-   * Concurrent strategy: no locking, process immediately.
+   * Concurrent strategy: no locking, process immediately — but cap
+   * simultaneous handlers per thread at `maxConcurrent` (default Infinity).
    */
   private async handleConcurrent(
     adapter: Adapter,
     threadId: string,
     message: Message
   ): Promise<void> {
-    await this.dispatchToHandlers(adapter, threadId, message);
+    const { maxConcurrent } = this._concurrencyConfig;
+
+    if (!Number.isFinite(maxConcurrent)) {
+      await this.dispatchToHandlers(adapter, threadId, message);
+      return;
+    }
+
+    await this.acquireConcurrentSlot(threadId, maxConcurrent);
+    try {
+      await this.dispatchToHandlers(adapter, threadId, message);
+    } finally {
+      this.releaseConcurrentSlot(threadId);
+    }
+  }
+
+  private acquireConcurrentSlot(
+    threadId: string,
+    maxConcurrent: number
+  ): Promise<void> {
+    let slot = this._concurrentSlots.get(threadId);
+    if (!slot) {
+      slot = { inFlight: 0, waiters: [] };
+      this._concurrentSlots.set(threadId, slot);
+    }
+    if (slot.inFlight < maxConcurrent) {
+      slot.inFlight++;
+      return Promise.resolve();
+    }
+    return new Promise<void>((resolve) => {
+      slot.waiters.push(resolve);
+    });
+  }
+
+  private releaseConcurrentSlot(threadId: string): void {
+    const slot = this._concurrentSlots.get(threadId);
+    if (!slot) {
+      return;
+    }
+    const next = slot.waiters.shift();
+    if (next) {
+      // Hand the slot directly to the next waiter; inFlight stays the same.
+      next();
+      return;
+    }
+    slot.inFlight--;
+    if (slot.inFlight === 0 && slot.waiters.length === 0) {
+      this._concurrentSlots.delete(threadId);
+    }
   }
 
   /**


### PR DESCRIPTION
Closes #417.

- `handleConcurrent` now acquires a per-thread semaphore slot when `maxConcurrent` is finite; fast path preserved for the default `Infinity`.
- Constructor throws on `maxConcurrent < 1` (would deadlock) and warns when `maxConcurrent` is paired with a non-`concurrent` strategy (was previously ignored silently).