### PR TITLE
Adapter hardening pass

### DIFF
--- a/.changeset/security-high-fixes.md
+++ b/.changeset/security-high-fixes.md
@@ -1,0 +1,16 @@
+---
+"@chat-adapter/shared": minor
+"@chat-adapter/gchat": minor
+"@chat-adapter/github": patch
+"@chat-adapter/linear": minor
+"@chat-adapter/slack": patch
+"chat": patch
+---
+
+Security fixes for HIGH-severity findings:
+
+- **adapter-slack**: Replace timing-unsafe `!==` with `crypto.timingSafeEqual` when validating the `x-slack-socket-token` header on forwarded socket-mode events.
+- **adapter-github**: In multi-tenant App mode, eagerly auto-detect the bot user ID on the first installation client / first webhook so `isMe` checks work and self-reply loops are prevented. Falls back to `apps.getAuthenticated` + `users.getByUsername` when `users.getAuthenticated` is unavailable for installation tokens.
+- **adapter-linear**: Add optional `encryptionKey` config (or `LINEAR_ENCRYPTION_KEY` env var) that AES-256-GCM-encrypts `accessToken` and `refreshToken` at rest in the state store. Tolerates plaintext records for zero-downtime rollout.
+- **adapter-gchat**: Fail-closed by default — the constructor now throws `ValidationError` if neither `googleChatProjectNumber` nor `pubsubAudience` is configured. To accept unverified webhooks (development only), set the new `disableSignatureVerification: true` flag (or `GOOGLE_CHAT_DISABLE_SIGNATURE_VERIFICATION=true`). Mirrors the Slack adapter's signing-secret requirement.
+- **adapter-shared**: New `decodeKey` / `encryptToken` / `decryptToken` / `isEncryptedTokenData` utilities (AES-256-GCM, hex or base64 32-byte keys), shared by Slack and Linear.

--- a/.changeset/tame-owls-laugh.md
+++ b/.changeset/tame-owls-laugh.md
@@ -1,0 +1,9 @@
+---
+"@chat-adapter/github": patch
+"@chat-adapter/linear": patch
+"@chat-adapter/shared": patch
+"@chat-adapter/gchat": patch
+"@chat-adapter/slack": patch
+---
+
+Env var validation tightening

--- a/.changeset/tame-owls-laugh.md
+++ b/.changeset/tame-owls-laugh.md
@@ -1,9 +1,0 @@
----
-"@chat-adapter/github": patch
-"@chat-adapter/linear": patch
-"@chat-adapter/shared": patch
-"@chat-adapter/gchat": patch
-"@chat-adapter/slack": patch
----
-
-Env var validation tightening

--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,4 @@ next-env.d.ts
 .source
 
 packages/chat/docs
+.deepsec

--- a/examples/nextjs-chat/src/app/api/linear/install/callback/route.ts
+++ b/examples/nextjs-chat/src/app/api/linear/install/callback/route.ts
@@ -1,4 +1,8 @@
 import { bot } from "@/lib/bot";
+import { consumeAndVerifyOAuthState } from "@/lib/oauth-state";
+
+const STATE_COOKIE = "linear_oauth_state";
+const CALLBACK_PATH = "/api/linear/install/callback";
 
 export async function GET(request: Request) {
   const adapter = bot.getAdapter("linear");
@@ -12,6 +16,15 @@ export async function GET(request: Request) {
     return new Response("LINEAR_REDIRECT_URI is not configured", {
       status: 500,
     });
+  }
+
+  const stateOk = await consumeAndVerifyOAuthState({
+    request,
+    cookieName: STATE_COOKIE,
+    callbackPath: CALLBACK_PATH,
+  });
+  if (!stateOk) {
+    return new Response("OAuth state mismatch", { status: 400 });
   }
 
   try {

--- a/examples/nextjs-chat/src/app/api/linear/install/route.ts
+++ b/examples/nextjs-chat/src/app/api/linear/install/route.ts
@@ -1,3 +1,5 @@
+import { issueOAuthState } from "@/lib/oauth-state";
+
 const LINEAR_INSTALL_SCOPES = [
   "read",
   "write",
@@ -6,7 +8,10 @@ const LINEAR_INSTALL_SCOPES = [
   "app:mentionable",
 ];
 
-export function GET() {
+const STATE_COOKIE = "linear_oauth_state";
+const CALLBACK_PATH = "/api/linear/install/callback";
+
+export async function GET() {
   const clientId = process.env.LINEAR_CLIENT_ID;
   const redirectUri = process.env.LINEAR_REDIRECT_URI;
 
@@ -20,12 +25,18 @@ export function GET() {
     });
   }
 
+  const state = await issueOAuthState({
+    cookieName: STATE_COOKIE,
+    callbackPath: CALLBACK_PATH,
+  });
+
   const installUrl = new URL("https://linear.app/oauth/authorize");
   installUrl.searchParams.set("client_id", clientId);
   installUrl.searchParams.set("redirect_uri", redirectUri);
   installUrl.searchParams.set("response_type", "code");
   installUrl.searchParams.set("actor", "app");
   installUrl.searchParams.set("scope", LINEAR_INSTALL_SCOPES.join(","));
+  installUrl.searchParams.set("state", state);
 
   return Response.redirect(installUrl.toString(), 302);
 }

--- a/examples/nextjs-chat/src/app/api/slack/install/callback/route.ts
+++ b/examples/nextjs-chat/src/app/api/slack/install/callback/route.ts
@@ -1,10 +1,23 @@
 import { bot } from "@/lib/bot";
+import { consumeAndVerifyOAuthState } from "@/lib/oauth-state";
+
+const STATE_COOKIE = "slack_oauth_state";
+const CALLBACK_PATH = "/api/slack/install/callback";
 
 export async function GET(request: Request) {
   const adapter = bot.getAdapter("slack");
 
   if (!adapter) {
     return new Response("Slack adapter not configured", { status: 500 });
+  }
+
+  const stateOk = await consumeAndVerifyOAuthState({
+    request,
+    cookieName: STATE_COOKIE,
+    callbackPath: CALLBACK_PATH,
+  });
+  if (!stateOk) {
+    return new Response("OAuth state mismatch", { status: 400 });
   }
 
   try {

--- a/examples/nextjs-chat/src/app/api/slack/install/route.ts
+++ b/examples/nextjs-chat/src/app/api/slack/install/route.ts
@@ -1,3 +1,5 @@
+import { issueOAuthState } from "@/lib/oauth-state";
+
 const BOT_SCOPES = [
   "app_mentions:read",
   "channels:history",
@@ -16,16 +18,25 @@ const BOT_SCOPES = [
   "users:read",
 ];
 
-export function GET() {
+const STATE_COOKIE = "slack_oauth_state";
+const CALLBACK_PATH = "/api/slack/install/callback";
+
+export async function GET() {
   const clientId = process.env.SLACK_CLIENT_ID;
 
   if (!clientId) {
     return new Response("SLACK_CLIENT_ID is not configured", { status: 500 });
   }
 
+  const state = await issueOAuthState({
+    cookieName: STATE_COOKIE,
+    callbackPath: CALLBACK_PATH,
+  });
+
   const installUrl = new URL("https://slack.com/oauth/v2/authorize");
   installUrl.searchParams.set("client_id", clientId);
   installUrl.searchParams.set("scope", BOT_SCOPES.join(","));
+  installUrl.searchParams.set("state", state);
 
   return Response.redirect(installUrl.toString(), 302);
 }

--- a/examples/nextjs-chat/src/lib/oauth-state.ts
+++ b/examples/nextjs-chat/src/lib/oauth-state.ts
@@ -1,0 +1,64 @@
+import { randomBytes, timingSafeEqual } from "node:crypto";
+import { cookies } from "next/headers";
+
+/**
+ * OAuth `state` (CSRF) helpers for install/callback routes.
+ *
+ * Generate a fresh, opaque, single-use state value before redirecting to the
+ * provider, persist it in an HttpOnly cookie scoped to the callback path, and
+ * validate it on the way back. This binds the user who started the flow to
+ * the user who completes it, defeating the classic OAuth login-CSRF where
+ * an attacker tricks a victim into completing the attacker's flow (or vice
+ * versa) and the wrong tokens get associated with the wrong account.
+ *
+ * Cookie: HttpOnly + Secure (in production) + SameSite=Lax + scoped to the
+ * callback path so the browser sends it nowhere else. The cookie is consumed
+ * (deleted) on first read so a stolen state can't be replayed.
+ */
+
+const STATE_BYTE_LENGTH = 32;
+const STATE_TTL_SECONDS = 10 * 60;
+
+/** Generate an opaque state value, store it in a scoped cookie, and return it. */
+export async function issueOAuthState(options: {
+  cookieName: string;
+  callbackPath: string;
+}): Promise<string> {
+  const value = randomBytes(STATE_BYTE_LENGTH).toString("base64url");
+  const store = await cookies();
+  store.set(options.cookieName, value, {
+    httpOnly: true,
+    secure: process.env.NODE_ENV === "production",
+    sameSite: "lax",
+    path: options.callbackPath,
+    maxAge: STATE_TTL_SECONDS,
+  });
+  return value;
+}
+
+/**
+ * Read and consume the state cookie, then constant-time-compare it to the
+ * `state` query parameter on the incoming request. Returns true only if both
+ * are present and match.
+ */
+export async function consumeAndVerifyOAuthState(options: {
+  request: Request;
+  cookieName: string;
+  callbackPath: string;
+}): Promise<boolean> {
+  const url = new URL(options.request.url);
+  const queryState = url.searchParams.get("state");
+  const store = await cookies();
+  const cookieState = store.get(options.cookieName)?.value;
+  // Always clear, even on failure — the value is single-use.
+  store.delete({ name: options.cookieName, path: options.callbackPath });
+  if (!(queryState && cookieState)) {
+    return false;
+  }
+  const a = Buffer.from(queryState);
+  const b = Buffer.from(cookieState);
+  if (a.length !== b.length) {
+    return false;
+  }
+  return timingSafeEqual(a, b);
+}

--- a/packages/adapter-gchat/src/index.test.ts
+++ b/packages/adapter-gchat/src/index.test.ts
@@ -15,6 +15,8 @@ import type {
 
 const GCHAT_PREFIX_PATTERN = /^gchat:/;
 const DM_SUFFIX_PATTERN = /:dm$/;
+const VERIFICATION_REQUIRED_PATTERN =
+  /Webhook signature verification is required/;
 
 // Test credentials
 const mockLogger: Logger = {
@@ -28,6 +30,12 @@ const TEST_CREDENTIALS = {
   client_email: "test@test.iam.gserviceaccount.com",
   private_key: "-----BEGIN PRIVATE KEY-----\ntest\n-----END PRIVATE KEY-----\n",
 };
+
+// The adapter now fails closed by default when no JWT verification config is
+// provided. Most tests in this file exercise non-security mechanics and don't
+// supply one, so set the explicit opt-out env var globally; specific
+// verification-behavior tests override it locally.
+process.env.GOOGLE_CHAT_DISABLE_SIGNATURE_VERIFICATION = "true";
 
 // Mock StateAdapter for testing
 function createMockStateAdapter(): StateAdapter & {
@@ -259,6 +267,9 @@ describe("GoogleChatAdapter", () => {
           delete process.env[key];
         }
       }
+      // Restore the opt-out flag so non-security tests can construct adapters
+      // without supplying JWT verification config.
+      process.env.GOOGLE_CHAT_DISABLE_SIGNATURE_VERIFICATION = "true";
     });
 
     afterEach(() => {
@@ -345,6 +356,9 @@ describe("GoogleChatAdapter", () => {
           delete process.env[key];
         }
       }
+      // Restore the opt-out flag so non-security tests can construct adapters
+      // without supplying JWT verification config.
+      process.env.GOOGLE_CHAT_DISABLE_SIGNATURE_VERIFICATION = "true";
     });
 
     afterEach(() => {
@@ -2917,34 +2931,122 @@ describe("GoogleChatAdapter", () => {
       });
     });
 
-    it("should allow direct webhook without verification when project number is not configured and warn once", async () => {
-      const { adapter } = await createInitializedAdapter();
+    it("should fail-closed in constructor when no JWT verification config is provided", () => {
+      const previous = process.env.GOOGLE_CHAT_DISABLE_SIGNATURE_VERIFICATION;
+      // Any value other than "true" disables the opt-out and should make the
+      // constructor refuse to start.
+      process.env.GOOGLE_CHAT_DISABLE_SIGNATURE_VERIFICATION = "false";
+      try {
+        expect(() =>
+          createGoogleChatAdapter({
+            credentials: TEST_CREDENTIALS,
+            logger: mockLogger,
+          })
+        ).toThrow(VERIFICATION_REQUIRED_PATTERN);
+      } finally {
+        if (previous !== undefined) {
+          process.env.GOOGLE_CHAT_DISABLE_SIGNATURE_VERIFICATION = previous;
+        }
+      }
+    });
+
+    it("should accept direct webhook with disableSignatureVerification opt-in (fail-open)", async () => {
+      // Regression: previously the adapter accepted unverified webhooks
+      // silently when no project number was configured. Now this requires
+      // an explicit opt-in flag.
+      const adapter = createGoogleChatAdapter({
+        credentials: TEST_CREDENTIALS,
+        logger: mockLogger,
+        disableSignatureVerification: true,
+      });
+      const mockState = createMockStateAdapter();
+      const mockChat = createMockChatInstance(mockState);
+      await adapter.initialize(mockChat);
 
       const event = makeMessageEvent({ messageText: "Hello" });
-      const request1 = new Request("https://example.com/webhook", {
-        method: "POST",
-        headers: { "content-type": "application/json" },
-        body: JSON.stringify(event),
-      });
-      const request2 = new Request("https://example.com/webhook", {
+      const request = new Request("https://example.com/webhook", {
         method: "POST",
         headers: { "content-type": "application/json" },
         body: JSON.stringify(event),
       });
 
-      const response1 = await adapter.handleWebhook(request1);
-      expect(response1.status).toBe(200);
+      const response = await adapter.handleWebhook(request);
+      expect(response.status).toBe(200);
       expect(verifyIdTokenSpy).not.toHaveBeenCalled();
-      expect(mockLogger.warn).toHaveBeenCalledWith(
-        expect.stringContaining("GOOGLE_CHAT_PROJECT_NUMBER")
-      );
+    });
 
-      // Second call should not warn again
-      (mockLogger.warn as ReturnType<typeof vi.fn>).mockClear();
-      await adapter.handleWebhook(request2);
-      expect(mockLogger.warn).not.toHaveBeenCalledWith(
-        expect.stringContaining("GOOGLE_CHAT_PROJECT_NUMBER")
-      );
+    it("should reject Pub/Sub-shaped requests when only googleChatProjectNumber is configured", async () => {
+      // Regression: the two transports share one endpoint. With only the
+      // direct-webhook verifier configured, a Pub/Sub-shaped request
+      // previously fell through to "warn once" and was processed unverified.
+      // The module-level GOOGLE_CHAT_DISABLE_SIGNATURE_VERIFICATION=true
+      // would otherwise route this through the opt-out path; clear it for
+      // this test.
+      const previous = process.env.GOOGLE_CHAT_DISABLE_SIGNATURE_VERIFICATION;
+      process.env.GOOGLE_CHAT_DISABLE_SIGNATURE_VERIFICATION = "false";
+      try {
+        const adapter = createGoogleChatAdapter({
+          credentials: TEST_CREDENTIALS,
+          logger: mockLogger,
+          googleChatProjectNumber: "123456789",
+        });
+        const mockState = createMockStateAdapter();
+        const mockChat = createMockChatInstance(mockState);
+        await adapter.initialize(mockChat);
+
+        const pubsubMessage = makePubSubPushMessage({
+          message: {
+            name: "spaces/ABC123/messages/msg1",
+            text: "Hello",
+            sender: { name: "users/100", displayName: "User", type: "HUMAN" },
+            createTime: new Date().toISOString(),
+          },
+        });
+        const request = new Request("https://example.com/webhook", {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify(pubsubMessage),
+        });
+
+        const response = await adapter.handleWebhook(request);
+        expect(response.status).toBe(401);
+        expect(verifyIdTokenSpy).not.toHaveBeenCalled();
+      } finally {
+        if (previous !== undefined) {
+          process.env.GOOGLE_CHAT_DISABLE_SIGNATURE_VERIFICATION = previous;
+        }
+      }
+    });
+
+    it("should reject direct webhook events when only pubsubAudience is configured", async () => {
+      // Inverse of the previous test.
+      const previous = process.env.GOOGLE_CHAT_DISABLE_SIGNATURE_VERIFICATION;
+      process.env.GOOGLE_CHAT_DISABLE_SIGNATURE_VERIFICATION = "false";
+      try {
+        const adapter = createGoogleChatAdapter({
+          credentials: TEST_CREDENTIALS,
+          logger: mockLogger,
+          pubsubAudience: "https://example.com/webhook/pubsub",
+        });
+        const mockState = createMockStateAdapter();
+        const mockChat = createMockChatInstance(mockState);
+        await adapter.initialize(mockChat);
+
+        const event = makeMessageEvent({ messageText: "Hello" });
+        const request = new Request("https://example.com/webhook", {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify(event),
+        });
+
+        const response = await adapter.handleWebhook(request);
+        expect(response.status).toBe(401);
+        expect(verifyIdTokenSpy).not.toHaveBeenCalled();
+      } finally {
+        if (previous !== undefined) {
+          process.env.GOOGLE_CHAT_DISABLE_SIGNATURE_VERIFICATION = previous;
+        }
+      }
     });
 
     it("should reject Pub/Sub webhook without Authorization header when pubsubAudience is configured", async () => {
@@ -2971,38 +3073,33 @@ describe("GoogleChatAdapter", () => {
       expect(response.status).toBe(401);
     });
 
-    it("should allow Pub/Sub webhook without verification when pubsubAudience is not configured and warn once", async () => {
-      const { adapter } = await createInitializedAdapter();
+    it("should accept Pub/Sub webhook with disableSignatureVerification opt-in (fail-open)", async () => {
+      const adapter = createGoogleChatAdapter({
+        credentials: TEST_CREDENTIALS,
+        logger: mockLogger,
+        disableSignatureVerification: true,
+      });
+      const mockState = createMockStateAdapter();
+      const mockChat = createMockChatInstance(mockState);
+      await adapter.initialize(mockChat);
 
-      const makePubSubRequest = () => {
-        const pubsubMessage = makePubSubPushMessage({
-          message: {
-            name: "spaces/ABC123/messages/msg1",
-            text: "Hello",
-            sender: { name: "users/100", displayName: "User", type: "HUMAN" },
-            createTime: new Date().toISOString(),
-          },
-        });
-        return new Request("https://example.com/webhook", {
-          method: "POST",
-          headers: { "content-type": "application/json" },
-          body: JSON.stringify(pubsubMessage),
-        });
-      };
+      const pubsubMessage = makePubSubPushMessage({
+        message: {
+          name: "spaces/ABC123/messages/msg1",
+          text: "Hello",
+          sender: { name: "users/100", displayName: "User", type: "HUMAN" },
+          createTime: new Date().toISOString(),
+        },
+      });
+      const request = new Request("https://example.com/webhook", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify(pubsubMessage),
+      });
 
-      const response1 = await adapter.handleWebhook(makePubSubRequest());
-      expect(response1.status).toBe(200);
+      const response = await adapter.handleWebhook(request);
+      expect(response.status).toBe(200);
       expect(verifyIdTokenSpy).not.toHaveBeenCalled();
-      expect(mockLogger.warn).toHaveBeenCalledWith(
-        expect.stringContaining("GOOGLE_CHAT_PUBSUB_AUDIENCE")
-      );
-
-      // Second call should not warn again
-      (mockLogger.warn as ReturnType<typeof vi.fn>).mockClear();
-      await adapter.handleWebhook(makePubSubRequest());
-      expect(mockLogger.warn).not.toHaveBeenCalledWith(
-        expect.stringContaining("GOOGLE_CHAT_PUBSUB_AUDIENCE")
-      );
     });
 
     it("should reject Pub/Sub webhook with invalid token when pubsubAudience is configured", async () => {

--- a/packages/adapter-gchat/src/index.ts
+++ b/packages/adapter-gchat/src/index.ts
@@ -74,6 +74,15 @@ export interface GoogleChatAdapterBaseConfig {
   /** Override the Google Chat API root URL. Defaults to GOOGLE_CHAT_API_URL env var. */
   apiUrl?: string;
   /**
+   * Explicit opt-in to disable webhook signature verification. Required to
+   * accept incoming webhooks when neither `googleChatProjectNumber` nor
+   * `pubsubAudience` is configured. Without this flag set the constructor
+   * throws — fail-closed by default. Only enable in development or when an
+   * upstream layer (e.g. Cloud Run authenticated invocations) is providing
+   * equivalent guarantees.
+   */
+  disableSignatureVerification?: boolean;
+  /**
    * HTTP endpoint URL for button click actions.
    * Required for HTTP endpoint apps - button clicks will be routed to this URL.
    * Should be the full URL of your webhook endpoint (e.g., "https://your-app.vercel.app/api/webhooks/gchat")
@@ -308,6 +317,8 @@ export class GoogleChatAdapter implements Adapter<GoogleChatThreadId, unknown> {
   private readonly googleChatProjectNumber?: string;
   /** Expected audience for Pub/Sub push message JWT verification */
   private readonly pubsubAudience?: string;
+  /** Explicit opt-in to skip JWT verification (fail-open). */
+  private readonly disableSignatureVerification: boolean;
   /** OAuth2 client for verifying Google-signed JWTs */
   private readonly oauth2Client = new auth.OAuth2();
   /** Track whether we've already warned about missing verification config */
@@ -332,6 +343,26 @@ export class GoogleChatAdapter implements Adapter<GoogleChatThreadId, unknown> {
       config.googleChatProjectNumber ?? process.env.GOOGLE_CHAT_PROJECT_NUMBER;
     this.pubsubAudience =
       config.pubsubAudience ?? process.env.GOOGLE_CHAT_PUBSUB_AUDIENCE;
+    this.disableSignatureVerification =
+      config.disableSignatureVerification ??
+      process.env.GOOGLE_CHAT_DISABLE_SIGNATURE_VERIFICATION === "true";
+
+    // Fail-closed: refuse to start if no verification config is provided and
+    // the operator has not explicitly opted into the unsafe path. Previously
+    // the adapter accepted any webhook in this state, allowing forged
+    // payloads to impersonate users / trigger handlers.
+    if (
+      !(
+        this.googleChatProjectNumber ||
+        this.pubsubAudience ||
+        this.disableSignatureVerification
+      )
+    ) {
+      throw new ValidationError(
+        "gchat",
+        "Webhook signature verification is required. Set googleChatProjectNumber (or GOOGLE_CHAT_PROJECT_NUMBER) for direct webhooks and/or pubsubAudience (or GOOGLE_CHAT_PUBSUB_AUDIENCE) for Pub/Sub. To accept unverified webhooks (NOT recommended in production), set disableSignatureVerification: true."
+      );
+    }
     const apiRootUrl = config.apiUrl ?? process.env.GOOGLE_CHAT_API_URL;
 
     let authClient: Parameters<typeof chat>[0]["auth"];
@@ -767,7 +798,12 @@ export class GoogleChatAdapter implements Adapter<GoogleChatThreadId, unknown> {
     // Check if this is a Pub/Sub push message (from Workspace Events subscription)
     const maybePubSub = parsed as PubSubPushMessage;
     if (maybePubSub.message?.data && maybePubSub.subscription) {
-      // Verify Pub/Sub JWT if audience is configured
+      // Verify Pub/Sub JWT if audience is configured. The two transports
+      // share a single endpoint, so each shape must be independently
+      // verified — otherwise an attacker could send the unconfigured shape
+      // to bypass the configured verifier. The constructor's "at least one
+      // verifier OR disableSignatureVerification" check is not sufficient
+      // here for that reason.
       if (this.pubsubAudience) {
         const valid = await this.verifyBearerToken(
           request,
@@ -776,16 +812,28 @@ export class GoogleChatAdapter implements Adapter<GoogleChatThreadId, unknown> {
         if (!valid) {
           return new Response("Unauthorized", { status: 401 });
         }
-      } else if (!this.warnedNoPubsubVerification) {
-        this.warnedNoPubsubVerification = true;
+      } else if (this.disableSignatureVerification) {
+        if (!this.warnedNoPubsubVerification) {
+          this.warnedNoPubsubVerification = true;
+          this.logger.warn(
+            "Pub/Sub webhook verification is disabled. Set GOOGLE_CHAT_PUBSUB_AUDIENCE or pubsubAudience to verify incoming requests."
+          );
+        }
+      } else {
+        // Direct webhook verifier may be configured but Pub/Sub verifier is
+        // not — reject rather than silently process an unverified payload
+        // that a peer transport's config does nothing to authenticate.
         this.logger.warn(
-          "Pub/Sub webhook verification is disabled. Set GOOGLE_CHAT_PUBSUB_AUDIENCE or pubsubAudience to verify incoming requests."
+          "Rejected Pub/Sub webhook: pubsubAudience is not configured. Set GOOGLE_CHAT_PUBSUB_AUDIENCE, or set disableSignatureVerification to accept unverified Pub/Sub payloads."
         );
+        return new Response("Unauthorized", { status: 401 });
       }
       return this.handlePubSubMessage(maybePubSub, options);
     }
 
-    // Verify direct Google Chat webhook JWT if project number is configured
+    // Verify direct Google Chat webhook JWT if project number is configured.
+    // Same reasoning as the Pub/Sub branch: each shape requires its own
+    // verifier (or explicit opt-out) to prevent cross-transport bypass.
     if (this.googleChatProjectNumber) {
       const valid = await this.verifyBearerToken(
         request,
@@ -794,11 +842,18 @@ export class GoogleChatAdapter implements Adapter<GoogleChatThreadId, unknown> {
       if (!valid) {
         return new Response("Unauthorized", { status: 401 });
       }
-    } else if (!this.warnedNoWebhookVerification) {
-      this.warnedNoWebhookVerification = true;
+    } else if (this.disableSignatureVerification) {
+      if (!this.warnedNoWebhookVerification) {
+        this.warnedNoWebhookVerification = true;
+        this.logger.warn(
+          "Google Chat webhook verification is disabled. Set GOOGLE_CHAT_PROJECT_NUMBER or googleChatProjectNumber to verify incoming requests."
+        );
+      }
+    } else {
       this.logger.warn(
-        "Google Chat webhook verification is disabled. Set GOOGLE_CHAT_PROJECT_NUMBER or googleChatProjectNumber to verify incoming requests."
+        "Rejected direct Google Chat webhook: googleChatProjectNumber is not configured. Set GOOGLE_CHAT_PROJECT_NUMBER, or set disableSignatureVerification to accept unverified payloads."
       );
+      return new Response("Unauthorized", { status: 401 });
     }
 
     // Otherwise, treat as a direct Google Chat webhook event

--- a/packages/adapter-github/src/index.test.ts
+++ b/packages/adapter-github/src/index.test.ts
@@ -27,6 +27,8 @@ const mockReactionsListForPullRequestReviewComment = vi.fn();
 const mockReactionsDeleteForIssueComment = vi.fn();
 const mockReactionsDeleteForPullRequestComment = vi.fn();
 const mockUsersGetAuthenticated = vi.fn();
+const mockUsersGetByUsername = vi.fn();
+const mockAppsGetAuthenticated = vi.fn();
 const mockReposGet = vi.fn();
 const mockRequest = vi.fn();
 
@@ -59,6 +61,10 @@ vi.mock("@octokit/rest", () => {
     };
     users = {
       getAuthenticated: mockUsersGetAuthenticated,
+      getByUsername: mockUsersGetByUsername,
+    };
+    apps = {
+      getAuthenticated: mockAppsGetAuthenticated,
     };
     repos = {
       get: mockReposGet,
@@ -289,6 +295,9 @@ describe("GitHubAdapter", () => {
       mockUsersGetAuthenticated.mockRejectedValueOnce(
         new Error("Bad credentials")
       );
+      mockAppsGetAuthenticated.mockRejectedValueOnce(
+        new Error("Bad credentials")
+      );
 
       const mockChat = {
         getLogger: vi.fn(),
@@ -301,7 +310,7 @@ describe("GitHubAdapter", () => {
       await adapter.initialize(mockChat);
 
       expect(mockLogger.warn).toHaveBeenCalledWith(
-        "Could not fetch bot user ID",
+        "Could not auto-detect GitHub bot user ID",
         expect.any(Object)
       );
       expect(adapter.botUserId).toBeUndefined();
@@ -830,6 +839,105 @@ describe("GitHubAdapter", () => {
       const response = await adapter.handleWebhook(request);
       expect(response.status).toBe(200);
       expect(mockChat.processMessage).not.toHaveBeenCalled();
+    });
+
+    it("should auto-detect botUserId on first webhook in multi-tenant mode (regression for self-reply loop)", async () => {
+      // Regression: previously the multi-tenant App constructor left
+      // this.octokit null, so initialize()'s detection branch was skipped.
+      // The fallback only ran inside removeReaction(), so bots that never
+      // remove reactions had _botUserId === null forever — meaning isMe was
+      // always false and the bot would re-process its own replies in an
+      // unbounded loop.
+      const state = createMockState();
+      const mockChat = {
+        getLogger: vi.fn(),
+        getState: vi.fn(() => state),
+        getUserName: vi.fn(),
+        handleIncomingMessage: vi.fn(),
+        processMessage: vi.fn(),
+      };
+
+      const multiTenantAdapter = new GitHubAdapter({
+        appId: "12345",
+        privateKey:
+          "-----BEGIN RSA PRIVATE KEY-----\nfake\n-----END RSA PRIVATE KEY-----",
+        webhookSecret: WEBHOOK_SECRET,
+        userName: "test-bot[bot]",
+        logger: mockLogger,
+      });
+      expect(multiTenantAdapter.isMultiTenant).toBe(true);
+      await multiTenantAdapter.initialize(mockChat);
+      // No detection happens at initialize time in multi-tenant mode.
+      expect(multiTenantAdapter.botUserId).toBeUndefined();
+
+      mockUsersGetAuthenticated.mockResolvedValueOnce({
+        data: { id: 777, login: "test-bot[bot]" },
+      });
+
+      // Bot's own reply arrives as a webhook from a tenant installation.
+      const payload = makeIssueCommentPayload({
+        installation: { id: 789 },
+        sender: { id: 777, login: "test-bot[bot]", type: "Bot" },
+        comment: {
+          ...makeIssueCommentPayload().comment,
+          user: { id: 777, login: "test-bot[bot]", type: "Bot" },
+        },
+      });
+      const body = JSON.stringify(payload);
+      const signature = signPayload(body);
+      const request = makeWebhookRequest(body, "issue_comment", signature);
+
+      const response = await multiTenantAdapter.handleWebhook(request);
+      expect(response.status).toBe(200);
+      // botUserId must be set after the first webhook so isMe works.
+      expect(multiTenantAdapter.botUserId).toBe("777");
+      // The bot's own reply must NOT be dispatched to handlers.
+      expect(mockChat.processMessage).not.toHaveBeenCalled();
+    });
+
+    it("should fall back to apps.getAuthenticated when users.getAuthenticated rejects (multi-tenant App)", async () => {
+      // Belt-and-suspenders: in multi-tenant App mode, /user may not be
+      // available with installation tokens depending on permissions. Fall
+      // back to /app + /users/{slug}[bot] to recover the bot user ID.
+      const state = createMockState();
+      const mockChat = {
+        getLogger: vi.fn(),
+        getState: vi.fn(() => state),
+        getUserName: vi.fn(),
+        handleIncomingMessage: vi.fn(),
+        processMessage: vi.fn(),
+      };
+
+      const multiTenantAdapter = new GitHubAdapter({
+        appId: "12345",
+        privateKey:
+          "-----BEGIN RSA PRIVATE KEY-----\nfake\n-----END RSA PRIVATE KEY-----",
+        webhookSecret: WEBHOOK_SECRET,
+        userName: "test-bot[bot]",
+        logger: mockLogger,
+      });
+      await multiTenantAdapter.initialize(mockChat);
+
+      mockUsersGetAuthenticated.mockRejectedValueOnce(
+        new Error("Not Found: /user is unavailable for installation tokens")
+      );
+      mockAppsGetAuthenticated.mockResolvedValueOnce({
+        data: { slug: "test-bot" },
+      });
+      mockUsersGetByUsername.mockResolvedValueOnce({
+        data: { id: 777, login: "test-bot[bot]" },
+      });
+
+      const payload = makeIssueCommentPayload({
+        installation: { id: 789 },
+      });
+      const body = JSON.stringify(payload);
+      const signature = signPayload(body);
+      const request = makeWebhookRequest(body, "issue_comment", signature);
+
+      const response = await multiTenantAdapter.handleWebhook(request);
+      expect(response.status).toBe(200);
+      expect(multiTenantAdapter.botUserId).toBe("777");
     });
   });
 

--- a/packages/adapter-github/src/index.ts
+++ b/packages/adapter-github/src/index.ts
@@ -283,26 +283,77 @@ export class GitHubAdapter
       this.logger.debug("Created Octokit client for installation", {
         installationId,
       });
+      // Eagerly detect _botUserId on the first installation client. The bot
+      // identity is the same across all installations of the same App, so we
+      // only do this once. Without this, multi-tenant deployments never set
+      // _botUserId — leading to isMe always being false and self-reply loops
+      // in handlers that respond to every message.
+      if (this._botUserId === null) {
+        this.detectBotUserId(client).catch((error) => {
+          this.logger.warn("Could not auto-detect bot user ID", { error });
+        });
+      }
     }
 
     return client;
   }
 
+  /**
+   * Fetch the bot's user ID from GitHub. Used for self-message detection.
+   * Best-effort: errors are swallowed so they don't block webhook processing.
+   * The returned promise resolves once detection completes (or fails).
+   */
+  private async detectBotUserId(octokit: Octokit): Promise<void> {
+    if (this._botUserId !== null) {
+      return;
+    }
+    // For App installations, /user is not available. Fetch the App's bot user
+    // via /app then look up the slug to get a numeric user ID. The /user
+    // endpoint works for PAT mode and (returns the bot user) for installation
+    // tokens too, so we try it first.
+    try {
+      const { data: user } = await octokit.users.getAuthenticated();
+      this._botUserId = user.id;
+      this.logger.info("GitHub bot user ID auto-detected", {
+        botUserId: this._botUserId,
+        login: user.login,
+      });
+      return;
+    } catch (error) {
+      this.logger.debug(
+        "users.getAuthenticated failed; falling back to apps.getAuthenticated",
+        { error }
+      );
+    }
+    try {
+      // For App-authenticated installation tokens, use apps.getAuthenticated
+      // and resolve the bot user via /users/{login}[bot].
+      const { data: app } = await octokit.apps.getAuthenticated();
+      if (app) {
+        const login = `${app.slug}[bot]`;
+        const { data: botUser } = await octokit.users.getByUsername({
+          username: login,
+        });
+        this._botUserId = botUser.id;
+        this.logger.info("GitHub bot user ID auto-detected via app slug", {
+          botUserId: this._botUserId,
+          login,
+        });
+      }
+    } catch (error) {
+      this.logger.warn("Could not auto-detect GitHub bot user ID", { error });
+    }
+  }
+
   async initialize(chat: ChatInstance): Promise<void> {
     this.chat = chat;
 
-    // Fetch bot user ID if not provided (only works for single-tenant or PAT mode)
+    // Fetch bot user ID if not provided. For multi-tenant mode there's no
+    // global octokit yet — detection happens lazily in getOctokit() on first
+    // installation client creation, and synchronously in handleWebhook() on
+    // the first webhook so isMe checks work for the very first reply.
     if (!this._botUserId && this.octokit) {
-      try {
-        const { data: user } = await this.octokit.users.getAuthenticated();
-        this._botUserId = user.id;
-        this.logger.info("GitHub auth completed", {
-          botUserId: this._botUserId,
-          login: user.login,
-        });
-      } catch (error) {
-        this.logger.warn("Could not fetch bot user ID", { error });
-      }
+      await this.detectBotUserId(this.octokit);
     }
   }
 
@@ -454,6 +505,12 @@ export class GitHubAdapter
         repo.name,
         installationId
       );
+      // Eagerly resolve the bot user ID before dispatching to handlers, so
+      // isMe checks work on the very first webhook. Without this, multi-tenant
+      // adapters can self-reply-loop until detection fires lazily elsewhere.
+      if (this._botUserId === null) {
+        await this.detectBotUserId(this.getOctokit(installationId));
+      }
     }
 
     // Handle events
@@ -939,14 +996,8 @@ export class GitHubAdapter
 
     const octokit = await this.getOctokitForThread(owner, repo);
 
-    // Multi-tenant mode has no global octokit, so initialize() can't detect _botUserId
-    if (!this._botUserId) {
-      try {
-        const { data: user } = await octokit.users.getAuthenticated();
-        this._botUserId = user.id;
-      } catch {
-        this.logger.warn("Could not detect bot user ID for reaction removal");
-      }
+    if (this._botUserId === null) {
+      await this.detectBotUserId(octokit);
     }
 
     // List reactions to find the one to delete

--- a/packages/adapter-linear/src/index.test.ts
+++ b/packages/adapter-linear/src/index.test.ts
@@ -9,6 +9,7 @@ import type {
 import { createLinearAdapter, LinearAdapter } from "./index";
 
 const WEBHOOK_SECRET = "test-webhook-secret";
+const BYTES_32_PATTERN = /32 bytes/;
 
 afterEach(() => {
   vi.restoreAllMocks();
@@ -3516,6 +3517,121 @@ describe("multi-tenant installations", () => {
 
     expect(revokedResponse.status).toBe(200);
     expect(await adapter.getInstallation("org-123")).toBeNull();
+  });
+
+  describe("token encryption", () => {
+    // 32-byte AES-256 key as 64-char hex
+    const TEST_KEY_HEX =
+      "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
+
+    it("encrypts accessToken and refreshToken at rest in the state store", async () => {
+      const state = createMockState();
+      const adapter = attachLegacyClientAlias(
+        new LinearAdapter({
+          clientId: "test-client-id",
+          clientSecret: "test-client-secret",
+          webhookSecret: WEBHOOK_SECRET,
+          userName: "test-bot",
+          logger: createMockLogger(),
+          encryptionKey: TEST_KEY_HEX,
+        })
+      );
+      await adapter.initialize(createMockChatInstance(state));
+
+      await adapter.setInstallation(
+        "org-123",
+        createInstallation({
+          accessToken: "plaintext-access",
+          refreshToken: "plaintext-refresh",
+        })
+      );
+
+      const raw = state.cache.get("linear:installation:org-123") as {
+        accessToken: unknown;
+        refreshToken: unknown;
+      };
+      // Tokens must NOT be present in plaintext on disk.
+      expect(raw.accessToken).not.toBe("plaintext-access");
+      expect(raw.refreshToken).not.toBe("plaintext-refresh");
+      // They must be encrypted envelopes ({ iv, data, tag }).
+      expect(raw.accessToken).toEqual(
+        expect.objectContaining({
+          iv: expect.any(String),
+          data: expect.any(String),
+          tag: expect.any(String),
+        })
+      );
+      expect(raw.refreshToken).toEqual(
+        expect.objectContaining({
+          iv: expect.any(String),
+          data: expect.any(String),
+          tag: expect.any(String),
+        })
+      );
+
+      // Round-trip: getInstallation must return plaintext to callers.
+      const fetched = await adapter.getInstallation("org-123");
+      expect(fetched?.accessToken).toBe("plaintext-access");
+      expect(fetched?.refreshToken).toBe("plaintext-refresh");
+    });
+
+    it("stores plaintext when no encryptionKey is configured (legacy behavior)", async () => {
+      const state = createMockState();
+      const adapter = createMultiTenantAdapter();
+      await adapter.initialize(createMockChatInstance(state));
+      await adapter.setInstallation(
+        "org-123",
+        createInstallation({ accessToken: "leak-me" })
+      );
+
+      const raw = state.cache.get("linear:installation:org-123") as {
+        accessToken: unknown;
+      };
+      expect(raw.accessToken).toBe("leak-me");
+    });
+
+    it("getInstallation tolerates legacy plaintext records when encryption is enabled (zero-downtime key rotation in)", async () => {
+      const state = createMockState();
+      // Pre-populate state with a plaintext (legacy) install before encryption
+      // is enabled.
+      state.cache.set("linear:installation:org-123", {
+        organizationId: "org-123",
+        accessToken: "legacy-plaintext",
+        refreshToken: "legacy-refresh",
+        expiresAt: Date.now() + 600_000,
+        botUserId: "bot-user-id",
+      });
+
+      const adapter = attachLegacyClientAlias(
+        new LinearAdapter({
+          clientId: "test-client-id",
+          clientSecret: "test-client-secret",
+          webhookSecret: WEBHOOK_SECRET,
+          userName: "test-bot",
+          logger: createMockLogger(),
+          encryptionKey: TEST_KEY_HEX,
+        })
+      );
+      await adapter.initialize(createMockChatInstance(state));
+
+      const fetched = await adapter.getInstallation("org-123");
+      expect(fetched?.accessToken).toBe("legacy-plaintext");
+      expect(fetched?.refreshToken).toBe("legacy-refresh");
+    });
+
+    it("rejects an encryption key of the wrong length", () => {
+      expect(
+        () =>
+          new LinearAdapter({
+            clientId: "test-client-id",
+            clientSecret: "test-client-secret",
+            webhookSecret: WEBHOOK_SECRET,
+            userName: "test-bot",
+            logger: createMockLogger(),
+            encryptionKey: "tooshort",
+          })
+      ).toThrow(BYTES_32_PATTERN);
+    });
   });
 });
 

--- a/packages/adapter-linear/src/index.ts
+++ b/packages/adapter-linear/src/index.ts
@@ -2,6 +2,11 @@ import { AsyncLocalStorage } from "node:async_hooks";
 import {
   AdapterError,
   AuthenticationError,
+  decodeKey,
+  decryptToken,
+  type EncryptedTokenData,
+  encryptToken,
+  isEncryptedTokenData,
   ValidationError,
 } from "@chat-adapter/shared";
 import type { AgentActivityPayload, Comment } from "@linear/sdk";
@@ -73,6 +78,19 @@ interface LinearRequestContext {
   client: LinearClient;
   installation: LinearInstallation;
 }
+
+/**
+ * Persisted form of LinearInstallation. accessToken / refreshToken may be
+ * either a plaintext string (legacy / no encryption configured) or an
+ * EncryptedTokenData envelope (when an encryption key is set).
+ */
+type StoredLinearInstallation = Omit<
+  LinearInstallation,
+  "accessToken" | "refreshToken"
+> & {
+  accessToken: string | EncryptedTokenData;
+  refreshToken?: string | EncryptedTokenData;
+};
 
 // Re-export types
 export type {
@@ -163,6 +181,8 @@ export class LinearAdapter
   private accessTokenExpiry: number | null = null;
   // Custom API base URL
   private readonly apiUrl?: string;
+  // Optional AES-256-GCM key for encrypting OAuth tokens at rest
+  private readonly encryptionKey: Buffer | undefined;
 
   constructor(config: LinearAdapterConfig = {} as LinearAdapterAutoConfig) {
     const webhookSecret =
@@ -179,6 +199,11 @@ export class LinearAdapter
     this.userName =
       config.userName ?? process.env.LINEAR_BOT_USERNAME ?? "linear-bot";
     this.apiUrl = config.apiUrl ?? process.env.LINEAR_API_URL;
+    const encryptionKey =
+      config.encryptionKey ?? process.env.LINEAR_ENCRYPTION_KEY;
+    if (encryptionKey) {
+      this.encryptionKey = decodeKey(encryptionKey);
+    }
 
     if ("apiKey" in config && config.apiKey) {
       this.defaultClient = new LinearClient({
@@ -396,9 +421,10 @@ export class LinearAdapter
       );
     }
 
+    const dataToStore = this.encryptInstallation(installation);
     await this.chat
       .getState()
-      .set(this.installationKey(organizationId), installation);
+      .set(this.installationKey(organizationId), dataToStore);
     this.logger.info("Linear installation saved", { organizationId });
   }
 
@@ -424,11 +450,70 @@ export class LinearAdapter
       return contextInstallation.installation;
     }
 
-    const installation = await this.chat
+    const stored = await this.chat
       .getState()
-      .get<LinearInstallation>(this.installationKey(organizationId));
+      .get<StoredLinearInstallation>(this.installationKey(organizationId));
 
-    return installation ?? null;
+    if (!stored) {
+      return null;
+    }
+
+    return this.decryptInstallation(stored);
+  }
+
+  /**
+   * Encrypt installation tokens before persisting to the state store, if an
+   * encryption key is configured. Without a key, the installation is stored
+   * as-is (legacy behavior, with a warning logged at construction time
+   * elsewhere is left to the deployer's discretion).
+   */
+  private encryptInstallation(
+    installation: LinearInstallation
+  ): StoredLinearInstallation {
+    if (!this.encryptionKey) {
+      return installation;
+    }
+    return {
+      ...installation,
+      accessToken: encryptToken(installation.accessToken, this.encryptionKey),
+      ...(installation.refreshToken
+        ? {
+            refreshToken: encryptToken(
+              installation.refreshToken,
+              this.encryptionKey
+            ),
+          }
+        : {}),
+    };
+  }
+
+  /**
+   * Decrypt installation tokens from the state store. Tolerates plaintext
+   * values (legacy installs from before encryption was enabled) so rotating
+   * keys in is non-breaking.
+   */
+  private decryptInstallation(
+    stored: StoredLinearInstallation
+  ): LinearInstallation {
+    const accessToken = this.maybeDecrypt(stored.accessToken);
+    const refreshToken =
+      stored.refreshToken === undefined
+        ? undefined
+        : this.maybeDecrypt(stored.refreshToken);
+    return {
+      botUserId: stored.botUserId,
+      expiresAt: stored.expiresAt,
+      organizationId: stored.organizationId,
+      accessToken,
+      ...(refreshToken !== undefined ? { refreshToken } : {}),
+    };
+  }
+
+  private maybeDecrypt(value: string | EncryptedTokenData): string {
+    if (this.encryptionKey && isEncryptedTokenData(value)) {
+      return decryptToken(value, this.encryptionKey);
+    }
+    return value as string;
   }
 
   /**

--- a/packages/adapter-linear/src/types.ts
+++ b/packages/adapter-linear/src/types.ts
@@ -49,6 +49,15 @@ export type LinearAdapterMode = "agent-sessions" | "comments";
 interface LinearAdapterBaseConfig {
   /** Override the Linear API base URL. Defaults to LINEAR_API_URL env var. */
   apiUrl?: string;
+  /**
+   * Optional 32-byte AES-256-GCM key used to encrypt OAuth `accessToken` and
+   * `refreshToken` values at rest in the state store. Accepts either a 64-char
+   * hex string or a 44-char base64 string. Defaults to the
+   * `LINEAR_ENCRYPTION_KEY` env var. Strongly recommended for multi-tenant
+   * deployments — without it, a state-store compromise yields plaintext per-
+   * tenant Linear API tokens.
+   */
+  encryptionKey?: string;
   /** Logger instance for error reporting. Defaults to ConsoleLogger. */
   logger?: Logger;
   /**

--- a/packages/adapter-shared/src/crypto.ts
+++ b/packages/adapter-shared/src/crypto.ts
@@ -1,0 +1,87 @@
+import crypto from "node:crypto";
+
+/**
+ * Token encryption helpers shared across adapters that persist OAuth/bot
+ * tokens to a state store. Uses AES-256-GCM with a randomly generated 12-byte
+ * IV per encryption. Adapters call decodeKey() once at construction to turn a
+ * user-supplied hex/base64 key string into a Buffer, then pass it to
+ * encryptToken / decryptToken.
+ */
+
+const ALGORITHM = "aes-256-gcm";
+const IV_LENGTH = 12;
+const AUTH_TAG_LENGTH = 16;
+const HEX_KEY_PATTERN = /^[0-9a-fA-F]{64}$/;
+
+export interface EncryptedTokenData {
+  data: string;
+  iv: string;
+  tag: string;
+}
+
+export function encryptToken(
+  plaintext: string,
+  key: Buffer
+): EncryptedTokenData {
+  const iv = crypto.randomBytes(IV_LENGTH);
+  const cipher = crypto.createCipheriv(ALGORITHM, key, iv, {
+    authTagLength: AUTH_TAG_LENGTH,
+  });
+  const ciphertext = Buffer.concat([
+    cipher.update(plaintext, "utf8"),
+    cipher.final(),
+  ]);
+  const tag = cipher.getAuthTag();
+
+  return {
+    iv: iv.toString("base64"),
+    data: ciphertext.toString("base64"),
+    tag: tag.toString("base64"),
+  };
+}
+
+export function decryptToken(
+  encrypted: EncryptedTokenData,
+  key: Buffer
+): string {
+  const iv = Buffer.from(encrypted.iv, "base64");
+  const ciphertext = Buffer.from(encrypted.data, "base64");
+  const tag = Buffer.from(encrypted.tag, "base64");
+
+  const decipher = crypto.createDecipheriv(ALGORITHM, key, iv, {
+    authTagLength: AUTH_TAG_LENGTH,
+  });
+  decipher.setAuthTag(tag);
+
+  return Buffer.concat([
+    decipher.update(ciphertext),
+    decipher.final(),
+  ]).toString("utf8");
+}
+
+export function isEncryptedTokenData(
+  value: unknown
+): value is EncryptedTokenData {
+  if (!value || typeof value !== "object") {
+    return false;
+  }
+  const obj = value as Record<string, unknown>;
+  return (
+    typeof obj.iv === "string" &&
+    typeof obj.data === "string" &&
+    typeof obj.tag === "string"
+  );
+}
+
+export function decodeKey(rawKey: string): Buffer {
+  const trimmed = rawKey.trim();
+  // Detect hex encoding: 64 hex chars = 32 bytes
+  const isHex = HEX_KEY_PATTERN.test(trimmed);
+  const key = Buffer.from(trimmed, isHex ? "hex" : "base64");
+  if (key.length !== 32) {
+    throw new Error(
+      `Encryption key must decode to exactly 32 bytes (received ${key.length}). Use a 64-char hex string or 44-char base64 string.`
+    );
+  }
+  return key;
+}

--- a/packages/adapter-shared/src/index.ts
+++ b/packages/adapter-shared/src/index.ts
@@ -29,6 +29,15 @@ export {
   renderGfmTable,
 } from "./card-utils";
 
+// Token encryption helpers (AES-256-GCM)
+export {
+  decodeKey,
+  decryptToken,
+  type EncryptedTokenData,
+  encryptToken,
+  isEncryptedTokenData,
+} from "./crypto";
+
 // Standardized adapter errors
 export {
   AdapterError,

--- a/packages/adapter-slack/src/crypto.ts
+++ b/packages/adapter-slack/src/crypto.ts
@@ -1,79 +1,10 @@
-import crypto from "node:crypto";
-
-const ALGORITHM = "aes-256-gcm";
-const IV_LENGTH = 12;
-const AUTH_TAG_LENGTH = 16;
-const HEX_KEY_PATTERN = /^[0-9a-fA-F]{64}$/;
-
-export interface EncryptedTokenData {
-  data: string;
-  iv: string;
-  tag: string;
-}
-
-export function encryptToken(
-  plaintext: string,
-  key: Buffer
-): EncryptedTokenData {
-  const iv = crypto.randomBytes(IV_LENGTH);
-  const cipher = crypto.createCipheriv(ALGORITHM, key, iv, {
-    authTagLength: AUTH_TAG_LENGTH,
-  });
-  const ciphertext = Buffer.concat([
-    cipher.update(plaintext, "utf8"),
-    cipher.final(),
-  ]);
-  const tag = cipher.getAuthTag();
-
-  return {
-    iv: iv.toString("base64"),
-    data: ciphertext.toString("base64"),
-    tag: tag.toString("base64"),
-  };
-}
-
-export function decryptToken(
-  encrypted: EncryptedTokenData,
-  key: Buffer
-): string {
-  const iv = Buffer.from(encrypted.iv, "base64");
-  const ciphertext = Buffer.from(encrypted.data, "base64");
-  const tag = Buffer.from(encrypted.tag, "base64");
-
-  const decipher = crypto.createDecipheriv(ALGORITHM, key, iv, {
-    authTagLength: AUTH_TAG_LENGTH,
-  });
-  decipher.setAuthTag(tag);
-
-  return Buffer.concat([
-    decipher.update(ciphertext),
-    decipher.final(),
-  ]).toString("utf8");
-}
-
-export function isEncryptedTokenData(
-  value: unknown
-): value is EncryptedTokenData {
-  if (!value || typeof value !== "object") {
-    return false;
-  }
-  const obj = value as Record<string, unknown>;
-  return (
-    typeof obj.iv === "string" &&
-    typeof obj.data === "string" &&
-    typeof obj.tag === "string"
-  );
-}
-
-export function decodeKey(rawKey: string): Buffer {
-  const trimmed = rawKey.trim();
-  // Detect hex encoding: 64 hex chars = 32 bytes
-  const isHex = HEX_KEY_PATTERN.test(trimmed);
-  const key = Buffer.from(trimmed, isHex ? "hex" : "base64");
-  if (key.length !== 32) {
-    throw new Error(
-      `Encryption key must decode to exactly 32 bytes (received ${key.length}). Use a 64-char hex string or 44-char base64 string.`
-    );
-  }
-  return key;
-}
+// Re-export shared token encryption helpers. Slack-specific call sites import
+// from "./crypto" historically; now they all delegate to @chat-adapter/shared
+// so the same primitives are reused across adapters (Linear, etc.).
+export {
+  decodeKey,
+  decryptToken,
+  type EncryptedTokenData,
+  encryptToken,
+  isEncryptedTokenData,
+} from "@chat-adapter/shared";

--- a/packages/adapter-slack/src/index.test.ts
+++ b/packages/adapter-slack/src/index.test.ts
@@ -6298,6 +6298,68 @@ describe("socket mode forwarding - handleWebhook", () => {
     expect(response.status).toBe(200);
   });
 
+  it("rejects forwarded event with token of correct length but wrong content (timing-safe)", async () => {
+    // Regression: previously used `!==` string equality which short-circuits on
+    // first byte mismatch, leaking secret bytes via response timing. Now uses
+    // timingSafeEqual on equal-length Buffers.
+    const forwardingSecret = "abcdef0123456789";
+    const adapter = createSlackAdapter({
+      botToken: "xoxb-test-token",
+      signingSecret: secret,
+      appToken,
+      socketForwardingSecret: forwardingSecret,
+      logger: mockLogger,
+    });
+
+    // Same length as the secret, but every byte different.
+    const wrongSameLength = "0000000000000000";
+    expect(wrongSameLength.length).toBe(forwardingSecret.length);
+
+    const request = new Request("https://example.com/webhook", {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "x-slack-socket-token": wrongSameLength,
+      },
+      body: JSON.stringify({
+        type: "socket_event",
+        eventType: "events_api",
+        body: {},
+        timestamp: Date.now(),
+      }),
+    });
+
+    const response = await adapter.handleWebhook(request);
+    expect(response.status).toBe(401);
+  });
+
+  it("rejects forwarded event when supplied token has different length than secret", async () => {
+    const adapter = createSlackAdapter({
+      botToken: "xoxb-test-token",
+      signingSecret: secret,
+      appToken,
+      socketForwardingSecret: "abcdef0123456789",
+      logger: mockLogger,
+    });
+
+    const request = new Request("https://example.com/webhook", {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "x-slack-socket-token": "short",
+      },
+      body: JSON.stringify({
+        type: "socket_event",
+        eventType: "events_api",
+        body: {},
+        timestamp: Date.now(),
+      }),
+    });
+
+    const response = await adapter.handleWebhook(request);
+    expect(response.status).toBe(401);
+  });
+
   it("rejects forwarded event with appToken when socketForwardingSecret is set", async () => {
     const adapter = createSlackAdapter({
       botToken: "xoxb-test-token",

--- a/packages/adapter-slack/src/index.ts
+++ b/packages/adapter-slack/src/index.ts
@@ -83,6 +83,21 @@ const SLACK_USER_ID_EXACT_PATTERN = /^U[A-Z0-9]+$/;
 // network latency so the HTTP response lands before Slack gives up.
 const OPTIONS_LOAD_TIMEOUT_MS = 2500;
 
+/**
+ * Compare two strings in constant time to avoid leaking information about how
+ * many leading bytes match via response timing. Returns false on length
+ * mismatch (which itself is not a secret-leaking signal because the secret's
+ * length is fixed at configuration time).
+ */
+function timingSafeStringEqual(a: string, b: string): boolean {
+  const aBuf = Buffer.from(a, "utf8");
+  const bBuf = Buffer.from(b, "utf8");
+  if (aBuf.length !== bBuf.length) {
+    return false;
+  }
+  return timingSafeEqual(aBuf, bBuf);
+}
+
 /** Find the next `<@` or `<#` mention in text. */
 function findNextMention(text: string): number {
   const atIdx = text.indexOf("<@");
@@ -1030,8 +1045,10 @@ export class SlackAdapter implements Adapter<SlackThreadId, unknown> {
     const socketToken = request.headers.get("x-slack-socket-token");
     if (socketToken) {
       if (
-        !this.socketForwardingSecret ||
-        socketToken !== this.socketForwardingSecret
+        !(
+          this.socketForwardingSecret &&
+          timingSafeStringEqual(socketToken, this.socketForwardingSecret)
+        )
       ) {
         this.logger.warn("Invalid socket forwarding token");
         return new Response("Invalid socket token", { status: 401 });

--- a/packages/integration-tests/src/gchat.test.ts
+++ b/packages/integration-tests/src/gchat.test.ts
@@ -51,6 +51,9 @@ describe("Google Chat Integration", () => {
       credentials: GCHAT_TEST_CREDENTIALS,
       userName: GCHAT_BOT_NAME,
       logger: mockLogger,
+      // Integration tests inject pre-built event payloads directly; no real
+      // webhook signature is exercised here.
+      disableSignatureVerification: true,
     });
 
     mockChatApi = createMockGoogleChatApi();

--- a/packages/integration-tests/src/replay-dm.test.ts
+++ b/packages/integration-tests/src/replay-dm.test.ts
@@ -374,6 +374,8 @@ describe("DM Replay Tests", () => {
         credentials: GCHAT_TEST_CREDENTIALS,
         userName: gchatFixtures.botName,
         logger: mockLogger,
+        // Replay tests inject pre-recorded webhook payloads directly.
+        disableSignatureVerification: true,
       });
       gchatAdapter.botUserId = gchatFixtures.botUserId;
 

--- a/packages/integration-tests/src/replay-test-utils.ts
+++ b/packages/integration-tests/src/replay-test-utils.ts
@@ -424,6 +424,9 @@ export function createGchatTestContext(
     credentials: GCHAT_TEST_CREDENTIALS,
     userName: fixtures.botName,
     logger: mockLogger,
+    // Replay tests inject pre-recorded webhook payloads directly; the JWT
+    // verification path is not exercised, so explicitly opt out.
+    disableSignatureVerification: true,
   });
   adapter.botUserId = fixtures.botUserId;
 


### PR DESCRIPTION
A round of correctness and configuration tightening across the platform adapters and the example app's OAuth install flows. Each change is small in surface area but several shift defaults, so I've called those out explicitly.

## Summary of changes

### `@chat-adapter/gchat` — require explicit verification configuration

The Google Chat adapter previously accepted the construction call when neither `googleChatProjectNumber` nor `pubsubAudience` was set, logged a one-shot warning, and then processed every incoming webhook. That made the warning easy to miss in deployment logs and meant the safe configuration was the path of greatest effort.

The constructor now refuses to start unless one of the following is true:

- `googleChatProjectNumber` (or `GOOGLE_CHAT_PROJECT_NUMBER`) is configured for direct webhook JWT verification, or
- `pubsubAudience` (or `GOOGLE_CHAT_PUBSUB_AUDIENCE`) is configured for Pub/Sub push JWT verification, or
- the new `disableSignatureVerification: true` flag (or `GOOGLE_CHAT_DISABLE_SIGNATURE_VERIFICATION=true`) is set.

The thrown `ValidationError` names all three escape hatches so the resolution is obvious from the message alone. This mirrors what the Slack adapter already does for `signingSecret`/`webhookVerifier`.

Two transports share one HTTP endpoint here, so the constructor check alone is not sufficient: a deployment that only sets `googleChatProjectNumber` would still happily process Pub/Sub-shaped requests, and vice versa. `handleWebhook` now treats each shape independently — if the verifier for the incoming shape is unconfigured and `disableSignatureVerification` is not set, the handler returns 401 instead of falling through to processing.

**This is a breaking change for any deployment that was relying on the old warn-and-process default.** The fix is one env var. We chose loud-at-startup over silent-at-runtime intentionally — the example app (`examples/nextjs-chat/src/lib/adapters.ts`) catches the throw and the gchat adapter will simply no-op until configured, so it doesn't take down the rest of the bot.

### `@chat-adapter/github` — multi-tenant bot identity auto-detection

In multi-tenant App mode, `this.octokit` is null at construction time and only populated lazily in `getOctokit()` per installation. The previous `initialize()` only fetched `_botUserId` when a global Octokit existed — so multi-tenant bots ran with `_botUserId === null`, which meant `parseAuthor()`'s `isMe: user.id === this._botUserId` check was always false (real GitHub user IDs are positive integers).

For bots that respond to events that include their own replies, this caused self-message detection to silently fail and let the bot loop on its own messages.

The fix:

- New private `detectBotUserId(octokit)` helper called eagerly the first time a per-installation Octokit is created in `getOctokit()`, and synchronously inside `handleWebhook()` once the installation ID is known so `isMe` works on the very first dispatch.
- `users.getAuthenticated` is the primary path; if that fails (some installation tokens don't have access to `/user`), it falls back to `apps.getAuthenticated` + `users.getByUsername` for `${slug}[bot]`.
- `removeReaction()`'s ad-hoc lazy detection was deduplicated into the same helper.

Single-tenant and PAT modes are unaffected — `initialize()` still does the same single fetch it always did, just routed through the new helper.

### `@chat-adapter/slack` — constant-time compare on socket forwarding token

`handleWebhook` validated the `x-slack-socket-token` header with `!==`, while every other auth check in the same file routed through `crypto.timingSafeEqual`. Switched to a small `timingSafeStringEqual` helper that buffers both sides and length-checks before delegating to `timingSafeEqual`, matching `verifySignature`'s pattern.

No behavior change for callers — same 401/200 outcomes for the same inputs.

### `@chat-adapter/linear` — optional at-rest encryption for OAuth tokens

The Linear adapter persists per-organization `accessToken` and `refreshToken` values to whatever `StateAdapter` the chat instance is configured with. Previously these went in plaintext; the Slack adapter has had AES-256-GCM token encryption support since the Slack OAuth work landed.

This PR brings Linear to parity:

- New optional `encryptionKey` config field (or `LINEAR_ENCRYPTION_KEY` env var). Accepts the same hex-64 / base64-44 formats as the Slack adapter.
- `setInstallation()` encrypts `accessToken` and `refreshToken` before writing when a key is configured.
- `getInstallation()` decrypts on read; it tolerates legacy plaintext records (encryption key set, but stored value isn't an `EncryptedTokenData` envelope), which lets operators rotate encryption *in* without flushing existing installs.
- Without an `encryptionKey`, behavior is identical to before — plaintext storage, no changes to the on-disk format.

To avoid duplicating the AES-GCM primitives across Slack and Linear, the actual encryption helpers (`encryptToken`, `decryptToken`, `decodeKey`, `isEncryptedTokenData`, `EncryptedTokenData`) moved from `packages/adapter-slack/src/crypto.ts` into `packages/adapter-shared/src/crypto.ts`. Slack's `crypto.ts` re-exports from shared, so the public surface (including the `decodeKey` and `EncryptedTokenData` re-exports from `@chat-adapter/slack`) is unchanged.

### `@chat-adapter/shared` — token encryption helpers

New module: `packages/adapter-shared/src/crypto.ts`. AES-256-GCM with a randomly generated 12-byte IV per encryption, exported from the package entry point so any adapter that needs to encrypt tokens can pull it in instead of re-implementing.

### `examples/nextjs-chat` — OAuth state on Slack and Linear install flows

Both `/api/slack/install` and `/api/linear/install` now generate a 32-byte opaque `state` value, stash it in an HttpOnly + SameSite=Lax cookie scoped to the matching callback path with a 10-minute TTL, and redirect to the provider with the value in the authorize URL. The corresponding callback routes read the state cookie, consume it (delete on first read so it can't be replayed), and `crypto.timingSafeEqual`-compare against the `?state=` query parameter. Mismatch returns 400 before `handleOAuthCallback` is called.

Logic is shared via `examples/nextjs-chat/src/lib/oauth-state.ts` (`issueOAuthState` / `consumeAndVerifyOAuthState`) so any future install flow can adopt the same pattern with two function calls. There is no library-side change here — this is example-app only — but the pattern is what we'd recommend for real deployments.

In-flight install flows started against the old code will fail with `OAuth state mismatch` after this lands; users just need to restart the flow.

## Tests

- `@chat-adapter/slack`: two new index.test.ts cases for the timing-safe compare — same-length / wrong-content and length-mismatch — both expect 401.
- `@chat-adapter/github`: two new self-message-detection tests covering multi-tenant first-webhook detection and the `apps.getAuthenticated` fallback path. The existing "should handle auth failure gracefully" test was updated to reflect the new fallback chain (rejects both `users.getAuthenticated` and `apps.getAuthenticated`) and the new warning string.
- `@chat-adapter/linear`: four new tests under a `token encryption` describe — ciphertext-on-disk verification, plaintext-when-no-key (legacy behavior preserved), legacy-plaintext-tolerance for zero-downtime key rotation in, and key-length validation.
- `@chat-adapter/gchat`: replaced two old "fail-open with warning" tests with new ones covering the constructor throw, the `disableSignatureVerification` opt-in, and the two cross-transport rejection cases (Pub/Sub-shaped to a `googleChatProjectNumber`-only adapter, and the inverse). The existing test helpers and module-level env var have been updated so the rest of the file's 240+ tests continue to construct adapters without verification config.
- `@chat-adapter/integration-tests`: the three replay/test contexts that construct gchat adapters with mock credentials now pass `disableSignatureVerification: true`, since these tests inject pre-built event payloads directly and don't exercise the JWT path.

`pnpm validate` (knip + check + typecheck + test + build) is green across all 16 tasks. A changeset is included.
