### PR TITLE
chore: add Vercel Code Approvers files

### DIFF
--- a/.changeset/.vercel.approvers
+++ b/.changeset/.vercel.approvers
@@ -1,0 +1,1 @@
+config.json @cramforce

--- a/.github/.vercel.approvers
+++ b/.github/.vercel.approvers
@@ -1,0 +1,1 @@
+CODEOWNERS @cramforce

--- a/.github/workflows/.vercel.approvers
+++ b/.github/workflows/.vercel.approvers
@@ -1,0 +1,1 @@
+release.yml @cramforce

--- a/.vercel.approvers
+++ b/.vercel.approvers
@@ -1,0 +1,1 @@
+@vercel/chat-sdk


### PR DESCRIPTION
- Mirrors `.github/CODEOWNERS` into Vercel [Code Approvers](https://vercel.com/docs/code-owners/code-approvers) (`.vercel.approvers`) so the `Vercel – Code Owners` GitHub check can enforce the same approval rules.
- Splits across four files because `.vercel.approvers` patterns disallow `/` in the middle — each pinned path lives in its own directory, and `@vercel/chat-sdk` covers the rest via inheritance from the root file.

| File | Rule |
| --- | --- |
| `.vercel.approvers` | `@vercel/chat-sdk` (default scope) |
| `.changeset/.vercel.approvers` | `config.json @cramforce` |
| `.github/.vercel.approvers` | `CODEOWNERS @cramforce` |
| `.github/workflows/.vercel.approvers` | `release.yml @cramforce` |