### PR TITLE
docs: add Blooio iMessage adapter

### DIFF
--- a/apps/docs/adapters.json
+++ b/apps/docs/adapters.json
@@ -225,6 +225,16 @@
     "readme": "https://github.com/midday-ai/chat-adapter-sendblue/tree/5125a9d018f5d05dca063cd4d7e554fdb92ecce8"
   },
   {
+    "name": "Blooio iMessage",
+    "slug": "blooio",
+    "type": "platform",
+    "community": true,
+    "description": "Blooio adapter for Chat SDK to send and receive iMessage, RCS, and SMS from your bot.",
+    "packageName": "chat-adapter-blooio",
+    "author": "midday-ai",
+    "readme": "https://github.com/midday-ai/chat-adapter-blooio/tree/283678e3490275c7b440221ce3cdeac56bbfb60a"
+  },
+  {
     "name": "Zalo",
     "slug": "zalo",
     "type": "platform",

--- a/apps/docs/app/[lang]/(home)/adapters/for/[messenger]/page.tsx
+++ b/apps/docs/app/[lang]/(home)/adapters/for/[messenger]/page.tsx
@@ -21,7 +21,7 @@ const messengerConfig: Record<
     name: "iMessage",
     description:
       "Build bots for iMessage with Chat SDK. Browse official and community adapters that support iMessage integration.",
-    adapterSlugs: ["imessage", "sendblue"],
+    adapterSlugs: ["imessage", "blooio", "sendblue"],
     keywords: ["imessage"],
   },
   whatsapp: {


### PR DESCRIPTION
## Summary
- Adds `chat-adapter-blooio` to the adapters registry with a pinned README commit.
- Includes Blooio in the iMessage adapters category page.

## Test plan
- `node -e "JSON.parse(require('node:fs').readFileSync('apps/docs/adapters.json', 'utf8')); console.log('adapters.json is valid JSON')"`