### PR TITLE
feat(chat): add Transcripts API + rename per-thread cache to threadHistory

### DIFF
--- a/.changeset/thread-history-rename.md
+++ b/.changeset/thread-history-rename.md
@@ -1,0 +1,26 @@
+---
+"chat": minor
+"@chat-adapter/telegram": patch
+"@chat-adapter/whatsapp": patch
+---
+
+Rename `messageHistory` → `threadHistory` (with backwards compatibility).
+
+The per-thread history cache was previously named `messageHistory`, which collides conceptually with the new cross-platform per-user [Messages API](./messages.ts). Renamed to `threadHistory` to make the distinction clear.
+
+**Renamed:**
+
+- `ChatConfig.messageHistory` → `ChatConfig.threadHistory`
+- `Adapter.persistMessageHistory` → `Adapter.persistThreadHistory`
+- `MessageHistoryCache` → `ThreadHistoryCache`
+- `MessageHistoryConfig` → `ThreadHistoryConfig`
+- File `message-history.ts` → `thread-history.ts`
+
+**Backwards compatibility:**
+
+- The old `ChatConfig.messageHistory` field is still read; `threadHistory` takes precedence when both are set.
+- The old `Adapter.persistMessageHistory` flag is still read; either flag being `true` enables persistence.
+- `MessageHistoryCache` and `MessageHistoryConfig` are re-exported as deprecated aliases of the new names.
+- The state-adapter storage key prefix (`msg-history:`) is **unchanged** — renaming it would silently orphan existing data.
+
+The `@chat-adapter/telegram` and `@chat-adapter/whatsapp` adapters now use `persistThreadHistory`. Custom adapters built against `persistMessageHistory` continue to work unchanged.

--- a/.changeset/thread-history-rename.md
+++ b/.changeset/thread-history-rename.md
@@ -6,7 +6,7 @@
 
 Rename `messageHistory` → `threadHistory` (with backwards compatibility).
 
-The per-thread history cache was previously named `messageHistory`, which collides conceptually with the new cross-platform per-user [Messages API](./messages.ts). Renamed to `threadHistory` to make the distinction clear.
+The per-thread history cache was previously named `messageHistory`, which collides conceptually with the new cross-platform per-user Transcripts API. Renamed to `threadHistory` to make the distinction clear.
 
 **Renamed:**
 

--- a/.changeset/transcripts-api.md
+++ b/.changeset/transcripts-api.md
@@ -1,0 +1,11 @@
+---
+"chat": minor
+---
+
+Add Transcripts API for cross-platform per-user message persistence.
+
+`bot.transcripts` (when configured via `ChatConfig.transcripts` + `ChatConfig.identity`) provides `append` / `list` / `count` / `delete` keyed by a stable cross-platform user key. Backed by the existing `StateAdapter.appendToList` primitive, so every built-in state adapter (`memory`, `redis`, `ioredis`, `pg`) supports it with no changes.
+
+- `IdentityResolver` runs once per inbound message during dispatch; the result is cached on the `Message` instance as `message.userKey`.
+- Distinct from the existing per-thread `threadHistory` config (which backfills thread context for adapters that lack server-side history).
+- `delete` wipes every stored entry under a user key. Single-entry and time-range deletes are not part of this API — the underlying `appendToList` primitive can't support them safely under concurrent writes.

--- a/apps/docs/content/docs/api/meta.json
+++ b/apps/docs/content/docs/api/meta.json
@@ -7,6 +7,7 @@
     "channel",
     "message",
     "postable-message",
+    "transcripts",
     "cards",
     "markdown",
     "modals"

--- a/apps/docs/content/docs/api/transcripts.mdx
+++ b/apps/docs/content/docs/api/transcripts.mdx
@@ -1,0 +1,220 @@
+---
+title: Transcripts
+description: Cross-platform per-user transcript persistence — configuration, methods, and entry shape.
+type: reference
+---
+
+`bot.transcripts` provides per-user message persistence keyed by a stable cross-platform identifier. See the [Conversation history](/docs/conversation-history) guide for usage patterns.
+
+```typescript
+import { Chat } from "chat";
+```
+
+## Configuration
+
+`transcripts` and `identity` are configured on `ChatConfig`. Both must be set together — passing `transcripts` without `identity` throws at construction.
+
+### ChatConfig.transcripts
+
+<TypeTable
+  type={{
+    retention: {
+      description: 'List TTL, refreshed on every append. Accepts ms or a duration string ("45s", "30m", "6h", "7d"). Omit for no expiry.',
+      type: 'number | DurationString | undefined',
+    },
+    maxPerUser: {
+      description: 'Hard cap per user. Older entries are evicted on append.',
+      type: 'number',
+      default: '200',
+    },
+    storeFormatted: {
+      description: 'Persist the mdast `formatted` field alongside `text`. Off by default to keep storage small.',
+      type: 'boolean',
+      default: 'false',
+    },
+  }}
+/>
+
+### ChatConfig.identity
+
+```typescript
+identity: (context: IdentityContext) => string | null | Promise<string | null>;
+```
+
+Called once per inbound message during dispatch. The result is attached to the `Message` instance as `message.userKey`. Return `null` to skip persistence for an event.
+
+#### IdentityContext
+
+<TypeTable
+  type={{
+    adapter: {
+      description: 'Adapter name (e.g. "slack", "discord").',
+      type: 'string',
+    },
+    author: {
+      description: 'Message author info.',
+      type: 'Author',
+    },
+    message: {
+      description: 'The inbound message.',
+      type: 'Message',
+    },
+  }}
+/>
+
+## Methods
+
+Access via `bot.transcripts`. Throws if `transcripts` was not configured on the `Chat` instance.
+
+### append
+
+Persist a `Message` (typically the inbound user message) or an `AppendInput` (typically a bot reply you just posted).
+
+```typescript
+append(
+  thread: Postable,
+  message: Message | AppendInput,
+  options?: AppendOptions,
+): Promise<TranscriptEntry | null>;
+```
+
+When `message` is a `Message`, `userKey` is read from the instance. If it's `undefined` (the resolver returned `null`), the call is a no-op and returns `null`. When `message` is an `AppendInput`, `options.userKey` is required.
+
+#### AppendInput
+
+<TypeTable
+  type={{
+    role: {
+      description: 'Role tag for the entry.',
+      type: '"user" | "assistant" | "system"',
+    },
+    text: {
+      description: 'Plain-text body.',
+      type: 'string',
+    },
+    formatted: {
+      description: 'Optional mdast AST. Only stored when `transcripts.storeFormatted` is true.',
+      type: 'Root | undefined',
+    },
+    platformMessageId: {
+      description: 'Platform-native message ID, when known.',
+      type: 'string | undefined',
+    },
+  }}
+/>
+
+#### AppendOptions
+
+<TypeTable
+  type={{
+    userKey: {
+      description: 'Required when appending an `AppendInput` (assistant or system role); ignored when appending a `Message`.',
+      type: 'string | undefined',
+    },
+  }}
+/>
+
+### list
+
+Returns entries in chronological order (oldest first). When `limit` is set, returns the newest `N` entries — still chronologically.
+
+```typescript
+list(query: ListQuery): Promise<TranscriptEntry[]>;
+```
+
+#### ListQuery
+
+<TypeTable
+  type={{
+    userKey: {
+      description: 'Cross-platform user key.',
+      type: 'string',
+    },
+    limit: {
+      description: 'Maximum entries returned. Cannot exceed `maxPerUser` because that is the storage cap.',
+      type: 'number',
+      default: '50',
+    },
+    platforms: {
+      description: 'Filter to a subset of adapter names.',
+      type: 'string[] | undefined',
+    },
+    threadId: {
+      description: 'Filter to a single thread.',
+      type: 'string | undefined',
+    },
+    roles: {
+      description: 'Filter to specific roles.',
+      type: '("user" | "assistant" | "system")[] | undefined',
+    },
+  }}
+/>
+
+### count
+
+```typescript
+count(query: { userKey: string }): Promise<number>;
+```
+
+Returns the total number of entries stored under the user key.
+
+### delete
+
+```typescript
+delete(target: { userKey: string }): Promise<{ deleted: number }>;
+```
+
+Wipes every entry stored under the user key. Returns the count that was removed. Single-entry and time-range deletes are not supported — the underlying `appendToList` primitive can't support them safely under concurrent writes.
+
+## TranscriptEntry
+
+Returned by `append` and `list`.
+
+<TypeTable
+  type={{
+    id: {
+      description: 'UUID assigned by the SDK at append time.',
+      type: 'string',
+    },
+    userKey: {
+      description: 'Cross-platform user key from the IdentityResolver.',
+      type: 'string',
+    },
+    role: {
+      description: 'Role tag.',
+      type: '"user" | "assistant" | "system"',
+    },
+    text: {
+      description: 'Plain-text body — canonical for prompt building.',
+      type: 'string',
+    },
+    formatted: {
+      description: 'mdast AST. Only present when `transcripts.storeFormatted` is true.',
+      type: 'Root | undefined',
+    },
+    platform: {
+      description: 'Originating adapter name.',
+      type: 'string',
+    },
+    threadId: {
+      description: 'Originating thread ID.',
+      type: 'string',
+    },
+    platformMessageId: {
+      description: 'Platform-native message ID, when known.',
+      type: 'string | undefined',
+    },
+    timestamp: {
+      description: 'ms-since-epoch, set at append time on the SDK side.',
+      type: 'number',
+    },
+  }}
+/>
+
+## Storage
+
+Backed by `StateAdapter.appendToList` / `getList` / `delete`. Every built-in state adapter (`memory`, `redis`, `ioredis`, `pg`) supports these primitives.
+
+Entries are stored under `transcripts:user:{userKey}` as a capped list. `appendToList` is atomic, so concurrent inbound messages don't race.
+
+The `retention` value is applied as the list TTL and refreshed on every append. With `retention: "30d"`, a user who hasn't talked to the bot in 30 days has their transcript expire automatically.

--- a/apps/docs/content/docs/api/transcripts.mdx
+++ b/apps/docs/content/docs/api/transcripts.mdx
@@ -94,7 +94,7 @@ When `message` is a `Message`, `userKey` is read from the instance. If it's `und
     },
     formatted: {
       description: 'Optional mdast AST. Only stored when `transcripts.storeFormatted` is true.',
-      type: 'Root | undefined',
+      type: 'FormattedContent | undefined',
     },
     platformMessageId: {
       description: 'Platform-native message ID, when known.',
@@ -153,10 +153,10 @@ list(query: ListQuery): Promise<TranscriptEntry[]>;
 ### count
 
 ```typescript
-count(query: { userKey: string }): Promise<number>;
+count(query: CountQuery): Promise<number>;
 ```
 
-Returns the total number of entries stored under the user key.
+Returns the total number of entries stored under the user key. `CountQuery` has a single field, `userKey: string`.
 
 ### delete
 
@@ -190,7 +190,7 @@ Returned by `append` and `list`.
     },
     formatted: {
       description: 'mdast AST. Only present when `transcripts.storeFormatted` is true.',
-      type: 'Root | undefined',
+      type: 'FormattedContent | undefined',
     },
     platform: {
       description: 'Originating adapter name.',

--- a/apps/docs/content/docs/conversation-history.mdx
+++ b/apps/docs/content/docs/conversation-history.mdx
@@ -1,0 +1,137 @@
+---
+title: Conversation history
+description: Persist messages per user across every platform — for LLM context, audit, or compliance.
+type: guide
+prerequisites:
+  - /docs/state
+related:
+  - /docs/handling-events
+  - /docs/api/transcripts
+---
+
+Bots that hold context across a user's conversations need somewhere to store it. The platform's own message history won't do — a user might talk to your bot in Slack today and Discord tomorrow, and you want the same memory to follow them.
+
+`bot.transcripts` keeps a per-user transcript in your state adapter, keyed by a stable identifier you choose (an email, an internal user ID, anything that's the same person no matter where they are).
+
+## Setup
+
+You opt in by setting two fields on `ChatConfig`:
+
+```typescript title="lib/bot.ts" lineNumbers
+import { Chat } from "chat";
+import { createSlackAdapter } from "@chat-adapter/slack";
+import { createDiscordAdapter } from "@chat-adapter/discord";
+import { createRedisState } from "@chat-adapter/state-redis";
+
+const bot = new Chat({
+  userName: "mybot",
+  adapters: {
+    slack: createSlackAdapter(),
+    discord: createDiscordAdapter(),
+  },
+  state: createRedisState({ url: process.env.REDIS_URL! }),
+
+  // Resolve the cross-platform identifier for an inbound message.
+  // Return null for messages you don't want to remember.
+  identity: ({ author }) => author.email ?? null,
+
+  // Storage tuning. retention is the list TTL, refreshed on every append.
+  transcripts: {
+    retention: "30d",
+    maxPerUser: 200,
+  },
+});
+```
+
+`transcripts` and `identity` are paired — set one without the other and the constructor throws. This keeps the API loud rather than silently no-op'ing on every call.
+
+## Building LLM context
+
+The most common pattern: append the user's message, build a prompt from recent transcript entries, post the reply, append the reply too.
+
+```typescript title="lib/bot.ts" lineNumbers
+bot.onSubscribedMessage(async (thread, msg) => {
+  await bot.transcripts.append(thread, msg);
+
+  const recent = await bot.transcripts.list({
+    userKey: msg.userKey!,
+    limit: 20,
+  });
+
+  const reply = await generateReply(recent, msg);
+  await thread.post(reply);
+
+  await bot.transcripts.append(
+    thread,
+    { role: "assistant", text: reply },
+    { userKey: msg.userKey! }
+  );
+});
+```
+
+A few things worth knowing:
+
+- **`msg.userKey`** is set automatically from your `identity` resolver before your handler runs. If the resolver returned `null`, it stays `undefined` and the `append` call no-ops.
+- **Bot replies are explicit.** The SDK doesn't auto-capture `thread.post()` output — you decide what gets remembered. That's important for retries, intermediate streaming chunks, and anything you don't want feeding back into the model later.
+- **Order is chronological.** `list` returns oldest-first, ready to feed into a model. Set `limit` to keep prompts bounded.
+
+## Identity resolution
+
+`identity` runs once per inbound message during dispatch. The `author`, `message`, and `adapter` name are all available:
+
+```typescript
+identity: async ({ adapter, author, message }) => {
+  // Look up by email when the platform exposes it
+  if (author.email) {
+    return author.email;
+  }
+  // Or map a platform user to an internal ID
+  return await lookupUser(adapter, author.userId);
+}
+```
+
+Return `null` when you can't resolve a key. The SDK won't fall back to a platform-specific ID — that would silently fragment a user's transcript across platforms, which is exactly what this feature is here to prevent.
+
+If your resolver throws, the SDK logs a warning and dispatches the message without a `userKey`. Handlers still run; only the persistence is skipped.
+
+## Filtering entries
+
+`list` accepts a few filters. They compose, and they're applied after `getList` — useful for narrowing prompts without restructuring storage.
+
+```typescript
+// Recent N across all platforms
+await bot.transcripts.list({ userKey: "mike@acme.com", limit: 50 });
+
+// Single platform
+await bot.transcripts.list({ userKey: "mike@acme.com", platforms: ["slack"] });
+
+// Single thread
+await bot.transcripts.list({
+  userKey: "mike@acme.com",
+  threadId: "slack:C123:1234.5678",
+});
+
+// Only the user's own messages
+await bot.transcripts.list({ userKey: "mike@acme.com", roles: ["user"] });
+```
+
+## Deleting a user's transcript
+
+For data-subject requests or simple "forget me" flows:
+
+```typescript
+await bot.transcripts.delete({ userKey: "mike@acme.com" });
+// → { deleted: 47 }
+```
+
+This wipes every entry stored under the key. Single-entry and time-range deletes aren't part of the API — `appendToList` doesn't support them safely under concurrent writes.
+
+## Where it's stored
+
+`bot.transcripts` is backed by `StateAdapter.appendToList` / `getList` / `delete`. Every built-in state adapter (`memory`, `redis`, `ioredis`, `pg`) supports these primitives, so this works on whichever one you've already configured.
+
+Entries are written under the key `transcripts:user:{userKey}` as a capped list. `appendToList` is atomic, so concurrent inbound messages on the same user don't race.
+
+## Reference
+
+See [Transcripts](/docs/api/transcripts) for full type signatures, configuration options, and the entry shape.

--- a/apps/docs/content/docs/meta.json
+++ b/apps/docs/content/docs/meta.json
@@ -13,6 +13,7 @@
     "state",
     "---Features---",
     "concurrency",
+    "conversation-history",
     "...",
     "error-handling",
     "---API Reference---",

--- a/examples/nextjs-chat/src/lib/bot.tsx
+++ b/examples/nextjs-chat/src/lib/bot.tsx
@@ -22,6 +22,7 @@ import {
   Table,
   CardText as Text,
   TextInput,
+  type TranscriptEntry,
   toAiMessages,
 } from "chat";
 import { buildAdapters } from "./adapters";
@@ -30,6 +31,12 @@ const AI_MENTION_REGEX = /\bAI\b/i;
 const DISABLE_AI_REGEX = /disable\s*AI/i;
 const ENABLE_AI_REGEX = /enable\s*AI/i;
 const DM_ME_REGEX = /^dm\s*me$/i;
+
+// Hardcoded user key for testing the Transcripts API — every inbound message
+// is persisted under this single key, so you can exercise append/list/delete
+// without juggling real user identities. Swap the `identity` resolver below
+// for `({ author }) => author.email ?? author.userId` in production.
+const TEST_USER_KEY = "test-user";
 
 const state = process.env.REDIS_URL
   ? createRedisState({
@@ -42,7 +49,6 @@ const adapters = buildAdapters();
 // Define thread state type
 interface ThreadState {
   aiMode?: boolean;
-  history?: AiMessage[];
 }
 
 // Create the bot instance with typed thread state
@@ -52,6 +58,17 @@ export const bot = new Chat<typeof adapters, ThreadState>({
   adapters,
   state,
   logger: "debug",
+
+  // Hardcoded for testing — see `TEST_USER_KEY` above.
+  identity: () => TEST_USER_KEY,
+
+  // Persist a per-user transcript across every adapter the user talks
+  // through. Used below to backfill conversation context for platforms
+  // that don't expose server-side message history.
+  transcripts: {
+    retention: "30d",
+    maxPerUser: 100,
+  },
 });
 
 // AI agent for AI mode
@@ -60,6 +77,14 @@ const agent = new ToolLoopAgent({
   instructions:
     "You are a helpful assistant in a chat thread. Answer the user's queries in a concise manner.",
 });
+
+// Map transcript entries to AI SDK chat-message shape.
+function transcriptToAiMessages(entries: TranscriptEntry[]): AiMessage[] {
+  return entries.map((entry) => ({
+    role: entry.role === "assistant" ? "assistant" : "user",
+    content: entry.text,
+  }));
+}
 
 // Handle new @mentions of the bot
 bot.onNewMention(async (thread, message) => {
@@ -122,6 +147,10 @@ bot.onNewMention(async (thread, message) => {
           Send Feedback
         </Button>
         <Button id="messages">Fetch Messages</Button>
+        <Button id="transcripts">Show Transcripts</Button>
+        <Button id="clear-transcripts" style="danger">
+          Clear Transcripts
+        </Button>
         <Button id="channel-post">Channel Post</Button>
         <Button id="show-table">Show Table</Button>
         <Button id="who-am-i">Who Am I</Button>
@@ -596,6 +625,61 @@ bot.onModalClose("feedback_form", (event) => {
 });
 
 // Demonstrate fetchMessages and allMessages
+bot.onAction("transcripts", async (event) => {
+  if (!event.thread) {
+    return;
+  }
+  const entries = await bot.transcripts.list({
+    userKey: TEST_USER_KEY,
+    limit: 50,
+  });
+
+  if (entries.length === 0) {
+    await event.thread.post(
+      <Card title={`${emoji.memo} Transcripts`}>
+        <Text>No entries stored yet for `{TEST_USER_KEY}`.</Text>
+        <Text>
+          Mention the bot with "AI" to enable AI mode, then send a few messages
+          — they'll be persisted here.
+        </Text>
+      </Card>
+    );
+    return;
+  }
+
+  const truncate = (s: string, n = 80) =>
+    s.length > n ? `${s.slice(0, n)}…` : s;
+  const lines = entries
+    .map(
+      (e, i) =>
+        `${i + 1}. **[${e.role}]** \`${e.platform}\` — ${truncate(e.text)}`
+    )
+    .join("\n");
+
+  await event.thread.post(
+    <Card
+      subtitle={`userKey: ${TEST_USER_KEY}`}
+      title={`${emoji.memo} Transcripts (${entries.length})`}
+    >
+      <Text>{lines}</Text>
+    </Card>
+  );
+});
+
+bot.onAction("clear-transcripts", async (event) => {
+  if (!event.thread) {
+    return;
+  }
+  const { deleted } = await bot.transcripts.delete({
+    userKey: TEST_USER_KEY,
+  });
+  await event.thread.post(
+    <Card title={`${emoji.check} Transcripts cleared`}>
+      <Text>{`Removed ${deleted} entr${deleted === 1 ? "y" : "ies"} for \`${TEST_USER_KEY}\`.`}</Text>
+    </Card>
+  );
+});
+
 bot.onAction("messages", async (event) => {
   if (!event.thread) {
     return;
@@ -784,28 +868,36 @@ bot.onSubscribedMessage(async (thread, message) => {
 
   // If AI mode is enabled (or this is a DM), use the AI agent
   if (threadState?.aiMode) {
+    // Capture the user's message in their cross-platform transcript so we can
+    // backfill context on platforms without server-side history.
+    await bot.transcripts.append(thread, message);
+
     // Build conversation history: try fetchMessages first, then fall back to
-    // stored history in thread state (for platforms without message history API)
+    // the user's stored transcript (filtered to this thread) for platforms
+    // without a message history API.
     let history: AiMessage[];
     try {
       const result = await thread.adapter.fetchMessages(thread.id, {
         limit: 20,
       });
-      if (result.messages.length > 0) {
-        history = await toAiMessages(result.messages);
-      } else {
-        // No messages from API — use stored history + current message
-        history = [
-          ...(threadState?.history ?? []),
-          { role: "user" as const, content: message.text },
-        ];
-      }
+      history =
+        result.messages.length > 0
+          ? await toAiMessages(result.messages)
+          : transcriptToAiMessages(
+              await bot.transcripts.list({
+                userKey: message.userKey ?? "",
+                threadId: thread.id,
+                limit: 20,
+              })
+            );
     } catch {
-      // fetchMessages not supported — use stored history + current message
-      history = [
-        ...(threadState?.history ?? []),
-        { role: "user" as const, content: message.text },
-      ];
+      history = transcriptToAiMessages(
+        await bot.transcripts.list({
+          userKey: message.userKey ?? "",
+          threadId: thread.id,
+          limit: 20,
+        })
+      );
     }
 
     await thread.startTyping("Thinking...");
@@ -813,9 +905,15 @@ bot.onSubscribedMessage(async (thread, message) => {
       const result = await agent.stream({ prompt: history });
       await thread.post(result.fullStream);
       const responseText = await result.text;
-      // Persist updated history for platforms without message history API
-      history.push({ role: "assistant", content: responseText });
-      await thread.setState({ history });
+      // Persist the assistant reply alongside the user message, so the next
+      // turn can read both sides of the conversation from the transcript.
+      if (message.userKey) {
+        await bot.transcripts.append(
+          thread,
+          { role: "assistant", text: responseText },
+          { userKey: message.userKey }
+        );
+      }
     } catch (err) {
       console.error("Error in AI response:", err);
       await thread.post(

--- a/examples/nextjs-chat/src/lib/bot.tsx
+++ b/examples/nextjs-chat/src/lib/bot.tsx
@@ -624,7 +624,7 @@ bot.onModalClose("feedback_form", (event) => {
   console.log(`${event.user.userName} cancelled the feedback form`);
 });
 
-// Demonstrate fetchMessages and allMessages
+// Demonstrate bot.transcripts.list / count / delete
 bot.onAction("transcripts", async (event) => {
   if (!event.thread) {
     return;

--- a/packages/adapter-telegram/src/index.ts
+++ b/packages/adapter-telegram/src/index.ts
@@ -200,7 +200,7 @@ export class TelegramAdapter
 {
   readonly name = "telegram";
   readonly lockScope = "channel" as const;
-  readonly persistMessageHistory = true;
+  readonly persistThreadHistory = true;
 
   private readonly botToken: string;
   private readonly apiBaseUrl: string;

--- a/packages/adapter-whatsapp/src/index.ts
+++ b/packages/adapter-whatsapp/src/index.ts
@@ -117,7 +117,7 @@ export class WhatsAppAdapter
 {
   readonly name = "whatsapp";
   readonly lockScope = "channel" as const;
-  readonly persistMessageHistory = true;
+  readonly persistThreadHistory = true;
   readonly userName: string;
 
   private readonly accessToken: string;

--- a/packages/chat/src/channel.ts
+++ b/packages/chat/src/channel.ts
@@ -11,8 +11,8 @@ import {
   toPlainText,
 } from "./markdown";
 import { Message } from "./message";
-import type { MessageHistoryCache } from "./message-history";
 import { isPostableObject, postPostableObject } from "./postable-object";
+import type { ThreadHistoryCache } from "./thread-history";
 import type {
   Adapter,
   AdapterPostableMessage,
@@ -53,8 +53,8 @@ interface ChannelImplConfigWithAdapter {
   channelVisibility?: ChannelVisibility;
   id: string;
   isDM?: boolean;
-  messageHistory?: MessageHistoryCache;
   stateAdapter: StateAdapter;
+  threadHistory?: ThreadHistoryCache;
 }
 
 /**
@@ -95,7 +95,7 @@ export class ChannelImpl<TState = Record<string, unknown>>
   private readonly _adapterName?: string;
   private _stateAdapterInstance?: StateAdapter;
   private _name: string | null = null;
-  private readonly _messageHistory?: MessageHistoryCache;
+  private readonly _threadHistory?: ThreadHistoryCache;
 
   constructor(config: ChannelImplConfig) {
     this.id = config.id;
@@ -107,7 +107,7 @@ export class ChannelImpl<TState = Record<string, unknown>>
     } else {
       this._adapter = config.adapter;
       this._stateAdapterInstance = config.stateAdapter;
-      this._messageHistory = config.messageHistory;
+      this._threadHistory = config.threadHistory;
     }
   }
 
@@ -175,7 +175,7 @@ export class ChannelImpl<TState = Record<string, unknown>>
   get messages(): AsyncIterable<Message> {
     const adapter = this.adapter;
     const channelId = this.id;
-    const messageHistory = this._messageHistory;
+    const threadHistory = this._threadHistory;
 
     return {
       async *[Symbol.asyncIterator]() {
@@ -204,8 +204,8 @@ export class ChannelImpl<TState = Record<string, unknown>>
         }
 
         // Fall back to cached history if adapter returned nothing
-        if (!yieldedAny && messageHistory) {
-          const cached = await messageHistory.getMessages(channelId);
+        if (!yieldedAny && threadHistory) {
+          const cached = await threadHistory.getMessages(channelId);
           // Yield newest first
           for (let i = cached.length - 1; i >= 0; i--) {
             yield cached[i];
@@ -330,8 +330,8 @@ export class ChannelImpl<TState = Record<string, unknown>>
       rawMessage.threadId
     );
 
-    if (this._messageHistory) {
-      await this._messageHistory.append(this.id, new Message(sent));
+    if (this._threadHistory) {
+      await this._threadHistory.append(this.id, new Message(sent));
     }
 
     return sent;

--- a/packages/chat/src/chat.test.ts
+++ b/packages/chat/src/chat.test.ts
@@ -3776,5 +3776,101 @@ describe("Chat", () => {
       );
       expect(historyKeys).toHaveLength(0);
     });
+
+    it("honors top-level config.messageHistory (deprecated alias) when threadHistory is not set", async () => {
+      const adapter = createMockAdapter("whatsapp");
+      (adapter as { persistThreadHistory: boolean }).persistThreadHistory =
+        true;
+      const state = createMockState();
+
+      const persistChat = new Chat({
+        userName: "testbot",
+        adapters: { whatsapp: adapter },
+        state,
+        logger: mockLogger,
+        messageHistory: { maxMessages: 5, ttlMs: 12_345 },
+      });
+
+      await persistChat.webhooks.whatsapp(
+        new Request("http://test.com", { method: "POST" })
+      );
+
+      const message = createTestMessage("msg-1", "Hello");
+      await persistChat.handleIncomingMessage(
+        adapter,
+        "whatsapp:phone:user1",
+        message
+      );
+
+      expect(state.appendToList).toHaveBeenCalledWith(
+        "msg-history:whatsapp:phone:user1",
+        expect.objectContaining({ id: "msg-1" }),
+        { maxLength: 5, ttlMs: 12_345 }
+      );
+    });
+
+    it("threadHistory takes precedence when both threadHistory and messageHistory are set", async () => {
+      const adapter = createMockAdapter("whatsapp");
+      (adapter as { persistThreadHistory: boolean }).persistThreadHistory =
+        true;
+      const state = createMockState();
+
+      const persistChat = new Chat({
+        userName: "testbot",
+        adapters: { whatsapp: adapter },
+        state,
+        logger: mockLogger,
+        threadHistory: { maxMessages: 5, ttlMs: 1_000 },
+        messageHistory: { maxMessages: 999, ttlMs: 999_999 },
+      });
+
+      await persistChat.webhooks.whatsapp(
+        new Request("http://test.com", { method: "POST" })
+      );
+
+      const message = createTestMessage("msg-1", "Hello");
+      await persistChat.handleIncomingMessage(
+        adapter,
+        "whatsapp:phone:user1",
+        message
+      );
+
+      expect(state.appendToList).toHaveBeenCalledWith(
+        "msg-history:whatsapp:phone:user1",
+        expect.objectContaining({ id: "msg-1" }),
+        { maxLength: 5, ttlMs: 1_000 }
+      );
+    });
+
+    it("persists when both persistThreadHistory and persistMessageHistory are set on the adapter", async () => {
+      const adapter = createMockAdapter("whatsapp");
+      (adapter as { persistThreadHistory: boolean }).persistThreadHistory =
+        true;
+      (adapter as { persistMessageHistory: boolean }).persistMessageHistory =
+        true;
+      const state = createMockState();
+
+      const persistChat = new Chat({
+        userName: "testbot",
+        adapters: { whatsapp: adapter },
+        state,
+        logger: mockLogger,
+      });
+
+      await persistChat.webhooks.whatsapp(
+        new Request("http://test.com", { method: "POST" })
+      );
+
+      const message = createTestMessage("msg-1", "Hello");
+      await persistChat.handleIncomingMessage(
+        adapter,
+        "whatsapp:phone:user1",
+        message
+      );
+
+      const stored = state.cache.get("msg-history:whatsapp:phone:user1");
+      expect(stored).toBeDefined();
+      expect((stored as Array<{ id: string }>)[0].id).toBe("msg-1");
+    });
   });
 });

--- a/packages/chat/src/chat.test.ts
+++ b/packages/chat/src/chat.test.ts
@@ -3700,8 +3700,38 @@ describe("Chat", () => {
     });
   });
 
-  describe("persistMessageHistory", () => {
-    it("should cache incoming messages when adapter has persistMessageHistory", async () => {
+  describe("persistThreadHistory", () => {
+    it("caches incoming messages when adapter sets persistThreadHistory", async () => {
+      const adapter = createMockAdapter("whatsapp");
+      (adapter as { persistThreadHistory: boolean }).persistThreadHistory =
+        true;
+      const state = createMockState();
+
+      const persistChat = new Chat({
+        userName: "testbot",
+        adapters: { whatsapp: adapter },
+        state,
+        logger: mockLogger,
+      });
+
+      await persistChat.webhooks.whatsapp(
+        new Request("http://test.com", { method: "POST" })
+      );
+
+      const message = createTestMessage("msg-1", "Hello from WhatsApp");
+      await persistChat.handleIncomingMessage(
+        adapter,
+        "whatsapp:phone:user1",
+        message
+      );
+
+      const stored = state.cache.get("msg-history:whatsapp:phone:user1");
+      expect(stored).toBeDefined();
+      expect(Array.isArray(stored)).toBe(true);
+      expect((stored as Array<{ id: string }>)[0].id).toBe("msg-1");
+    });
+
+    it("caches incoming messages when adapter sets the deprecated persistMessageHistory flag", async () => {
       const adapter = createMockAdapter("whatsapp");
       (adapter as { persistMessageHistory: boolean }).persistMessageHistory =
         true;
@@ -3725,14 +3755,13 @@ describe("Chat", () => {
         message
       );
 
-      // Check that message was stored in state cache
       const stored = state.cache.get("msg-history:whatsapp:phone:user1");
       expect(stored).toBeDefined();
       expect(Array.isArray(stored)).toBe(true);
       expect((stored as Array<{ id: string }>)[0].id).toBe("msg-1");
     });
 
-    it("should NOT cache incoming messages when adapter does not set persistMessageHistory", async () => {
+    it("does not cache when adapter sets neither flag", async () => {
       const message = createTestMessage("msg-2", "Hello from Slack");
       await chat.handleIncomingMessage(
         mockAdapter,
@@ -3740,7 +3769,6 @@ describe("Chat", () => {
         message
       );
 
-      // No msg-history key should exist
       const stored = (mockState as unknown as { cache: Map<string, unknown> })
         .cache;
       const historyKeys = [...stored.keys()].filter((k) =>

--- a/packages/chat/src/chat.ts
+++ b/packages/chat/src/chat.ts
@@ -2322,8 +2322,8 @@ export class Chat<
       isSubscribed
     );
 
-    // Resolve cross-platform user key (Messages API). Cached on the Message
-    // instance so handlers and the Messages API see the same value without
+    // Resolve cross-platform user key (Transcripts API). Cached on the Message
+    // instance so handlers and the Transcripts API see the same value without
     // re-invoking the resolver.
     if (this._identity && message.userKey === undefined) {
       try {
@@ -2339,6 +2339,7 @@ export class Chat<
         this.logger.warn("Identity resolver threw; skipping userKey", {
           error: err,
           adapter: adapter.name,
+          threadId,
           authorUserId: message.author.userId,
         });
       }

--- a/packages/chat/src/chat.ts
+++ b/packages/chat/src/chat.ts
@@ -6,10 +6,11 @@ import {
 } from "./chat-singleton";
 import { isJSX, toModalElement } from "./jsx-runtime";
 import { Message, type SerializedMessage } from "./message";
-import { MessageHistoryCache } from "./message-history";
 import type { ModalElement } from "./modals";
 import { reviver as standaloneReviver } from "./reviver";
 import { type SerializedThread, ThreadImpl } from "./thread";
+import { ThreadHistoryCache } from "./thread-history";
+import { TranscriptsApiImpl } from "./transcripts";
 import type {
   ActionEvent,
   ActionHandler,
@@ -30,6 +31,7 @@ import type {
   DirectMessageHandler,
   EmojiValue,
   FormattedContent,
+  IdentityResolver,
   LinkPreview,
   Lock,
   LockScope,
@@ -56,6 +58,7 @@ import type {
   StateAdapter,
   SubscribedMessageHandler,
   Thread,
+  TranscriptsApi,
   UserInfo,
   WebhookOptions,
 } from "./types";
@@ -192,6 +195,22 @@ export class Chat<
   }
 
   /**
+   * Cross-platform per-user transcript store.
+   *
+   * Available only when `transcripts` is configured on the Chat instance
+   * (and an `identity` resolver is set). Throws on access otherwise so
+   * callers fail loudly rather than silently no-op'ing.
+   */
+  get transcripts(): TranscriptsApi {
+    if (!this._transcripts) {
+      throw new Error(
+        "chat.transcripts is not configured — pass `transcripts` and `identity` to ChatConfig to enable it"
+      );
+    }
+    return this._transcripts;
+  }
+
+  /**
    * Get the registered singleton Chat instance.
    * Throws if no singleton has been registered.
    */
@@ -214,7 +233,9 @@ export class Chat<
   private readonly _fallbackStreamingPlaceholderText: string | null;
   private readonly _dedupeTtlMs: number;
   private readonly _onLockConflict: ChatConfig["onLockConflict"];
-  private readonly _messageHistory: MessageHistoryCache;
+  private readonly _threadHistory: ThreadHistoryCache;
+  private readonly _identity: IdentityResolver | undefined;
+  private readonly _transcripts: TranscriptsApiImpl | undefined;
   private readonly _concurrencyStrategy: ConcurrencyStrategy;
   private readonly _concurrencyConfig: Required<
     Omit<ConcurrencyConfig, "strategy">
@@ -324,10 +345,25 @@ export class Chat<
       };
     }
 
-    this._messageHistory = new MessageHistoryCache(
+    this._threadHistory = new ThreadHistoryCache(
       this._stateAdapter,
-      config.messageHistory
+      config.threadHistory ?? config.messageHistory
     );
+
+    if (config.transcripts) {
+      if (!config.identity) {
+        throw new Error(
+          "ChatConfig.transcripts requires ChatConfig.identity to be set — the cross-platform user key must be resolvable"
+        );
+      }
+      this._identity = config.identity;
+      this._transcripts = new TranscriptsApiImpl(
+        this._stateAdapter,
+        config.transcripts
+      );
+    } else {
+      this._identity = config.identity;
+    }
 
     // Register adapters and create webhook handlers
     const webhooks = {} as Record<string, WebhookHandler>;
@@ -1888,11 +1924,11 @@ export class Chat<
     // Persist incoming message BEFORE acquiring the lock.
     // If the lock is already held (e.g., bot is processing a previous message),
     // we still want to save this message to history so it's not lost.
-    if (adapter.persistMessageHistory) {
+    if (adapter.persistThreadHistory || adapter.persistMessageHistory) {
       const channelId = adapter.channelIdFromThreadId(threadId);
-      const appends = [this._messageHistory.append(threadId, message)];
+      const appends = [this._threadHistory.append(threadId, message)];
       if (channelId !== threadId) {
-        appends.push(this._messageHistory.append(channelId, message));
+        appends.push(this._threadHistory.append(channelId, message));
       }
       await Promise.all(appends);
     }
@@ -2286,6 +2322,28 @@ export class Chat<
       isSubscribed
     );
 
+    // Resolve cross-platform user key (Messages API). Cached on the Message
+    // instance so handlers and the Messages API see the same value without
+    // re-invoking the resolver.
+    if (this._identity && message.userKey === undefined) {
+      try {
+        const resolved = await this._identity({
+          adapter: adapter.name,
+          author: message.author,
+          message,
+        });
+        if (resolved) {
+          message.userKey = resolved;
+        }
+      } catch (err) {
+        this.logger.warn("Identity resolver threw; skipping userKey", {
+          error: err,
+          adapter: adapter.name,
+          authorUserId: message.author.userId,
+        });
+      }
+    }
+
     // Check for DM first - always route to direct message handlers
     const isDM = adapter.isDM?.(threadId) ?? false;
     if (isDM && this.directMessageHandlers.length > 0) {
@@ -2391,9 +2449,10 @@ export class Chat<
       logger: this.logger,
       streamingUpdateIntervalMs: this._streamingUpdateIntervalMs,
       fallbackStreamingPlaceholderText: this._fallbackStreamingPlaceholderText,
-      messageHistory: adapter.persistMessageHistory
-        ? this._messageHistory
-        : undefined,
+      threadHistory:
+        adapter.persistThreadHistory || adapter.persistMessageHistory
+          ? this._threadHistory
+          : undefined,
     });
   }
 

--- a/packages/chat/src/index.ts
+++ b/packages/chat/src/index.ts
@@ -316,6 +316,7 @@ export type {
   ChatInstance,
   ConcurrencyConfig,
   ConcurrencyStrategy,
+  CountQuery,
   CustomEmojiMap,
   DeleteTarget,
   DirectMessageHandler,

--- a/packages/chat/src/index.ts
+++ b/packages/chat/src/index.ts
@@ -23,7 +23,9 @@ export {
   type SerializedMessage,
 } from "./message";
 export {
+  /** @deprecated Use `ThreadHistoryCache` instead. */
   MessageHistoryCache,
+  /** @deprecated Use `ThreadHistoryConfig` instead. */
   type MessageHistoryConfig,
 } from "./message-history";
 export type {
@@ -51,6 +53,10 @@ export {
   type StreamingPlanOptions,
 } from "./streaming-plan";
 export { type SerializedThread, ThreadImpl } from "./thread";
+export {
+  ThreadHistoryCache,
+  type ThreadHistoryConfig,
+} from "./thread-history";
 
 // Card builders - import then re-export to ensure values are properly exported
 import {
@@ -293,6 +299,8 @@ export type {
   ActionHandler,
   Adapter,
   AdapterPostableMessage,
+  AppendInput,
+  AppendOptions,
   AppHomeOpenedEvent,
   AppHomeOpenedHandler,
   AssistantContextChangedEvent,
@@ -309,7 +317,9 @@ export type {
   ConcurrencyConfig,
   ConcurrencyStrategy,
   CustomEmojiMap,
+  DeleteTarget,
   DirectMessageHandler,
+  DurationString,
   Emoji,
   EmojiFormats,
   EmojiMapConfig,
@@ -319,7 +329,10 @@ export type {
   FetchResult,
   FileUpload,
   FormattedContent,
+  IdentityContext,
+  IdentityResolver,
   LinkPreview,
+  ListQuery,
   ListThreadsOptions,
   ListThreadsResult,
   Lock,
@@ -373,6 +386,10 @@ export type {
   Thread,
   ThreadInfo,
   ThreadSummary,
+  TranscriptEntry,
+  TranscriptRole,
+  TranscriptsApi,
+  TranscriptsConfig,
   UserInfo,
   WebhookOptions,
   WellKnownEmoji,

--- a/packages/chat/src/message-history.ts
+++ b/packages/chat/src/message-history.ts
@@ -1,72 +1,17 @@
-import { Message, type SerializedMessage } from "./message";
-import type { StateAdapter } from "./types";
-
-/** Default maximum number of messages to store per thread */
-const DEFAULT_MAX_MESSAGES = 100;
-
-/** Default TTL for message history (7 days in milliseconds) */
-const DEFAULT_TTL_MS = 7 * 24 * 60 * 60 * 1000;
-
-/** Key prefix for message history entries */
-const KEY_PREFIX = "msg-history:";
-
-export interface MessageHistoryConfig {
-  /** Maximum messages to keep per thread (default: 100) */
-  maxMessages?: number;
-  /** TTL for cached history in milliseconds (default: 7 days) */
-  ttlMs?: number;
-}
-
 /**
- * Persistent message history cache backed by the StateAdapter.
+ * @deprecated Renamed — import from `./thread-history` instead.
  *
- * Used by adapters that lack server-side message history APIs (e.g., WhatsApp, Telegram).
- * Messages are atomically appended via `state.appendToList()`, which is safe
- * without holding a thread lock.
+ * This module is preserved for backwards compatibility and re-exports the
+ * new names under the old identifiers. New code should use `ThreadHistoryCache`
+ * and `ThreadHistoryConfig` directly.
  */
-export class MessageHistoryCache {
-  private readonly state: StateAdapter;
-  private readonly maxMessages: number;
-  private readonly ttlMs: number;
 
-  constructor(state: StateAdapter, config?: MessageHistoryConfig) {
-    this.state = state;
-    this.maxMessages = config?.maxMessages ?? DEFAULT_MAX_MESSAGES;
-    this.ttlMs = config?.ttlMs ?? DEFAULT_TTL_MS;
-  }
+import { ThreadHistoryCache, type ThreadHistoryConfig } from "./thread-history";
 
-  /**
-   * Atomically append a message to the history for a thread.
-   * Trims to maxMessages (keeps newest) and refreshes TTL.
-   */
-  async append(threadId: string, message: Message): Promise<void> {
-    const key = `${KEY_PREFIX}${threadId}`;
+/** @deprecated Use `ThreadHistoryConfig` from `./thread-history` instead. */
+export type MessageHistoryConfig = ThreadHistoryConfig;
 
-    // Serialize with raw nulled out to save storage
-    const serialized = message.toJSON();
-    serialized.raw = null;
-
-    await this.state.appendToList(key, serialized, {
-      maxLength: this.maxMessages,
-      ttlMs: this.ttlMs,
-    });
-  }
-
-  /**
-   * Get messages for a thread in chronological order (oldest first).
-   *
-   * @param threadId - The thread ID
-   * @param limit - Optional limit on number of messages to return (returns newest N)
-   */
-  async getMessages(threadId: string, limit?: number): Promise<Message[]> {
-    const key = `${KEY_PREFIX}${threadId}`;
-    const stored = await this.state.getList<SerializedMessage>(key);
-
-    const sliced =
-      limit && stored.length > limit
-        ? stored.slice(stored.length - limit)
-        : stored;
-
-    return sliced.map((s) => Message.fromJSON(s));
-  }
-}
+/** @deprecated Use `ThreadHistoryCache` from `./thread-history` instead. */
+export const MessageHistoryCache = ThreadHistoryCache;
+/** @deprecated Use `ThreadHistoryCache` from `./thread-history` instead. */
+export type MessageHistoryCache = ThreadHistoryCache;

--- a/packages/chat/src/message.ts
+++ b/packages/chat/src/message.ts
@@ -152,7 +152,7 @@ export class Message<TRawMessage = unknown> {
    * `ChatConfig.identity` is configured. `undefined` if no resolver is
    * configured; `undefined` (i.e. absent) when the resolver returned null.
    *
-   * Used by the Messages API to look up / append per-user transcripts.
+   * Used by the Transcripts API to look up / append per-user transcripts.
    */
   userKey?: string;
 

--- a/packages/chat/src/message.ts
+++ b/packages/chat/src/message.ts
@@ -145,6 +145,17 @@ export class Message<TRawMessage = unknown> {
    */
   isMention?: boolean;
 
+  /**
+   * Cross-platform user key for this message's author.
+   *
+   * Set by the Chat SDK before passing the message to handlers, when
+   * `ChatConfig.identity` is configured. `undefined` if no resolver is
+   * configured; `undefined` (i.e. absent) when the resolver returned null.
+   *
+   * Used by the Messages API to look up / append per-user transcripts.
+   */
+  userKey?: string;
+
   /** Links found in the message */
   links: LinkPreview[];
 

--- a/packages/chat/src/thread-history.test.ts
+++ b/packages/chat/src/thread-history.test.ts
@@ -1,16 +1,15 @@
 import { beforeEach, describe, expect, it } from "vitest";
-
-import { MessageHistoryCache } from "./message-history";
 import type { MockStateAdapter } from "./mock-adapter";
 import { createMockState, createTestMessage } from "./mock-adapter";
+import { ThreadHistoryCache } from "./thread-history";
 
-describe("MessageHistoryCache", () => {
+describe("ThreadHistoryCache", () => {
   let state: MockStateAdapter;
-  let cache: MessageHistoryCache;
+  let cache: ThreadHistoryCache;
 
   beforeEach(() => {
     state = createMockState();
-    cache = new MessageHistoryCache(state);
+    cache = new ThreadHistoryCache(state);
   });
 
   it("should append and retrieve messages", async () => {
@@ -42,7 +41,7 @@ describe("MessageHistoryCache", () => {
   });
 
   it("should trim to maxMessages, keeping newest", async () => {
-    const smallCache = new MessageHistoryCache(state, { maxMessages: 3 });
+    const smallCache = new ThreadHistoryCache(state, { maxMessages: 3 });
 
     for (let i = 1; i <= 5; i++) {
       await smallCache.append(
@@ -102,5 +101,19 @@ describe("MessageHistoryCache", () => {
     expect(msgs1[0].text).toBe("Thread 1");
     expect(msgs2).toHaveLength(1);
     expect(msgs2[0].text).toBe("Thread 2");
+  });
+});
+
+describe("MessageHistoryCache (deprecated alias)", () => {
+  it("re-exports ThreadHistoryCache under the old name", async () => {
+    const { MessageHistoryCache } = await import("./message-history");
+    expect(MessageHistoryCache).toBe(ThreadHistoryCache);
+
+    const state = createMockState();
+    const cache = new MessageHistoryCache(state);
+    await cache.append("t-1", createTestMessage("m1", "hello"));
+    const msgs = await cache.getMessages("t-1");
+    expect(msgs).toHaveLength(1);
+    expect(msgs[0].text).toBe("hello");
   });
 });

--- a/packages/chat/src/thread-history.ts
+++ b/packages/chat/src/thread-history.ts
@@ -1,0 +1,81 @@
+import { Message, type SerializedMessage } from "./message";
+import type { StateAdapter } from "./types";
+
+/** Default maximum number of messages to store per thread */
+const DEFAULT_MAX_MESSAGES = 100;
+
+/** Default TTL for thread history (7 days in milliseconds) */
+const DEFAULT_TTL_MS = 7 * 24 * 60 * 60 * 1000;
+
+/**
+ * Key prefix for thread history entries.
+ *
+ * Kept as `msg-history:` for backwards compatibility — renaming would silently
+ * orphan every existing user's stored data. The user-facing names changed; the
+ * storage shape didn't.
+ */
+const KEY_PREFIX = "msg-history:";
+
+export interface ThreadHistoryConfig {
+  /** Maximum messages to keep per thread (default: 100) */
+  maxMessages?: number;
+  /** TTL for cached history in milliseconds (default: 7 days) */
+  ttlMs?: number;
+}
+
+/**
+ * Persistent per-thread history cache backed by the StateAdapter.
+ *
+ * Used by adapters that lack server-side message history APIs (e.g. WhatsApp,
+ * Telegram). Messages are atomically appended via `state.appendToList()`,
+ * which is safe without holding a thread lock.
+ *
+ * Distinct from the cross-platform per-user [Messages API](./messages.ts) —
+ * this cache is keyed by thread, not user.
+ */
+export class ThreadHistoryCache {
+  private readonly state: StateAdapter;
+  private readonly maxMessages: number;
+  private readonly ttlMs: number;
+
+  constructor(state: StateAdapter, config?: ThreadHistoryConfig) {
+    this.state = state;
+    this.maxMessages = config?.maxMessages ?? DEFAULT_MAX_MESSAGES;
+    this.ttlMs = config?.ttlMs ?? DEFAULT_TTL_MS;
+  }
+
+  /**
+   * Atomically append a message to the history for a thread.
+   * Trims to maxMessages (keeps newest) and refreshes TTL.
+   */
+  async append(threadId: string, message: Message): Promise<void> {
+    const key = `${KEY_PREFIX}${threadId}`;
+
+    // Serialize with raw nulled out to save storage
+    const serialized = message.toJSON();
+    serialized.raw = null;
+
+    await this.state.appendToList(key, serialized, {
+      maxLength: this.maxMessages,
+      ttlMs: this.ttlMs,
+    });
+  }
+
+  /**
+   * Get messages for a thread in chronological order (oldest first).
+   *
+   * @param threadId - The thread ID
+   * @param limit - Optional limit on number of messages to return (returns newest N)
+   */
+  async getMessages(threadId: string, limit?: number): Promise<Message[]> {
+    const key = `${KEY_PREFIX}${threadId}`;
+    const stored = await this.state.getList<SerializedMessage>(key);
+
+    const sliced =
+      limit && stored.length > limit
+        ? stored.slice(stored.length - limit)
+        : stored;
+
+    return sliced.map((s) => Message.fromJSON(s));
+  }
+}

--- a/packages/chat/src/thread-history.ts
+++ b/packages/chat/src/thread-history.ts
@@ -30,8 +30,8 @@ export interface ThreadHistoryConfig {
  * Telegram). Messages are atomically appended via `state.appendToList()`,
  * which is safe without holding a thread lock.
  *
- * Distinct from the cross-platform per-user [Messages API](./messages.ts) —
- * this cache is keyed by thread, not user.
+ * Distinct from the cross-platform per-user {@link TranscriptsApi} (see
+ * `transcripts.ts`) — this cache is keyed by thread, not user.
  */
 export class ThreadHistoryCache {
   private readonly state: StateAdapter;

--- a/packages/chat/src/thread.ts
+++ b/packages/chat/src/thread.ts
@@ -14,9 +14,9 @@ import {
   toPlainText,
 } from "./markdown";
 import { Message, type SerializedMessage } from "./message";
-import type { MessageHistoryCache } from "./message-history";
 import { isPostableObject, postPostableObject } from "./postable-object";
 import { StreamingMarkdownRenderer } from "./streaming-markdown";
+import type { ThreadHistoryCache } from "./thread-history";
 import type {
   Adapter,
   AdapterPostableMessage,
@@ -65,9 +65,9 @@ interface ThreadImplConfigWithAdapter {
   isDM?: boolean;
   isSubscribedContext?: boolean;
   logger?: Logger;
-  messageHistory?: MessageHistoryCache;
   stateAdapter: StateAdapter;
   streamingUpdateIntervalMs?: number;
+  threadHistory?: ThreadHistoryCache;
 }
 
 /**
@@ -134,8 +134,8 @@ export class ThreadImpl<TState = Record<string, unknown>>
   private readonly _fallbackStreamingPlaceholderText: string | null;
   /** Cached channel instance */
   private _channel?: Channel<TState>;
-  /** Message history cache (set only for adapters with persistMessageHistory) */
-  private readonly _messageHistory?: MessageHistoryCache;
+  /** Thread history cache (set only for adapters with persistThreadHistory) */
+  private readonly _threadHistory?: ThreadHistoryCache;
   private readonly _logger?: Logger;
 
   constructor(config: ThreadImplConfig) {
@@ -159,7 +159,7 @@ export class ThreadImpl<TState = Record<string, unknown>>
       // Direct mode - store adapter and state instances
       this._adapter = config.adapter;
       this._stateAdapterInstance = config.stateAdapter;
-      this._messageHistory = config.messageHistory;
+      this._threadHistory = config.threadHistory;
     }
 
     if (config.initialMessage) {
@@ -261,7 +261,7 @@ export class ThreadImpl<TState = Record<string, unknown>>
         stateAdapter: this._stateAdapter,
         isDM: this.isDM,
         channelVisibility: this.channelVisibility,
-        messageHistory: this._messageHistory,
+        threadHistory: this._threadHistory,
       });
     }
     return this._channel;
@@ -274,7 +274,7 @@ export class ThreadImpl<TState = Record<string, unknown>>
   get messages(): AsyncIterable<Message> {
     const adapter = this.adapter;
     const threadId = this.id;
-    const messageHistory = this._messageHistory;
+    const threadHistory = this._threadHistory;
 
     return {
       async *[Symbol.asyncIterator]() {
@@ -303,8 +303,8 @@ export class ThreadImpl<TState = Record<string, unknown>>
         }
 
         // Fall back to cached history if adapter returned nothing
-        if (!yieldedAny && messageHistory) {
-          const cached = await messageHistory.getMessages(threadId);
+        if (!yieldedAny && threadHistory) {
+          const cached = await threadHistory.getMessages(threadId);
           // Yield newest first
           for (let i = cached.length - 1; i >= 0; i--) {
             yield cached[i];
@@ -317,7 +317,7 @@ export class ThreadImpl<TState = Record<string, unknown>>
   get allMessages(): AsyncIterable<Message> {
     const adapter = this.adapter;
     const threadId = this.id;
-    const messageHistory = this._messageHistory;
+    const threadHistory = this._threadHistory;
 
     return {
       async *[Symbol.asyncIterator]() {
@@ -346,8 +346,8 @@ export class ThreadImpl<TState = Record<string, unknown>>
         }
 
         // Fall back to cached history if adapter returned nothing
-        if (!yieldedAny && messageHistory) {
-          const cached = await messageHistory.getMessages(threadId);
+        if (!yieldedAny && threadHistory) {
+          const cached = await threadHistory.getMessages(threadId);
           for (const message of cached) {
             yield message;
           }
@@ -469,8 +469,8 @@ export class ThreadImpl<TState = Record<string, unknown>>
     );
 
     // Cache sent message for adapters with persistent history
-    if (this._messageHistory) {
-      await this._messageHistory.append(this.id, new Message(result));
+    if (this._threadHistory) {
+      await this._threadHistory.append(this.id, new Message(result));
     }
 
     return result;
@@ -615,8 +615,8 @@ export class ThreadImpl<TState = Record<string, unknown>>
         raw.threadId
       );
 
-      if (this._messageHistory) {
-        await this._messageHistory.append(this.id, new Message(sent));
+      if (this._threadHistory) {
+        await this._threadHistory.append(this.id, new Message(sent));
       }
 
       return sent;
@@ -808,8 +808,8 @@ export class ThreadImpl<TState = Record<string, unknown>>
       threadIdForEdits
     );
 
-    if (this._messageHistory) {
-      await this._messageHistory.append(this.id, new Message(sent));
+    if (this._threadHistory) {
+      await this._threadHistory.append(this.id, new Message(sent));
     }
 
     return sent;
@@ -819,12 +819,9 @@ export class ThreadImpl<TState = Record<string, unknown>>
     const result = await this.adapter.fetchMessages(this.id, { limit: 50 });
     if (result.messages.length > 0) {
       this._recentMessages = result.messages;
-    } else if (this._messageHistory) {
+    } else if (this._threadHistory) {
       // Fall back to cached history for adapters without native message APIs
-      this._recentMessages = await this._messageHistory.getMessages(
-        this.id,
-        50
-      );
+      this._recentMessages = await this._threadHistory.getMessages(this.id, 50);
     } else {
       this._recentMessages = [];
     }

--- a/packages/chat/src/transcripts-wiring.test.ts
+++ b/packages/chat/src/transcripts-wiring.test.ts
@@ -1,0 +1,218 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { Chat } from "./chat";
+import {
+  createMockAdapter,
+  createMockState,
+  createTestMessage,
+  mockLogger,
+} from "./mock-adapter";
+import type { Adapter, StateAdapter } from "./types";
+
+const TRANSCRIPTS_NOT_CONFIGURED_RE = /chat\.transcripts is not configured/;
+const IDENTITY_REQUIRED_RE = /requires ChatConfig\.identity/;
+
+describe("Chat — Transcripts API wiring", () => {
+  let mockAdapter: Adapter;
+  let mockState: StateAdapter;
+
+  beforeEach(() => {
+    mockAdapter = createMockAdapter("slack");
+    mockState = createMockState();
+  });
+
+  it("throws at construction when transcripts is set without identity", () => {
+    expect(
+      () =>
+        new Chat({
+          userName: "testbot",
+          adapters: { slack: mockAdapter },
+          state: mockState,
+          logger: mockLogger,
+          transcripts: {},
+        })
+    ).toThrow(IDENTITY_REQUIRED_RE);
+  });
+
+  it("does not throw when neither transcripts nor identity is set", () => {
+    expect(
+      () =>
+        new Chat({
+          userName: "testbot",
+          adapters: { slack: mockAdapter },
+          state: mockState,
+          logger: mockLogger,
+        })
+    ).not.toThrow();
+  });
+
+  it("does not throw when identity is set without transcripts", () => {
+    expect(
+      () =>
+        new Chat({
+          userName: "testbot",
+          adapters: { slack: mockAdapter },
+          state: mockState,
+          logger: mockLogger,
+          identity: () => "u1",
+        })
+    ).not.toThrow();
+  });
+
+  it("chat.transcripts getter throws when transcripts was not configured", () => {
+    const chat = new Chat({
+      userName: "testbot",
+      adapters: { slack: mockAdapter },
+      state: mockState,
+      logger: mockLogger,
+    });
+
+    expect(() => chat.transcripts).toThrow(TRANSCRIPTS_NOT_CONFIGURED_RE);
+  });
+
+  it("chat.transcripts returns the API instance when configured", () => {
+    const chat = new Chat({
+      userName: "testbot",
+      adapters: { slack: mockAdapter },
+      state: mockState,
+      logger: mockLogger,
+      identity: () => "u1",
+      transcripts: {},
+    });
+
+    const api = chat.transcripts;
+    expect(api).toBeDefined();
+    expect(typeof api.append).toBe("function");
+    expect(typeof api.list).toBe("function");
+    expect(typeof api.count).toBe("function");
+    expect(typeof api.delete).toBe("function");
+  });
+
+  describe("dispatch hook", () => {
+    it("populates message.userKey from the resolver before handlers run", async () => {
+      const identity = vi.fn().mockResolvedValue("user@example.com");
+      const handler = vi.fn().mockResolvedValue(undefined);
+
+      const chat = new Chat({
+        userName: "testbot",
+        adapters: { slack: mockAdapter },
+        state: mockState,
+        logger: mockLogger,
+        identity,
+        transcripts: {},
+      });
+      await chat.webhooks.slack(
+        new Request("http://test.com", { method: "POST" })
+      );
+      chat.onSubscribedMessage(handler);
+      await mockState.subscribe("slack:C123:1234.5678");
+
+      const message = createTestMessage("msg-1", "hello");
+      await chat.handleIncomingMessage(
+        mockAdapter,
+        "slack:C123:1234.5678",
+        message
+      );
+
+      expect(identity).toHaveBeenCalledTimes(1);
+      expect(identity).toHaveBeenCalledWith(
+        expect.objectContaining({
+          adapter: "slack",
+          author: message.author,
+          message,
+        })
+      );
+      expect(handler).toHaveBeenCalled();
+      expect(message.userKey).toBe("user@example.com");
+    });
+
+    it("leaves userKey undefined when the resolver returns null", async () => {
+      const identity = vi.fn().mockResolvedValue(null);
+      const handler = vi.fn().mockResolvedValue(undefined);
+
+      const chat = new Chat({
+        userName: "testbot",
+        adapters: { slack: mockAdapter },
+        state: mockState,
+        logger: mockLogger,
+        identity,
+        transcripts: {},
+      });
+      await chat.webhooks.slack(
+        new Request("http://test.com", { method: "POST" })
+      );
+      chat.onSubscribedMessage(handler);
+      await mockState.subscribe("slack:C123:1234.5678");
+
+      const message = createTestMessage("msg-1", "hello");
+      await chat.handleIncomingMessage(
+        mockAdapter,
+        "slack:C123:1234.5678",
+        message
+      );
+
+      expect(handler).toHaveBeenCalled();
+      expect(message.userKey).toBeUndefined();
+    });
+
+    it("logs and proceeds without userKey when the resolver throws", async () => {
+      const identity = vi.fn().mockRejectedValue(new Error("lookup failed"));
+      const handler = vi.fn().mockResolvedValue(undefined);
+      const warn = vi.fn();
+      const logger = { ...mockLogger, warn };
+
+      const chat = new Chat({
+        userName: "testbot",
+        adapters: { slack: mockAdapter },
+        state: mockState,
+        logger,
+        identity,
+        transcripts: {},
+      });
+      await chat.webhooks.slack(
+        new Request("http://test.com", { method: "POST" })
+      );
+      chat.onSubscribedMessage(handler);
+      await mockState.subscribe("slack:C123:1234.5678");
+
+      const message = createTestMessage("msg-1", "hello");
+      await chat.handleIncomingMessage(
+        mockAdapter,
+        "slack:C123:1234.5678",
+        message
+      );
+
+      expect(warn).toHaveBeenCalledWith(
+        expect.stringContaining("Identity resolver threw"),
+        expect.objectContaining({ error: expect.any(Error) })
+      );
+      expect(handler).toHaveBeenCalled();
+      expect(message.userKey).toBeUndefined();
+    });
+
+    it("does not call the resolver when no identity is configured", async () => {
+      const handler = vi.fn().mockResolvedValue(undefined);
+      const chat = new Chat({
+        userName: "testbot",
+        adapters: { slack: mockAdapter },
+        state: mockState,
+        logger: mockLogger,
+      });
+      await chat.webhooks.slack(
+        new Request("http://test.com", { method: "POST" })
+      );
+      chat.onSubscribedMessage(handler);
+      await mockState.subscribe("slack:C123:1234.5678");
+
+      const message = createTestMessage("msg-1", "hello");
+      await chat.handleIncomingMessage(
+        mockAdapter,
+        "slack:C123:1234.5678",
+        message
+      );
+
+      expect(handler).toHaveBeenCalled();
+      expect(message.userKey).toBeUndefined();
+    });
+  });
+});

--- a/packages/chat/src/transcripts-wiring.test.ts
+++ b/packages/chat/src/transcripts-wiring.test.ts
@@ -126,8 +126,67 @@ describe("Chat — Transcripts API wiring", () => {
       expect(message.userKey).toBe("user@example.com");
     });
 
+    it("populates message.userKey from a sync resolver that returns a plain string", async () => {
+      const identity = vi.fn().mockReturnValue("sync-user@example.com");
+      const handler = vi.fn().mockResolvedValue(undefined);
+
+      const chat = new Chat({
+        userName: "testbot",
+        adapters: { slack: mockAdapter },
+        state: mockState,
+        logger: mockLogger,
+        identity,
+        transcripts: {},
+      });
+      await chat.webhooks.slack(
+        new Request("http://test.com", { method: "POST" })
+      );
+      chat.onSubscribedMessage(handler);
+      await mockState.subscribe("slack:C123:1234.5678");
+
+      const message = createTestMessage("msg-1", "hello");
+      await chat.handleIncomingMessage(
+        mockAdapter,
+        "slack:C123:1234.5678",
+        message
+      );
+
+      expect(identity).toHaveBeenCalledTimes(1);
+      expect(handler).toHaveBeenCalled();
+      expect(message.userKey).toBe("sync-user@example.com");
+    });
+
     it("leaves userKey undefined when the resolver returns null", async () => {
       const identity = vi.fn().mockResolvedValue(null);
+      const handler = vi.fn().mockResolvedValue(undefined);
+
+      const chat = new Chat({
+        userName: "testbot",
+        adapters: { slack: mockAdapter },
+        state: mockState,
+        logger: mockLogger,
+        identity,
+        transcripts: {},
+      });
+      await chat.webhooks.slack(
+        new Request("http://test.com", { method: "POST" })
+      );
+      chat.onSubscribedMessage(handler);
+      await mockState.subscribe("slack:C123:1234.5678");
+
+      const message = createTestMessage("msg-1", "hello");
+      await chat.handleIncomingMessage(
+        mockAdapter,
+        "slack:C123:1234.5678",
+        message
+      );
+
+      expect(handler).toHaveBeenCalled();
+      expect(message.userKey).toBeUndefined();
+    });
+
+    it("treats resolver returning empty string as no userKey", async () => {
+      const identity = vi.fn().mockResolvedValue("");
       const handler = vi.fn().mockResolvedValue(undefined);
 
       const chat = new Chat({

--- a/packages/chat/src/transcripts.test.ts
+++ b/packages/chat/src/transcripts.test.ts
@@ -1,0 +1,371 @@
+import { beforeEach, describe, expect, it } from "vitest";
+
+import { parseMarkdown } from "./markdown";
+import type { MockStateAdapter } from "./mock-adapter";
+import { createMockState, createTestMessage } from "./mock-adapter";
+import { TranscriptsApiImpl } from "./transcripts";
+import type { Postable } from "./types";
+
+const UUID_RE = /^[\da-f]{8}-[\da-f]{4}-[\da-f]{4}-[\da-f]{4}-[\da-f]{12}$/;
+const USER_KEY_REQUIRED_RE = /options\.userKey is required/;
+const INVALID_DURATION_RE = /Invalid duration/;
+
+function createTestThread(
+  adapterName = "slack",
+  threadId = "slack:C123:1234.5678"
+): Postable {
+  return {
+    adapter: { name: adapterName },
+    id: threadId,
+  } as unknown as Postable;
+}
+
+describe("TranscriptsApiImpl", () => {
+  let state: MockStateAdapter;
+  let api: TranscriptsApiImpl;
+
+  beforeEach(() => {
+    state = createMockState();
+    api = new TranscriptsApiImpl(state, {});
+  });
+
+  describe("append", () => {
+    it("persists a Message under the resolved userKey", async () => {
+      const thread = createTestThread();
+      const msg = createTestMessage("m1", "Hello");
+      msg.userKey = "user@example.com";
+
+      const stored = await api.append(thread, msg);
+
+      expect(stored).not.toBeNull();
+      expect(stored?.userKey).toBe("user@example.com");
+      expect(stored?.text).toBe("Hello");
+      expect(stored?.role).toBe("user");
+      expect(stored?.platform).toBe("slack");
+      expect(stored?.threadId).toBe("slack:C123:1234.5678");
+      expect(stored?.platformMessageId).toBe("m1");
+      expect(stored?.id).toMatch(UUID_RE);
+      expect(stored?.timestamp).toBeGreaterThan(0);
+
+      expect(state.appendToList).toHaveBeenCalledWith(
+        "transcripts:user:user@example.com",
+        expect.objectContaining({ userKey: "user@example.com" }),
+        { maxLength: 200, ttlMs: undefined }
+      );
+    });
+
+    it("no-ops when Message has no userKey", async () => {
+      const thread = createTestThread();
+      const msg = createTestMessage("m1", "Hello");
+      // userKey deliberately not set
+
+      const stored = await api.append(thread, msg);
+
+      expect(stored).toBeNull();
+      expect(state.appendToList).not.toHaveBeenCalled();
+    });
+
+    it("requires options.userKey when appending an AppendInput", async () => {
+      const thread = createTestThread();
+
+      await expect(
+        api.append(thread, { role: "assistant", text: "hi" })
+      ).rejects.toThrow(USER_KEY_REQUIRED_RE);
+    });
+
+    it("appends an assistant message with explicit userKey", async () => {
+      const thread = createTestThread();
+
+      const stored = await api.append(
+        thread,
+        { role: "assistant", text: "Hello, Mike" },
+        { userKey: "mike@acme.com" }
+      );
+
+      expect(stored?.role).toBe("assistant");
+      expect(stored?.userKey).toBe("mike@acme.com");
+      expect(stored?.text).toBe("Hello, Mike");
+      expect(stored?.platformMessageId).toBeUndefined();
+    });
+
+    it("omits formatted by default", async () => {
+      const thread = createTestThread();
+      const msg = createTestMessage("m1", "Hello");
+      msg.userKey = "u1";
+
+      const stored = await api.append(thread, msg);
+
+      expect(stored?.formatted).toBeUndefined();
+    });
+
+    it("includes formatted when storeFormatted is true", async () => {
+      api = new TranscriptsApiImpl(state, { storeFormatted: true });
+      const thread = createTestThread();
+      const msg = createTestMessage("m1", "**bold**");
+      msg.userKey = "u1";
+
+      const stored = await api.append(thread, msg);
+
+      expect(stored?.formatted).toBeDefined();
+      expect(stored?.formatted?.type).toBe("root");
+
+      const round = await api.list({ userKey: "u1" });
+      expect(round[0]?.formatted).toEqual(stored?.formatted);
+    });
+
+    it("passes retention duration string through as ttlMs", async () => {
+      api = new TranscriptsApiImpl(state, { retention: "7d" });
+      const thread = createTestThread();
+      const msg = createTestMessage("m1", "Hello");
+      msg.userKey = "u1";
+
+      await api.append(thread, msg);
+
+      expect(state.appendToList).toHaveBeenCalledWith(
+        "transcripts:user:u1",
+        expect.anything(),
+        { maxLength: 200, ttlMs: 7 * 24 * 60 * 60 * 1000 }
+      );
+    });
+
+    it("passes numeric retention through unchanged", async () => {
+      api = new TranscriptsApiImpl(state, {
+        retention: 60_000,
+        maxPerUser: 50,
+      });
+      const thread = createTestThread();
+      const msg = createTestMessage("m1", "Hello");
+      msg.userKey = "u1";
+
+      await api.append(thread, msg);
+
+      expect(state.appendToList).toHaveBeenCalledWith(
+        "transcripts:user:u1",
+        expect.anything(),
+        { maxLength: 50, ttlMs: 60_000 }
+      );
+    });
+
+    it("rejects malformed duration strings", () => {
+      expect(
+        () =>
+          new TranscriptsApiImpl(state, {
+            retention: "7days" as unknown as `${number}d`,
+          })
+      ).toThrow(INVALID_DURATION_RE);
+    });
+  });
+
+  describe("list", () => {
+    async function seed(userKey: string) {
+      const thread = createTestThread();
+      for (let i = 0; i < 5; i++) {
+        const msg = createTestMessage(`m${i}`, `msg ${i}`);
+        msg.userKey = userKey;
+        await api.append(thread, msg);
+      }
+    }
+
+    it("returns all messages in chronological order by default", async () => {
+      await seed("u1");
+
+      const list = await api.list({ userKey: "u1" });
+
+      expect(list).toHaveLength(5);
+      expect(list.map((m) => m.text)).toEqual([
+        "msg 0",
+        "msg 1",
+        "msg 2",
+        "msg 3",
+        "msg 4",
+      ]);
+    });
+
+    it("returns empty array when no messages exist", async () => {
+      const list = await api.list({ userKey: "nobody" });
+      expect(list).toEqual([]);
+    });
+
+    it("returns the newest N when limit is set, still chronological", async () => {
+      await seed("u1");
+
+      const list = await api.list({ userKey: "u1", limit: 2 });
+
+      expect(list).toHaveLength(2);
+      expect(list.map((m) => m.text)).toEqual(["msg 3", "msg 4"]);
+    });
+
+    it("filters by platform", async () => {
+      const slackThread = createTestThread("slack");
+      const discordThread = createTestThread("discord", "discord:C:T");
+      const slackMsg = createTestMessage("s1", "from slack");
+      slackMsg.userKey = "u1";
+      const discordMsg = createTestMessage("d1", "from discord");
+      discordMsg.userKey = "u1";
+
+      await api.append(slackThread, slackMsg);
+      await api.append(discordThread, discordMsg);
+
+      const slackOnly = await api.list({
+        userKey: "u1",
+        platforms: ["slack"],
+      });
+      expect(slackOnly).toHaveLength(1);
+      expect(slackOnly[0]?.platform).toBe("slack");
+    });
+
+    it("filters by threadId", async () => {
+      const a = createTestThread("slack", "slack:C:A");
+      const b = createTestThread("slack", "slack:C:B");
+      const m1 = createTestMessage("m1", "thread A");
+      m1.userKey = "u1";
+      const m2 = createTestMessage("m2", "thread B");
+      m2.userKey = "u1";
+
+      await api.append(a, m1);
+      await api.append(b, m2);
+
+      const list = await api.list({ userKey: "u1", threadId: "slack:C:A" });
+      expect(list).toHaveLength(1);
+      expect(list[0]?.text).toBe("thread A");
+    });
+
+    it("filters by role", async () => {
+      const thread = createTestThread();
+      const userMsg = createTestMessage("m1", "user msg");
+      userMsg.userKey = "u1";
+      await api.append(thread, userMsg);
+      await api.append(
+        thread,
+        { role: "assistant", text: "bot msg" },
+        { userKey: "u1" }
+      );
+
+      const userOnly = await api.list({ userKey: "u1", roles: ["user"] });
+      expect(userOnly).toHaveLength(1);
+      expect(userOnly[0]?.role).toBe("user");
+
+      const assistantOnly = await api.list({
+        userKey: "u1",
+        roles: ["assistant"],
+      });
+      expect(assistantOnly).toHaveLength(1);
+      expect(assistantOnly[0]?.role).toBe("assistant");
+    });
+  });
+
+  describe("count", () => {
+    it("returns the total stored count for a userKey", async () => {
+      const thread = createTestThread();
+      for (let i = 0; i < 3; i++) {
+        const msg = createTestMessage(`m${i}`, `msg ${i}`);
+        msg.userKey = "u1";
+        await api.append(thread, msg);
+      }
+
+      const total = await api.count({ userKey: "u1" });
+      expect(total).toBe(3);
+    });
+
+    it("returns 0 for unknown userKey", async () => {
+      expect(await api.count({ userKey: "nobody" })).toBe(0);
+    });
+  });
+
+  describe("delete", () => {
+    it("clears all stored entries for a userKey and reports the count", async () => {
+      const thread = createTestThread();
+      for (let i = 0; i < 4; i++) {
+        const msg = createTestMessage(`m${i}`, `msg ${i}`);
+        msg.userKey = "u1";
+        await api.append(thread, msg);
+      }
+
+      const result = await api.delete({ userKey: "u1" });
+
+      expect(result.deleted).toBe(4);
+      expect(await api.count({ userKey: "u1" })).toBe(0);
+      expect(await api.list({ userKey: "u1" })).toEqual([]);
+    });
+
+    it("returns deleted: 0 for unknown userKey", async () => {
+      const result = await api.delete({ userKey: "nobody" });
+      expect(result.deleted).toBe(0);
+    });
+
+    it("hides the tombstone from list/count after deletion", async () => {
+      const thread = createTestThread();
+      const msg = createTestMessage("m1", "before");
+      msg.userKey = "u1";
+      await api.append(thread, msg);
+      await api.delete({ userKey: "u1" });
+
+      // list and count both ignore the tombstone marker
+      expect(await api.list({ userKey: "u1" })).toEqual([]);
+      expect(await api.count({ userKey: "u1" })).toBe(0);
+    });
+
+    it("appends after delete behave as if the list were freshly empty", async () => {
+      const thread = createTestThread();
+      const before = createTestMessage("m1", "before");
+      before.userKey = "u1";
+      await api.append(thread, before);
+      await api.delete({ userKey: "u1" });
+
+      const after = createTestMessage("m2", "after");
+      after.userKey = "u1";
+      await api.append(thread, after);
+
+      const list = await api.list({ userKey: "u1" });
+      expect(list).toHaveLength(1);
+      expect(list[0]?.text).toBe("after");
+      expect(await api.count({ userKey: "u1" })).toBe(1);
+    });
+
+    it("does not double-count if delete is called twice", async () => {
+      const thread = createTestThread();
+      const msg = createTestMessage("m1", "hello");
+      msg.userKey = "u1";
+      await api.append(thread, msg);
+
+      const first = await api.delete({ userKey: "u1" });
+      const second = await api.delete({ userKey: "u1" });
+
+      expect(first.deleted).toBe(1);
+      expect(second.deleted).toBe(0);
+    });
+  });
+
+  describe("maxPerUser eviction", () => {
+    it("trims to maxPerUser via appendToList semantics", async () => {
+      api = new TranscriptsApiImpl(state, { maxPerUser: 3 });
+      const thread = createTestThread();
+
+      for (let i = 0; i < 5; i++) {
+        const msg = createTestMessage(`m${i}`, `msg ${i}`);
+        msg.userKey = "u1";
+        await api.append(thread, msg);
+      }
+
+      const list = await api.list({ userKey: "u1" });
+      expect(list).toHaveLength(3);
+      expect(list.map((m) => m.text)).toEqual(["msg 2", "msg 3", "msg 4"]);
+    });
+  });
+
+  describe("formatted round-trip", () => {
+    it("preserves mdast Root through state serialization", async () => {
+      api = new TranscriptsApiImpl(state, { storeFormatted: true });
+      const thread = createTestThread();
+      const original = parseMarkdown("# Hello\n\n*world*");
+      const msg = createTestMessage("m1", "Hello world");
+      msg.userKey = "u1";
+      msg.formatted = original;
+
+      await api.append(thread, msg);
+      const list = await api.list({ userKey: "u1" });
+
+      expect(list[0]?.formatted).toEqual(original);
+    });
+  });
+});

--- a/packages/chat/src/transcripts.test.ts
+++ b/packages/chat/src/transcripts.test.ts
@@ -334,6 +334,38 @@ describe("TranscriptsApiImpl", () => {
       expect(first.deleted).toBe(1);
       expect(second.deleted).toBe(0);
     });
+
+    it("preserves invariants when append/delete/append are interleaved without awaits", async () => {
+      const thread = createTestThread();
+      const before = createTestMessage("m0", "before");
+      before.userKey = "u1";
+      await api.append(thread, before);
+
+      const post1 = createTestMessage("m1", "post1");
+      post1.userKey = "u1";
+      const post2 = createTestMessage("m2", "post2");
+      post2.userKey = "u1";
+
+      await Promise.all([
+        api.append(thread, post1),
+        api.delete({ userKey: "u1" }),
+        api.append(thread, post2),
+      ]);
+
+      const list = await api.list({ userKey: "u1" });
+      const count = await api.count({ userKey: "u1" });
+
+      // count() and list() must agree — neither should leak the tombstone.
+      expect(count).toBe(list.length);
+      // Whatever survives is a real entry under the right userKey, and
+      // never the pre-delete entry (which delete() must have evicted).
+      for (const entry of list) {
+        expect(entry.userKey).toBe("u1");
+        expect(entry.text).not.toBe("before");
+      }
+      // Final size is bounded by the two post-delete appends.
+      expect(count).toBeLessThanOrEqual(2);
+    });
   });
 
   describe("maxPerUser eviction", () => {

--- a/packages/chat/src/transcripts.ts
+++ b/packages/chat/src/transcripts.ts
@@ -1,0 +1,196 @@
+import { Message } from "./message";
+import type {
+  AppendInput,
+  AppendOptions,
+  DeleteTarget,
+  DurationString,
+  ListQuery,
+  Postable,
+  StateAdapter,
+  TranscriptEntry,
+  TranscriptRole,
+  TranscriptsApi,
+  TranscriptsConfig,
+} from "./types";
+
+const KEY_PREFIX = "transcripts:user:";
+const DEFAULT_MAX_PER_USER = 200;
+const DEFAULT_LIST_LIMIT = 50;
+const DURATION_RE = /^(\d+)([smhd])$/;
+
+/**
+ * Sentinel value written by `delete()` so the underlying list is functionally
+ * empty without needing a `clearList` primitive on the state adapter contract.
+ *
+ * `appendToList(key, tombstone, { maxLength: 1 })` evicts every prior entry
+ * across all built-in state adapters (memory shares storage; redis/ioredis use
+ * LTRIM; pg trims via DELETE … WHERE seq <= …). The remaining single tombstone
+ * is filtered out by `list()` and `count()`, and is pushed out naturally on the
+ * next append once `maxPerUser` writes have happened.
+ */
+const TOMBSTONE_MARKER = "__chatSdkTombstone";
+
+interface Tombstone {
+  [TOMBSTONE_MARKER]: true;
+}
+
+function isTombstone(value: unknown): boolean {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    (value as Record<string, unknown>)[TOMBSTONE_MARKER] === true
+  );
+}
+
+const MS_PER_UNIT = {
+  s: 1_000,
+  m: 60_000,
+  h: 3_600_000,
+  d: 86_400_000,
+} as const;
+
+/**
+ * Cross-platform per-user transcript store, backed by `StateAdapter.appendToList`.
+ *
+ * Distinct from `ThreadHistoryCache` (which is per-thread, used by adapters
+ * that lack server-side history APIs). This store is keyed by a resolved
+ * cross-platform user key from `ChatConfig.identity`.
+ */
+export class TranscriptsApiImpl implements TranscriptsApi {
+  private readonly state: StateAdapter;
+  private readonly maxPerUser: number;
+  private readonly retentionMs: number | undefined;
+  private readonly storeFormatted: boolean;
+
+  constructor(state: StateAdapter, config: TranscriptsConfig) {
+    this.state = state;
+    this.maxPerUser = config.maxPerUser ?? DEFAULT_MAX_PER_USER;
+    this.retentionMs = parseDuration(config.retention);
+    this.storeFormatted = config.storeFormatted ?? false;
+  }
+
+  async append<TState = Record<string, unknown>, TRawMessage = unknown>(
+    thread: Postable<TState, TRawMessage>,
+    message: Message | AppendInput,
+    options?: AppendOptions
+  ): Promise<TranscriptEntry | null> {
+    const isMessage = message instanceof Message;
+
+    let userKey: string | undefined;
+    let role: TranscriptRole;
+    let platformMessageId: string | undefined;
+
+    if (isMessage) {
+      userKey = message.userKey;
+      role = "user";
+      platformMessageId = message.id;
+      if (!userKey) {
+        return null;
+      }
+    } else {
+      userKey = options?.userKey;
+      role = message.role;
+      platformMessageId = message.platformMessageId;
+      if (!userKey) {
+        throw new Error(
+          "transcripts.append: options.userKey is required when appending an AppendInput"
+        );
+      }
+    }
+
+    const entry: TranscriptEntry = {
+      id: crypto.randomUUID(),
+      userKey,
+      role,
+      text: message.text,
+      platform: thread.adapter.name,
+      threadId: thread.id,
+      timestamp: Date.now(),
+    };
+    if (this.storeFormatted && message.formatted) {
+      entry.formatted = message.formatted;
+    }
+    if (platformMessageId !== undefined) {
+      entry.platformMessageId = platformMessageId;
+    }
+
+    await this.state.appendToList(keyFor(userKey), entry, {
+      maxLength: this.maxPerUser,
+      ttlMs: this.retentionMs,
+    });
+
+    return entry;
+  }
+
+  async list(query: ListQuery): Promise<TranscriptEntry[]> {
+    const raw = await this.state.getList<TranscriptEntry | Tombstone>(
+      keyFor(query.userKey)
+    );
+    let filtered = raw.filter(
+      (entry): entry is TranscriptEntry => !isTombstone(entry)
+    );
+
+    if (query.platforms && query.platforms.length > 0) {
+      const platforms = new Set(query.platforms);
+      filtered = filtered.filter((m) => platforms.has(m.platform));
+    }
+    if (query.threadId !== undefined) {
+      const tid = query.threadId;
+      filtered = filtered.filter((m) => m.threadId === tid);
+    }
+    if (query.roles && query.roles.length > 0) {
+      const roles = new Set(query.roles);
+      filtered = filtered.filter((m) => roles.has(m.role));
+    }
+
+    const limit = query.limit ?? DEFAULT_LIST_LIMIT;
+    if (filtered.length > limit) {
+      filtered = filtered.slice(filtered.length - limit);
+    }
+    return filtered;
+  }
+
+  async count(query: { userKey: string }): Promise<number> {
+    const raw = await this.state.getList(keyFor(query.userKey));
+    return raw.filter((entry) => !isTombstone(entry)).length;
+  }
+
+  async delete(target: DeleteTarget): Promise<{ deleted: number }> {
+    const key = keyFor(target.userKey);
+    const existing = await this.state.getList(key);
+    const previous = existing.filter((entry) => !isTombstone(entry)).length;
+    // Append a tombstone with maxLength: 1 to evict every prior entry. The
+    // remaining tombstone is filtered out by list()/count(), and is naturally
+    // pushed out by the next append once maxPerUser writes accumulate.
+    const tombstone: Tombstone = { [TOMBSTONE_MARKER]: true };
+    await this.state.appendToList(key, tombstone, {
+      maxLength: 1,
+      ttlMs: this.retentionMs,
+    });
+    return { deleted: previous };
+  }
+}
+
+function keyFor(userKey: string): string {
+  return `${KEY_PREFIX}${userKey}`;
+}
+
+function parseDuration(
+  value: number | DurationString | undefined
+): number | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+  if (typeof value === "number") {
+    return value;
+  }
+  const match = DURATION_RE.exec(value);
+  if (!match) {
+    throw new Error(
+      `Invalid duration: ${value} (expected number of ms, or "<n>[smhd]")`
+    );
+  }
+  const n = Number.parseInt(match[1] as string, 10);
+  const unit = match[2] as keyof typeof MS_PER_UNIT;
+  return n * MS_PER_UNIT[unit];
+}

--- a/packages/chat/src/types.ts
+++ b/packages/chat/src/types.ts
@@ -85,6 +85,14 @@ export interface ChatConfig<
    */
   fallbackStreamingPlaceholderText?: string | null;
   /**
+   * Resolves a stable cross-platform user key from inbound messages.
+   *
+   * Required when `messages` is configured. Called once per inbound
+   * message during dispatch; the result is attached to the Message
+   * instance as `message.userKey` for handlers to use.
+   */
+  identity?: IdentityResolver;
+  /**
    * Lock scope determines which messages contend for the same lock.
    *
    * - `'thread'`: lock per threadId (default for most adapters)
@@ -103,13 +111,12 @@ export interface ChatConfig<
    */
   logger?: Logger | LogLevel;
   /**
-   * Configuration for persistent message history.
-   * Only used by adapters that set `persistMessageHistory: true`.
+   * @deprecated Renamed to {@link ChatConfig.threadHistory}. Both fields are
+   * read for backwards compatibility; `threadHistory` takes precedence when
+   * both are set.
    */
   messageHistory?: {
-    /** Maximum messages to store per thread (default: 100) */
     maxMessages?: number;
-    /** TTL for cached history in milliseconds (default: 7 days) */
     ttlMs?: number;
   };
   /**
@@ -139,6 +146,28 @@ export interface ChatConfig<
    * Defaults to 500ms. Lower values provide smoother updates but may hit rate limits.
    */
   streamingUpdateIntervalMs?: number;
+  /**
+   * Configuration for persistent per-thread message history backfill.
+   *
+   * Only used by adapters that set `persistThreadHistory: true` (e.g.
+   * Telegram, WhatsApp). Distinct from `messages` (the cross-platform
+   * per-user Messages API).
+   */
+  threadHistory?: {
+    /** Maximum messages to store per thread (default: 100) */
+    maxMessages?: number;
+    /** TTL for cached history in milliseconds (default: 7 days) */
+    ttlMs?: number;
+  };
+  /**
+   * Cross-platform per-user message persistence.
+   *
+   * When set, `chat.messages` is available for append/list/count/delete
+   * keyed by a resolved cross-platform user key.
+   *
+   * Requires `identity` to also be set; the constructor throws otherwise.
+   */
+  transcripts?: TranscriptsConfig;
   /** Default bot username across all adapters */
   userName: string;
 }
@@ -395,12 +424,19 @@ export interface Adapter<TThreadId = unknown, TRawMessage = unknown> {
 
   /** Parse platform message format to normalized format */
   parseMessage(raw: TRawMessage): Message<TRawMessage>;
-
   /**
-   * When true, the SDK persists message history in the state adapter for this platform.
-   * Use this for platforms that lack server-side message history APIs (e.g., WhatsApp, Telegram).
+   * @deprecated Renamed to {@link Adapter.persistThreadHistory}. Both flags
+   * are read for backwards compatibility; either being `true` enables
+   * persistence.
    */
   readonly persistMessageHistory?: boolean;
+
+  /**
+   * When true, the SDK persists per-thread message history in the state
+   * adapter for this platform. Use for platforms that lack server-side
+   * message history APIs (e.g. WhatsApp, Telegram).
+   */
+  readonly persistThreadHistory?: boolean;
 
   /**
    * Post a message to channel top-level (not in a thread).
@@ -2318,3 +2354,143 @@ export interface MemberJoinedChannelEvent {
 export type MemberJoinedChannelHandler = (
   event: MemberJoinedChannelEvent
 ) => void | Promise<void>;
+
+// =============================================================================
+// Messages API (cross-platform per-user message persistence)
+// =============================================================================
+
+/**
+ * Resolves a stable, cross-platform user key from an inbound message context.
+ *
+ * Return `null` to skip persistence for this event (unknown user, system
+ * message, or the bot itself). The SDK fails loudly rather than silently
+ * falling back to a platform-specific ID.
+ */
+export type IdentityResolver = (
+  context: IdentityContext
+) => string | null | Promise<string | null>;
+
+export interface IdentityContext {
+  /** Adapter name (e.g. "slack", "discord"). */
+  adapter: string;
+  author: Author;
+  message: Message;
+}
+
+/**
+ * Role tag on a stored message.
+ *
+ * - `user`: produced by the resolved end-user
+ * - `assistant`: produced by this bot
+ * - `system`: SDK-injected marker (handoff, summary). Adapters never produce it.
+ */
+export type TranscriptRole = "user" | "assistant" | "system";
+
+export interface TranscriptEntry {
+  /** mdast AST. Only present when `messages.storeFormatted` is true. */
+  formatted?: FormattedContent;
+  /** ULID assigned at append time. Lexicographically sortable; encodes ms timestamp. */
+  id: string;
+  /** Originating adapter name. */
+  platform: string;
+  /** Platform-native message ID, when known. */
+  platformMessageId?: string;
+  role: TranscriptRole;
+  /** Plain-text body — canonical field for prompt building. */
+  text: string;
+  /** Originating thread ID. */
+  threadId: string;
+  /** ms-since-epoch, set at append time on the SDK side. */
+  timestamp: number;
+  /** Cross-platform user key from the IdentityResolver. */
+  userKey: string;
+}
+
+/** Duration shorthand: e.g. `"7d"`, `"30m"`, `"2h"`, `"45s"`. */
+export type DurationString = `${number}${"s" | "m" | "h" | "d"}`;
+
+export interface TranscriptsConfig {
+  /** Hard cap; older messages evicted on append. Default 200. */
+  maxPerUser?: number;
+  /**
+   * Default retention applied as the list TTL. Refreshed on every append
+   * (matches `appendToList` semantics). Omit for no expiry.
+   */
+  retention?: number | DurationString;
+  /** Persist `formatted` (mdast). Default false to keep storage small. */
+  storeFormatted?: boolean;
+}
+
+/**
+ * Input shape for appending a non-Message (e.g. an assistant reply you
+ * just posted via `thread.post()`).
+ */
+export interface AppendInput {
+  formatted?: FormattedContent;
+  platformMessageId?: string;
+  role: TranscriptRole;
+  text: string;
+}
+
+export interface AppendOptions {
+  /**
+   * Required when appending an `AppendInput` (assistant/system role) — the
+   * SDK has no Message instance from which to read the resolved key.
+   *
+   * Ignored when appending a Message; the Message's own `userKey` is used.
+   */
+  userKey?: string;
+}
+
+export interface ListQuery {
+  /** Newest N kept (still returned in chronological order). Default 50. */
+  limit?: number;
+  /** Filter to a subset of adapter names. */
+  platforms?: string[];
+  /** Filter to specific roles. Default: all. */
+  roles?: TranscriptRole[];
+  /** Filter to a single thread. */
+  threadId?: string;
+  userKey: string;
+}
+
+/**
+ * Target for {@link TranscriptsApi.delete}. Wipes every stored message under
+ * the given user key.
+ */
+export interface DeleteTarget {
+  userKey: string;
+}
+
+/**
+ * Cross-platform per-user message store.
+ *
+ * Distinct from the existing per-thread `messageHistory` config (which exists
+ * to backfill thread context for adapters that lack server-side history APIs).
+ * The Messages API is keyed by a resolved cross-platform user key and is
+ * intended for transcript-style use cases (LLM context building, audit).
+ */
+export interface TranscriptsApi {
+  /**
+   * Persist a Message (or AppendInput) under the user key.
+   *
+   * - For Message: `userKey` is read from the Message instance (set by the
+   *   SDK during inbound dispatch via the configured IdentityResolver).
+   *   No-op if the Message has no `userKey` (resolver returned null).
+   * - For AppendInput: `options.userKey` is required.
+   */
+  append<TState = Record<string, unknown>, TRawMessage = unknown>(
+    thread: Postable<TState, TRawMessage>,
+    message: Message | AppendInput,
+    options?: AppendOptions
+  ): Promise<TranscriptEntry | null>;
+
+  /** Total stored count for a user key. */
+  count(query: { userKey: string }): Promise<number>;
+
+  /** GDPR / DSR delete — wipes every stored message under the user key. */
+  delete(target: DeleteTarget): Promise<{ deleted: number }>;
+
+  /** Returns messages in chronological order (oldest first). */
+  list(query: ListQuery): Promise<TranscriptEntry[]>;
+}

--- a/packages/chat/src/types.ts
+++ b/packages/chat/src/types.ts
@@ -87,7 +87,7 @@ export interface ChatConfig<
   /**
    * Resolves a stable cross-platform user key from inbound messages.
    *
-   * Required when `messages` is configured. Called once per inbound
+   * Required when `transcripts` is configured. Called once per inbound
    * message during dispatch; the result is attached to the Message
    * instance as `message.userKey` for handlers to use.
    */
@@ -150,8 +150,8 @@ export interface ChatConfig<
    * Configuration for persistent per-thread message history backfill.
    *
    * Only used by adapters that set `persistThreadHistory: true` (e.g.
-   * Telegram, WhatsApp). Distinct from `messages` (the cross-platform
-   * per-user Messages API).
+   * Telegram, WhatsApp). Distinct from `transcripts` (the cross-platform
+   * per-user Transcripts API).
    */
   threadHistory?: {
     /** Maximum messages to store per thread (default: 100) */
@@ -162,7 +162,7 @@ export interface ChatConfig<
   /**
    * Cross-platform per-user message persistence.
    *
-   * When set, `chat.messages` is available for append/list/count/delete
+   * When set, `chat.transcripts` is available for append/list/count/delete
    * keyed by a resolved cross-platform user key.
    *
    * Requires `identity` to also be set; the constructor throws otherwise.
@@ -728,6 +728,13 @@ export interface ChatInstance {
     },
     options: WebhookOptions | undefined
   ): void;
+
+  /**
+   * Cross-platform per-user transcript store. Throws on access when
+   * `transcripts` is not configured on the Chat instance — callers should
+   * check `ChatConfig.transcripts` if they need a no-throw guard.
+   */
+  readonly transcripts: TranscriptsApi;
 }
 
 // =============================================================================
@@ -2356,7 +2363,7 @@ export type MemberJoinedChannelHandler = (
 ) => void | Promise<void>;
 
 // =============================================================================
-// Messages API (cross-platform per-user message persistence)
+// Transcripts API (cross-platform per-user message persistence)
 // =============================================================================
 
 /**
@@ -2387,9 +2394,14 @@ export interface IdentityContext {
 export type TranscriptRole = "user" | "assistant" | "system";
 
 export interface TranscriptEntry {
-  /** mdast AST. Only present when `messages.storeFormatted` is true. */
+  /** mdast AST. Only present when `transcripts.storeFormatted` is true. */
   formatted?: FormattedContent;
-  /** ULID assigned at append time. Lexicographically sortable; encodes ms timestamp. */
+  /**
+   * UUID assigned by the SDK at append time. Opaque — not lexicographically
+   * sortable. Entries are returned by `list()` in append order (the underlying
+   * list semantics of `state.appendToList`); use `timestamp` to reason about
+   * ordering across stores.
+   */
   id: string;
   /** Originating adapter name. */
   platform: string;
@@ -2462,12 +2474,17 @@ export interface DeleteTarget {
   userKey: string;
 }
 
+/** Query shape for {@link TranscriptsApi.count}. */
+export interface CountQuery {
+  userKey: string;
+}
+
 /**
  * Cross-platform per-user message store.
  *
- * Distinct from the existing per-thread `messageHistory` config (which exists
+ * Distinct from the existing per-thread `threadHistory` config (which exists
  * to backfill thread context for adapters that lack server-side history APIs).
- * The Messages API is keyed by a resolved cross-platform user key and is
+ * The Transcripts API is keyed by a resolved cross-platform user key and is
  * intended for transcript-style use cases (LLM context building, audit).
  */
 export interface TranscriptsApi {
@@ -2486,11 +2503,19 @@ export interface TranscriptsApi {
   ): Promise<TranscriptEntry | null>;
 
   /** Total stored count for a user key. */
-  count(query: { userKey: string }): Promise<number>;
+  count(query: CountQuery): Promise<number>;
 
   /** GDPR / DSR delete — wipes every stored message under the user key. */
   delete(target: DeleteTarget): Promise<{ deleted: number }>;
 
-  /** Returns messages in chronological order (oldest first). */
+  /**
+   * Returns the most recent entries in chronological order (oldest first),
+   * capped at `query.limit` (default 50).
+   *
+   * Pagination is intentionally not supported — the store keeps at most
+   * `transcripts.maxPerUser` entries per user. To widen the window, raise
+   * `maxPerUser`; to fetch a different slice, narrow with `threadId` /
+   * `platforms` / `roles`.
+   */
   list(query: ListQuery): Promise<TranscriptEntry[]>;
 }


### PR DESCRIPTION
Adds a new `bot.transcripts` API for cross-platform per-user message persistence,
and renames the existing per-thread cache from `messageHistory` to `threadHistory`
so the two persistence concepts don't share a "messages" name.

### What's new

**Transcripts API** (`bot.transcripts`, gated on `ChatConfig.transcripts` + `ChatConfig.identity`):

- `append`, `list`, `count`, `delete` keyed by a stable cross-platform user key
  resolved by `ChatConfig.identity` once per inbound message during dispatch
  (cached on the `Message` instance as `message.userKey`).
- Backed by the existing `StateAdapter.appendToList` primitive, so every built-in
  state adapter (`memory`, `redis`, `ioredis`, `pg`) supports it without changes.
- `delete` is implemented via a tombstone written with `appendToList(key, _, { maxLength: 1 })`
  because `state.delete` only addresses the k/v namespace; `list()`/`count()`
  filter the tombstone out. This avoids extending the `StateAdapter` contract.
- Single-entry / time-range deletes are intentionally not part of this API —
  the underlying `appendToList` primitive can't support them safely under
  concurrent writes.

**`messageHistory` → `threadHistory` rename** (with full backwards compatibility):

| Old name | New name |
|----------|----------|
| `ChatConfig.messageHistory` | `ChatConfig.threadHistory` |
| `Adapter.persistMessageHistory` | `Adapter.persistThreadHistory` |
| `MessageHistoryCache` | `ThreadHistoryCache` |
| `MessageHistoryConfig` | `ThreadHistoryConfig` |
| `message-history.ts` | `thread-history.ts` |

- Both `ChatConfig.threadHistory` and `ChatConfig.messageHistory` are read at
  construction; `threadHistory` takes precedence when both are set.
- Both `Adapter.persistThreadHistory` and `Adapter.persistMessageHistory` are
  read at the persistence sites; either flag enables persistence.
- `MessageHistoryCache` / `MessageHistoryConfig` re-exported as `@deprecated`
  aliases of the new names.
- The state-adapter storage key prefix (`msg-history:`) is **intentionally
  unchanged** — renaming it would silently orphan existing user data.
- `@chat-adapter/telegram` and `@chat-adapter/whatsapp` updated to use
  `persistThreadHistory`. Custom adapters built against `persistMessageHistory`
  continue to work.

### Public types added/exported

`TranscriptsApi`, `TranscriptEntry`, `TranscriptRole`, `TranscriptsConfig`,
`AppendInput`, `AppendOptions`, `ListQuery`, `CountQuery`, `DeleteTarget`,
`IdentityResolver`, `IdentityContext`, `DurationString`, `ThreadHistoryCache`,
`ThreadHistoryConfig`.

`ChatInstance` interface gains a `readonly transcripts: TranscriptsApi` so
callers typed against the public interface can reach `bot.transcripts`.

### Docs

- New guide: [Conversation history](apps/docs/content/docs/conversation-history.mdx)
  covering both `threadHistory` and the Transcripts API together with usage patterns.
- New API reference: [Transcripts](apps/docs/content/docs/api/transcripts.mdx).
- Both wired into the docs sidebar / API reference `meta.json`.

### Example

`examples/nextjs-chat` — AI mode handler (`onSubscribedMessage`) now persists
inbound user messages and assistant replies via `bot.transcripts`, and reads
context from `bot.transcripts.list({ threadId })` when the adapter doesn't
expose `fetchMessages`. New `transcripts` and `clear-transcripts` action
buttons demonstrate `list` / `count` / `delete`. `TEST_USER_KEY` is hardcoded
and clearly labelled for demo purposes.

## Test plan

- [x] `pnpm validate` (knip + check + typecheck + 914 tests + build) — all 16 tasks pass
- [x] `pnpm --filter chat test` — 914 tests, 21 files, all green
- [x] `pnpm --filter docs build` — 113 static pages generated, no broken links

## Migration notes

For consumers on the previous `messageHistory` API, **no code changes
required** — the deprecated names continue to work and read the same data.
Tests, types, and JSDoc all carry `@deprecated` hints toward the new names.

## Checklist

- [x] All commits are signed and verified
- [x] `pnpm validate` passes
- [x] Changeset added (`.changeset/transcripts-api.md` minor for `chat`;
      `.changeset/thread-history-rename.md` minor for `chat`, patch for
      `@chat-adapter/telegram` + `@chat-adapter/whatsapp`)
- [x] Documentation updated (new guide + API reference + sidebar entries)
