### PR TITLE
fix(adapter-telegram): handle video_note (round video messages) in extractAttachments

### DIFF
--- a/.changeset/telegram-video-note.md
+++ b/.changeset/telegram-video-note.md
@@ -1,0 +1,5 @@
+---
+"@chat-adapter/telegram": patch
+---
+
+Handle `video_note` (round video messages) in `extractAttachments`. Previously these messages were silently dropped; now they are returned as `video` attachments with `width`/`height` set to the clip's `length`.

--- a/packages/adapter-telegram/src/index.test.ts
+++ b/packages/adapter-telegram/src/index.test.ts
@@ -1897,6 +1897,45 @@ describe("TelegramAdapter", () => {
     expect(attachment?.mimeType).toBe("video/mp4");
   });
 
+  it("extracts video_note attachments from round video messages", async () => {
+    mockFetch.mockResolvedValueOnce(
+      telegramOk({
+        id: 999,
+        is_bot: true,
+        first_name: "Bot",
+        username: "mybot",
+      })
+    );
+
+    const adapter = createTelegramAdapter({
+      botToken: "token",
+      mode: "webhook",
+      logger: mockLogger,
+      userName: "mybot",
+    });
+
+    await adapter.initialize(createMockChat());
+
+    const videoNoteMessage = sampleMessage({
+      video_note: {
+        file_id: "vn1",
+        file_unique_id: "uvn1",
+        length: 240,
+        duration: 10,
+        file_size: 512000,
+      },
+    });
+
+    const parsed = adapter.parseMessage(videoNoteMessage);
+
+    expect(parsed.attachments).toHaveLength(1);
+    const attachment = parsed.attachments[0];
+    expect(attachment?.type).toBe("video");
+    expect(attachment?.width).toBe(240);
+    expect(attachment?.height).toBe(240);
+    expect(attachment?.size).toBe(512000);
+  });
+
   it("isDM returns true for private chats (positive chat ID)", async () => {
     const adapter = createTelegramAdapter({
       botToken: "token",

--- a/packages/adapter-telegram/src/index.ts
+++ b/packages/adapter-telegram/src/index.ts
@@ -1181,6 +1181,16 @@ export class TelegramAdapter
       );
     }
 
+    if (raw.video_note) {
+      attachments.push(
+        this.createAttachment("video", raw.video_note.file_id, {
+          size: raw.video_note.file_size,
+          width: raw.video_note.length,
+          height: raw.video_note.length,
+        })
+      );
+    }
+
     return attachments;
   }
 

--- a/packages/adapter-telegram/src/types.ts
+++ b/packages/adapter-telegram/src/types.ts
@@ -159,6 +159,7 @@ export interface TelegramMessage {
     mime_type?: string;
     file_name?: string;
   };
+  video_note?: TelegramFile & { length?: number; duration?: number };
   voice?: TelegramFile & { duration?: number; mime_type?: string };
 }
 


### PR DESCRIPTION
## Summary

Closes #456

Telegram's round video clips (`video_note`) were silently dropped by `extractAttachments` — the function had no branch for them, so messages sent as circular videos produced an empty attachment list with no text.

### Changes

**`packages/adapter-telegram/src/types.ts`**
- Added `video_note` field to `TelegramMessage` interface

**`packages/adapter-telegram/src/index.ts`**
- Added `video_note` handling in `extractAttachments`, extracted as a `"video"` attachment with `width`/`height` set to the clip's `length` (round videos always have equal dimensions)

### Telegram Bot API reference

[`video_note`](https://core.telegram.org/bots/api#videonote) — `length` is both width and height; no `mime_type` or `file_name`.

### Test plan

- [ ] Send a round video in Telegram to a bot using this adapter and verify the message has a `video` attachment with non-null `width`/`height`
- [ ] Verify existing attachment types (photo, video, audio, voice, document) are unaffected