### PR TITLE
[slack] add support for external installation providers for bot token management

### DIFF
--- a/.changeset/rich-humans-speak.md
+++ b/.changeset/rich-humans-speak.md
@@ -1,0 +1,5 @@
+---
+"@chat-adapter/slack": minor
+---
+
+Adding support for custom installation providers

--- a/.changeset/rich-humans-speak.md
+++ b/.changeset/rich-humans-speak.md
@@ -2,4 +2,7 @@
 "@chat-adapter/slack": minor
 ---
 
-Adding support for custom installation providers
+Add support for external `installationProvider` and Enterprise Grid org-wide installs.
+
+- New optional `installationProvider` config: `{ getInstallation(installationId, isEnterpriseInstall) => Promise<SlackInstallation | null> }`. When set, the adapter resolves bot tokens for incoming events, slash commands, and interactive payloads through the provider instead of the internal `StateAdapter` — useful for hosted token-management systems (e.g. Vercel Connect). The provider is read-only; OAuth callback writes (`setInstallation`, `handleOAuthCallback`) and the `getInstallation`/`deleteInstallation` public methods continue to use internal state, so callers using a provider should manage their own writes.
+- Enterprise Grid org-wide installs (`is_enterprise_install: true`) are now keyed on `enterprise_id` instead of `team_id` across event_callback, slash command, and interactive payload paths. Multi-workspace deployments using the internal `StateAdapter` for org-wide installs must repopulate installations under the `enterprise_id` key — previously, org-wide events would fall through to a `team_id` lookup that did not match what the OAuth flow had stored.

--- a/packages/adapter-slack/README.md
+++ b/packages/adapter-slack/README.md
@@ -62,7 +62,7 @@ If both `signingSecret` and `webhookVerifier` are set, `signingSecret` wins. Whe
 
 ## Multi-workspace mode
 
-For apps installed across multiple Slack workspaces via OAuth, omit `botToken` and provide OAuth credentials instead. The adapter resolves tokens dynamically from your state adapter using the `team_id` from incoming webhooks.
+For apps installed across multiple Slack workspaces via OAuth, omit `botToken` and provide OAuth credentials instead. The adapter resolves tokens dynamically from your state adapter using the `team_id` from incoming webhooks — or `enterprise_id` for Enterprise Grid org-wide installs (`is_enterprise_install: true`).
 
 When you pass any auth-related config (like `clientId`), the adapter won't fall back to env vars for other auth fields, preventing accidental mixing of auth modes.
 
@@ -130,6 +130,26 @@ openssl rand -base64 32
 ```
 
 When `encryptionKey` is set, `setInstallation()` encrypts the token before storing and `getInstallation()` decrypts it transparently.
+
+### External installation provider
+
+For deployments that manage Slack tokens in an external system (e.g. Vercel Connect), pass `installationProvider` to bypass the internal state adapter when resolving tokens for incoming webhooks:
+
+```typescript
+createSlackAdapter({
+  clientId: process.env.SLACK_CLIENT_ID!,
+  clientSecret: process.env.SLACK_CLIENT_SECRET!,
+  installationProvider: {
+    getInstallation: async (installationId, isEnterpriseInstall) => {
+      // installationId is enterprise_id when isEnterpriseInstall is true,
+      // otherwise team_id. Return null if not found.
+      return await myTokenStore.lookup(installationId, isEnterpriseInstall);
+    },
+  },
+});
+```
+
+When configured, the provider's `getInstallation` is called for every webhook event, slash command, and interactive payload. It is read-only — the adapter's `setInstallation`, `deleteInstallation`, and `handleOAuthCallback` continue to write to the internal state adapter, so callers using a provider should manage their own writes through their external system.
 
 ## Socket mode
 
@@ -304,7 +324,8 @@ All options are auto-detected from environment variables when not provided. You 
 | `clientId` | No | App client ID for multi-workspace OAuth. Auto-detected from `SLACK_CLIENT_ID` |
 | `clientSecret` | No | App client secret for multi-workspace OAuth. Auto-detected from `SLACK_CLIENT_SECRET` |
 | `encryptionKey` | No | AES-256-GCM key for encrypting stored tokens. Auto-detected from `SLACK_ENCRYPTION_KEY` |
-| `installationKeyPrefix` | No | Prefix for the state key used to store workspace installations. Defaults to `slack:installation`. The full key is `{prefix}:{teamId}` |
+| `installationKeyPrefix` | No | Prefix for the state key used to store workspace installations. Defaults to `slack:installation`. The full key is `{prefix}:{teamId}` (or `{prefix}:{enterpriseId}` for Enterprise Grid org-wide installs) |
+| `installationProvider` | No | External installation lookup `{ getInstallation(installationId, isEnterpriseInstall) => Promise<SlackInstallation \| null> }`. When set, bypasses the internal state adapter for token resolution on incoming webhooks. Read-only — manage your own writes externally |
 | `apiUrl` | No | Override the Slack Web API base URL (e.g. for GovSlack or a self-hosted gateway). Auto-detected from `SLACK_API_URL` |
 | `logger` | No | Logger instance (defaults to `ConsoleLogger("info")`) |
 

--- a/packages/adapter-slack/src/index.test.ts
+++ b/packages/adapter-slack/src/index.test.ts
@@ -2173,6 +2173,214 @@ describe("installationProvider", () => {
       true
     );
   });
+
+  it("rehydrateAttachment uses installationProvider for token resolution", async () => {
+    const mockProvider = {
+      getInstallation: vi.fn().mockResolvedValue({
+        botToken: "xoxb-rehydrate-token",
+        botUserId: "U_BOT_REHYDRATE",
+      }),
+    };
+
+    const state = createMockState();
+    const chatInstance = createMockChatInstance(state);
+    const adapter = createSlackAdapter({
+      signingSecret: secret,
+      logger: mockLogger,
+      installationProvider: mockProvider,
+    });
+    await adapter.initialize(chatInstance);
+
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(new ArrayBuffer(8), {
+        status: 200,
+        headers: { "content-type": "application/octet-stream" },
+      })
+    );
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = fetchMock as unknown as typeof globalThis.fetch;
+
+    try {
+      const rehydrated = adapter.rehydrateAttachment({
+        type: "image",
+        url: "https://files.slack.com/img.png",
+        fetchMetadata: {
+          url: "https://files.slack.com/img.png",
+          teamId: "T_REHYDRATE",
+        },
+      });
+
+      expect(rehydrated.fetchData).toBeDefined();
+      await rehydrated.fetchData?.();
+
+      expect(mockProvider.getInstallation).toHaveBeenCalledWith(
+        "T_REHYDRATE",
+        false
+      );
+      expect(fetchMock).toHaveBeenCalledWith(
+        "https://files.slack.com/img.png",
+        expect.objectContaining({
+          headers: { Authorization: "Bearer xoxb-rehydrate-token" },
+        })
+      );
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  it("rehydrateAttachment uses enterprise_id when isEnterpriseInstall is true", async () => {
+    const mockProvider = {
+      getInstallation: vi.fn().mockResolvedValue({
+        botToken: "xoxb-ent-rehydrate-token",
+        botUserId: "U_BOT_ENT_REHYDRATE",
+      }),
+    };
+
+    const state = createMockState();
+    const chatInstance = createMockChatInstance(state);
+    const adapter = createSlackAdapter({
+      signingSecret: secret,
+      logger: mockLogger,
+      installationProvider: mockProvider,
+    });
+    await adapter.initialize(chatInstance);
+
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(new ArrayBuffer(8), {
+        status: 200,
+        headers: { "content-type": "application/octet-stream" },
+      })
+    );
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = fetchMock as unknown as typeof globalThis.fetch;
+
+    try {
+      const rehydrated = adapter.rehydrateAttachment({
+        type: "image",
+        url: "https://files.slack.com/img.png",
+        fetchMetadata: {
+          url: "https://files.slack.com/img.png",
+          teamId: "T_WORKSPACE",
+          enterpriseId: "E_ORG",
+          isEnterpriseInstall: "true",
+        },
+      });
+
+      await rehydrated.fetchData?.();
+
+      expect(mockProvider.getInstallation).toHaveBeenCalledWith("E_ORG", true);
+      expect(fetchMock).toHaveBeenCalledWith(
+        "https://files.slack.com/img.png",
+        expect.objectContaining({
+          headers: { Authorization: "Bearer xoxb-ent-rehydrate-token" },
+        })
+      );
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  it("rehydrateAttachment throws when installationProvider returns null", async () => {
+    const mockProvider = {
+      getInstallation: vi.fn().mockResolvedValue(null),
+    };
+
+    const state = createMockState();
+    const chatInstance = createMockChatInstance(state);
+    const adapter = createSlackAdapter({
+      signingSecret: secret,
+      logger: mockLogger,
+      installationProvider: mockProvider,
+    });
+    await adapter.initialize(chatInstance);
+
+    const rehydrated = adapter.rehydrateAttachment({
+      type: "image",
+      url: "https://files.slack.com/img.png",
+      fetchMetadata: {
+        url: "https://files.slack.com/img.png",
+        teamId: "T_MISSING",
+      },
+    });
+
+    await expect(rehydrated.fetchData?.()).rejects.toThrow(
+      "Installation not found for team T_MISSING"
+    );
+    expect(mockProvider.getInstallation).toHaveBeenCalledWith(
+      "T_MISSING",
+      false
+    );
+  });
+
+  it("event_callback with file attachment captures Enterprise Grid metadata", async () => {
+    const mockProvider = {
+      getInstallation: vi.fn().mockResolvedValue({
+        botToken: "xoxb-ent-event-token",
+        botUserId: "U_BOT_ENT_EVENT",
+      }),
+    };
+
+    const state = createMockState();
+    const chatInstance = createMockChatInstance(state);
+
+    // Invoke the factory while still inside the AsyncLocalStorage frame so
+    // createAttachment can read the per-request enterprise context. The
+    // capture happens during processMessage, before run() returns.
+    let dispatched:
+      | { attachments?: Array<{ fetchMetadata?: Record<string, string> }> }
+      | undefined;
+    (
+      chatInstance.processMessage as ReturnType<typeof vi.fn>
+    ).mockImplementation(async (_adapter, _threadId, factory) => {
+      dispatched = await factory();
+    });
+
+    const adapter = createSlackAdapter({
+      signingSecret: secret,
+      logger: mockLogger,
+      installationProvider: mockProvider,
+    });
+    await adapter.initialize(chatInstance);
+
+    const body = JSON.stringify({
+      type: "event_callback",
+      team_id: "T_ENT_WORKSPACE",
+      enterprise_id: "E_ENT_FILE_ORG",
+      is_enterprise_install: true,
+      event: {
+        type: "message",
+        channel: "C_TEST",
+        user: "U_USER",
+        // username present so parseSlackMessage skips the user-lookup API call
+        username: "testuser",
+        text: "with file",
+        ts: "1234567890.123456",
+        files: [
+          {
+            id: "F1",
+            mimetype: "image/png",
+            url_private: "https://files.slack.com/captured.png",
+            name: "captured.png",
+          },
+        ],
+      },
+    });
+
+    const request = createWebhookRequest(body, secret);
+    await adapter.handleWebhook(request);
+    // Let the queued processMessage Promise settle.
+    await new Promise((resolve) => setImmediate(resolve));
+
+    const attachment = dispatched?.attachments?.[0];
+    expect(attachment?.fetchMetadata).toEqual(
+      expect.objectContaining({
+        url: "https://files.slack.com/captured.png",
+        teamId: "T_ENT_WORKSPACE",
+        enterpriseId: "E_ENT_FILE_ORG",
+        isEnterpriseInstall: "true",
+      })
+    );
+  });
 });
 
 // ============================================================================

--- a/packages/adapter-slack/src/index.test.ts
+++ b/packages/adapter-slack/src/index.test.ts
@@ -2083,6 +2083,96 @@ describe("installationProvider", () => {
     // Event should not be processed because provider returned null
     expect(chatInstance.handleIncomingMessage).not.toHaveBeenCalled();
   });
+
+  it("uses installationProvider for interactive payloads (block_actions)", async () => {
+    const mockProvider = {
+      getInstallation: vi.fn().mockResolvedValue({
+        botToken: "xoxb-interactive-token",
+        botUserId: "U_BOT_INTER",
+      }),
+    };
+
+    const state = createMockState();
+    const chatInstance = createMockChatInstance(state);
+    const adapter = createSlackAdapter({
+      signingSecret: secret,
+      logger: mockLogger,
+      installationProvider: mockProvider,
+    });
+    await adapter.initialize(chatInstance);
+
+    const payload = JSON.stringify({
+      type: "block_actions",
+      team: { id: "T_INTER_PROVIDER" },
+      user: { id: "U123", username: "testuser", name: "Test User" },
+      container: {
+        type: "message",
+        message_ts: "1234567890.123456",
+        channel_id: "C_INTER",
+      },
+      channel: { id: "C_INTER", name: "general" },
+      message: { ts: "1234567890.123456" },
+      actions: [{ type: "button", action_id: "test_action", value: "v" }],
+    });
+    const body = `payload=${encodeURIComponent(payload)}`;
+    const request = createWebhookRequest(body, secret, {
+      contentType: "application/x-www-form-urlencoded",
+    });
+
+    const response = await adapter.handleWebhook(request);
+
+    expect(response.status).toBe(200);
+    expect(mockProvider.getInstallation).toHaveBeenCalledWith(
+      "T_INTER_PROVIDER",
+      false
+    );
+  });
+
+  it("uses enterprise_id for interactive payloads in Enterprise Grid", async () => {
+    const mockProvider = {
+      getInstallation: vi.fn().mockResolvedValue({
+        botToken: "xoxb-ent-interactive-token",
+        botUserId: "U_BOT_ENT_INTER",
+      }),
+    };
+
+    const state = createMockState();
+    const chatInstance = createMockChatInstance(state);
+    const adapter = createSlackAdapter({
+      signingSecret: secret,
+      logger: mockLogger,
+      installationProvider: mockProvider,
+    });
+    await adapter.initialize(chatInstance);
+
+    const payload = JSON.stringify({
+      type: "block_actions",
+      team: { id: "T_ENT_INTER_WORKSPACE" },
+      enterprise: { id: "E_ENT_INTER_ORG" },
+      is_enterprise_install: true,
+      user: { id: "U123", username: "testuser", name: "Test User" },
+      container: {
+        type: "message",
+        message_ts: "1234567890.123456",
+        channel_id: "C_ENT_INTER",
+      },
+      channel: { id: "C_ENT_INTER", name: "general" },
+      message: { ts: "1234567890.123456" },
+      actions: [{ type: "button", action_id: "test_action", value: "v" }],
+    });
+    const body = `payload=${encodeURIComponent(payload)}`;
+    const request = createWebhookRequest(body, secret, {
+      contentType: "application/x-www-form-urlencoded",
+    });
+
+    const response = await adapter.handleWebhook(request);
+
+    expect(response.status).toBe(200);
+    expect(mockProvider.getInstallation).toHaveBeenCalledWith(
+      "E_ENT_INTER_ORG",
+      true
+    );
+  });
 });
 
 // ============================================================================

--- a/packages/adapter-slack/src/index.test.ts
+++ b/packages/adapter-slack/src/index.test.ts
@@ -1787,6 +1787,305 @@ describe("multi-workspace mode", () => {
 });
 
 // ============================================================================
+// External Installation Provider Tests
+// ============================================================================
+
+describe("installationProvider", () => {
+  const secret = "test-signing-secret";
+
+  it("uses installationProvider for token resolution in event_callback", async () => {
+    const mockProvider = {
+      getInstallation: vi.fn().mockResolvedValue({
+        botToken: "xoxb-external-token",
+        botUserId: "U_BOT_EXT",
+      }),
+    };
+
+    const state = createMockState();
+    const chatInstance = createMockChatInstance(state);
+    const adapter = createSlackAdapter({
+      signingSecret: secret,
+      logger: mockLogger,
+      installationProvider: mockProvider,
+    });
+    await adapter.initialize(chatInstance);
+
+    const body = JSON.stringify({
+      type: "event_callback",
+      team_id: "T_EXTERNAL_1",
+      event: {
+        type: "message",
+        channel: "C_TEST",
+        user: "U_USER",
+        text: "hello",
+        ts: "1234567890.123456",
+      },
+    });
+
+    const request = createWebhookRequest(body, secret);
+    const response = await adapter.handleWebhook(request);
+
+    expect(response.status).toBe(200);
+    expect(mockProvider.getInstallation).toHaveBeenCalledWith(
+      "T_EXTERNAL_1",
+      false
+    );
+  });
+
+  it("uses enterprise_id when is_enterprise_install is true", async () => {
+    const mockProvider = {
+      getInstallation: vi.fn().mockResolvedValue({
+        botToken: "xoxb-enterprise-token",
+        botUserId: "U_BOT_ENT",
+      }),
+    };
+
+    const state = createMockState();
+    const chatInstance = createMockChatInstance(state);
+    const adapter = createSlackAdapter({
+      signingSecret: secret,
+      logger: mockLogger,
+      installationProvider: mockProvider,
+    });
+    await adapter.initialize(chatInstance);
+
+    const body = JSON.stringify({
+      type: "event_callback",
+      team_id: "T_WORKSPACE_1",
+      enterprise_id: "E_ENTERPRISE_1",
+      is_enterprise_install: true,
+      event: {
+        type: "message",
+        channel: "C_TEST",
+        user: "U_USER",
+        text: "hello from enterprise",
+        ts: "1234567890.123456",
+      },
+    });
+
+    const request = createWebhookRequest(body, secret);
+    const response = await adapter.handleWebhook(request);
+
+    expect(response.status).toBe(200);
+    expect(mockProvider.getInstallation).toHaveBeenCalledWith(
+      "E_ENTERPRISE_1",
+      true
+    );
+  });
+
+  it("uses team_id when is_enterprise_install is false", async () => {
+    const mockProvider = {
+      getInstallation: vi.fn().mockResolvedValue({
+        botToken: "xoxb-team-token",
+        botUserId: "U_BOT_TEAM",
+      }),
+    };
+
+    const state = createMockState();
+    const chatInstance = createMockChatInstance(state);
+    const adapter = createSlackAdapter({
+      signingSecret: secret,
+      logger: mockLogger,
+      installationProvider: mockProvider,
+    });
+    await adapter.initialize(chatInstance);
+
+    const body = JSON.stringify({
+      type: "event_callback",
+      team_id: "T_TEAM_ONLY",
+      enterprise_id: "E_SHOULD_IGNORE",
+      is_enterprise_install: false,
+      event: {
+        type: "message",
+        channel: "C_TEST",
+        user: "U_USER",
+        text: "hello",
+        ts: "1234567890.123456",
+      },
+    });
+
+    const request = createWebhookRequest(body, secret);
+    await adapter.handleWebhook(request);
+
+    expect(mockProvider.getInstallation).toHaveBeenCalledWith(
+      "T_TEAM_ONLY",
+      false
+    );
+  });
+
+  it("returns 200 ok when installationProvider returns null", async () => {
+    const mockProvider = {
+      getInstallation: vi.fn().mockResolvedValue(null),
+    };
+
+    const state = createMockState();
+    const chatInstance = createMockChatInstance(state);
+    const adapter = createSlackAdapter({
+      signingSecret: secret,
+      logger: mockLogger,
+      installationProvider: mockProvider,
+    });
+    await adapter.initialize(chatInstance);
+
+    const body = JSON.stringify({
+      type: "event_callback",
+      team_id: "T_UNKNOWN",
+      event: {
+        type: "message",
+        channel: "C_TEST",
+        user: "U_USER",
+        text: "hello",
+        ts: "1234567890.123456",
+      },
+    });
+
+    const request = createWebhookRequest(body, secret);
+    const response = await adapter.handleWebhook(request);
+
+    expect(response.status).toBe(200);
+    expect(mockProvider.getInstallation).toHaveBeenCalledWith(
+      "T_UNKNOWN",
+      false
+    );
+  });
+
+  it("uses installationProvider for slash commands", async () => {
+    const mockProvider = {
+      getInstallation: vi.fn().mockResolvedValue({
+        botToken: "xoxb-slash-token",
+        botUserId: "U_BOT_SLASH",
+      }),
+    };
+
+    const state = createMockState();
+    const chatInstance = createMockChatInstance(state);
+    const adapter = createSlackAdapter({
+      signingSecret: secret,
+      logger: mockLogger,
+      installationProvider: mockProvider,
+    });
+    await adapter.initialize(chatInstance);
+
+    mockClientMethod(
+      adapter,
+      "users.info",
+      vi.fn().mockResolvedValue({
+        ok: true,
+        user: { name: "user", profile: { display_name: "User" } },
+      })
+    );
+
+    const params = new URLSearchParams({
+      command: "/test",
+      text: "hello",
+      team_id: "T_SLASH_TEAM",
+      channel_id: "C_SLASH",
+      user_id: "U_SLASHER",
+      response_url: "https://hooks.slack.com/commands/xxx",
+    });
+
+    const request = createWebhookRequest(params.toString(), secret, {
+      contentType: "application/x-www-form-urlencoded",
+    });
+    await adapter.handleWebhook(request);
+
+    expect(mockProvider.getInstallation).toHaveBeenCalledWith(
+      "T_SLASH_TEAM",
+      false
+    );
+  });
+
+  it("uses enterprise_id for slash commands in Enterprise Grid", async () => {
+    const mockProvider = {
+      getInstallation: vi.fn().mockResolvedValue({
+        botToken: "xoxb-ent-slash-token",
+        botUserId: "U_BOT_ENT_SLASH",
+      }),
+    };
+
+    const state = createMockState();
+    const chatInstance = createMockChatInstance(state);
+    const adapter = createSlackAdapter({
+      signingSecret: secret,
+      logger: mockLogger,
+      installationProvider: mockProvider,
+    });
+    await adapter.initialize(chatInstance);
+
+    mockClientMethod(
+      adapter,
+      "users.info",
+      vi.fn().mockResolvedValue({
+        ok: true,
+        user: { name: "user", profile: { display_name: "User" } },
+      })
+    );
+
+    const params = new URLSearchParams({
+      command: "/test",
+      text: "hello",
+      team_id: "T_ENT_WORKSPACE",
+      enterprise_id: "E_ENT_ORG",
+      is_enterprise_install: "true",
+      channel_id: "C_SLASH",
+      user_id: "U_SLASHER",
+      response_url: "https://hooks.slack.com/commands/xxx",
+    });
+
+    const request = createWebhookRequest(params.toString(), secret, {
+      contentType: "application/x-www-form-urlencoded",
+    });
+    await adapter.handleWebhook(request);
+
+    expect(mockProvider.getInstallation).toHaveBeenCalledWith(
+      "E_ENT_ORG",
+      true
+    );
+  });
+
+  it("does not fall back to state when installationProvider is set", async () => {
+    const mockProvider = {
+      getInstallation: vi.fn().mockResolvedValue(null),
+    };
+
+    const state = createMockState();
+    const chatInstance = createMockChatInstance(state);
+    const adapter = createSlackAdapter({
+      signingSecret: secret,
+      logger: mockLogger,
+      installationProvider: mockProvider,
+    });
+    await adapter.initialize(chatInstance);
+
+    // Set an installation in state - should NOT be used
+    await adapter.setInstallation("T_STATE_TEAM", {
+      botToken: "xoxb-state-token",
+      botUserId: "U_BOT_STATE",
+    });
+
+    const body = JSON.stringify({
+      type: "event_callback",
+      team_id: "T_STATE_TEAM",
+      event: {
+        type: "message",
+        channel: "C_TEST",
+        user: "U_USER",
+        text: "hello",
+        ts: "1234567890.123456",
+      },
+    });
+
+    const request = createWebhookRequest(body, secret);
+    const response = await adapter.handleWebhook(request);
+
+    expect(response.status).toBe(200);
+    expect(mockProvider.getInstallation).toHaveBeenCalled();
+    // Event should not be processed because provider returned null
+    expect(chatInstance.handleIncomingMessage).not.toHaveBeenCalled();
+  });
+});
+
+// ============================================================================
 // Multi-workspace Mode with Encryption Tests
 // ============================================================================
 

--- a/packages/adapter-slack/src/index.ts
+++ b/packages/adapter-slack/src/index.ts
@@ -569,6 +569,8 @@ export class SlackAdapter implements Adapter<SlackThreadId, unknown> {
     token: string;
     botUserId?: string;
     isExtSharedChannel?: boolean;
+    enterpriseId?: string;
+    isEnterpriseInstall?: boolean;
   }>();
 
   /** Bot user ID (e.g., U_BOT_123) used for mention detection */
@@ -930,9 +932,11 @@ export class SlackAdapter implements Adapter<SlackThreadId, unknown> {
    * Extract installation info from an interactive payload (form-urlencoded).
    * For Enterprise Grid org-wide installs, returns enterprise_id; otherwise team_id.
    */
-  private extractInstallationFromInteractive(
-    body: string
-  ): { installationId: string; isEnterpriseInstall: boolean } | null {
+  private extractInstallationFromInteractive(body: string): {
+    installationId: string;
+    isEnterpriseInstall: boolean;
+    enterpriseId?: string;
+  } | null {
     try {
       const params = new URLSearchParams(body);
       const payloadStr = params.get("payload");
@@ -941,14 +945,16 @@ export class SlackAdapter implements Adapter<SlackThreadId, unknown> {
       }
       const payload = JSON.parse(payloadStr);
       const isEnterpriseInstall = Boolean(payload.is_enterprise_install);
-      const installationId = isEnterpriseInstall
-        ? payload.enterprise?.id || payload.enterprise_id
-        : payload.team?.id || payload.team_id;
+      const enterpriseId: string | undefined =
+        payload.enterprise?.id || payload.enterprise_id || undefined;
+      const teamId: string | undefined =
+        payload.team?.id || payload.team_id || undefined;
+      const installationId = isEnterpriseInstall ? enterpriseId : teamId;
 
       if (!installationId) {
         return null;
       }
-      return { installationId, isEnterpriseInstall };
+      return { installationId, isEnterpriseInstall, enterpriseId };
     } catch {
       return null;
     }
@@ -1181,8 +1187,13 @@ export class SlackAdapter implements Adapter<SlackThreadId, unknown> {
               isEnterpriseInstall
             );
             if (ctx) {
-              return this.requestContext.run(ctx, () =>
-                this.handleSlashCommand(params, options)
+              return this.requestContext.run(
+                {
+                  ...ctx,
+                  enterpriseId: params.get("enterprise_id") ?? undefined,
+                  isEnterpriseInstall,
+                },
+                () => this.handleSlashCommand(params, options)
               );
             }
             this.logger.warn("Could not resolve token for slash command", {
@@ -1202,8 +1213,13 @@ export class SlackAdapter implements Adapter<SlackThreadId, unknown> {
             installationInfo.isEnterpriseInstall
           );
           if (ctx) {
-            return this.requestContext.run(ctx, () =>
-              this.handleInteractivePayload(body, options)
+            return this.requestContext.run(
+              {
+                ...ctx,
+                enterpriseId: installationInfo.enterpriseId,
+                isEnterpriseInstall: installationInfo.isEnterpriseInstall,
+              },
+              () => this.handleInteractivePayload(body, options)
             );
           }
         }
@@ -1239,10 +1255,17 @@ export class SlackAdapter implements Adapter<SlackThreadId, unknown> {
           isEnterpriseInstall
         );
         if (ctx) {
-          return this.requestContext.run(ctx, () => {
-            this.processEventPayload(payload, options);
-            return new Response("ok", { status: 200 });
-          });
+          return this.requestContext.run(
+            {
+              ...ctx,
+              enterpriseId: payload.enterprise_id,
+              isEnterpriseInstall,
+            },
+            () => {
+              this.processEventPayload(payload, options);
+              return new Response("ok", { status: 200 });
+            }
+          );
         }
         this.logger.warn("Could not resolve token for installation", {
           installationId,
@@ -2903,10 +2926,14 @@ export class SlackAdapter implements Adapter<SlackThreadId, unknown> {
     teamId?: string
   ): Attachment {
     const url = file.url_private;
-    // Capture per-request token from the active webhook context so fetchData
-    // can run later without being inside the AsyncLocalStorage context.
-    // For single-workspace, the default provider is resolved at fetch time.
-    const ctxToken = this.requestContext.getStore()?.token;
+    // Capture per-request context (token + Enterprise Grid info) from the
+    // active webhook context so fetchData can run later without being inside
+    // the AsyncLocalStorage frame, and rehydrateAttachment can resolve tokens
+    // through the same lookup logic on a different process invocation.
+    const reqCtx = this.requestContext.getStore();
+    const ctxToken = reqCtx?.token;
+    const ctxEnterpriseId = reqCtx?.enterpriseId;
+    const ctxIsEnterpriseInstall = reqCtx?.isEnterpriseInstall;
 
     // Determine type based on mimetype
     let type: Attachment["type"] = "file";
@@ -2924,6 +2951,12 @@ export class SlackAdapter implements Adapter<SlackThreadId, unknown> {
     }
     if (teamId) {
       fetchMeta.teamId = teamId;
+    }
+    if (ctxEnterpriseId) {
+      fetchMeta.enterpriseId = ctxEnterpriseId;
+    }
+    if (ctxIsEnterpriseInstall) {
+      fetchMeta.isEnterpriseInstall = "true";
     }
 
     return {
@@ -2968,6 +3001,9 @@ export class SlackAdapter implements Adapter<SlackThreadId, unknown> {
   rehydrateAttachment(attachment: Attachment): Attachment {
     const url = attachment.fetchMetadata?.url ?? attachment.url;
     const teamId = attachment.fetchMetadata?.teamId;
+    const enterpriseId = attachment.fetchMetadata?.enterpriseId;
+    const isEnterpriseInstall =
+      attachment.fetchMetadata?.isEnterpriseInstall === "true";
     if (!url) {
       return attachment;
     }
@@ -2975,15 +3011,24 @@ export class SlackAdapter implements Adapter<SlackThreadId, unknown> {
       ...attachment,
       fetchData: async () => {
         let token: string;
-        if (teamId) {
-          const installation = await this.getInstallation(teamId);
-          if (!installation) {
+        const installationId = isEnterpriseInstall ? enterpriseId : teamId;
+        if (installationId) {
+          // Route through resolveTokenForTeam so installationProvider (when
+          // configured) is honored — otherwise this falls back to internal
+          // state via getInstallation, matching the prior behavior.
+          const ctx = await this.resolveTokenForTeam(
+            installationId,
+            isEnterpriseInstall
+          );
+          if (!ctx) {
             throw new AuthenticationError(
               "slack",
-              `Installation not found for team ${teamId}`
+              `Installation not found for ${
+                isEnterpriseInstall ? "enterprise" : "team"
+              } ${installationId}`
             );
           }
-          token = installation.botToken;
+          token = ctx.token;
         } else {
           token = await this.getToken();
         }

--- a/packages/adapter-slack/src/index.ts
+++ b/packages/adapter-slack/src/index.ts
@@ -885,7 +885,7 @@ export class SlackAdapter implements Adapter<SlackThreadId, unknown> {
     isEnterpriseInstall = false
   ): Promise<{ token: string; botUserId?: string } | null> {
     try {
-      // Check external installation provider first (e.g., Connex)
+      // Check external installation provider first (e.g., Vercel Connect)
       if (this.installationProvider) {
         const installation = await this.installationProvider.getInstallation(
           installationId,

--- a/packages/adapter-slack/src/index.ts
+++ b/packages/adapter-slack/src/index.ts
@@ -188,6 +188,21 @@ export interface SlackAdapterConfig {
    * Defaults to `slack:installation`. The full key will be `{prefix}:{teamId}`.
    */
   installationKeyPrefix?: string;
+
+  /**
+   * External installation provider for multi-workspace apps using external
+   * token management (e.g., Vercel Connect). When set, the adapter bypasses
+   * internal StateAdapter storage for token lookups.
+   *
+   * For Enterprise Grid org-wide installs, `installationId` will be the
+   * enterprise ID; otherwise it will be the team ID.
+   */
+  installationProvider?: {
+    getInstallation: (
+      installationId: string,
+      isEnterpriseInstall: boolean
+    ) => Promise<SlackInstallation | null>;
+  };
   /** Logger instance for error reporting. Defaults to ConsoleLogger. */
   logger?: Logger;
   /** Connection mode: "webhook" (default) or "socket" */
@@ -386,6 +401,8 @@ interface SlackUserChangeEvent {
 /** Slack webhook payload envelope */
 interface SlackWebhookPayload {
   challenge?: string;
+  /** Enterprise ID for Enterprise Grid org-wide installs */
+  enterprise_id?: string;
   event?:
     | SlackEvent
     | SlackReactionEvent
@@ -396,6 +413,8 @@ interface SlackWebhookPayload {
     | SlackUserChangeEvent;
   event_id?: string;
   event_time?: number;
+  /** Whether this is an Enterprise Grid org-wide install */
+  is_enterprise_install?: boolean;
   /** Whether this event occurred in an externally shared channel (Slack Connect) */
   is_ext_shared_channel?: boolean;
   team_id?: string;
@@ -545,6 +564,7 @@ export class SlackAdapter implements Adapter<SlackThreadId, unknown> {
   private readonly clientSecret: string | undefined;
   private readonly encryptionKey: Buffer | undefined;
   private readonly installationKeyPrefix: string;
+  private readonly installationProvider: SlackAdapterConfig["installationProvider"];
   private readonly requestContext = new AsyncLocalStorage<{
     token: string;
     botUserId?: string;
@@ -630,6 +650,8 @@ export class SlackAdapter implements Adapter<SlackThreadId, unknown> {
     if (encryptionKey) {
       this.encryptionKey = decodeKey(encryptionKey);
     }
+
+    this.installationProvider = config.installationProvider;
   }
 
   /**
@@ -854,24 +876,50 @@ export class SlackAdapter implements Adapter<SlackThreadId, unknown> {
   // ===========================================================================
 
   /**
-   * Resolve the bot token for a team from the state adapter.
+   * Resolve the bot token for an installation from the external provider or state adapter.
+   * @param installationId - team_id or enterprise_id depending on install type
+   * @param isEnterpriseInstall - true if this is an Enterprise Grid org-wide install
    */
   private async resolveTokenForTeam(
-    teamId: string
+    installationId: string,
+    isEnterpriseInstall = false
   ): Promise<{ token: string; botUserId?: string } | null> {
     try {
-      const installation = await this.getInstallation(teamId);
+      // Check external installation provider first (e.g., Connex)
+      if (this.installationProvider) {
+        const installation = await this.installationProvider.getInstallation(
+          installationId,
+          isEnterpriseInstall
+        );
+        if (installation) {
+          return {
+            token: installation.botToken,
+            botUserId: installation.botUserId,
+          };
+        }
+        this.logger.warn("No installation found from provider", {
+          installationId,
+          isEnterpriseInstall,
+        });
+        return null;
+      }
+      // Fall back to internal state adapter
+      const installation = await this.getInstallation(installationId);
       if (installation) {
         return {
           token: installation.botToken,
           botUserId: installation.botUserId,
         };
       }
-      this.logger.warn("No installation found for team", { teamId });
+      this.logger.warn("No installation found for team", {
+        installationId,
+        isEnterpriseInstall,
+      });
       return null;
     } catch (error) {
       this.logger.error("Failed to resolve token for team", {
-        teamId,
+        installationId,
+        isEnterpriseInstall,
         error,
       });
       return null;
@@ -879,9 +927,12 @@ export class SlackAdapter implements Adapter<SlackThreadId, unknown> {
   }
 
   /**
-   * Extract team_id from an interactive payload (form-urlencoded).
+   * Extract installation info from an interactive payload (form-urlencoded).
+   * For Enterprise Grid org-wide installs, returns enterprise_id; otherwise team_id.
    */
-  private extractTeamIdFromInteractive(body: string): string | null {
+  private extractInstallationFromInteractive(
+    body: string
+  ): { installationId: string; isEnterpriseInstall: boolean } | null {
     try {
       const params = new URLSearchParams(body);
       const payloadStr = params.get("payload");
@@ -889,7 +940,15 @@ export class SlackAdapter implements Adapter<SlackThreadId, unknown> {
         return null;
       }
       const payload = JSON.parse(payloadStr);
-      return payload.team?.id || payload.team_id || null;
+      const isEnterpriseInstall = Boolean(payload.is_enterprise_install);
+      const installationId = isEnterpriseInstall
+        ? payload.enterprise?.id || payload.enterprise_id
+        : payload.team?.id || payload.team_id;
+
+      if (!installationId) {
+        return null;
+      }
+      return { installationId, isEnterpriseInstall };
     } catch {
       return null;
     }
@@ -1108,23 +1167,40 @@ export class SlackAdapter implements Adapter<SlackThreadId, unknown> {
     if (contentType.includes("application/x-www-form-urlencoded")) {
       const params = new URLSearchParams(body);
       if (params.has("command") && !params.has("payload")) {
-        const teamId = params.get("team_id");
-        if (!this.defaultBotTokenProvider && teamId) {
-          const ctx = await this.resolveTokenForTeam(teamId);
-          if (ctx) {
-            return this.requestContext.run(ctx, () =>
-              this.handleSlashCommand(params, options)
+        if (!this.defaultBotTokenProvider) {
+          // For Enterprise Grid org-wide installs, use enterprise_id; otherwise use team_id
+          const isEnterpriseInstall =
+            params.get("is_enterprise_install") === "true";
+          const installationId = isEnterpriseInstall
+            ? params.get("enterprise_id")
+            : params.get("team_id");
+
+          if (installationId) {
+            const ctx = await this.resolveTokenForTeam(
+              installationId,
+              isEnterpriseInstall
             );
+            if (ctx) {
+              return this.requestContext.run(ctx, () =>
+                this.handleSlashCommand(params, options)
+              );
+            }
+            this.logger.warn("Could not resolve token for slash command", {
+              installationId,
+              isEnterpriseInstall,
+            });
           }
-          this.logger.warn("Could not resolve token for slash command");
         }
         return this.handleSlashCommand(params, options);
       }
-      // In multi-workspace mode, resolve token before processing
+      // In multi-workspace mode, resolve token before processing interactive payloads
       if (!this.defaultBotTokenProvider) {
-        const teamId = this.extractTeamIdFromInteractive(body);
-        if (teamId) {
-          const ctx = await this.resolveTokenForTeam(teamId);
+        const installationInfo = this.extractInstallationFromInteractive(body);
+        if (installationInfo) {
+          const ctx = await this.resolveTokenForTeam(
+            installationInfo.installationId,
+            installationInfo.isEnterpriseInstall
+          );
           if (ctx) {
             return this.requestContext.run(ctx, () =>
               this.handleInteractivePayload(body, options)
@@ -1149,18 +1225,29 @@ export class SlackAdapter implements Adapter<SlackThreadId, unknown> {
       return Response.json({ challenge: payload.challenge });
     }
 
-    // In multi-workspace mode, resolve token from team_id before processing events
+    // In multi-workspace mode, resolve token before processing events
     if (!this.defaultBotTokenProvider && payload.type === "event_callback") {
-      const teamId = payload.team_id;
-      if (teamId) {
-        const ctx = await this.resolveTokenForTeam(teamId);
+      // For Enterprise Grid org-wide installs, use enterprise_id; otherwise use team_id
+      const isEnterpriseInstall = Boolean(payload.is_enterprise_install);
+      const installationId = isEnterpriseInstall
+        ? payload.enterprise_id
+        : payload.team_id;
+
+      if (installationId) {
+        const ctx = await this.resolveTokenForTeam(
+          installationId,
+          isEnterpriseInstall
+        );
         if (ctx) {
           return this.requestContext.run(ctx, () => {
             this.processEventPayload(payload, options);
             return new Response("ok", { status: 200 });
           });
         }
-        this.logger.warn("Could not resolve token for team", { teamId });
+        this.logger.warn("Could not resolve token for installation", {
+          installationId,
+          isEnterpriseInstall,
+        });
         return new Response("ok", { status: 200 });
       }
     }
@@ -4936,6 +5023,7 @@ export function createSlackAdapter(
       (zeroConfig ? process.env.SLACK_CLIENT_SECRET : undefined),
     encryptionKey: config?.encryptionKey ?? process.env.SLACK_ENCRYPTION_KEY,
     installationKeyPrefix: config?.installationKeyPrefix,
+    installationProvider: config?.installationProvider,
     logger: config?.logger ?? new ConsoleLogger("info").child("slack"),
     socketForwardingSecret:
       config?.socketForwardingSecret ??


### PR DESCRIPTION
Adding external `installationProvider` support for Slack adapter. Adds support for Enterprise Grid installs by using `enterprise_id` when `is_enterprise_install` is true, instead of always keying on `team_id`.