### PR TITLE
fix(telegram): apply MarkdownV2 entity safety trim to streaming chunks

### DIFF
--- a/.changeset/smooth-insects-dig.md
+++ b/.changeset/smooth-insects-dig.md
@@ -1,0 +1,5 @@
+---
+"@chat-adapter/telegram": patch
+---
+
+fix(telegram): apply MarkdownV2 entity safety trim to streaming chunks

--- a/packages/adapter-telegram/src/markdown.test.ts
+++ b/packages/adapter-telegram/src/markdown.test.ts
@@ -510,6 +510,31 @@ describe("truncateForTelegram", () => {
     expect(result.length).toBeLessThanOrEqual(100);
     expect(result.endsWith("\\.\\.\\.")).toBe(true);
   });
+
+  it("strips unpaired entity markers when under the limit (streaming leak)", () => {
+    const input = "Hello *world* _italic and bold *bold*";
+    const result = truncateForTelegram(input, 4096, "MarkdownV2");
+    const underscores = [...result].filter((c) => c === "_").length;
+    expect(underscores % 2).toBe(0);
+  });
+
+  it("preserves code fences with literal asterisks (no false-positive trim)", () => {
+    const input = "```python\nprint(*args, **kwargs)\n```";
+    const result = truncateForTelegram(input, 4096, "MarkdownV2");
+    expect(result).toBe(input);
+  });
+
+  it("does not modify plain parseMode messages", () => {
+    const input = "Hello *world* _unclosed";
+    const result = truncateForTelegram(input, 4096, "plain");
+    expect(result).toBe(input);
+  });
+
+  it("preserves balanced MarkdownV2 under the limit (no-op)", () => {
+    const input = "*bold* _italic_ ~strike~ `code`";
+    const result = truncateForTelegram(input, 4096, "MarkdownV2");
+    expect(result).toBe(input);
+  });
 });
 
 describe("findUnescapedPositions", () => {

--- a/packages/adapter-telegram/src/markdown.ts
+++ b/packages/adapter-telegram/src/markdown.ts
@@ -97,6 +97,52 @@ export function findUnescapedPositions(text: string, marker: string): number[] {
   return positions;
 }
 
+/**
+ * Like `findUnescapedPositions` but skips occurrences inside fenced code
+ * blocks (``` ```) or inline code spans (`` ` ``). Inside those regions
+ * Telegram treats `*`, `_`, `~`, `[`, `]` as literal text.
+ */
+function findUnescapedPositionsOutsideCode(
+  text: string,
+  marker: string
+): number[] {
+  const positions: number[] = [];
+  let inFence = false;
+  let inInline = false;
+  let backslashes = 0;
+
+  for (let i = 0; i < text.length; i++) {
+    const ch = text[i];
+
+    if (ch === "\\") {
+      backslashes++;
+      continue;
+    }
+
+    const escaped = backslashes % 2 === 1;
+    backslashes = 0;
+
+    if (ch === "`" && !escaped) {
+      const isTriple = text[i + 1] === "`" && text[i + 2] === "`";
+      if (isTriple && !inInline) {
+        inFence = !inFence;
+        i += 2;
+        continue;
+      }
+      if (!inFence) {
+        inInline = !inInline;
+      }
+      continue;
+    }
+
+    if (ch === marker && !escaped && !inFence && !inInline) {
+      positions.push(i);
+    }
+  }
+
+  return positions;
+}
+
 export function endsWithOrphanBackslash(text: string): boolean {
   let trailing = 0;
   for (let i = text.length - 1; i >= 0 && text[i] === "\\"; i--) {
@@ -130,7 +176,10 @@ function trimToMarkdownV2SafeBoundary(text: string): string {
     let minUnsafePosition = current.length;
 
     for (const marker of MARKDOWN_V2_ENTITY_MARKERS) {
-      const positions = findUnescapedPositions(current, marker);
+      const positions =
+        marker === "`"
+          ? findUnescapedPositions(current, marker)
+          : findUnescapedPositionsOutsideCode(current, marker);
       if (positions.length % 2 === 1) {
         const lastUnpaired = positions.at(-1) ?? current.length;
         if (lastUnpaired < minUnsafePosition) {
@@ -139,8 +188,8 @@ function trimToMarkdownV2SafeBoundary(text: string): string {
       }
     }
 
-    const openBrackets = findUnescapedPositions(current, "[");
-    const closeBrackets = findUnescapedPositions(current, "]");
+    const openBrackets = findUnescapedPositionsOutsideCode(current, "[");
+    const closeBrackets = findUnescapedPositionsOutsideCode(current, "]");
     if (openBrackets.length > closeBrackets.length) {
       const lastOpen = openBrackets.at(-1) ?? current.length;
       if (lastOpen < minUnsafePosition) {
@@ -174,11 +223,12 @@ export function truncateForTelegram(
   limit: number,
   parseMode: TelegramParseMode
 ): string {
+  const isMarkdownV2 = parseMode === "MarkdownV2";
+
   if (text.length <= limit) {
-    return text;
+    return isMarkdownV2 ? trimToMarkdownV2SafeBoundary(text) : text;
   }
 
-  const isMarkdownV2 = parseMode === "MarkdownV2";
   const ellipsis = isMarkdownV2 ? MARKDOWN_V2_ELLIPSIS : PLAIN_ELLIPSIS;
   let slice = text.slice(0, limit - ellipsis.length);
 


### PR DESCRIPTION
## summary

streaming chunks under 4096 chars bypassed `trimToMarkdownV2SafeBoundary` because the guard only ran on length-overflow truncation. during LLM streaming, intermediate edits with unclosed entity markers (e.g. `_All timestamps are *UTC*` mid-sentence) were sent directly to Telegram and rejected with `Bad Request: can't parse entities`

the fix applies the safety trim universally for MarkdownV2 messages and makes the trim fence-aware so code blocks with literal `*`/`_` characters don't trigger false-positive stripping

- apply `trimToMarkdownV2SafeBoundary` when text is under the limit (not just on overflow)
- add `findUnescapedPositionsOutsideCode` helper that skips markers inside fenced/inline code
- no effect on plain-text messages or other adapters