### PR TITLE
fix(docs): stack get-started cta and snippet on narrow viewports

### DIFF
--- a/apps/docs/app/[lang]/(home)/components/get-started-section.tsx
+++ b/apps/docs/app/[lang]/(home)/components/get-started-section.tsx
@@ -109,7 +109,7 @@ export const GetStartedSection = ({ data }: { data: Template[] }) => (
           template.
         </p>
       </div>
-      <div className="flex shrink-0 items-center gap-3">
+      <div className="flex flex-col items-stretch gap-3 sm:shrink-0 sm:flex-row sm:items-center">
         <Button asChild className="h-[42px] rounded-full px-5" size="default">
           <DynamicLink href="/[lang]/docs">Visit Documentation</DynamicLink>
         </Button>


### PR DESCRIPTION
## summary

- on samsung and other phones below the `sm:` (640px) breakpoint, the "Visit Documentation" button and the `npm i chat` snippet were rendered side-by-side in a row that didn't have enough horizontal space, so the snippet's text wrapped onto two lines (e.g. "npm i" / "chat") inside its fixed-height pill — looked broken
- switch the inner button + snippet container from `flex shrink-0 items-center gap-3` to `flex flex-col items-stretch gap-3 sm:flex-row sm:shrink-0 sm:items-center` so the two elements stack vertically below `sm:` and sit side-by-side from `sm:` upward
- both elements stay `h-[42px]` pills, just full-width when stacked

## test plan

- [x] visual check at 360, 390, 412, 540, 768 — wrap fixed, layout matches design at sm: and above
- [x] `pnpm -w run check` clean
- [x] `pnpm dev` on docs app, scrolled to "Build with Chat SDK today" section