### PR TITLE
docs: fix stale API examples, adapter matrix, and broken links

### DIFF
--- a/.changeset/late-sites-unite.md
+++ b/.changeset/late-sites-unite.md
@@ -1,0 +1,5 @@
+---
+"chat": patch
+---
+
+fix StreamEvent type from step-finish to finish-step

--- a/apps/docs/content/docs/actions.mdx
+++ b/apps/docs/content/docs/actions.mdx
@@ -94,7 +94,7 @@ bot.onAction("feedback", async (event) => {
 ```
 
 <Callout type="info">
-  Modals are currently supported on Slack. Other platforms will receive a no-op
+  Modals are currently supported on Slack and Teams. Other platforms will receive a no-op
   or fallback behavior.
 </Callout>
 

--- a/apps/docs/content/docs/adapters.mdx
+++ b/apps/docs/content/docs/adapters.mdx
@@ -19,10 +19,10 @@ Ready to build your own? Follow the [building](/docs/contributing/building) guid
 | Feature | [Slack](/adapters/slack) | [Teams](/adapters/teams) | [Google Chat](/adapters/google-chat) | [Discord](/adapters/discord) | [Telegram](/adapters/telegram) | [GitHub](/adapters/github) | [Linear](/adapters/linear) | [WhatsApp](/adapters/whatsapp) | [Messenger](/adapters/messenger) |
 |---------|-------|-------|-------------|---------|---------|--------|--------|-----------|-----------|
 | Post message | <Check /> | <Check /> | <Check /> | <Check /> | <Check /> | <Check /> | <Check /> | <Check /> | <Check /> |
-| Edit message | <Check /> | <Check /> | <Check /> | <Check /> | <Check /> | <Check /> | <Check /> | <Check /> | <Cross /> |
-| Delete message | <Check /> | <Check /> | <Check /> | <Check /> | <Check /> | <Check /> | <Check /> | <Cross /> | <Cross /> |
+| Edit message | <Check /> | <Check /> | <Check /> | <Check /> | <Check /> | <Check /> | <Warn /> Partial | <Cross /> | <Cross /> |
+| Delete message | <Check /> | <Check /> | <Check /> | <Check /> | <Check /> | <Check /> | <Warn /> Partial | <Cross /> | <Cross /> |
 | File uploads | <Check /> | <Check /> | <Cross /> | <Check /> | <Warn /> Single file | <Cross /> | <Cross /> | <Check /> Images, audio, docs | <Cross /> |
-| Streaming | <Check /> Native | <Warn /> Native (DMs) / Post+Edit | <Warn /> Post+Edit | <Warn /> Post+Edit | <Warn /> Post+Edit | <Cross /> | <Cross /> | <Cross /> | <Cross /> |
+| Streaming | <Check /> Native | <Warn /> Native (DMs) / Post+Edit | <Warn /> Post+Edit | <Warn /> Post+Edit | <Warn /> Post+Edit | <Warn /> Buffered | <Warn /> Agent sessions / Post+Edit | <Warn /> Buffered | <Warn /> Buffered |
 | Scheduled messages | <Check /> Native | <Cross /> | <Cross /> | <Cross /> | <Cross /> | <Cross /> | <Cross /> | <Cross /> | <Cross /> |
 
 ### Rich content
@@ -44,12 +44,12 @@ Ready to build your own? Follow the [building](/docs/contributing/building) guid
 |---------|-------|-------|-------------|---------|----------|--------|--------|-----------|-----------|
 | Slash commands | <Check /> | <Cross /> | <Cross /> | <Check /> | <Cross /> | <Cross /> | <Cross /> | <Cross /> | <Cross /> |
 | Mentions | <Check /> | <Check /> | <Check /> | <Check /> | <Check /> | <Check /> | <Check /> | <Cross /> | <Check /> |
-| Add reactions | <Check /> | <Cross /> | <Check /> | <Check /> | <Check /> | <Check /> | <Check /> | <Cross /> | <Cross /> |
-| Remove reactions | <Check /> | <Cross /> | <Check /> | <Check /> | <Check /> | <Warn /> | <Warn /> | <Cross /> | <Cross /> |
-| Typing indicator | <Cross /> | <Check /> | <Cross /> | <Check /> | <Check /> | <Cross /> | <Cross /> | <Cross /> | <Check /> |
+| Add reactions | <Check /> | <Cross /> | <Check /> | <Check /> | <Check /> | <Check /> | <Check /> | <Check /> | <Cross /> |
+| Remove reactions | <Check /> | <Cross /> | <Check /> | <Check /> | <Check /> | <Warn /> | <Warn /> | <Check /> | <Cross /> |
+| Typing indicator | <Check /> | <Check /> | <Cross /> | <Check /> | <Check /> | <Cross /> | <Warn /> Agent sessions | <Cross /> | <Check /> |
 | DMs | <Check /> | <Check /> | <Check /> | <Check /> | <Check /> | <Cross /> | <Cross /> | <Check /> | <Check /> |
 | Ephemeral messages | <Check /> Native | <Cross /> | <Check /> Native | <Cross /> | <Cross /> | <Cross /> | <Cross /> | <Cross /> | <Cross /> |
-| User lookup ([`getUser`](/docs/api/chat#getuser)) | <Check /> | <Warn /> Cached | <Warn /> Cached | <Check /> | <Warn /> Seen users | <Check /> | <Check /> | <Cross /> | <Warn /> Cached |
+| User lookup ([`getUser`](/docs/api/chat#getuser)) | <Check /> | <Warn /> Cached | <Warn /> Cached | <Check /> | <Warn /> Seen users | <Check /> | <Check /> | <Cross /> | <Cross /> |
 | Parent subject ([`message.subject`](/docs/subject)) | <Cross /> | <Cross /> | <Cross /> | <Cross /> | <Cross /> | <Check /> | <Check /> | <Cross /> | <Cross /> |
 | Native client ([`.client`](/docs/api/chat#getadapter)) | <Cross /> | <Cross /> | <Cross /> | <Cross /> | <Cross /> | <Check /> | <Check /> | <Cross /> | <Cross /> |
 | Custom API endpoint (`apiUrl`) | <Check /> | <Check /> | <Check /> | <Check /> | <Check /> | <Check /> | <Check /> | <Check /> | <Check /> |
@@ -59,9 +59,9 @@ Ready to build your own? Follow the [building](/docs/contributing/building) guid
 | Feature | Slack | Teams | Google Chat | Discord | Telegram | GitHub | Linear | WhatsApp | Messenger |
 |---------|-------|-------|-------------|---------|----------|--------|--------|-----------|-----------|
 | Fetch messages | <Check /> | <Check /> | <Check /> | <Check /> | <Warn /> Cached | <Check /> | <Check /> | <Warn /> Cached sent messages only | <Warn /> Cached sent messages only |
-| Fetch single message | <Check /> | <Cross /> | <Cross /> | <Cross /> | <Warn /> Cached | <Cross /> | <Cross /> | <Warn /> Cached sent messages only | <Warn /> Cached |
-| Fetch thread info | <Check /> | <Check /> | <Check /> | <Check /> | <Check /> | <Check /> | <Check /> | <Cross /> | <Check /> |
-| Fetch channel messages | <Check /> | <Check /> | <Check /> | <Check /> | <Warn /> Cached | <Check /> | <Cross /> | <Warn /> Cached sent messages only | <Warn /> Cached |
+| Fetch single message | <Check /> | <Cross /> | <Cross /> | <Cross /> | <Warn /> Cached | <Cross /> | <Cross /> | <Cross /> | <Warn /> Cached |
+| Fetch thread info | <Check /> | <Check /> | <Check /> | <Check /> | <Check /> | <Check /> | <Check /> | <Check /> | <Check /> |
+| Fetch channel messages | <Check /> | <Check /> | <Check /> | <Check /> | <Warn /> Cached | <Check /> | <Cross /> | <Cross /> | <Warn /> Cached |
 | List threads | <Check /> | <Check /> | <Check /> | <Check /> | <Cross /> | <Check /> | <Cross /> | <Cross /> | <Cross /> |
 | Fetch channel info | <Check /> | <Check /> | <Check /> | <Check /> | <Check /> | <Check /> | <Cross /> | <Cross /> | <Check /> |
 | Post channel message | <Check /> | <Check /> | <Check /> | <Check /> | <Check /> | <Cross /> | <Cross /> | <Check /> | <Check /> |

--- a/apps/docs/content/docs/adapters.mdx
+++ b/apps/docs/content/docs/adapters.mdx
@@ -22,7 +22,7 @@ Ready to build your own? Follow the [building](/docs/contributing/building) guid
 | Edit message | <Check /> | <Check /> | <Check /> | <Check /> | <Check /> | <Check /> | <Warn /> Partial | <Cross /> | <Cross /> |
 | Delete message | <Check /> | <Check /> | <Check /> | <Check /> | <Check /> | <Check /> | <Warn /> Partial | <Cross /> | <Cross /> |
 | File uploads | <Check /> | <Check /> | <Cross /> | <Check /> | <Warn /> Single file | <Cross /> | <Cross /> | <Check /> Images, audio, docs | <Cross /> |
-| Streaming | <Check /> Native | <Warn /> Native (DMs) / Post+Edit | <Warn /> Post+Edit | <Warn /> Post+Edit | <Warn /> Post+Edit | <Warn /> Buffered | <Warn /> Agent sessions / Post+Edit | <Warn /> Buffered | <Warn /> Buffered |
+| Streaming | <Check /> Native | <Warn /> Native (DMs) / Buffered | <Warn /> Post+Edit | <Warn /> Post+Edit | <Warn /> Post+Edit | <Warn /> Buffered | <Warn /> Agent sessions / Post+Edit | <Warn /> Buffered | <Warn /> Buffered |
 | Scheduled messages | <Check /> Native | <Cross /> | <Cross /> | <Cross /> | <Cross /> | <Cross /> | <Cross /> | <Cross /> | <Cross /> |
 
 ### Rich content

--- a/apps/docs/content/docs/api/chat.mdx
+++ b/apps/docs/content/docs/api/chat.mdx
@@ -168,7 +168,9 @@ Fires when a user clicks a button or selects an option in a card.
 ```typescript
 // Single action
 bot.onAction("approve", async (event) => {
-  await event.thread.post("Approved!");
+  if (event.thread) {
+    await event.thread.post("Approved!");
+  }
 });
 
 // Multiple actions
@@ -193,8 +195,8 @@ bot.onAction(async (event) => { /* ... */ });
       type: 'Author',
     },
     'event.thread': {
-      description: 'The thread containing the card.',
-      type: 'Thread',
+      description: 'The thread containing the card, or null for view-based actions.',
+      type: 'Thread | null',
     },
     'event.triggerId': {
       description: 'Trigger ID for opening modals (platform-specific, may expire quickly).',
@@ -301,7 +303,7 @@ Return an array of `OptionsLoadGroup` (`{ label, options }[]`) instead of a flat
 
 ### onSlashCommand
 
-Fires when a user invokes a `/command` in the message composer. Currently supported on Slack.
+Fires when a user invokes a `/command` in the message composer. Currently supported on Slack and Discord.
 
 ```typescript
 // Specific command

--- a/apps/docs/content/docs/api/meta.json
+++ b/apps/docs/content/docs/api/meta.json
@@ -6,6 +6,7 @@
     "thread",
     "channel",
     "message",
+    "to-ai-messages",
     "postable-message",
     "transcripts",
     "cards",

--- a/apps/docs/content/docs/api/postable-message.mdx
+++ b/apps/docs/content/docs/api/postable-message.mdx
@@ -180,7 +180,7 @@ await thread.post(planned);
       type: 'unknown[] | undefined',
     },
     updateIntervalMs: {
-      description: 'Fallback adapters: minimum interval between post+edit cycles in ms.',
+      description: 'Post+edit adapters: minimum interval between update cycles in ms.',
       type: 'number | undefined',
       default: '500',
     },

--- a/apps/docs/content/docs/direct-messages.mdx
+++ b/apps/docs/content/docs/direct-messages.mdx
@@ -6,7 +6,7 @@ prerequisites:
   - /docs/usage
 ---
 
-Open direct message conversations with users using `bot.openDM()`. The adapter is automatically inferred from the user ID format.
+Open direct message conversations with users using `bot.openDM()`. For globally recognizable user IDs, the adapter is automatically inferred from the ID format.
 
 ## DM behavior
 
@@ -40,10 +40,19 @@ const dmThread = await bot.openDM("U1234567890"); // Slack
 
 | Format | Platform |
 |--------|----------|
-| `U...` | Slack |
+| `U...` / `W...` | Slack |
 | `29:...` | Teams |
 | `users/...` | Google Chat |
-| Snowflake (numeric) | Discord |
+| Numeric ID | Discord or Telegram |
+
+<Callout type="info">
+  Numeric IDs can be ambiguous when multiple numeric-ID adapters are registered. For platforms whose user IDs are not globally distinguishable, call the adapter directly and wrap the returned thread ID with `bot.thread()`.
+</Callout>
+
+```typescript title="lib/bot.ts"
+const threadId = await bot.getAdapter("whatsapp").openDM("15551234567");
+const dmThread = bot.thread(threadId);
+```
 
 ## Check if a thread is a DM
 

--- a/apps/docs/content/docs/index.mdx
+++ b/apps/docs/content/docs/index.mdx
@@ -52,7 +52,7 @@ Each adapter factory auto-detects credentials from environment variables (`SLACK
 | Platform | Package | Mentions | Reactions | Cards | Modals | Streaming | DMs |
 |----------|---------|----------|-----------|-------|--------|-----------|-----|
 | Slack | `@chat-adapter/slack` | Yes | Yes | Yes | Yes | Native | Yes |
-| Microsoft Teams | `@chat-adapter/teams` | Yes | Read-only | Yes | Yes | Native (DMs) / Post+Edit | Yes |
+| Microsoft Teams | `@chat-adapter/teams` | Yes | Read-only | Yes | Yes | Native (DMs) / Buffered | Yes |
 | Google Chat | `@chat-adapter/gchat` | Yes | Yes | Yes | No | Post+Edit | Yes |
 | Discord | `@chat-adapter/discord` | Yes | Yes | Yes | No | Post+Edit | Yes |
 | Telegram | `@chat-adapter/telegram` | Yes | Yes | Partial | No | Post+Edit | Yes |

--- a/apps/docs/content/docs/index.mdx
+++ b/apps/docs/content/docs/index.mdx
@@ -4,7 +4,7 @@ description: A unified SDK for building chat bots across Slack, Microsoft Teams,
 type: overview
 ---
 
-Chat SDK is a TypeScript library for building chat bots that work across multiple platforms with a single codebase. Write your bot logic once and deploy it to Slack, Microsoft Teams, Google Chat, Discord, Telegram, GitHub, Linear, and WhatsApp.
+Chat SDK is a TypeScript library for building chat bots that work across multiple platforms with a single codebase. Write your bot logic once and deploy it to Slack, Microsoft Teams, Google Chat, Discord, Telegram, GitHub, Linear, WhatsApp, and Messenger.
 
 ## Why Chat SDK?
 
@@ -52,13 +52,14 @@ Each adapter factory auto-detects credentials from environment variables (`SLACK
 | Platform | Package | Mentions | Reactions | Cards | Modals | Streaming | DMs |
 |----------|---------|----------|-----------|-------|--------|-----------|-----|
 | Slack | `@chat-adapter/slack` | Yes | Yes | Yes | Yes | Native | Yes |
-| Microsoft Teams | `@chat-adapter/teams` | Yes | Read-only | Yes | No | Native (DMs) / Post+Edit | Yes |
+| Microsoft Teams | `@chat-adapter/teams` | Yes | Read-only | Yes | Yes | Native (DMs) / Post+Edit | Yes |
 | Google Chat | `@chat-adapter/gchat` | Yes | Yes | Yes | No | Post+Edit | Yes |
 | Discord | `@chat-adapter/discord` | Yes | Yes | Yes | No | Post+Edit | Yes |
 | Telegram | `@chat-adapter/telegram` | Yes | Yes | Partial | No | Post+Edit | Yes |
-| GitHub | `@chat-adapter/github` | Yes | Yes | No | No | No | No |
-| Linear | `@chat-adapter/linear` | Yes | Yes | No | No | No | No |
-| WhatsApp | `@chat-adapter/whatsapp` | N/A | Yes | Partial | No | No | Yes |
+| GitHub | `@chat-adapter/github` | Yes | Yes | No | No | Buffered | No |
+| Linear | `@chat-adapter/linear` | Yes | Yes | No | No | Agent sessions / Post+Edit | No |
+| WhatsApp | `@chat-adapter/whatsapp` | N/A | Yes | Partial | No | Buffered | Yes |
+| Messenger | `@chat-adapter/messenger` | Yes | Receive-only | Partial | No | Buffered | Yes |
 
 ## AI coding agent support
 
@@ -85,6 +86,7 @@ The SDK is distributed as a set of packages you install based on your needs:
 | `@chat-adapter/github` | GitHub Issues adapter |
 | `@chat-adapter/linear` | Linear Issues adapter |
 | `@chat-adapter/whatsapp` | WhatsApp Business adapter |
+| `@chat-adapter/messenger` | Facebook Messenger adapter |
 | `@chat-adapter/state-redis` | Redis state adapter (production) |
 | `@chat-adapter/state-ioredis` | ioredis state adapter (alternative) |
 | `@chat-adapter/state-pg` | PostgreSQL state adapter (production) |

--- a/apps/docs/content/docs/posting-messages.mdx
+++ b/apps/docs/content/docs/posting-messages.mdx
@@ -139,7 +139,7 @@ See the [Cards](/docs/cards) page for the full list of card components.
 
 ## Streaming
 
-Pass an AI SDK stream to `thread.post()` to stream a message in real time. The SDK uses platform-native streaming where available and falls back to post-then-edit on other platforms.
+Pass an AI SDK stream to `thread.post()` to stream a message in real time. The SDK uses platform-native streaming where available and falls back to post-then-edit or buffered delivery depending on the platform.
 
 ```typescript title="lib/bot.ts" lineNumbers
 import { ToolLoopAgent } from "ai";

--- a/apps/docs/content/docs/streaming.mdx
+++ b/apps/docs/content/docs/streaming.mdx
@@ -6,7 +6,7 @@ prerequisites:
   - /docs/usage
 ---
 
-Chat SDK accepts any `AsyncIterable<string>` as a message, enabling real-time streaming of AI responses and other incremental content to chat platforms. For platforms with native streaming support (Slack), you can also stream structured `StreamChunk` objects for rich content like task progress cards and plan updates.
+Chat SDK accepts any `AsyncIterable<string>` as a message, enabling real-time streaming of AI responses and other incremental content to chat platforms. For platforms with native or structured streaming support, you can also stream `StreamChunk` objects for rich content like task progress cards and plan updates.
 
 ## AI SDK integration
 
@@ -59,10 +59,14 @@ await thread.post(stream);
 | Platform | Method | Description |
 |----------|--------|-------------|
 | Slack | Native streaming API | Uses Slack's `chatStream` for smooth, real-time updates |
-| Teams | Native (DMs) / Post + Edit (group chats) | Uses the Teams SDK's native `stream.emit()` for direct messages; falls back to post+edit in group chats |
+| Teams | Native (DMs) / Buffered (group chats) | Uses the Teams SDK's native `stream.emit()` for direct messages; accumulates chunks and posts one final message when no native streamer is active |
 | Google Chat | Post + Edit | Posts a message then edits it as chunks arrive |
 | Discord | Post + Edit | Posts a message then edits it as chunks arrive |
 | Telegram | Post + Edit | Posts a message then edits it as chunks arrive |
+| GitHub | Buffered | Accumulates chunks and posts one final comment |
+| Linear | Agent sessions / Post + Edit | Uses agent session activities in agent-session threads; falls back to post+edit comments in issue threads |
+| WhatsApp | Buffered | Accumulates chunks and sends one final message |
+| Messenger | Buffered | Accumulates chunks and sends one final message |
 
 The post+edit fallback throttles edits to avoid rate limits. Configure the update interval when creating your `Chat` instance:
 
@@ -105,9 +109,9 @@ When streaming content that contains GFM tables (e.g. from an LLM), the SDK auto
 
 This happens transparently — no configuration needed.
 
-## Structured streaming chunks (Slack only)
+## Structured streaming chunks
 
-For Slack's native streaming API, you can yield `StreamChunk` objects alongside plain text for rich content:
+For Slack native streams and Linear agent-session streams, you can yield `StreamChunk` objects alongside plain text for rich progress updates:
 
 ```typescript title="lib/bot.ts" lineNumbers
 import type { StreamChunk } from "chat";
@@ -145,8 +149,8 @@ await thread.post(stream);
 | Type | Fields | Description |
 |------|--------|-------------|
 | `markdown_text` | `text` | Streamed text content |
-| `task_update` | `id`, `title`, `status`, `details?`, `output?` | Tool/step progress cards (`pending`, `in_progress`, `complete`, `error`) with optional extra task context |
-| `plan_update` | `title` | Plan title updates |
+| `task_update` | `id`, `title`, `status`, `details?`, `output?` | Tool/step progress updates (`pending`, `in_progress`, `complete`, `error`) with optional extra task context |
+| `plan_update` | `title` | Plan title updates on supported platforms |
 
 ### Streaming with options
 
@@ -158,7 +162,7 @@ import { StreamingPlan } from "chat";
 const planned = new StreamingPlan(stream, {
   groupTasks: "plan",         // Slack: render task cards as a single grouped block
   endWith: [feedbackBlock],   // Slack: Block Kit elements appended after stream stops
-  updateIntervalMs: 750,      // Fallback mode: post+edit cadence on non-native adapters
+  updateIntervalMs: 750,      // Post+edit cadence on supported adapters
 });
 
 await thread.post(planned);
@@ -168,7 +172,7 @@ await thread.post(planned);
 |--------|----------|-------------|
 | `groupTasks` | Slack | `"timeline"` (default) renders task cards inline; `"plan"` groups them into one plan block |
 | `endWith` | Slack | Block Kit elements attached when the stream stops (e.g. retry / feedback buttons) |
-| `updateIntervalMs` | Fallback adapters (Teams, Google Chat, Telegram) | Minimum interval between post+edit cycles in ms (default `500`) |
+| `updateIntervalMs` | Post+edit adapters | Minimum interval between post+edit cycles in ms (default `500`) |
 
 Adapters without structured chunk support extract text from `markdown_text` chunks and ignore other types. Slack-only options are silently ignored on other platforms.
 

--- a/apps/docs/content/docs/threads-messages-channels.mdx
+++ b/apps/docs/content/docs/threads-messages-channels.mdx
@@ -20,7 +20,7 @@ const thread = bot.thread("slack:C123ABC:1234567890.123456");
 await thread.post("Reminder from a cron job");
 ```
 
-For DM-style conversations, use [`bot.openDM(adapter, userId)`](/docs/direct-messages) instead — it resolves the right channel and thread on each platform.
+For DM-style conversations, use [`bot.openDM(userIdOrAuthor)`](/docs/direct-messages) instead. It resolves the right channel and thread for user ID formats the SDK can infer.
 
 ### Post a message
 

--- a/apps/docs/content/docs/usage.mdx
+++ b/apps/docs/content/docs/usage.mdx
@@ -34,7 +34,7 @@ bot.onNewMention(async (thread) => {
 ```
 
 <Callout type="info">
-  This example uses Redis. Chat SDK also supports [PostgreSQL](/docs/state/postgres) and [ioredis](/docs/state/ioredis) as production state adapters. See [State Adapters](/docs/state) for all options.
+  This example uses Redis. Chat SDK also supports [PostgreSQL](/adapters/postgres) and [ioredis](/adapters/ioredis) as production state adapters. See [State Adapters](/docs/state) for all options.
 </Callout>
 
 Each adapter factory auto-detects credentials from environment variables (`SLACK_BOT_TOKEN`, `SLACK_SIGNING_SECRET`, `REDIS_URL`, etc.), so you can get started with zero config. Pass explicit values to override.
@@ -148,7 +148,7 @@ const bot = Chat.getSingleton();
 Open a DM thread with a user by passing their platform user ID or an `Author` object:
 
 ```typescript title="lib/bot.ts" lineNumbers
-const dm = await bot.openDM("slack:U123ABC");
+const dm = await bot.openDM("U123ABC");
 await dm.post("Hey! Just wanted to follow up on your request.");
 ```
 

--- a/packages/adapter-discord/README.md
+++ b/packages/adapter-discord/README.md
@@ -102,7 +102,9 @@ export async function GET(request: Request): Promise<Response> {
 
   await bot.initialize();
 
-  return bot.adapters.discord.startGatewayListener(
+  const discord = bot.getAdapter("discord");
+
+  return discord.startGatewayListener(
     { waitUntil: (task) => after(() => task) },
     durationMs,
     undefined,

--- a/packages/adapter-github/README.md
+++ b/packages/adapter-github/README.md
@@ -230,7 +230,7 @@ GITHUB_API_URL=https://github.example.com/api/v3
 | Edit message | Yes |
 | Delete message | Yes |
 | File uploads | No |
-| Streaming | No |
+| Streaming | Buffered (accumulates then sends) |
 
 ### Rich content
 

--- a/packages/adapter-linear/README.md
+++ b/packages/adapter-linear/README.md
@@ -286,7 +286,7 @@ LINEAR_API_URL=...
 | Edit message | Partial |
 | Delete message | Partial |
 | File uploads | No |
-| Streaming | Agent sessions only |
+| Streaming | Agent sessions / Post+Edit fallback |
 
 ### Rich content
 

--- a/packages/adapter-messenger/README.md
+++ b/packages/adapter-messenger/README.md
@@ -98,11 +98,11 @@ Messenger uses two webhook mechanisms:
 import { bot } from "@/lib/bot";
 
 export async function GET(request: Request) {
-  return bot.adapters.messenger.handleWebhook(request);
+  return bot.webhooks.messenger(request);
 }
 
 export async function POST(request: Request) {
-  return bot.adapters.messenger.handleWebhook(request);
+  return bot.webhooks.messenger(request);
 }
 ```
 

--- a/packages/adapter-teams/README.md
+++ b/packages/adapter-teams/README.md
@@ -148,7 +148,7 @@ TEAMS_API_URL=...        # Optional, for GCC-High or sovereign-cloud deployments
 | Edit message | Yes |
 | Delete message | Yes |
 | File uploads | Yes |
-| Streaming | Native (DMs) / Post+Edit fallback (group chats) |
+| Streaming | Native (DMs) / Buffered fallback (group chats) |
 
 ### Rich content
 

--- a/packages/adapter-teams/src/index.ts
+++ b/packages/adapter-teams/src/index.ts
@@ -1172,7 +1172,7 @@ export class TeamsAdapter implements Adapter<TeamsThreadId, unknown> {
 
   /**
    * Stream responses using the Teams SDK's native streaming protocol when
-   * an active IStreamer exists (DMs), falling back to post+edit otherwise.
+   * an active IStreamer exists (DMs), falling back to a buffered final message otherwise.
    */
   async stream(
     threadId: string,

--- a/packages/adapter-whatsapp/README.md
+++ b/packages/adapter-whatsapp/README.md
@@ -97,11 +97,11 @@ WhatsApp uses two webhook mechanisms:
 import { bot } from "@/lib/bot";
 
 export async function GET(request: Request) {
-  return bot.adapters.whatsapp.handleWebhook(request);
+  return bot.webhooks.whatsapp(request);
 }
 
 export async function POST(request: Request) {
-  return bot.adapters.whatsapp.handleWebhook(request);
+  return bot.webhooks.whatsapp(request);
 }
 ```
 

--- a/packages/chat/src/streaming-plan.ts
+++ b/packages/chat/src/streaming-plan.ts
@@ -19,7 +19,7 @@ export interface StreamingPlanOptions {
   groupTasks?: "plan" | "timeline";
   /**
    * Minimum interval between updates in ms (default: 500).
-   * Used for fallback mode (post+edit on adapters without native streaming).
+   * Used by post+edit streaming paths.
    */
   updateIntervalMs?: number;
 }

--- a/packages/chat/src/thread.ts
+++ b/packages/chat/src/thread.ts
@@ -595,7 +595,7 @@ export class ThreadImpl<TState = Record<string, unknown>>
   /**
    * Handle streaming from an AsyncIterable.
    * Normalizes the stream (supports both textStream and fullStream from AI SDK),
-   * then uses adapter's native streaming if available, otherwise falls back to post+edit.
+   * then uses the adapter's stream implementation if available, otherwise falls back to post+edit.
    */
   private async handleStream(
     rawStream: AsyncIterable<string | StreamChunk | StreamEvent>,
@@ -615,7 +615,7 @@ export class ThreadImpl<TState = Record<string, unknown>>
       );
     }
 
-    // Use native streaming if adapter supports it
+    // Use adapter-provided streaming if available.
     if (this.adapter.stream) {
       // Wrap stream to collect accumulated text while passing through to adapter.
       // StreamChunk objects are passed through; only plain strings are accumulated.

--- a/packages/chat/src/types.ts
+++ b/packages/chat/src/types.ts
@@ -1560,12 +1560,12 @@ export type PostableMessage =
 /**
  * Duck-typed stream event compatible with AI SDK's `fullStream`.
  * - `text-delta` events are extracted as text output.
- * - `step-finish` events trigger paragraph separators between steps.
+ * - `finish-step` events trigger paragraph separators between steps.
  * - All other event types (tool-call, tool-result, etc.) are silently skipped.
  */
 export type StreamEvent =
   | { textDelta: string; type: "text-delta" }
-  | { type: "step-finish" }
+  | { type: "finish-step" }
   | { type: string };
 
 export interface PostableRaw {


### PR DESCRIPTION
## summary

fix documentation inaccuracies across guides, API reference, and adapter READMEs

- fix `bot.openDM("slack:U123ABC")` to `bot.openDM("U123ABC")` (adapter infers from raw ID)
- fix `bot.openDM(adapter, userId)` to `bot.openDM(userIdOrAuthor)`
- fix `bot.adapters.messenger.handleWebhook()` to `bot.webhooks.messenger()` in Messenger/WhatsApp READMEs
- fix `bot.adapters.discord` to `bot.getAdapter("discord")` in Discord README
- fix `ActionEvent.thread` type from `Thread` to `Thread | null` with null guard in example
- fix modals support: "Slack only" to "Slack and Teams" in actions and homepage docs
- fix slash commands: "Slack only" to "Slack and Discord" in API reference
- fix `StreamEvent` type from `step-finish` to `finish-step` (matches AI SDK and implementation)
- add Messenger to homepage platform list and package table
- add `to-ai-messages` to API sidebar meta.json
- fix broken `/docs/state/postgres` and `/docs/state/ioredis` links to `/adapters/postgres` and `/adapters/ioredis`
- add numeric ID ambiguity callout and `bot.thread()` example to DM docs
- update adapter matrix: WhatsApp edit/delete as unsupported, streaming labels (Buffered/Agent sessions), Slack typing as supported, Linear edit/delete as Partial, Messenger support row
- update GitHub/Linear/WhatsApp/Messenger README feature tables