### PR TITLE
docs: update documentation for 4.27.0 release

### DIFF
--- a/apps/docs/content/docs/adapters.mdx
+++ b/apps/docs/content/docs/adapters.mdx
@@ -20,7 +20,7 @@ Ready to build your own? Follow the [building](/docs/contributing/building) guid
 | Edit message | <Check /> | <Check /> | <Check /> | <Check /> | <Check /> | <Check /> | <Check /> | <Check /> |
 | Delete message | <Check /> | <Check /> | <Check /> | <Check /> | <Check /> | <Check /> | <Check /> | <Cross /> |
 | File uploads | <Check /> | <Check /> | <Cross /> | <Check /> | <Warn /> Single file | <Cross /> | <Cross /> | <Check /> Images, audio, docs |
-| Streaming | <Check /> Native | <Warn /> Post+Edit | <Warn /> Post+Edit | <Warn /> Post+Edit | <Warn /> Post+Edit | <Cross /> | <Cross /> | <Cross /> |
+| Streaming | <Check /> Native | <Warn /> Native (DMs) / Post+Edit | <Warn /> Post+Edit | <Warn /> Post+Edit | <Warn /> Post+Edit | <Cross /> | <Cross /> | <Cross /> |
 | Scheduled messages | <Check /> Native | <Cross /> | <Cross /> | <Cross /> | <Cross /> | <Cross /> | <Cross /> | <Cross /> |
 
 ### Rich content
@@ -47,6 +47,8 @@ Ready to build your own? Follow the [building](/docs/contributing/building) guid
 | Typing indicator | <Cross /> | <Check /> | <Cross /> | <Check /> | <Check /> | <Cross /> | <Cross /> | <Cross /> |
 | DMs | <Check /> | <Check /> | <Check /> | <Check /> | <Check /> | <Cross /> | <Cross /> | <Check /> |
 | Ephemeral messages | <Check /> Native | <Cross /> | <Check /> Native | <Cross /> | <Cross /> | <Cross /> | <Cross /> | <Cross /> |
+| User lookup ([`getUser`](/docs/api/chat#getuser)) | <Check /> | <Warn /> Cached | <Warn /> Cached | <Check /> | <Warn /> Seen users | <Check /> | <Check /> | <Cross /> |
+| Custom API endpoint ([`apiUrl`](/docs/getting-started)) | <Check /> | <Check /> | <Check /> | <Check /> | <Check /> | <Check /> | <Check /> | <Check /> |
 
 ### Message history
 

--- a/apps/docs/content/docs/adapters.mdx
+++ b/apps/docs/content/docs/adapters.mdx
@@ -48,7 +48,7 @@ Ready to build your own? Follow the [building](/docs/contributing/building) guid
 | DMs | <Check /> | <Check /> | <Check /> | <Check /> | <Check /> | <Cross /> | <Cross /> | <Check /> |
 | Ephemeral messages | <Check /> Native | <Cross /> | <Check /> Native | <Cross /> | <Cross /> | <Cross /> | <Cross /> | <Cross /> |
 | User lookup ([`getUser`](/docs/api/chat#getuser)) | <Check /> | <Warn /> Cached | <Warn /> Cached | <Check /> | <Warn /> Seen users | <Check /> | <Check /> | <Cross /> |
-| Custom API endpoint ([`apiUrl`](/docs/getting-started)) | <Check /> | <Check /> | <Check /> | <Check /> | <Check /> | <Check /> | <Check /> | <Check /> |
+| Custom API endpoint (`apiUrl`) | <Check /> | <Check /> | <Check /> | <Check /> | <Check /> | <Check /> | <Check /> | <Check /> |
 
 ### Message history
 

--- a/apps/docs/content/docs/api/chat.mdx
+++ b/apps/docs/content/docs/api/chat.mdx
@@ -539,12 +539,13 @@ const user = await bot.getUser(message.author);
   Fields that aren't available return `undefined`. Numeric user IDs (Discord/Telegram/GitHub) can be ambiguous when multiple of those adapters are registered — `bot.getUser` throws a `ChatError` with code `AMBIGUOUS_USER_ID` in that case. Pass an `Author` from a message handler (which already carries the adapter), or call the adapter directly (`adapter.getUser(userId)`).
 </Callout>
 
-`bot.getUser` throws a `ChatError` in two distinct cases. Handle both if your bot runs on multiple platforms:
+`bot.getUser` throws a `ChatError` in three cases. Handle them if your bot runs on multiple platforms:
 
 | Code | When |
 |------|------|
 | `NOT_SUPPORTED` | The resolved adapter doesn't implement `getUser` (e.g. WhatsApp) |
 | `AMBIGUOUS_USER_ID` | A numeric user ID could belong to more than one registered adapter (Discord/Telegram/GitHub) |
+| `UNKNOWN_USER_ID_FORMAT` | The `userId` string doesn't match any registered platform's ID format |
 
 ```typescript
 import { ChatError } from "chat";
@@ -560,6 +561,8 @@ try {
       // This adapter doesn't support user lookups
     } else if (error.code === "AMBIGUOUS_USER_ID") {
       // Pass message.author or call adapter.getUser(userId) directly
+    } else if (error.code === "UNKNOWN_USER_ID_FORMAT") {
+      // userId doesn't match any known platform format
     }
   }
 }

--- a/apps/docs/content/docs/api/chat.mdx
+++ b/apps/docs/content/docs/api/chat.mdx
@@ -261,6 +261,44 @@ Returns `ModalResponse | undefined` to control the modal after submission:
 - `{ action: "update", modal: ModalElement }` — replace the modal content
 - `{ action: "push", modal: ModalElement }` — push a new modal view onto the stack
 
+### onOptionsLoad
+
+Fires when an `ExternalSelect` requests options dynamically. The handler is keyed on the select's `id` and must return options synchronously enough for Slack's 3-second budget (the adapter caps the loader at ~2.5s and substitutes an empty result on timeout). Slack-only.
+
+```typescript
+bot.onOptionsLoad("assignee", async (event) => {
+  const people = await peopleService.search(event.query);
+  return people.map((p) => ({ label: p.fullName, value: p.id }));
+});
+```
+
+Return an array of `OptionsLoadGroup` (`{ label, options }[]`) instead of a flat array to render grouped headers (e.g. "Recent" / "All"). Slack limits: max 100 groups, max 100 options per group.
+
+<TypeTable
+  type={{
+    'event.actionId': {
+      description: 'The id of the select requesting options (matches the id passed to bot.onOptionsLoad).',
+      type: 'string',
+    },
+    'event.query': {
+      description: 'The text the user has typed so far.',
+      type: 'string',
+    },
+    'event.user': {
+      description: 'The user requesting options.',
+      type: 'Author',
+    },
+    'event.adapter': {
+      description: 'The adapter that received this event.',
+      type: 'Adapter',
+    },
+    'event.raw': {
+      description: 'Raw platform-specific payload.',
+      type: 'unknown',
+    },
+  }}
+/>
+
 ### onSlashCommand
 
 Fires when a user invokes a `/command` in the message composer. Currently supported on Slack.
@@ -498,10 +536,15 @@ const user = await bot.getUser(message.author);
   - **GitHub** — `email` is `null` unless the user made it public, or you authenticated with the `user:email` scope.
   - **Linear** — full profile (incl. email + avatar) for any active workspace member.
 
-  Fields that aren't available return `undefined`. Numeric user IDs (Discord/Telegram/GitHub) can be ambiguous when multiple of those adapters are registered — call the platform's adapter directly (`adapter.getUser(userId)`) in that case.
+  Fields that aren't available return `undefined`. Numeric user IDs (Discord/Telegram/GitHub) can be ambiguous when multiple of those adapters are registered — `bot.getUser` throws a `ChatError` with code `AMBIGUOUS_USER_ID` in that case. Pass an `Author` from a message handler (which already carries the adapter), or call the adapter directly (`adapter.getUser(userId)`).
 </Callout>
 
-Adapters that don't support user lookups will throw a `ChatError` with code `NOT_SUPPORTED`. Handle both cases if your bot runs on multiple platforms:
+`bot.getUser` throws a `ChatError` in two distinct cases. Handle both if your bot runs on multiple platforms:
+
+| Code | When |
+|------|------|
+| `NOT_SUPPORTED` | The resolved adapter doesn't implement `getUser` (e.g. WhatsApp) |
+| `AMBIGUOUS_USER_ID` | A numeric user ID could belong to more than one registered adapter (Discord/Telegram/GitHub) |
 
 ```typescript
 import { ChatError } from "chat";
@@ -512,8 +555,12 @@ try {
     // User not found on this platform
   }
 } catch (error) {
-  if (error instanceof ChatError && error.code === "NOT_SUPPORTED") {
-    // This adapter doesn't support user lookups
+  if (error instanceof ChatError) {
+    if (error.code === "NOT_SUPPORTED") {
+      // This adapter doesn't support user lookups
+    } else if (error.code === "AMBIGUOUS_USER_ID") {
+      // Pass message.author or call adapter.getUser(userId) directly
+    }
   }
 }
 ```

--- a/apps/docs/content/docs/api/index.mdx
+++ b/apps/docs/content/docs/api/index.mdx
@@ -31,6 +31,8 @@ import { Chat, root, paragraph, text, Card, Button, emoji } from "chat";
 | Export | Description |
 |--------|-------------|
 | [`PostableMessage`](/docs/api/postable-message) | Union type accepted by `thread.post()` |
+| [`Plan`](/docs/api/postable-message#plan) | Step-by-step task list that mutates after posting |
+| [`StreamingPlan`](/docs/api/postable-message#streamingplan) | Wraps an async iterable with platform-specific streaming options |
 | [`Cards`](/docs/api/cards) | Rich card components — `Card`, `Text`, `Button`, `Actions`, etc. |
 | [`Markdown`](/docs/api/markdown) | AST builder functions — `root`, `paragraph`, `text`, `strong`, etc. |
 | [`Modals`](/docs/api/modals) | Modal form components — `Modal`, `TextInput`, `Select`, etc. |

--- a/apps/docs/content/docs/api/markdown.mdx
+++ b/apps/docs/content/docs/api/markdown.mdx
@@ -15,6 +15,25 @@ import {
 } from "chat";
 ```
 
+## Type re-exports
+
+The chat package re-exports mdast's union and content types so adapters and downstream code can build exhaustively-typed AST walkers without depending on `mdast` directly:
+
+```typescript
+import type { Nodes, Root, Content } from "chat";
+
+function render(node: Nodes): string {
+  switch (node.type) {
+    case "text": return node.value;
+    case "strong": return node.children.map(render).join("");
+    // ...
+    default: throw new Error(`Unhandled: ${node satisfies never}`);
+  }
+}
+```
+
+Adapters use this pattern to make the type checker reject the build when a new mdast node type is introduced upstream.
+
 ## Node builders
 
 ### root

--- a/apps/docs/content/docs/api/modals.mdx
+++ b/apps/docs/content/docs/api/modals.mdx
@@ -167,6 +167,52 @@ Select({
   }}
 />
 
+## ExternalSelect
+
+Dropdown that loads options dynamically from a handler as the user types. Slack-only. Pair with [`bot.onOptionsLoad`](/docs/api/chat#onoptionsload) to supply options. See [Modals → ExternalSelect](/docs/modals#externalselect) for a full example, grouped-options support, and Slack setup notes.
+
+```typescript
+ExternalSelect({
+  id: "assignee",
+  label: "Assignee",
+  placeholder: "Search people",
+  minQueryLength: 1,
+  initialOption: { label: "Alice", value: "U123" },
+})
+```
+
+<TypeTable
+  type={{
+    id: {
+      description: 'Input ID — used as the key in event.values.',
+      type: 'string',
+    },
+    label: {
+      description: 'Label displayed above the select.',
+      type: 'string',
+    },
+    placeholder: {
+      description: 'Placeholder text.',
+      type: 'string',
+    },
+    minQueryLength: {
+      description: 'Minimum characters before the loader fires (Slack default: 3).',
+      type: 'number',
+    },
+    initialOption: {
+      description: 'Pre-selected option when the modal opens. Unlike static Select where initialOption is a value string, ExternalSelect needs the full label/value object since the loader has not run yet.',
+      type: '{ label: string, value: string }',
+    },
+    optional: {
+      description: 'Whether the field can be left empty.',
+      type: 'boolean',
+      default: 'false',
+    },
+  }}
+/>
+
+The loader registered via `bot.onOptionsLoad("assignee", handler)` returns either a flat `SelectOptionElement[]` or `OptionsLoadGroup[]` (`{ label, options }[]`) for grouped options.
+
 ## RadioSelect
 
 Radio button group for mutually exclusive choices.

--- a/apps/docs/content/docs/api/postable-message.mdx
+++ b/apps/docs/content/docs/api/postable-message.mdx
@@ -7,8 +7,13 @@ type: reference
 `PostableMessage` is the union of all message formats accepted by `thread.post()` and `sent.edit()`.
 
 ```typescript
-type PostableMessage = AdapterPostableMessage | AsyncIterable<string | StreamChunk | StreamEvent>;
+type PostableMessage =
+  | AdapterPostableMessage
+  | AsyncIterable<string | StreamChunk | StreamEvent>
+  | PostableObject;
 ```
+
+`PostableObject` covers `Plan` (mutable task lists) and `StreamingPlan` (streams with platform-specific options) — both documented below.
 
 ## String
 
@@ -129,6 +134,55 @@ await thread.post({
     files: {
       description: 'Files to upload.',
       type: 'FileUpload[]',
+    },
+  }}
+/>
+
+## Plan
+
+A `Plan` is a step-by-step task list that mutates after posting. Each `addTask` / `updateTask` / `complete` call re-renders the same message in place. See [Plan API](/docs/streaming#plan-api) for full usage.
+
+```typescript
+import { Plan } from "chat";
+
+const plan = new Plan({ initialMessage: "Researching options..." });
+await thread.post(plan);
+await plan.addTask({ title: "Look up records" });
+await plan.complete({ completeMessage: "Done!" });
+```
+
+Adapters that don't support `PostableObject` editing render the plan as fallback text and ignore subsequent mutations.
+
+## StreamingPlan
+
+Wraps an async iterable with platform-specific streaming options. Use this when you need to pass options like task grouping or stop blocks through `thread.post()`. See [Streaming with options](/docs/streaming#streaming-with-options).
+
+```typescript
+import { StreamingPlan } from "chat";
+
+const planned = new StreamingPlan(stream, {
+  groupTasks: "plan",
+  endWith: [feedbackBlock],
+  updateIntervalMs: 750,
+});
+
+await thread.post(planned);
+```
+
+<TypeTable
+  type={{
+    groupTasks: {
+      description: 'Slack: render task_update chunks as `"plan"` (single grouped block) or `"timeline"` (inline cards, default).',
+      type: '"plan" | "timeline" | undefined',
+    },
+    endWith: {
+      description: 'Slack: Block Kit elements appended when the stream stops (e.g. retry / feedback buttons).',
+      type: 'unknown[] | undefined',
+    },
+    updateIntervalMs: {
+      description: 'Fallback adapters: minimum interval between post+edit cycles in ms.',
+      type: 'number | undefined',
+      default: '500',
     },
   }}
 />

--- a/apps/docs/content/docs/api/thread.mdx
+++ b/apps/docs/content/docs/api/thread.mdx
@@ -39,7 +39,7 @@ A `Thread` is provided to your event handlers and represents a conversation thre
 
 ## post
 
-Post a message to the thread. Accepts strings, structured messages, cards, and streams.
+Post a message to the thread. Accepts strings, structured messages, cards, streams, and `PostableObject` instances (`Plan`, `StreamingPlan`).
 
 ```typescript
 // Plain text
@@ -56,11 +56,19 @@ await thread.post(Card({ title: "Hi", children: [Text("Hello")] }));
 
 // Stream (fullStream recommended for multi-step agents)
 await thread.post(result.fullStream);
+
+// Plan (mutable task list)
+const plan = new Plan({ initialMessage: "Working..." });
+await thread.post(plan);
+await plan.addTask({ title: "Step 1" });
+
+// Streaming with platform options
+await thread.post(new StreamingPlan(stream, { groupTasks: "plan" }));
 ```
 
 **Parameters:** `message: string | PostableMessage | CardJSXElement`
 
-**Returns:** `Promise<SentMessage>` — the sent message with `edit()`, `delete()`, `addReaction()`, and `removeReaction()` methods.
+**Returns:** `Promise<SentMessage | PostableObject>` — for plain messages and streams, a `SentMessage` with `edit()`, `delete()`, `addReaction()`, and `removeReaction()` methods; for `Plan` / `StreamingPlan` inputs, the same object is returned so you can keep mutating it.
 
 See [Posting Messages](/docs/posting-messages) for details on each format.
 

--- a/apps/docs/content/docs/concurrency.mdx
+++ b/apps/docs/content/docs/concurrency.mdx
@@ -124,6 +124,10 @@ const bot = new Chat({
 | `debounceMs` | debounce | `1500` | Debounce window in milliseconds |
 | `maxConcurrent` | concurrent | `Infinity` | Max concurrent handlers per thread |
 
+<Callout type="warn">
+`maxConcurrent` only applies to the `concurrent` strategy. Pairing it with any other strategy logs a warning and the value is ignored. Setting `maxConcurrent` to a value less than `1` throws at construction time — `0` would deadlock the strategy and is rejected up front.
+</Callout>
+
 ## MessageContext
 
 All handler types (`onNewMention`, `onSubscribedMessage`, `onNewMessage`) accept an optional `MessageContext` as their last parameter. It is only populated when using the `queue` strategy and messages were skipped.

--- a/apps/docs/content/docs/error-handling.mdx
+++ b/apps/docs/content/docs/error-handling.mdx
@@ -20,12 +20,12 @@ Base error class for all SDK errors. Every error below extends `ChatError`. The 
 
 | Code | Thrown by | Meaning |
 |------|-----------|---------|
-| `NOT_SUPPORTED` | `bot.openDM`, `bot.getUser`, `adapter.getUser` | The resolved adapter doesn't implement this method |
+| `NOT_SUPPORTED` | `bot.openDM`, `bot.getUser` | The resolved adapter doesn't implement this method |
 | `INVALID_THREAD_ID` | `bot.thread`, internal routing | Thread ID does not match the `adapter:channel:thread` shape |
 | `INVALID_CHANNEL_ID` | `bot.channel` | Channel ID does not match the `adapter:channel` shape |
 | `ADAPTER_NOT_FOUND` | `bot.thread`, `bot.channel` | Thread/channel ID references an adapter that wasn't registered on this `Chat` instance |
-| `AMBIGUOUS_USER_ID` | `bot.getUser` (string overload) | Numeric user ID could match more than one registered adapter (Discord/Telegram/GitHub) |
-| `UNKNOWN_USER_ID_FORMAT` | `bot.getUser` (string overload) | The `userId` doesn't match any platform's known ID format |
+| `AMBIGUOUS_USER_ID` | `bot.getUser`, `bot.openDM` | Numeric user ID could match more than one registered adapter (Discord/Telegram/GitHub) |
+| `UNKNOWN_USER_ID_FORMAT` | `bot.getUser`, `bot.openDM` | The `userId` doesn't match any platform's known ID format |
 | `RATE_LIMITED` | Any platform call | Platform returned 429; see `RateLimitError` below |
 | `NOT_IMPLEMENTED` | Any platform call | The adapter doesn't implement this feature; see `NotImplementedError` below |
 | `LOCK_FAILED` | Inbound message routing | Distributed lock was busy; see `LockError` below |

--- a/apps/docs/content/docs/error-handling.mdx
+++ b/apps/docs/content/docs/error-handling.mdx
@@ -16,7 +16,19 @@ import { ChatError, RateLimitError, NotImplementedError, LockError } from "chat"
 
 ### ChatError
 
-Base error class for all SDK errors. Every error below extends `ChatError`.
+Base error class for all SDK errors. Every error below extends `ChatError`. The `code` property carries a machine-readable identifier you can branch on:
+
+| Code | Thrown by | Meaning |
+|------|-----------|---------|
+| `NOT_SUPPORTED` | `bot.openDM`, `bot.getUser`, `adapter.getUser` | The resolved adapter doesn't implement this method |
+| `INVALID_THREAD_ID` | `bot.thread`, internal routing | Thread ID does not match the `adapter:channel:thread` shape |
+| `INVALID_CHANNEL_ID` | `bot.channel` | Channel ID does not match the `adapter:channel` shape |
+| `ADAPTER_NOT_FOUND` | `bot.thread`, `bot.channel` | Thread/channel ID references an adapter that wasn't registered on this `Chat` instance |
+| `AMBIGUOUS_USER_ID` | `bot.getUser` (string overload) | Numeric user ID could match more than one registered adapter (Discord/Telegram/GitHub) |
+| `UNKNOWN_USER_ID_FORMAT` | `bot.getUser` (string overload) | The `userId` doesn't match any platform's known ID format |
+| `RATE_LIMITED` | Any platform call | Platform returned 429; see `RateLimitError` below |
+| `NOT_IMPLEMENTED` | Any platform call | The adapter doesn't implement this feature; see `NotImplementedError` below |
+| `LOCK_FAILED` | Inbound message routing | Distributed lock was busy; see `LockError` below |
 
 <TypeTable
   type={{
@@ -25,7 +37,7 @@ Base error class for all SDK errors. Every error below extends `ChatError`.
       type: 'string',
     },
     code: {
-      description: 'Machine-readable error code.',
+      description: 'Machine-readable error code (see table above).',
       type: 'string',
     },
     cause: {

--- a/apps/docs/content/docs/index.mdx
+++ b/apps/docs/content/docs/index.mdx
@@ -52,7 +52,7 @@ Each adapter factory auto-detects credentials from environment variables (`SLACK
 | Platform | Package | Mentions | Reactions | Cards | Modals | Streaming | DMs |
 |----------|---------|----------|-----------|-------|--------|-----------|-----|
 | Slack | `@chat-adapter/slack` | Yes | Yes | Yes | Yes | Native | Yes |
-| Microsoft Teams | `@chat-adapter/teams` | Yes | Read-only | Yes | No | Post+Edit | Yes |
+| Microsoft Teams | `@chat-adapter/teams` | Yes | Read-only | Yes | No | Native (DMs) / Post+Edit | Yes |
 | Google Chat | `@chat-adapter/gchat` | Yes | Yes | Yes | No | Post+Edit | Yes |
 | Discord | `@chat-adapter/discord` | Yes | Yes | Yes | No | Post+Edit | Yes |
 | Telegram | `@chat-adapter/telegram` | Yes | Yes | Partial | No | Post+Edit | Yes |

--- a/apps/docs/content/docs/posting-messages.mdx
+++ b/apps/docs/content/docs/posting-messages.mdx
@@ -153,6 +153,8 @@ Both `fullStream` and `textStream` are supported. Use `fullStream` with multi-st
 
 For multi-turn conversations, use [`toAiMessages()`](/docs/api/to-ai-messages) to convert thread history into the `{ role, content }[]` format expected by AI SDKs.
 
+To pass platform-specific streaming options (e.g. Slack task grouping or stop blocks), wrap the stream in a [`StreamingPlan`](/docs/streaming#streaming-with-options) and post that.
+
 See the [Streaming](/docs/streaming) page for details on platform behavior and configuration.
 
 ## Attachments and files
@@ -178,5 +180,7 @@ See the [Files](/docs/files) page for more on attachments.
 | Card (function) | You need buttons, fields, or structured layouts | Approval flows, dashboards |
 | Card (JSX) | Same as above, with JSX syntax preference | Same use cases as function cards |
 | `AsyncIterable` | Streaming AI responses | Chat with LLMs |
+| [`Plan`](/docs/streaming#plan-api) | Step-by-step tasks that mutate after posting | Multi-step agents, deploy progress |
+| [`StreamingPlan`](/docs/streaming#streaming-with-options) | Streaming with platform-specific options | Slack streaming with grouped tasks or stop blocks |
 
 For most cases, **AST builders** give the best balance of control and simplicity. Reach for **cards** when you need interactive elements like buttons or dropdowns.

--- a/apps/docs/content/docs/streaming.mdx
+++ b/apps/docs/content/docs/streaming.mdx
@@ -59,9 +59,10 @@ await thread.post(stream);
 | Platform | Method | Description |
 |----------|--------|-------------|
 | Slack | Native streaming API | Uses Slack's `chatStream` for smooth, real-time updates |
-| Teams | Post + Edit | Posts a message then edits it as chunks arrive |
+| Teams | Native (DMs) / Post + Edit (group chats) | Uses the Teams SDK's native `stream.emit()` for direct messages; falls back to post+edit in group chats |
 | Google Chat | Post + Edit | Posts a message then edits it as chunks arrive |
 | Discord | Post + Edit | Posts a message then edits it as chunks arrive |
+| Telegram | Post + Edit | Posts a message then edits it as chunks arrive |
 
 The post+edit fallback throttles edits to avoid rate limits. Configure the update interval when creating your `Chat` instance:
 
@@ -147,36 +148,39 @@ await thread.post(stream);
 | `task_update` | `id`, `title`, `status`, `details?`, `output?` | Tool/step progress cards (`pending`, `in_progress`, `complete`, `error`) with optional extra task context |
 | `plan_update` | `title` | Plan title updates |
 
-### Task display mode
+### Streaming with options
 
-Control how `task_update` chunks render in Slack by passing `taskDisplayMode` via the adapter's streaming API. These options are currently only available through `adapter.stream()` directly:
+Wrap a stream in a `StreamingPlan` to pass platform-specific options through `thread.post()` without dropping down to `adapter.stream()` directly:
 
 ```typescript
-const raw = message.raw as { team_id?: string; team?: string };
-await thread.adapter.stream(thread.id, stream, {
-  recipientUserId: message.author.userId,
-  recipientTeamId: raw.team_id ?? raw.team,
-  taskDisplayMode: "plan",
+import { StreamingPlan } from "chat";
+
+const planned = new StreamingPlan(stream, {
+  groupTasks: "plan",         // Slack: render task cards as a single grouped block
+  endWith: [feedbackBlock],   // Slack: Block Kit elements appended after stream stops
+  updateIntervalMs: 750,      // Fallback mode: post+edit cadence on non-native adapters
 });
+
+await thread.post(planned);
 ```
 
-| Mode | Description |
-|------|-------------|
-| `"timeline"` | Individual task cards shown inline with text (default) |
-| `"plan"` | All tasks grouped into a single plan block |
+| Option | Platform | Description |
+|--------|----------|-------------|
+| `groupTasks` | Slack | `"timeline"` (default) renders task cards inline; `"plan"` groups them into one plan block |
+| `endWith` | Slack | Block Kit elements attached when the stream stops (e.g. retry / feedback buttons) |
+| `updateIntervalMs` | Fallback adapters (Teams, Google Chat, Telegram) | Minimum interval between post+edit cycles in ms (default `500`) |
 
-Adapters without structured chunk support extract text from `markdown_text` chunks and ignore other types.
+Adapters without structured chunk support extract text from `markdown_text` chunks and ignore other types. Slack-only options are silently ignored on other platforms.
 
 ## Stop blocks (Slack only)
 
-When streaming in Slack, you can attach Block Kit elements to the final message using `stopBlocks`. This is useful for adding action buttons after a streamed response completes:
+Use `endWith` on `StreamingPlan` to attach Block Kit elements to the final message. This is useful for adding action buttons after a streamed response completes:
 
 ```typescript title="lib/bot.ts" lineNumbers
-const raw = message.raw as { team_id?: string; team?: string };
-await thread.adapter.stream(thread.id, textStream, {
-  recipientUserId: message.author.userId,
-  recipientTeamId: raw.team_id ?? raw.team,
-  stopBlocks: [
+import { StreamingPlan } from "chat";
+
+const planned = new StreamingPlan(textStream, {
+  endWith: [
     {
       type: "actions",
       elements: [{
@@ -187,7 +191,47 @@ await thread.adapter.stream(thread.id, textStream, {
     },
   ],
 });
+
+await thread.post(planned);
 ```
+
+## Plan API
+
+For step-by-step task progress that lives outside an LLM stream, post a `Plan` directly. `Plan` is a `PostableObject` you can mutate after posting — every mutation re-renders the block in place.
+
+```typescript title="lib/bot.ts" lineNumbers
+import { Plan } from "chat";
+
+const plan = new Plan({ initialMessage: "Researching options..." });
+await thread.post(plan);
+
+const lookup = await plan.addTask({ title: "Look up customer record" });
+// ...do work...
+await plan.updateTask("Found 3 matches");
+
+await plan.addTask({ title: "Summarize findings" });
+await plan.complete({ completeMessage: "Done!" });
+```
+
+By default `updateTask()` mutates the most recent `in_progress` task. Pass `{ id }` to target a specific task — useful when work runs in parallel or out of order:
+
+```typescript
+const fetchTask = await plan.addTask({ title: "Fetch data" });
+const transformTask = await plan.addTask({ title: "Transform" });
+
+// Update a specific task by id, even if it isn't the most recent in_progress one.
+await plan.updateTask({ id: fetchTask.id, output: "Got 42 rows" });
+await plan.updateTask({ id: transformTask.id, status: "complete" });
+```
+
+Adapters that don't support PostableObject editing (e.g. WhatsApp) render the plan as a fallback emoji-list message; the plan still posts, but mutations are no-ops.
+
+| Method | Description |
+|--------|-------------|
+| `addTask({ title, children? })` | Append a new task. The previous in-progress task is auto-completed |
+| `updateTask(input)` | Mutate the current (or `{ id }`-targeted) task's `output`, `status`, or `title` |
+| `complete({ completeMessage })` | Mark all in-progress tasks complete and update the plan title |
+| `reset({ initialMessage })` | Discard all tasks and start fresh with a new initial message — useful when re-using a plan handle for a new run |
 
 ## Streaming with conversation history
 

--- a/apps/docs/content/docs/threads-messages-channels.mdx
+++ b/apps/docs/content/docs/threads-messages-channels.mdx
@@ -13,6 +13,15 @@ related:
 
 A `Thread` represents a conversation thread on any platform. It provides methods for posting messages, managing subscriptions, and accessing message history.
 
+Thread instances are most often supplied by the SDK to your event handlers. You can also construct one explicitly from a thread ID — useful for cron jobs, workflow steps, or any other context outside an inbound webhook:
+
+```typescript title="lib/bot.ts" lineNumbers
+const thread = bot.thread("slack:C123ABC:1234567890.123456");
+await thread.post("Reminder from a cron job");
+```
+
+For DM-style conversations, use [`bot.openDM(adapter, userId)`](/docs/direct-messages) instead — it resolves the right channel and thread on each platform.
+
 ### Post a message
 
 ```typescript title="lib/bot.ts" lineNumbers

--- a/packages/adapter-discord/README.md
+++ b/packages/adapter-discord/README.md
@@ -157,6 +157,7 @@ All options are auto-detected from environment variables when not provided.
 | `publicKey` | No* | Application public key. Auto-detected from `DISCORD_PUBLIC_KEY` |
 | `applicationId` | No* | Discord application ID. Auto-detected from `DISCORD_APPLICATION_ID` |
 | `mentionRoleIds` | No | Array of role IDs that trigger mention handlers. Auto-detected from `DISCORD_MENTION_ROLE_IDS` (comma-separated) |
+| `apiUrl` | No | Override the Discord API base URL. Auto-detected from `DISCORD_API_URL` |
 | `logger` | No | Logger instance (defaults to `ConsoleLogger("info")`) |
 
 *`botToken`, `publicKey`, and `applicationId` are required — either via config or env vars.
@@ -168,6 +169,7 @@ DISCORD_BOT_TOKEN=your-bot-token
 DISCORD_PUBLIC_KEY=your-application-public-key
 DISCORD_APPLICATION_ID=your-application-id
 DISCORD_MENTION_ROLE_IDS=1234567890,0987654321  # Optional
+DISCORD_API_URL=...                              # Optional, override the Discord API base URL
 CRON_SECRET=your-random-secret                   # For Gateway cron
 ```
 

--- a/packages/adapter-gchat/README.md
+++ b/packages/adapter-gchat/README.md
@@ -165,6 +165,7 @@ All options are auto-detected from environment variables when not provided.
 | `googleChatProjectNumber` | No | GCP project number for direct webhook JWT verification. Auto-detected from `GOOGLE_CHAT_PROJECT_NUMBER` |
 | `impersonateUser` | No | User email for domain-wide delegation. Auto-detected from `GOOGLE_CHAT_IMPERSONATE_USER` |
 | `auth` | No | Custom auth object (advanced) |
+| `apiUrl` | No | Override the Google Chat API base URL. Auto-detected from `GOOGLE_CHAT_API_URL` |
 | `logger` | No | Logger instance (defaults to `ConsoleLogger("info")`) |
 
 *Either `credentials`, `GOOGLE_CHAT_CREDENTIALS` env var, `useApplicationDefaultCredentials`, or `GOOGLE_CHAT_USE_ADC=true` is required.
@@ -181,6 +182,9 @@ GOOGLE_CHAT_IMPERSONATE_USER=admin@yourdomain.com
 # Optional: webhook verification (recommended for production)
 GOOGLE_CHAT_PROJECT_NUMBER=123456789          # For direct webhook JWT verification
 GOOGLE_CHAT_PUBSUB_AUDIENCE=https://your-domain.com/api/webhooks/gchat  # For Pub/Sub JWT verification
+
+# Optional: override the Google Chat API base URL
+GOOGLE_CHAT_API_URL=...
 ```
 
 ## Webhook verification

--- a/packages/adapter-github/README.md
+++ b/packages/adapter-github/README.md
@@ -179,6 +179,7 @@ All options are auto-detected from environment variables when not provided.
 | `webhookSecret` | No** | Webhook secret. Auto-detected from `GITHUB_WEBHOOK_SECRET` |
 | `userName` | No | Bot username for @mention detection. Auto-detected from `GITHUB_BOT_USERNAME` (default: `"github-bot"`) |
 | `botUserId` | No | Bot's numeric user ID (auto-detected if not provided) |
+| `apiUrl` | No | Override the GitHub API base URL (e.g. for GitHub Enterprise Server). Auto-detected from `GITHUB_API_URL` |
 | `logger` | No | Logger instance (defaults to `ConsoleLogger("info")`) |
 
 *Either `token`/`GITHUB_TOKEN` or `appId`+`privateKey`/`GITHUB_APP_ID`+`GITHUB_PRIVATE_KEY` is required.
@@ -198,6 +199,9 @@ GITHUB_INSTALLATION_ID=12345678  # Optional for multi-tenant
 
 # Required
 GITHUB_WEBHOOK_SECRET=your-webhook-secret
+
+# Optional: GitHub Enterprise Server
+GITHUB_API_URL=https://github.example.com/api/v3
 ```
 
 ## Features

--- a/packages/adapter-linear/README.md
+++ b/packages/adapter-linear/README.md
@@ -212,6 +212,7 @@ All options are auto-detected from environment variables when not provided.
 | `mode` | No | Inbound webhook handling mode. `"comments"` by default, or `"agent-sessions"` for app-actor installs |
 | `webhookSecret` | No** | Webhook signing secret. Auto-detected from `LINEAR_WEBHOOK_SECRET` |
 | `userName` | No | Bot display name. Auto-detected from `LINEAR_BOT_USERNAME` (default: `"linear-bot"`) |
+| `apiUrl` | No | Override the Linear GraphQL API base URL. Auto-detected from `LINEAR_API_URL` |
 | `logger` | No | Logger instance (defaults to `ConsoleLogger("info")`) |
 
 *One of `apiKey`, `accessToken`, top-level `clientId`/`clientSecret`, or `clientCredentials` is required (via config or env vars).
@@ -244,6 +245,9 @@ LINEAR_MODE=comments
 
 # Required
 LINEAR_WEBHOOK_SECRET=your-webhook-secret
+
+# Optional: override the Linear GraphQL API base URL
+LINEAR_API_URL=...
 ```
 
 ## Features

--- a/packages/adapter-slack/README.md
+++ b/packages/adapter-slack/README.md
@@ -305,6 +305,7 @@ All options are auto-detected from environment variables when not provided. You 
 | `clientSecret` | No | App client secret for multi-workspace OAuth. Auto-detected from `SLACK_CLIENT_SECRET` |
 | `encryptionKey` | No | AES-256-GCM key for encrypting stored tokens. Auto-detected from `SLACK_ENCRYPTION_KEY` |
 | `installationKeyPrefix` | No | Prefix for the state key used to store workspace installations. Defaults to `slack:installation`. The full key is `{prefix}:{teamId}` |
+| `apiUrl` | No | Override the Slack Web API base URL (e.g. for GovSlack or a self-hosted gateway). Auto-detected from `SLACK_API_URL` |
 | `logger` | No | Logger instance (defaults to `ConsoleLogger("info")`) |
 
 *`signingSecret` is required for webhook mode — either via config, `SLACK_SIGNING_SECRET` env var, or a `webhookVerifier`.
@@ -320,6 +321,7 @@ SLACK_SOCKET_FORWARDING_SECRET=...   # Optional, for socket event forwarding aut
 SLACK_CLIENT_ID=...                  # Multi-workspace only
 SLACK_CLIENT_SECRET=...              # Multi-workspace only
 SLACK_ENCRYPTION_KEY=...             # Optional, for token encryption
+SLACK_API_URL=...                    # Optional, for GovSlack or a self-hosted gateway
 ```
 
 ## Features
@@ -433,14 +435,18 @@ settings:
 
 ### Stream with stop blocks
 
-When streaming in an assistant thread, you can attach Block Kit elements to the final message:
+When streaming in an assistant thread, attach Block Kit elements to the final message by wrapping the stream in a `StreamingPlan` and passing `endWith`:
 
 ```typescript
-await thread.post(textStream, {
-  stopBlocks: [
-    { type: "actions", elements: [{ type: "button", text: { type: "plain_text", text: "Retry" }, action_id: "retry" }] },
-  ],
-});
+import { StreamingPlan } from "chat";
+
+await thread.post(
+  new StreamingPlan(textStream, {
+    endWith: [
+      { type: "actions", elements: [{ type: "button", text: { type: "plain_text", text: "Retry" }, action_id: "retry" }] },
+    ],
+  })
+);
 ```
 
 ## Troubleshooting

--- a/packages/adapter-teams/README.md
+++ b/packages/adapter-teams/README.md
@@ -96,6 +96,7 @@ All options are auto-detected from environment variables when not provided. Inte
 | `appType` | No | `"MultiTenant"` or `"SingleTenant"` (default: `"MultiTenant"`) |
 | `appTenantId` | For SingleTenant | Azure AD Tenant ID. Auto-detected from `TEAMS_APP_TENANT_ID` |
 | `userName` | No | Bot display name (default: `"bot"`) |
+| `apiUrl` | No | Override the Teams API base URL (e.g. for GCC-High or sovereign-cloud deployments). Auto-detected from `TEAMS_API_URL` |
 | `logger` | No | Logger instance (defaults to `ConsoleLogger("info")`) |
 
 \*`appId` is required — either via config or `TEAMS_APP_ID` env var.
@@ -134,6 +135,7 @@ createTeamsAdapter({
 TEAMS_APP_ID=...
 TEAMS_APP_PASSWORD=...
 TEAMS_APP_TENANT_ID=...  # Required for SingleTenant apps
+TEAMS_API_URL=...        # Optional, for GCC-High or sovereign-cloud deployments
 ```
 
 ## Features
@@ -146,7 +148,7 @@ TEAMS_APP_TENANT_ID=...  # Required for SingleTenant apps
 | Edit message | Yes |
 | Delete message | Yes |
 | File uploads | Yes |
-| Streaming | Post+Edit fallback |
+| Streaming | Native (DMs) / Post+Edit fallback (group chats) |
 
 ### Rich content
 

--- a/packages/adapter-telegram/README.md
+++ b/packages/adapter-telegram/README.md
@@ -118,7 +118,7 @@ All options are auto-detected from environment variables when not provided.
 | `mode` | No | Adapter mode: `auto` (default), `webhook`, or `polling` |
 | `longPolling` | No | Optional long polling config for `getUpdates` (`timeout`, `limit`, `allowedUpdates`, `deleteWebhook`, `dropPendingUpdates`, `retryDelayMs`) |
 | `userName` | No | Bot username used for mention detection. Auto-detected from `TELEGRAM_BOT_USERNAME` or `getMe` |
-| `apiBaseUrl` | No | Telegram API base URL. Auto-detected from `TELEGRAM_API_BASE_URL` |
+| `apiUrl` | No | Telegram API base URL. Auto-detected from `TELEGRAM_API_BASE_URL`. Use `apiUrl` for cross-adapter consistency; the legacy `apiBaseUrl` alias is still accepted |
 | `logger` | No | Logger instance (defaults to `ConsoleLogger("info")`) |
 
 *`botToken` is required — either via config or env vars.
@@ -181,6 +181,12 @@ TELEGRAM_API_BASE_URL=https://api.telegram.org
 | List threads | No |
 | Fetch channel info | Yes |
 | Post channel message | Yes |
+
+## Markdown formatting
+
+Outbound messages are sent with Telegram's `MarkdownV2` parse mode. The adapter walks the markdown AST and emits MarkdownV2 with context-aware escaping (normal text vs. code blocks vs. link URLs), so you author standard markdown (`**bold**`, `*italic*`, `` `code` ``, `[label](url)`) and the adapter handles every reserved character.
+
+Behavior change in 4.27.0: previous versions used Telegram's legacy `Markdown` parse mode, which used different syntax (`*bold*` instead of `**bold**`) and silently rejected any text containing unescaped `.`, `!`, `(`, `)`, `-`, `_`. If you were emitting raw legacy-Markdown strings or hand-escaping characters yourself, drop the manual escaping — the renderer does it for you. Pass `{ raw: "..." }` only if you need to ship a fully pre-escaped MarkdownV2 string.
 
 ## Notes
 

--- a/packages/adapter-whatsapp/README.md
+++ b/packages/adapter-whatsapp/README.md
@@ -69,6 +69,7 @@ All options are auto-detected from environment variables when not provided. You 
 | `verifyToken` | No* | Webhook verification secret. Auto-detected from `WHATSAPP_VERIFY_TOKEN` |
 | `apiVersion` | No | Graph API version (defaults to `v21.0`) |
 | `userName` | No | Bot username for self-message detection. Auto-detected from `WHATSAPP_BOT_USERNAME` (defaults to `whatsapp-bot`) |
+| `apiUrl` | No | Override the Meta Graph API base URL. Auto-detected from `WHATSAPP_API_URL` |
 | `logger` | No | Logger instance (defaults to `ConsoleLogger("info")`) |
 
 *Required at runtime — either via config or environment variable.
@@ -81,6 +82,7 @@ WHATSAPP_APP_SECRET=...            # App secret for X-Hub-Signature-256 verifica
 WHATSAPP_PHONE_NUMBER_ID=...       # Bot's phone number ID from Meta dashboard
 WHATSAPP_VERIFY_TOKEN=...          # User-defined secret for webhook verification
 WHATSAPP_BOT_USERNAME=...          # Optional, defaults to "whatsapp-bot"
+WHATSAPP_API_URL=...               # Optional, override the Meta Graph API base URL
 ```
 
 ## Webhook setup


### PR DESCRIPTION
## summary

fills documentation gaps for everything shipped in 4.27.0 - adapter config, streaming APIs, error codes, and API reference updates

- add `apiUrl` config option to all 8 adapter READMEs
- add Plan API and StreamingPlan docs to streaming, posting-messages, and api reference pages
- add ExternalSelect component + onOptionsLoad handler to api reference
- add ChatError code table (9 codes) to error-handling page
- add Teams native DM streaming to feature matrices
- add Telegram MarkdownV2 migration note
- add `bot.thread()` example for non-webhook contexts
- add `maxConcurrent` validation callout to concurrency page
- add mdast Nodes/Root/Content type re-exports to api/markdown
- update PostableMessage union type and thread.post return type
- fix stale stop blocks example in slack README (was using nonexistent thread.post options arg)