### PR TITLE
Add MySQL community state adapter listing

### DIFF
--- a/apps/docs/adapters.json
+++ b/apps/docs/adapters.json
@@ -130,6 +130,16 @@
     "readme": "https://github.com/dcartertwo/chat-state-cloudflare-do/tree/13ebf545b302b7c8fdabf7de9c5de678e047ce5e"
   },
   {
+    "name": "MySQL",
+    "slug": "mysql",
+    "type": "state",
+    "community": true,
+    "description": "Community MySQL state adapter with persistence, distributed locking, caching, lists, and queues.",
+    "packageName": "chat-state-mysql",
+    "author": "DivyanshGolyan",
+    "readme": "https://github.com/DivyanshGolyan/chat-state-mysql/tree/26502f2c43e2aee16b0b58f2066a81e01b2c289b"
+  },
+  {
     "name": "Beeper Matrix",
     "slug": "matrix",
     "type": "platform",


### PR DESCRIPTION
## What?

Adds `chat-state-mysql` to the community state adapter listings in `apps/docs/adapters.json`.

## Why?

This makes the MySQL state adapter discoverable through the Chat SDK docs while keeping it as a community-maintained package outside the official `@chat-adapter/*` scope.

## How?

- Adds a `state` adapter entry for MySQL with `community: true`
- Points `packageName` at `chat-state-mysql`
- Pins the rendered README source to the adapter repo commit `26502f2c43e2aee16b0b58f2066a81e01b2c289b`

External adapter repo: https://github.com/DivyanshGolyan/chat-state-mysql
npm package: https://www.npmjs.com/package/chat-state-mysql

## Testing?

For this docs PR:

- `pnpm validate`

For the external adapter package:

- `pnpm install`
- `pnpm typecheck`
- `pnpm test` (50 passed, 1 skipped)
- `pnpm build`
- `npm pack --dry-run`
- Live smoke tests against Docker MySQL 5.7.44 and 8.4.9 for long multibyte key-prefix isolation, list trimming, and queue trimming

## Additional Notes

The package source is pushed, tagged as `v0.1.0`, and published to npm as `chat-state-mysql@0.1.0`.