### PR TITLE
fix(docs): exclude opengraph-image.png from proxy matcher

### DIFF
--- a/apps/docs/proxy.ts
+++ b/apps/docs/proxy.ts
@@ -81,7 +81,7 @@ const proxy = (request: NextRequest, context: NextFetchEvent) => {
 export const config = {
   // Matcher ignoring `/_next/`, `/api/`, static assets, favicon, sitemap, robots, etc.
   matcher: [
-    "/((?!api|_next/static|_next/image|favicon.ico|sitemap.xml|robots.txt|AGENTS.md|\\.well-known).*)",
+    "/((?!api|_next/static|_next/image|favicon.ico|sitemap.xml|robots.txt|opengraph-image\\.png|AGENTS.md|\\.well-known).*)",
   ],
 };
 


### PR DESCRIPTION
## summary

`https://chat-sdk.dev/opengraph-image.png` returned 404 — the social-card image referenced in every page's `<meta og:image>` was broken.

root cause: the proxy matcher in `apps/docs/proxy.ts` excludes `favicon.ico`, `sitemap.xml`, `robots.txt` from middleware processing but not `opengraph-image.png`. Requests fell through to the fumadocs i18n middleware, which couldn't reconcile the root path with localized routing → 404. The image content was still in the build at `/_next/static/media/opengraph-image.0.u9ey1jktxlx.png`, just unreachable at the convention path.

## fix

add `opengraph-image\\.png` to the matcher exclusion list. matches the standard next.js middleware exclusion pattern from the [official docs](https://nextjs.org/docs/app/api-reference/file-conventions/proxy#negative-matching).

## test plan

- [x] local dev: `curl http://localhost:3000/opengraph-image.png` returns 200 (was 404)
- [x] dynamic doc page og images still work via `/og/{slug}/image.png` (proxy rewrites to `/en/og/{slug}/image.png` correctly)
- [x] `pnpm validate` passes 16/16