### PR TITLE
fix(docs): scroll code blocks in adapter READMEs

### DIFF
--- a/apps/docs/app/styles/geistdocs.css
+++ b/apps/docs/app/styles/geistdocs.css
@@ -556,4 +556,10 @@
 div[data-streamdown="code-block-body"] {
   overflow-x: auto;
   overflow-y: hidden;
+  padding-right: 0;
+}
+
+/* Move right padding inside the scrollable element so it survives scroll-end. */
+div[data-streamdown="code-block-body"] > pre {
+  padding-right: 1rem;
 }

--- a/apps/docs/app/styles/geistdocs.css
+++ b/apps/docs/app/styles/geistdocs.css
@@ -551,3 +551,9 @@
 :root {
   --color-fd-primary: var(--ds-gray-1000);
 }
+
+/* Streamdown clips long code lines with overflow-hidden — allow horizontal scroll. */
+div[data-streamdown="code-block-body"] {
+  overflow-x: auto;
+  overflow-y: hidden;
+}


### PR DESCRIPTION

in the top part is before, the bottom part is after.

We can now scroll on x and see full content

https://github.com/user-attachments/assets/da48337f-6113-4513-9a33-0e1e62f9c426



