### PR TITLE
feat(slack): expose direct WebClient access via adapter.client

### DIFF
--- a/.changeset/slack-direct-webclient-access.md
+++ b/.changeset/slack-direct-webclient-access.md
@@ -1,0 +1,28 @@
+---
+"@chat-adapter/slack": minor
+---
+
+feat(slack): expose direct `WebClient` access via `adapter.client`
+
+`bot.getAdapter("slack").client` now returns a typed `WebClient` from
+`@slack/web-api`, matching the existing pattern on the Linear and GitHub
+adapters. The returned client is bound to the bot token for the current
+request context (multi-workspace) or the configured default token
+(single-workspace). Use it for any Web API call not covered by the SDK's
+high-level methods, e.g. `adapter.client.pins.add(...)` or
+`adapter.client.usergroups.list(...)`.
+
+Resolution order:
+
+1. The token from the current `requestContext` — set during webhook
+   handling, or by `adapter.withBotToken(token, fn)`.
+2. The default `botToken`, when configured as a static string or a
+   synchronous resolver function.
+
+Throws `AuthenticationError` outside of any context in multi-workspace
+mode, or when `botToken` is configured as an async resolver function.
+For async tokens, await the token first and bind it explicitly with
+`adapter.withBotToken(token, () => adapter.client...)`.
+
+Also fixes `createSlackAdapter()` silently dropping the `apiUrl`
+config field.

--- a/apps/docs/content/docs/api/chat.mdx
+++ b/apps/docs/content/docs/api/chat.mdx
@@ -474,9 +474,13 @@ const slack = bot.getAdapter("slack");
 
 #### Direct client access
 
-Use `.client` to access the platform's typed native API client directly — available on Linear and GitHub:
+Use `.client` to access the platform's typed native API client directly — available on Slack, Linear, and GitHub:
 
 ```typescript
+// Slack - full WebClient from @slack/web-api
+const slack = bot.getAdapter("slack").client;
+await slack.pins.add({ channel: "C123ABC", timestamp: "1234567890.123456" });
+
 // Linear - full LinearClient from @linear/sdk
 const linear = bot.getAdapter("linear").client;
 const issue = await linear.issue("ENG-123");
@@ -491,14 +495,19 @@ const { data: pulls } = await github.rest.pulls.list({
 });
 ```
 
-The client uses the credentials from your adapter config. For multi-tenant adapters (Linear, GitHub), it returns the client for the current webhook request context.
+The client uses the credentials from your adapter config. For multi-tenant / multi-workspace adapters (Slack, Linear, GitHub), it returns the client bound to the credentials for the current webhook request context.
 
 <Callout type="warn">
-  For multi-tenant adapters (GitHub App without a fixed installation ID, Linear with per-org OAuth), `client` requires webhook handler context to resolve credentials. Calling it outside a handler throws. Single-tenant adapters (PAT, API key) work anywhere.
+  Multi-tenant adapters (GitHub App without a fixed installation ID, Linear with per-org OAuth, Slack in multi-workspace mode) require a webhook handler context to resolve credentials when `.client` is accessed. Calling it outside a handler throws.
+
+  For Slack, you can also bind a token explicitly outside a webhook with `adapter.withBotToken(token, () => adapter.client.…)` — useful for cron jobs or workflows. The same pattern is required when `botToken` is configured as an async resolver function, since `.client` resolves the token synchronously.
+
+  Single-tenant adapters (PAT, API key, static `botToken` string, or a synchronous `botToken` resolver) work anywhere.
 </Callout>
 
 | Adapter | `client` type |
 |---------|---------------|
+| Slack | `WebClient` from `@slack/web-api` |
 | Linear | `LinearClient` from `@linear/sdk` |
 | GitHub | `Octokit` from `@octokit/rest` |
 

--- a/apps/docs/content/docs/usage.mdx
+++ b/apps/docs/content/docs/usage.mdx
@@ -89,9 +89,10 @@ await slack.setSuggestedPrompts(channelId, threadTs, [
 ]);
 ```
 
-For typed access to the platform's native API client (Linear, GitHub), use `.client`:
+For typed access to the platform's native API client (Slack, Linear, GitHub), use `.client`:
 
 ```typescript title="lib/bot.ts" lineNumbers
+const slack = bot.getAdapter("slack").client; // WebClient
 const linear = bot.getAdapter("linear").client; // LinearClient
 const github = bot.getAdapter("github").client; // Octokit
 ```

--- a/examples/nextjs-chat/slack-manifest.yml
+++ b/examples/nextjs-chat/slack-manifest.yml
@@ -23,6 +23,7 @@ oauth_config:
       - mpim:read
       # Send messages and reactions
       - chat:write
+      - pins:write
       - reactions:write
       # User info for display names
       - users:read

--- a/examples/nextjs-chat/src/lib/bot.tsx
+++ b/examples/nextjs-chat/src/lib/bot.tsx
@@ -1,4 +1,5 @@
 /** @jsxImportSource chat */
+import type { SlackAdapter } from "@chat-adapter/slack";
 import { createMemoryState } from "@chat-adapter/state-memory";
 import { createRedisState } from "@chat-adapter/state-redis";
 import { ToolLoopAgent } from "ai";
@@ -46,6 +47,7 @@ const DISABLE_AI_REGEX = /disable\s*AI/i;
 const ENABLE_AI_REGEX = /enable\s*AI/i;
 const DM_ME_REGEX = /^dm\s*me$/i;
 const POSTCARD_TRIGGER_REGEX = /^post-card$/i;
+const SLACK_PREFIX_REGEX = /^slack:/;
 
 // Hardcoded user key for testing the Transcripts API — every inbound message
 // is persisted under this single key, so you can exercise append/list/delete
@@ -167,6 +169,7 @@ bot.onNewMention(async (thread, message) => {
           Clear Transcripts
         </Button>
         <Button id="channel-post">Channel Post</Button>
+        <Button id="channel-info">Channel Info (Slack)</Button>
         <Button id="show-table">Show Table</Button>
         <Button id="who-am-i">Who Am I</Button>
         <Button actionType="modal" id="report" value="bug">
@@ -892,6 +895,97 @@ bot.onAction("channel-post", async (event) => {
   } catch (err) {
     await thread.post(
       `${emoji.warning} Error reading channel: ${
+        err instanceof Error ? err.message : "Unknown error"
+      }`
+    );
+  }
+});
+
+// Demonstrate direct Slack WebClient access via adapter.client.
+// `conversations.info` requires the `channels:read` (or `groups:read`) scope.
+bot.onAction("channel-info", async (event) => {
+  if (!event.thread) {
+    return;
+  }
+  const { thread } = event;
+
+  if (event.adapter.name !== "slack") {
+    await thread.post(
+      `${emoji.warning} This demo uses the Slack \`WebClient\` directly. Try it from a Slack thread.`
+    );
+    return;
+  }
+
+  // Strip the "slack:" prefix to get the raw Slack channel ID.
+  const channelId = thread.channel.id.replace(SLACK_PREFIX_REGEX, "");
+
+  try {
+    const slack = (event.adapter as SlackAdapter).client;
+    const result = await slack.conversations.info({ channel: channelId });
+    const channel = result.channel as
+      | {
+          created?: number;
+          creator?: string;
+          id?: string;
+          is_archived?: boolean;
+          is_general?: boolean;
+          is_private?: boolean;
+          name?: string;
+          num_members?: number;
+          purpose?: { value?: string };
+          topic?: { value?: string };
+        }
+      | undefined;
+
+    if (!channel) {
+      await thread.post(
+        `${emoji.warning} Slack returned no channel info for \`${channelId}\`.`
+      );
+      return;
+    }
+
+    const created = channel.created
+      ? new Date(channel.created * 1000).toISOString()
+      : "unknown";
+
+    await thread.post(
+      <Card title={`${emoji.memo} Channel Info`}>
+        <Text>
+          {`Fetched via \`bot.getAdapter("slack").client.conversations.info\``}
+        </Text>
+        <Divider />
+        <Fields>
+          <Field label="Name" value={channel.name ? `#${channel.name}` : "—"} />
+          <Field label="ID" value={channel.id ?? channelId} />
+          <Field
+            label="Members"
+            value={
+              typeof channel.num_members === "number"
+                ? String(channel.num_members)
+                : "—"
+            }
+          />
+          <Field label="Created" value={created} />
+          <Field label="Creator" value={channel.creator ?? "—"} />
+          <Field label="Private" value={channel.is_private ? "Yes" : "No"} />
+          <Field label="Archived" value={channel.is_archived ? "Yes" : "No"} />
+          <Field
+            label="Default channel"
+            value={channel.is_general ? "Yes" : "No"}
+          />
+        </Fields>
+        <Divider />
+        <Section>
+          <Text>**Topic**</Text>
+          <Text>{channel.topic?.value?.trim() || "_(no topic set)_"}</Text>
+          <Text>**Purpose**</Text>
+          <Text>{channel.purpose?.value?.trim() || "_(no purpose set)_"}</Text>
+        </Section>
+      </Card>
+    );
+  } catch (err) {
+    await thread.post(
+      `${emoji.warning} Error fetching channel info: ${
         err instanceof Error ? err.message : "Unknown error"
       }`
     );

--- a/examples/nextjs-chat/src/lib/bot.tsx
+++ b/examples/nextjs-chat/src/lib/bot.tsx
@@ -922,7 +922,10 @@ bot.onAction("channel-info", async (event) => {
 
   try {
     const slack = (event.adapter as SlackAdapter).client;
-    const result = await slack.conversations.info({ channel: channelId });
+    const result = await slack.conversations.info({
+      channel: channelId,
+      include_num_members: true,
+    });
     const channel = result.channel as
       | {
           created?: number;
@@ -954,34 +957,26 @@ bot.onAction("channel-info", async (event) => {
         <Text>
           {`Fetched via \`bot.getAdapter("slack").client.conversations.info\``}
         </Text>
-        <Divider />
-        <Fields>
-          <Field label="Name" value={channel.name ? `#${channel.name}` : "—"} />
-          <Field label="ID" value={channel.id ?? channelId} />
-          <Field
-            label="Members"
-            value={
+        <Table
+          headers={["Field", "Value"]}
+          rows={[
+            ["Name", channel.name ? `#${channel.name}` : "—"],
+            ["ID", channel.id ?? channelId],
+            [
+              "Members",
               typeof channel.num_members === "number"
                 ? String(channel.num_members)
-                : "—"
-            }
-          />
-          <Field label="Created" value={created} />
-          <Field label="Creator" value={channel.creator ?? "—"} />
-          <Field label="Private" value={channel.is_private ? "Yes" : "No"} />
-          <Field label="Archived" value={channel.is_archived ? "Yes" : "No"} />
-          <Field
-            label="Default channel"
-            value={channel.is_general ? "Yes" : "No"}
-          />
-        </Fields>
-        <Divider />
-        <Section>
-          <Text>**Topic**</Text>
-          <Text>{channel.topic?.value?.trim() || "_(no topic set)_"}</Text>
-          <Text>**Purpose**</Text>
-          <Text>{channel.purpose?.value?.trim() || "_(no purpose set)_"}</Text>
-        </Section>
+                : "—",
+            ],
+            ["Created", created],
+            ["Creator", channel.creator ?? "—"],
+            ["Private", channel.is_private ? "Yes" : "No"],
+            ["Archived", channel.is_archived ? "Yes" : "No"],
+            ["Default channel", channel.is_general ? "Yes" : "No"],
+            ["Topic", channel.topic?.value?.trim() || "(no topic set)"],
+            ["Purpose", channel.purpose?.value?.trim() || "(no purpose set)"],
+          ]}
+        />
       </Card>
     );
   } catch (err) {

--- a/examples/nextjs-chat/src/lib/bot.tsx
+++ b/examples/nextjs-chat/src/lib/bot.tsx
@@ -170,6 +170,7 @@ bot.onNewMention(async (thread, message) => {
         </Button>
         <Button id="channel-post">Channel Post</Button>
         <Button id="channel-info">Channel Info (Slack)</Button>
+        <Button id="pin-message">Pin Message (Slack)</Button>
         <Button id="show-table">Show Table</Button>
         <Button id="who-am-i">Who Am I</Button>
         <Button actionType="modal" id="report" value="bug">
@@ -986,6 +987,38 @@ bot.onAction("channel-info", async (event) => {
   } catch (err) {
     await thread.post(
       `${emoji.warning} Error fetching channel info: ${
+        err instanceof Error ? err.message : "Unknown error"
+      }`
+    );
+  }
+});
+
+// Pin the card containing this button via the Slack WebClient.
+// `pins.add` requires the `pins:write` scope.
+bot.onAction("pin-message", async (event) => {
+  if (!event.thread) {
+    return;
+  }
+  const { thread } = event;
+
+  if (event.adapter.name !== "slack") {
+    await thread.post(
+      `${emoji.warning} This demo uses the Slack \`WebClient\` directly. Try it from a Slack thread.`
+    );
+    return;
+  }
+
+  const channelId = thread.channel.id.replace(SLACK_PREFIX_REGEX, "");
+
+  try {
+    const slack = (event.adapter as SlackAdapter).client;
+    await slack.pins.add({ channel: channelId, timestamp: event.messageId });
+    await thread.post(
+      `${emoji.pin} Pinned the welcome card via \`bot.getAdapter("slack").client.pins.add\`.`
+    );
+  } catch (err) {
+    await thread.post(
+      `${emoji.warning} Error pinning message: ${
         err instanceof Error ? err.message : "Unknown error"
       }`
     );

--- a/packages/adapter-slack/README.md
+++ b/packages/adapter-slack/README.md
@@ -403,6 +403,48 @@ SLACK_API_URL=...                    # Optional, for GovSlack or a self-hosted g
 | Member joined channel | Yes |
 | App Home tab | Yes |
 
+## Direct `WebClient` access
+
+Use `adapter.client` to get a typed `WebClient` from `@slack/web-api` for any
+Web API call that isn't wrapped by the SDK's high-level methods.
+
+```typescript
+import type { SlackAdapter } from "@chat-adapter/slack";
+
+bot.onAction("pin-this", async (event) => {
+  const slack = bot.getAdapter("slack") as SlackAdapter;
+  await slack.client.pins.add({
+    channel: event.thread!.channel.id.replace(/^slack:/, ""),
+    timestamp: event.messageId,
+  });
+});
+```
+
+The returned client is bound to the bot token resolved in this order:
+
+1. The token from the current request context — set automatically during
+   webhook handling, or by `adapter.withBotToken(token, fn)`.
+2. The default `botToken`, when configured as a static string or a
+   synchronous resolver function.
+
+`adapter.client` throws `AuthenticationError` outside of any context in
+multi-workspace mode, or when `botToken` is configured as an async resolver
+function. For both cases, await the token first and bind it explicitly:
+
+```typescript
+const install = await slackAdapter.getInstallation(teamId);
+if (!install) throw new Error("Workspace not installed");
+
+await slackAdapter.withBotToken(install.botToken, async () => {
+  const me = await slackAdapter.client.auth.test();
+  console.log("Bot user:", me.user_id);
+});
+```
+
+Internal API calls (`postMessage`, `editMessage`, `fetchMessages`, etc.) are
+unaffected — they continue to resolve tokens through the same async path
+they always have.
+
 ## Slack Assistants API
 
 The adapter supports Slack's [Assistants API](https://api.slack.com/docs/apps/ai) for building AI-powered assistant experiences. This enables suggested prompts, status indicators, and thread titles in assistant DM threads.

--- a/packages/adapter-slack/src/index.test.ts
+++ b/packages/adapter-slack/src/index.test.ts
@@ -2798,6 +2798,109 @@ describe("direct WebClient access via adapter.client", () => {
     expect(() => adapter.client).toThrow(AuthenticationError);
     expect(() => adapter.client).toThrow(ASYNC_RESOLVER_ERROR_PATTERN);
   });
+
+  it("returns distinct WebClient instances for distinct tokens", async () => {
+    const adapter = createSlackAdapter({
+      signingSecret: secret,
+      logger: mockLogger,
+    });
+
+    let clientA: WebClient | undefined;
+    let clientB: WebClient | undefined;
+    await adapter.withBotToken("xoxb-token-A", () => {
+      clientA = adapter.client;
+    });
+    await adapter.withBotToken("xoxb-token-B", () => {
+      clientB = adapter.client;
+    });
+
+    expect(clientA).toBeInstanceOf(WebClient);
+    expect(clientB).toBeInstanceOf(WebClient);
+    expect(clientA).not.toBe(clientB);
+    expect(clientA?.token).toBe("xoxb-token-A");
+    expect(clientB?.token).toBe("xoxb-token-B");
+  });
+
+  it("picks up apiUrl from SLACK_API_URL env var", () => {
+    const original = process.env.SLACK_API_URL;
+    process.env.SLACK_API_URL = "https://slack-gov.com/api/";
+    try {
+      const adapter = createSlackAdapter({
+        botToken: "xoxb-static-token",
+        signingSecret: secret,
+        logger: mockLogger,
+      });
+
+      expect(
+        (
+          adapter.client as unknown as {
+            axios: { defaults: { baseURL: string } };
+          }
+        ).axios.defaults.baseURL
+      ).toBe("https://slack-gov.com/api/");
+    } finally {
+      if (original === undefined) {
+        // biome-ignore lint/performance/noDelete: env var removal requires delete
+        delete process.env.SLACK_API_URL;
+      } else {
+        process.env.SLACK_API_URL = original;
+      }
+    }
+  });
+});
+
+// ============================================================================
+// End-to-end token resolution through adapter.client during webhook handling
+// ============================================================================
+
+describe("adapter.client end-to-end with multi-workspace webhook", () => {
+  const secret = "test-signing-secret";
+
+  it("resolves the installation's bot token in the action handler context", async () => {
+    const state = createMockState();
+    const chatInstance = createMockChatInstance(state);
+
+    // Capture the token observed by `event.adapter.client` when an action
+    // handler runs inside the request context set up by handleWebhook.
+    let observedToken: string | undefined;
+    chatInstance.processAction = vi.fn(async (event) => {
+      observedToken = (event.adapter as SlackAdapter).client.token;
+    });
+
+    const adapter = createSlackAdapter({
+      signingSecret: secret,
+      logger: mockLogger,
+    });
+    await adapter.initialize(chatInstance);
+
+    await adapter.setInstallation("T_E2E_1", {
+      botToken: "xoxb-installation-token",
+      botUserId: "U_BOT_E2E",
+    });
+
+    const payload = JSON.stringify({
+      type: "block_actions",
+      team: { id: "T_E2E_1" },
+      user: { id: "U_USER", username: "u", name: "User" },
+      container: {
+        type: "message",
+        message_ts: "1234567890.123456",
+        channel_id: "C_E2E",
+      },
+      channel: { id: "C_E2E", name: "general" },
+      message: { ts: "1234567890.123456" },
+      actions: [{ type: "button", action_id: "noop", value: "v" }],
+    });
+    const body = `payload=${encodeURIComponent(payload)}`;
+    const request = createWebhookRequest(body, secret, {
+      contentType: "application/x-www-form-urlencoded",
+    });
+
+    const response = await adapter.handleWebhook(request);
+    expect(response.status).toBe(200);
+    expect(chatInstance.processAction).toHaveBeenCalled();
+    expect(observedToken).toBe("xoxb-installation-token");
+  });
 });
 
 // ============================================================================

--- a/packages/adapter-slack/src/index.test.ts
+++ b/packages/adapter-slack/src/index.test.ts
@@ -3,7 +3,8 @@
  */
 
 import { createHmac, randomBytes } from "node:crypto";
-import { ValidationError } from "@chat-adapter/shared";
+import { AuthenticationError, ValidationError } from "@chat-adapter/shared";
+import { WebClient } from "@slack/web-api";
 import type {
   AdapterPostableMessage,
   ChatInstance,
@@ -2512,8 +2513,8 @@ describe("handleOAuthCallback", () => {
     });
 
     // Mock the oauth.v2.access call on the internal client
-    const mockClient = (adapter as unknown as { client: { oauth: unknown } })
-      .client;
+    const mockClient = (adapter as unknown as { _client: { oauth: unknown } })
+      ._client;
     const mockAccess = vi.fn().mockResolvedValue({
       ok: true,
       access_token: "xoxb-oauth-bot-token",
@@ -2684,6 +2685,118 @@ describe("withBotToken", () => {
 
     expect(tokens).toContain("A");
     expect(tokens).toContain("B");
+  });
+});
+
+// ============================================================================
+// Direct WebClient access (`adapter.client`) Tests
+// ============================================================================
+
+const ASYNC_RESOLVER_ERROR_PATTERN = /async resolver/;
+
+describe("direct WebClient access via adapter.client", () => {
+  const secret = "test-signing-secret";
+
+  it("returns a WebClient bound to the static botToken in single-workspace mode", () => {
+    const adapter = createSlackAdapter({
+      botToken: "xoxb-static-token",
+      signingSecret: secret,
+      logger: mockLogger,
+    });
+
+    const client = adapter.client;
+    expect(client).toBeInstanceOf(WebClient);
+    expect(client.token).toBe("xoxb-static-token");
+  });
+
+  it("caches the WebClient for repeated access with the same token", () => {
+    const adapter = createSlackAdapter({
+      botToken: "xoxb-static-token",
+      signingSecret: secret,
+      logger: mockLogger,
+    });
+
+    expect(adapter.client).toBe(adapter.client);
+  });
+
+  it("uses a synchronous botToken resolver", () => {
+    const adapter = createSlackAdapter({
+      botToken: () => "xoxb-sync-resolved",
+      signingSecret: secret,
+      logger: mockLogger,
+    });
+
+    expect(adapter.client.token).toBe("xoxb-sync-resolved");
+  });
+
+  it("returns a WebClient bound to the context token under withBotToken", async () => {
+    const adapter = createSlackAdapter({
+      signingSecret: secret,
+      logger: mockLogger,
+    });
+
+    let observedToken: string | undefined;
+    await adapter.withBotToken("xoxb-context-token", () => {
+      observedToken = adapter.client.token;
+    });
+
+    expect(observedToken).toBe("xoxb-context-token");
+  });
+
+  it("prefers the context token over the default in single-workspace mode", async () => {
+    const adapter = createSlackAdapter({
+      botToken: "xoxb-default",
+      signingSecret: secret,
+      logger: mockLogger,
+    });
+
+    let observedToken: string | undefined;
+    await adapter.withBotToken("xoxb-override", () => {
+      observedToken = adapter.client.token;
+    });
+
+    expect(observedToken).toBe("xoxb-override");
+    // Outside the context, the default is restored
+    expect(adapter.client.token).toBe("xoxb-default");
+  });
+
+  it("propagates apiUrl from createSlackAdapter to the bound WebClient", () => {
+    const adapter = createSlackAdapter({
+      botToken: "xoxb-static-token",
+      signingSecret: secret,
+      apiUrl: "https://slack-gov.com/api/",
+      logger: mockLogger,
+    });
+
+    expect(
+      (
+        adapter.client as unknown as {
+          axios: { defaults: { baseURL: string } };
+        }
+      ).axios.defaults.baseURL
+    ).toBe("https://slack-gov.com/api/");
+  });
+
+  it("throws when no token is available (multi-workspace, outside context)", () => {
+    const adapter = createSlackAdapter({
+      clientId: "test-client-id",
+      clientSecret: "test-client-secret",
+      signingSecret: secret,
+      logger: mockLogger,
+    });
+
+    expect(() => adapter.client).toThrow(AuthenticationError);
+  });
+
+  it("throws when botToken is configured as an async resolver", () => {
+    const adapter = createSlackAdapter({
+      botToken: async () => "xoxb-async",
+      signingSecret: secret,
+      logger: mockLogger,
+    });
+
+    expect(() => adapter.client).toThrow(AuthenticationError);
+    expect(() => adapter.client).toThrow(ASYNC_RESOLVER_ERROR_PATTERN);
   });
 });
 
@@ -3259,7 +3372,7 @@ interface MockableClient {
 }
 
 function getClient(adapter: SlackAdapter): MockableClient {
-  return (adapter as unknown as { client: MockableClient }).client;
+  return (adapter as unknown as { _client: MockableClient })._client;
 }
 
 function mockClientMethod(
@@ -6046,8 +6159,8 @@ describe("reverse user lookup", () => {
 
       // Mock Slack API
       const mockClient = (
-        adapter as unknown as { client: { users: { info: unknown } } }
-      ).client;
+        adapter as unknown as { _client: { users: { info: unknown } } }
+      )._client;
       mockClient.users.info = vi.fn().mockResolvedValue({
         user: {
           profile: { display_name: "dominik", real_name: "Dominik G" },
@@ -6290,8 +6403,8 @@ describe("reverse user lookup", () => {
 
       // Mock Slack API so lookupUser doesn't hit real API
       const mockClient = (
-        adapter as unknown as { client: { users: { info: unknown } } }
-      ).client;
+        adapter as unknown as { _client: { users: { info: unknown } } }
+      )._client;
       mockClient.users.info = vi.fn().mockResolvedValue({
         user: {
           profile: { display_name: "sender", real_name: "Sender One" },

--- a/packages/adapter-slack/src/index.ts
+++ b/packages/adapter-slack/src/index.ts
@@ -530,7 +530,9 @@ export class SlackAdapter implements Adapter<SlackThreadId, unknown> {
   readonly name = "slack";
   readonly userName: string;
 
-  private readonly client: WebClient;
+  private readonly _client: WebClient;
+  private readonly tokenClientCache = new Map<string, WebClient>();
+  private readonly slackApiUrl: string | undefined;
   private readonly signingSecret: string | undefined;
   private readonly webhookVerifier:
     | ((request: Request, body: string) => unknown | Promise<unknown>)
@@ -586,6 +588,57 @@ export class SlackAdapter implements Adapter<SlackThreadId, unknown> {
     return this.mode === "socket";
   }
 
+  /**
+   * Direct access to a `WebClient` from `@slack/web-api` bound to the bot
+   * token for the current request context (multi-workspace) or the
+   * configured default token (single-workspace). Use for any Slack Web API
+   * call not covered by the SDK's high-level methods — for example
+   * `adapter.client.pins.add(...)` or `adapter.client.usergroups.list(...)`.
+   *
+   * Resolution order:
+   *   1. Token from the current `requestContext` (set during webhook
+   *      handling, or by `withBotToken()`).
+   *   2. The default bot token, when configured as a static string or
+   *      synchronous resolver function.
+   *
+   * Throws `AuthenticationError` if neither is available — typical causes
+   * are calling `.client` outside any webhook/`withBotToken()` context in
+   * multi-workspace mode, or having configured `botToken` as an async
+   * function. In the latter case wrap the work in
+   * `adapter.withBotToken(token, () => adapter.client...)`.
+   */
+  get client(): WebClient {
+    const ctx = this.requestContext.getStore();
+    if (ctx?.token) {
+      return this.getClientForToken(ctx.token);
+    }
+    if (this.defaultBotTokenProvider) {
+      const result = this.defaultBotTokenProvider();
+      if (typeof result === "string") {
+        return this.getClientForToken(result);
+      }
+      throw new AuthenticationError(
+        "slack",
+        "botToken is configured as an async resolver and cannot be resolved synchronously for `.client`. Wrap the work in `adapter.withBotToken(token, () => adapter.client...)` after awaiting the token."
+      );
+    }
+    throw new AuthenticationError(
+      "slack",
+      "No bot token available. In multi-workspace mode, ensure the webhook is being processed or use `adapter.withBotToken(token, fn)` to bind a token explicitly."
+    );
+  }
+
+  private getClientForToken(token: string): WebClient {
+    let client = this.tokenClientCache.get(token);
+    if (!client) {
+      client = new WebClient(token, {
+        ...(this.slackApiUrl ? { slackApiUrl: this.slackApiUrl } : {}),
+      });
+      this.tokenClientCache.set(token, client);
+    }
+    return client;
+  }
+
   constructor(config: SlackAdapterConfig = {}) {
     const webhookVerifier = config.webhookVerifier;
     // webhookVerifier takes precedence over signingSecret (config) and the
@@ -619,11 +672,11 @@ export class SlackAdapter implements Adapter<SlackThreadId, unknown> {
       config.botToken ?? (zeroConfig ? process.env.SLACK_BOT_TOKEN : undefined);
     const botTokenProvider = normalizeBotTokenProvider(botTokenConfig);
 
-    const slackApiUrl = config.apiUrl ?? process.env.SLACK_API_URL;
+    this.slackApiUrl = config.apiUrl ?? process.env.SLACK_API_URL;
     // WebClient token argument is only a fallback; every API call below routes
     // through withToken() which resolves the current provider per-call.
-    this.client = new WebClient(undefined, {
-      ...(slackApiUrl ? { slackApiUrl } : {}),
+    this._client = new WebClient(undefined, {
+      ...(this.slackApiUrl ? { slackApiUrl: this.slackApiUrl } : {}),
     });
     // webhookVerifier takes precedence; signingSecret is only used when no
     // verifier is configured.
@@ -692,7 +745,7 @@ export class SlackAdapter implements Adapter<SlackThreadId, unknown> {
     // Only fetch bot user ID in single-workspace mode (when default token is available)
     if (this.defaultBotTokenProvider && !this._botUserId) {
       try {
-        const authResult = await this.client.auth.test(
+        const authResult = await this._client.auth.test(
           await this.withToken({})
         );
         this._botUserId = authResult.user_id as string;
@@ -823,7 +876,7 @@ export class SlackAdapter implements Adapter<SlackThreadId, unknown> {
     const redirectUri =
       options?.redirectUri ?? url.searchParams.get("redirect_uri") ?? undefined;
 
-    const result = await this.client.oauth.v2.access({
+    const result = await this._client.oauth.v2.access({
       client_id: this.clientId,
       client_secret: this.clientSecret,
       code,
@@ -976,7 +1029,7 @@ export class SlackAdapter implements Adapter<SlackThreadId, unknown> {
     }
 
     try {
-      const result = await this.client.users.info(
+      const result = await this._client.users.info(
         await this.withToken({ user: userId })
       );
       const user = result.user as {
@@ -1055,7 +1108,7 @@ export class SlackAdapter implements Adapter<SlackThreadId, unknown> {
     }
 
     try {
-      const result = await this.client.conversations.info(
+      const result = await this._client.conversations.info(
         await this.withToken({ channel: channelId })
       );
       const name =
@@ -2270,7 +2323,7 @@ export class SlackAdapter implements Adapter<SlackThreadId, unknown> {
     // event.item.ts is the reply's ts, not the parent thread_ts.
     let parentTs = event.item.ts;
     try {
-      const result = await this.client.conversations.replies(
+      const result = await this._client.conversations.replies(
         await this.withToken({
           channel: event.item.channel,
           ts: event.item.ts,
@@ -2504,7 +2557,7 @@ export class SlackAdapter implements Adapter<SlackThreadId, unknown> {
     userId: string,
     view: Record<string, unknown>
   ): Promise<void> {
-    await this.client.views.publish(
+    await this._client.views.publish(
       // biome-ignore lint/suspicious/noExplicitAny: view blocks are consumer-defined
       (await this.withToken({ user_id: userId, view })) as any
     );
@@ -2520,7 +2573,7 @@ export class SlackAdapter implements Adapter<SlackThreadId, unknown> {
     prompts: Array<{ title: string; message: string }>,
     title?: string
   ): Promise<void> {
-    await this.client.assistant.threads.setSuggestedPrompts(
+    await this._client.assistant.threads.setSuggestedPrompts(
       await this.withToken({
         channel_id: channelId,
         thread_ts: threadTs,
@@ -2540,7 +2593,7 @@ export class SlackAdapter implements Adapter<SlackThreadId, unknown> {
     status: string,
     loadingMessages?: string[]
   ): Promise<void> {
-    await this.client.assistant.threads.setStatus(
+    await this._client.assistant.threads.setStatus(
       await this.withToken({
         channel_id: channelId,
         thread_ts: threadTs,
@@ -2559,7 +2612,7 @@ export class SlackAdapter implements Adapter<SlackThreadId, unknown> {
     threadTs: string,
     title: string
   ): Promise<void> {
-    await this.client.assistant.threads.setTitle(
+    await this._client.assistant.threads.setTitle(
       await this.withToken({
         channel_id: channelId,
         thread_ts: threadTs,
@@ -2764,7 +2817,7 @@ export class SlackAdapter implements Adapter<SlackThreadId, unknown> {
     return {
       url,
       fetchMessage: async () => {
-        const result = await this.client.conversations.history(
+        const result = await this._client.conversations.history(
           await this.withToken({
             channel,
             latest: ts,
@@ -3219,7 +3272,7 @@ export class SlackAdapter implements Adapter<SlackThreadId, unknown> {
           blockCount: blocks.length,
         });
 
-        const result = await this.client.chat.postMessage(
+        const result = await this._client.chat.postMessage(
           await this.withToken({
             channel,
             thread_ts: threadTs,
@@ -3250,7 +3303,7 @@ export class SlackAdapter implements Adapter<SlackThreadId, unknown> {
         payloadKey: "markdown_text" in payload ? "markdown_text" : "text",
       });
 
-      const result = await this.client.chat.postMessage(
+      const result = await this._client.chat.postMessage(
         await this.withToken({
           channel,
           thread_ts: threadTs,
@@ -3300,7 +3353,7 @@ export class SlackAdapter implements Adapter<SlackThreadId, unknown> {
           blockCount: blocks.length,
         });
 
-        const result = await this.client.chat.postEphemeral(
+        const result = await this._client.chat.postEphemeral(
           await this.withToken({
             channel,
             thread_ts: threadTs,
@@ -3332,7 +3385,7 @@ export class SlackAdapter implements Adapter<SlackThreadId, unknown> {
         payloadKey: "markdown_text" in payload ? "markdown_text" : "text",
       });
 
-      const result = await this.client.chat.postEphemeral(
+      const result = await this._client.chat.postEphemeral(
         await this.withToken({
           channel,
           thread_ts: threadTs,
@@ -3404,7 +3457,7 @@ export class SlackAdapter implements Adapter<SlackThreadId, unknown> {
           blockCount: blocks.length,
         });
 
-        const result = await this.client.chat.scheduleMessage({
+        const result = await this._client.chat.scheduleMessage({
           token,
           channel,
           thread_ts: threadTs,
@@ -3424,7 +3477,7 @@ export class SlackAdapter implements Adapter<SlackThreadId, unknown> {
           postAt: options.postAt,
           raw: result,
           async cancel() {
-            await adapter.client.chat.deleteScheduledMessage({
+            await adapter._client.chat.deleteScheduledMessage({
               token: await resolveCancelToken(),
               channel,
               scheduled_message_id: scheduledMessageId,
@@ -3442,7 +3495,7 @@ export class SlackAdapter implements Adapter<SlackThreadId, unknown> {
         payloadKey: "markdown_text" in payload ? "markdown_text" : "text",
       });
 
-      const result = await this.client.chat.scheduleMessage({
+      const result = await this._client.chat.scheduleMessage({
         token,
         channel,
         thread_ts: threadTs,
@@ -3461,7 +3514,7 @@ export class SlackAdapter implements Adapter<SlackThreadId, unknown> {
         postAt: options.postAt,
         raw: result,
         async cancel() {
-          await adapter.client.chat.deleteScheduledMessage({
+          await adapter._client.chat.deleteScheduledMessage({
             token: await resolveCancelToken(),
             channel,
             scheduled_message_id: scheduledMessageId,
@@ -3490,7 +3543,7 @@ export class SlackAdapter implements Adapter<SlackThreadId, unknown> {
     });
 
     try {
-      const result = await this.client.views.open(
+      const result = await this._client.views.open(
         await this.withToken({
           trigger_id: triggerId,
           view,
@@ -3520,7 +3573,7 @@ export class SlackAdapter implements Adapter<SlackThreadId, unknown> {
     });
 
     try {
-      const result = await this.client.views.update(
+      const result = await this._client.views.update(
         await this.withToken({
           view_id: viewId,
           view,
@@ -3581,7 +3634,7 @@ export class SlackAdapter implements Adapter<SlackThreadId, unknown> {
       uploadArgs.thread_ts = threadTs;
     }
     uploadArgs.token = await this.getToken();
-    const result = (await this.client.files.uploadV2(uploadArgs)) as {
+    const result = (await this._client.files.uploadV2(uploadArgs)) as {
       ok: boolean;
       files?: Array<{ files?: Array<{ id?: string }> }>;
     };
@@ -3639,7 +3692,7 @@ export class SlackAdapter implements Adapter<SlackThreadId, unknown> {
           blockCount: blocks.length,
         });
 
-        const result = await this.client.chat.update(
+        const result = await this._client.chat.update(
           await this.withToken({
             channel,
             ts: messageId,
@@ -3668,7 +3721,7 @@ export class SlackAdapter implements Adapter<SlackThreadId, unknown> {
         payloadKey: "markdown_text" in payload ? "markdown_text" : "text",
       });
 
-      const result = await this.client.chat.update(
+      const result = await this._client.chat.update(
         await this.withToken({
           channel,
           ts: messageId,
@@ -3716,7 +3769,7 @@ export class SlackAdapter implements Adapter<SlackThreadId, unknown> {
         threadTs,
         blockCount: blocks.length,
       });
-      const result = await this.client.chat.postMessage(
+      const result = await this._client.chat.postMessage(
         await this.withToken({
           channel,
           thread_ts: threadTs,
@@ -3755,7 +3808,7 @@ export class SlackAdapter implements Adapter<SlackThreadId, unknown> {
         messageId,
         blockCount: blocks.length,
       });
-      const result = await this.client.chat.update(
+      const result = await this._client.chat.update(
         await this.withToken({
           channel,
           ts: messageId,
@@ -3872,7 +3925,7 @@ export class SlackAdapter implements Adapter<SlackThreadId, unknown> {
     try {
       this.logger.debug("Slack API: chat.delete", { channel, messageId });
 
-      await this.client.chat.delete(
+      await this._client.chat.delete(
         await this.withToken({
           channel,
           ts: messageId,
@@ -3902,7 +3955,7 @@ export class SlackAdapter implements Adapter<SlackThreadId, unknown> {
         emoji: name,
       });
 
-      await this.client.reactions.add(
+      await this._client.reactions.add(
         await this.withToken({
           channel,
           timestamp: messageId,
@@ -3933,7 +3986,7 @@ export class SlackAdapter implements Adapter<SlackThreadId, unknown> {
         emoji: name,
       });
 
-      await this.client.reactions.remove(
+      await this._client.reactions.remove(
         await this.withToken({
           channel,
           timestamp: messageId,
@@ -3971,7 +4024,7 @@ export class SlackAdapter implements Adapter<SlackThreadId, unknown> {
       status,
     });
     try {
-      await this.client.assistant.threads.setStatus(
+      await this._client.assistant.threads.setStatus(
         await this.withToken({
           channel_id: channel,
           thread_ts: threadTs,
@@ -4025,7 +4078,7 @@ export class SlackAdapter implements Adapter<SlackThreadId, unknown> {
     this.logger.debug("Slack: starting stream", { channel, threadTs });
 
     const token = await this.getToken();
-    const streamer = this.client.chatStream({
+    const streamer = this._client.chatStream({
       channel,
       thread_ts: threadTs,
       recipient_user_id: options.recipientUserId,
@@ -4153,7 +4206,7 @@ export class SlackAdapter implements Adapter<SlackThreadId, unknown> {
     try {
       this.logger.debug("Slack API: conversations.open", { userId });
 
-      const result = await this.client.conversations.open(
+      const result = await this._client.conversations.open(
         await this.withToken({ users: userId })
       );
 
@@ -4233,7 +4286,7 @@ export class SlackAdapter implements Adapter<SlackThreadId, unknown> {
       cursor,
     });
 
-    const result = await this.client.conversations.replies(
+    const result = await this._client.conversations.replies(
       await this.withToken({
         channel,
         ts: threadTs,
@@ -4296,7 +4349,7 @@ export class SlackAdapter implements Adapter<SlackThreadId, unknown> {
     // Slack API max is 1000 messages per request
     const fetchLimit = Math.min(1000, Math.max(limit * 2, 200));
 
-    const result = await this.client.conversations.replies(
+    const result = await this._client.conversations.replies(
       await this.withToken({
         channel,
         ts: threadTs,
@@ -4347,7 +4400,7 @@ export class SlackAdapter implements Adapter<SlackThreadId, unknown> {
     try {
       this.logger.debug("Slack API: conversations.info", { channel });
 
-      const result = await this.client.conversations.info(
+      const result = await this._client.conversations.info(
         await this.withToken({ channel })
       );
       const channelInfo = result.channel as
@@ -4403,7 +4456,7 @@ export class SlackAdapter implements Adapter<SlackThreadId, unknown> {
     const { channel, threadTs } = this.decodeThreadId(threadId);
 
     try {
-      const result = await this.client.conversations.replies(
+      const result = await this._client.conversations.replies(
         await this.withToken({
           channel,
           ts: threadTs,
@@ -4595,7 +4648,7 @@ export class SlackAdapter implements Adapter<SlackThreadId, unknown> {
       cursor,
     });
 
-    const result = await this.client.conversations.history(
+    const result = await this._client.conversations.history(
       await this.withToken({
         channel,
         limit,
@@ -4642,7 +4695,7 @@ export class SlackAdapter implements Adapter<SlackThreadId, unknown> {
       cursor,
     });
 
-    const result = await this.client.conversations.history(
+    const result = await this._client.conversations.history(
       await this.withToken({
         channel,
         limit,
@@ -4705,7 +4758,7 @@ export class SlackAdapter implements Adapter<SlackThreadId, unknown> {
         cursor: options.cursor,
       });
 
-      const result = await this.client.conversations.history(
+      const result = await this._client.conversations.history(
         await this.withToken({
           channel,
           limit: Math.min(limit * 3, 200), // Fetch extra since not all have threads
@@ -4770,7 +4823,7 @@ export class SlackAdapter implements Adapter<SlackThreadId, unknown> {
     try {
       this.logger.debug("Slack API: conversations.info (channel)", { channel });
 
-      const result = await this.client.conversations.info(
+      const result = await this._client.conversations.info(
         await this.withToken({ channel })
       );
 
@@ -5054,6 +5107,7 @@ export function createSlackAdapter(
   const zeroConfig = !config;
 
   const resolved: SlackAdapterConfig = {
+    apiUrl: config?.apiUrl,
     appToken,
     mode,
     signingSecret,

--- a/packages/integration-tests/src/slack-utils.ts
+++ b/packages/integration-tests/src/slack-utils.ts
@@ -251,7 +251,7 @@ export function injectMockSlackClient(
   mockClient: MockSlackClient
 ): void {
   // biome-ignore lint/suspicious/noExplicitAny: accessing private field for testing
-  (adapter as any).client = mockClient;
+  (adapter as any)._client = mockClient;
 }
 
 /**


### PR DESCRIPTION
Mirrors the Linear and GitHub adapter pattern by exposing the underlying `@slack/web-api` `WebClient` as `adapter.client`. Use it for any Slack Web API call not covered by the SDK's high-level methods, e.g. `bot.getAdapter("slack").client.pins.add(...)`.

Token resolution order:

1. The token from the current request context — set automatically during webhook handling, or by `adapter.withBotToken(token, fn)`.
2. The default `botToken` when configured as a static string or a synchronous resolver function.

Throws `AuthenticationError` outside any context in multi-workspace mode, or when `botToken` is configured as an async resolver. In both cases, `await` the token first and bind it explicitly with `adapter.withBotToken(token, () => adapter.client...)`.

Internally the existing private `client: WebClient` field is renamed to `_client` so the public getter can return per-token cached `WebClient` instances. All internal API calls continue to route through `_client.foo(await this.withToken(...))` unchanged.

## What's changed

**Slack adapter (`@chat-adapter/slack`)**
- New public `adapter.client` getter returning a token-bound `WebClient`.
- Per-token `WebClient` cache so repeated access reuses instances; distinct workspaces get distinct clients.
- `apiUrl` is now stored as a private field and threaded into the bound `WebClient`, including `SLACK_API_URL` env var resolution.
- Fix: `createSlackAdapter()` no longer silently drops the `apiUrl` config field — it's now passed through to the `SlackAdapter` constructor.
- Minor changeset.

**Integration tests (`@chat-adapter/integration-tests`)**
- `injectMockSlackClient` updated to write to the renamed internal `_client` field.

**Documentation**
- `apps/docs/content/docs/api/chat.mdx` — Slack added to "Direct client access" section, code example, type table row, and an updated Callout that spells out both multi-workspace and async-resolver constraints.
- `apps/docs/content/docs/usage.mdx` — Slack added to the typed-`.client` quick reference.
- `packages/adapter-slack/README.md` — new "Direct `WebClient` access" section with usage example, token resolution order, and the `withBotToken()` workaround for async resolvers.

**Example app (`examples/nextjs-chat`)**
- "Channel Info (Slack)" button: calls `slack.client.conversations.info` (uses existing `channels:read` scope) and renders the result as a two-column `<Table>`.
- "Pin Message (Slack)" button: calls `slack.client.pins.add` on the welcome card itself (`event.messageId`).
- `slack-manifest.yml` adds `pins:write` for the new Pin button.

**Tests**
- 11 new tests in `packages/adapter-slack/src/index.test.ts` covering: static-token binding, sync resolver, `withBotToken` override of default, `apiUrl` propagation through the factory, `SLACK_API_URL` env var resolution, distinct-tokens-distinct-clients caching, multi-workspace outside-context throw, async-resolver throw, and end-to-end token routing through `event.adapter.client.token` inside a real `block_actions` webhook dispatch.