### PR TITLE
feat: add @chat-adapter/email, email adapter with pluggable ESP providers

### DIFF
--- a/.changeset/add-email-adapter.md
+++ b/.changeset/add-email-adapter.md
@@ -1,0 +1,23 @@
+---
+"@chat-adapter/email": minor
+---
+
+Add `@chat-adapter/email` — a single Chat SDK adapter that owns email-shaped behavior (RFC-822 threading via `Message-ID` / `In-Reply-To` / `References`, MIME composition, HTML+text rendering of cards and markdown) and delegates outbound sending and inbound webhook parsing to pluggable Email Service Provider implementations.
+
+```ts
+import { createEmailAdapter } from "@chat-adapter/email";
+import { resend } from "@chat-adapter/email/providers";
+
+createEmailAdapter({
+  fromAddress: "support@yourdomain.com",
+  provider: resend(),
+});
+```
+
+- Built-in providers live at the `/providers` subpath:
+  - `resend` (bidirectional, Svix HMAC-SHA256 verification, fetches body via the Receiving API).
+  - `inbound` (bidirectional Inbound.new — token-based webhook verification, self-contained payloads, lazy-fetched attachments).
+- Pass `provider:` for the simple case where one ESP handles both directions, or pass `transport:` and `inbound:` directly for mix-and-match (e.g. send via Resend, receive via Inbound).
+- The main `@chat-adapter/email` entry exposes `createEmailAdapter`, `defineEmailProvider`, shared helpers for custom providers (`verifySvixSignature`, `verifySvixRequest`, `verifyConstantTimeToken`, `throwForEspError`, `parseAddress`, `normalizeHeaderKeys`), and all types — so anyone can publish a Postmark/SendGrid/Mailgun/SES provider against the same machinery.
+- Includes a self-contained markdown→HTML and Card→HTML renderer with inline styles tuned for email clients. Buttons render as anchor tags driven by `callbackUrl`.
+- Streaming (`stream()`) buffers chunks and sends one email at the end; edit/delete/reactions throw `NotImplementedError` (email is immutable).

--- a/apps/docs/adapters.json
+++ b/apps/docs/adapters.json
@@ -100,6 +100,16 @@
     "readme": "https://github.com/vercel/chat/tree/main/packages/adapter-web"
   },
   {
+    "name": "Email",
+    "slug": "email",
+    "type": "platform",
+    "description": "Bidirectional email adapter with pluggable Email Service Providers (Resend, Inbound). Threads via standard RFC-822 headers and renders cards as inline-styled HTML.",
+    "packageName": "@chat-adapter/email",
+    "icon": "email",
+    "beta": true,
+    "readme": "https://github.com/vercel/chat/tree/main/packages/adapter-email"
+  },
+  {
     "name": "Redis",
     "slug": "redis",
     "type": "state",

--- a/apps/docs/app/[lang]/(home)/adapters/components/adapter-card.tsx
+++ b/apps/docs/app/[lang]/(home)/adapters/components/adapter-card.tsx
@@ -10,6 +10,7 @@ import {
 } from "@/components/ui/card";
 import {
   discord,
+  email,
   gchat,
   github,
   ioredis,
@@ -35,6 +36,7 @@ const iconMap: Record<
   discord,
   github,
   web,
+  email,
   linear,
   telegram,
   redis,

--- a/apps/docs/app/[lang]/(home)/adapters/for/[messenger]/page.tsx
+++ b/apps/docs/app/[lang]/(home)/adapters/for/[messenger]/page.tsx
@@ -105,7 +105,7 @@ const messengerConfig: Record<
     name: "Email",
     description:
       "Build email bots with Chat SDK. Browse official and community adapters that support email integration.",
-    adapterSlugs: ["resend"],
+    adapterSlugs: ["email", "resend"],
     keywords: ["email"],
   },
   webex: {

--- a/apps/docs/content/docs/adapters.mdx
+++ b/apps/docs/content/docs/adapters.mdx
@@ -16,55 +16,55 @@ Ready to build your own? Follow the [building](/docs/contributing/building) guid
 
 ### Messaging
 
-| Feature | [Slack](/adapters/slack) | [Teams](/adapters/teams) | [Google Chat](/adapters/google-chat) | [Discord](/adapters/discord) | [Telegram](/adapters/telegram) | [GitHub](/adapters/github) | [Linear](/adapters/linear) | [WhatsApp](/adapters/whatsapp) | [Messenger](/adapters/messenger) |
-|---------|-------|-------|-------------|---------|---------|--------|--------|-----------|-----------|
-| Post message | <Check /> | <Check /> | <Check /> | <Check /> | <Check /> | <Check /> | <Check /> | <Check /> | <Check /> |
-| Edit message | <Check /> | <Check /> | <Check /> | <Check /> | <Check /> | <Check /> | <Warn /> Partial | <Cross /> | <Cross /> |
-| Delete message | <Check /> | <Check /> | <Check /> | <Check /> | <Check /> | <Check /> | <Warn /> Partial | <Cross /> | <Cross /> |
-| File uploads | <Check /> | <Check /> | <Cross /> | <Check /> | <Warn /> Single file | <Cross /> | <Cross /> | <Check /> Images, audio, docs | <Cross /> |
-| Streaming | <Check /> Native | <Warn /> Native (DMs) / Buffered | <Warn /> Post+Edit | <Warn /> Post+Edit | <Warn /> Post+Edit | <Warn /> Buffered | <Warn /> Agent sessions / Post+Edit | <Warn /> Buffered | <Warn /> Buffered |
-| Scheduled messages | <Check /> Native | <Cross /> | <Cross /> | <Cross /> | <Cross /> | <Cross /> | <Cross /> | <Cross /> | <Cross /> |
+| Feature | [Slack](/adapters/slack) | [Teams](/adapters/teams) | [Google Chat](/adapters/google-chat) | [Discord](/adapters/discord) | [Telegram](/adapters/telegram) | [GitHub](/adapters/github) | [Linear](/adapters/linear) | [WhatsApp](/adapters/whatsapp) | [Messenger](/adapters/messenger) | [Email](/adapters/email) |
+|---------|-------|-------|-------------|---------|---------|--------|--------|-----------|-----------|---------|
+| Post message | <Check /> | <Check /> | <Check /> | <Check /> | <Check /> | <Check /> | <Check /> | <Check /> | <Check /> | <Check /> |
+| Edit message | <Check /> | <Check /> | <Check /> | <Check /> | <Check /> | <Check /> | <Warn /> Partial | <Cross /> | <Cross /> | <Cross /> |
+| Delete message | <Check /> | <Check /> | <Check /> | <Check /> | <Check /> | <Check /> | <Warn /> Partial | <Cross /> | <Cross /> | <Cross /> |
+| File uploads | <Check /> | <Check /> | <Cross /> | <Check /> | <Warn /> Single file | <Cross /> | <Cross /> | <Check /> Images, audio, docs | <Cross /> | <Check /> Provider-dependent |
+| Streaming | <Check /> Native | <Warn /> Native (DMs) / Buffered | <Warn /> Post+Edit | <Warn /> Post+Edit | <Warn /> Post+Edit | <Warn /> Buffered | <Warn /> Agent sessions / Post+Edit | <Warn /> Buffered | <Warn /> Buffered | <Warn /> Buffered |
+| Scheduled messages | <Check /> Native | <Cross /> | <Cross /> | <Cross /> | <Cross /> | <Cross /> | <Cross /> | <Cross /> | <Cross /> | <Cross /> |
 
 ### Rich content
 
-| Feature | Slack | Teams | Google Chat | Discord | Telegram | GitHub | Linear | WhatsApp | Messenger |
-|---------|-------|-------|-------------|---------|----------|--------|--------|-----------|-----------|
-| Card format | Block Kit | Adaptive Cards | Google Chat Cards | Embeds | Markdown + inline keyboard buttons | GFM Markdown | Markdown | WhatsApp templates | Generic/Button Templates |
-| Buttons | <Check /> | <Check /> | <Check /> | <Check /> | <Warn /> Inline keyboard callbacks | <Cross /> | <Cross /> | <Check /> Interactive replies | <Warn /> Max 3, postback |
-| Link buttons | <Check /> | <Check /> | <Check /> | <Check /> | <Warn /> Inline keyboard URLs | <Cross /> | <Cross /> | <Cross /> | <Check /> |
-| Select menus | <Check /> | <Cross /> | <Check /> | <Cross /> | <Cross /> | <Cross /> | <Cross /> | <Cross /> | <Cross /> |
-| Tables | <Check /> Block Kit | <Check /> GFM | <Warn /> ASCII | <Check /> GFM | <Warn /> ASCII | <Check /> GFM | <Check /> GFM | <Cross /> | <Warn /> ASCII |
-| Fields | <Check /> | <Check /> | <Check /> | <Check /> | <Check /> | <Check /> | <Check /> | <Warn /> Template variables | <Warn /> ASCII |
-| Images in cards | <Check /> | <Check /> | <Check /> | <Check /> | <Cross /> | <Check /> | <Cross /> | <Check /> | <Check /> |
-| Modals | <Check /> | <Check /> | <Cross /> | <Cross /> | <Cross /> | <Cross /> | <Cross /> | <Cross /> | <Cross /> |
+| Feature | Slack | Teams | Google Chat | Discord | Telegram | GitHub | Linear | WhatsApp | Messenger | Email |
+|---------|-------|-------|-------------|---------|----------|--------|--------|-----------|-----------|-------|
+| Card format | Block Kit | Adaptive Cards | Google Chat Cards | Embeds | Markdown + inline keyboard buttons | GFM Markdown | Markdown | WhatsApp templates | Generic/Button Templates | HTML email |
+| Buttons | <Check /> | <Check /> | <Check /> | <Check /> | <Warn /> Inline keyboard callbacks | <Cross /> | <Cross /> | <Check /> Interactive replies | <Warn /> Max 3, postback | <Warn /> Callback URL only |
+| Link buttons | <Check /> | <Check /> | <Check /> | <Check /> | <Warn /> Inline keyboard URLs | <Cross /> | <Cross /> | <Cross /> | <Check /> | <Check /> |
+| Select menus | <Check /> | <Cross /> | <Check /> | <Cross /> | <Cross /> | <Cross /> | <Cross /> | <Cross /> | <Cross /> | <Cross /> |
+| Tables | <Check /> Block Kit | <Check /> GFM | <Warn /> ASCII | <Check /> GFM | <Warn /> ASCII | <Check /> GFM | <Check /> GFM | <Cross /> | <Warn /> ASCII | <Check /> HTML |
+| Fields | <Check /> | <Check /> | <Check /> | <Check /> | <Check /> | <Check /> | <Check /> | <Warn /> Template variables | <Warn /> ASCII | <Check /> |
+| Images in cards | <Check /> | <Check /> | <Check /> | <Check /> | <Cross /> | <Check /> | <Cross /> | <Check /> | <Check /> | <Check /> |
+| Modals | <Check /> | <Check /> | <Cross /> | <Cross /> | <Cross /> | <Cross /> | <Cross /> | <Cross /> | <Cross /> | <Cross /> |
 
 ### Conversations
 
-| Feature | Slack | Teams | Google Chat | Discord | Telegram | GitHub | Linear | WhatsApp | Messenger |
-|---------|-------|-------|-------------|---------|----------|--------|--------|-----------|-----------|
-| Slash commands | <Check /> | <Cross /> | <Cross /> | <Check /> | <Cross /> | <Cross /> | <Cross /> | <Cross /> | <Cross /> |
-| Mentions | <Check /> | <Check /> | <Check /> | <Check /> | <Check /> | <Check /> | <Check /> | <Cross /> | <Check /> |
-| Add reactions | <Check /> | <Cross /> | <Check /> | <Check /> | <Check /> | <Check /> | <Check /> | <Check /> | <Cross /> |
-| Remove reactions | <Check /> | <Cross /> | <Check /> | <Check /> | <Check /> | <Warn /> | <Warn /> | <Check /> | <Cross /> |
-| Typing indicator | <Check /> | <Check /> | <Cross /> | <Check /> | <Check /> | <Cross /> | <Warn /> Agent sessions | <Cross /> | <Check /> |
-| DMs | <Check /> | <Check /> | <Check /> | <Check /> | <Check /> | <Cross /> | <Cross /> | <Check /> | <Check /> |
-| Ephemeral messages | <Check /> Native | <Cross /> | <Check /> Native | <Cross /> | <Cross /> | <Cross /> | <Cross /> | <Cross /> | <Cross /> |
-| User lookup ([`getUser`](/docs/api/chat#getuser)) | <Check /> | <Warn /> Cached | <Warn /> Cached | <Check /> | <Warn /> Seen users | <Check /> | <Check /> | <Cross /> | <Cross /> |
-| Parent subject ([`message.subject`](/docs/subject)) | <Cross /> | <Cross /> | <Cross /> | <Cross /> | <Cross /> | <Check /> | <Check /> | <Cross /> | <Cross /> |
-| Native client ([`.client`](/docs/api/chat#getadapter)) | <Cross /> | <Cross /> | <Cross /> | <Cross /> | <Cross /> | <Check /> | <Check /> | <Cross /> | <Cross /> |
-| Custom API endpoint (`apiUrl`) | <Check /> | <Check /> | <Check /> | <Check /> | <Check /> | <Check /> | <Check /> | <Check /> | <Check /> |
+| Feature | Slack | Teams | Google Chat | Discord | Telegram | GitHub | Linear | WhatsApp | Messenger | Email |
+|---------|-------|-------|-------------|---------|----------|--------|--------|-----------|-----------|-------|
+| Slash commands | <Check /> | <Cross /> | <Cross /> | <Check /> | <Cross /> | <Cross /> | <Cross /> | <Cross /> | <Cross /> | <Cross /> |
+| Mentions | <Check /> | <Check /> | <Check /> | <Check /> | <Check /> | <Check /> | <Check /> | <Cross /> | <Check /> | <Cross /> |
+| Add reactions | <Check /> | <Cross /> | <Check /> | <Check /> | <Check /> | <Check /> | <Check /> | <Check /> | <Cross /> | <Cross /> |
+| Remove reactions | <Check /> | <Cross /> | <Check /> | <Check /> | <Check /> | <Warn /> | <Warn /> | <Check /> | <Cross /> | <Cross /> |
+| Typing indicator | <Check /> | <Check /> | <Cross /> | <Check /> | <Check /> | <Cross /> | <Warn /> Agent sessions | <Cross /> | <Check /> | <Cross /> |
+| DMs | <Check /> | <Check /> | <Check /> | <Check /> | <Check /> | <Cross /> | <Cross /> | <Check /> | <Check /> | <Check /> |
+| Ephemeral messages | <Check /> Native | <Cross /> | <Check /> Native | <Cross /> | <Cross /> | <Cross /> | <Cross /> | <Cross /> | <Cross /> | <Cross /> |
+| User lookup ([`getUser`](/docs/api/chat#getuser)) | <Check /> | <Warn /> Cached | <Warn /> Cached | <Check /> | <Warn /> Seen users | <Check /> | <Check /> | <Cross /> | <Cross /> | <Cross /> |
+| Parent subject ([`message.subject`](/docs/subject)) | <Cross /> | <Cross /> | <Cross /> | <Cross /> | <Cross /> | <Check /> | <Check /> | <Cross /> | <Cross /> | <Cross /> |
+| Native client ([`.client`](/docs/api/chat#getadapter)) | <Cross /> | <Cross /> | <Cross /> | <Cross /> | <Cross /> | <Check /> | <Check /> | <Cross /> | <Cross /> | <Cross /> |
+| Custom API endpoint (`apiUrl`) | <Check /> | <Check /> | <Check /> | <Check /> | <Check /> | <Check /> | <Check /> | <Check /> | <Check /> | <Check /> Per-provider |
 
 ### Message history
 
-| Feature | Slack | Teams | Google Chat | Discord | Telegram | GitHub | Linear | WhatsApp | Messenger |
-|---------|-------|-------|-------------|---------|----------|--------|--------|-----------|-----------|
-| Fetch messages | <Check /> | <Check /> | <Check /> | <Check /> | <Warn /> Cached | <Check /> | <Check /> | <Warn /> Cached sent messages only | <Warn /> Cached sent messages only |
-| Fetch single message | <Check /> | <Cross /> | <Cross /> | <Cross /> | <Warn /> Cached | <Cross /> | <Cross /> | <Cross /> | <Warn /> Cached |
-| Fetch thread info | <Check /> | <Check /> | <Check /> | <Check /> | <Check /> | <Check /> | <Check /> | <Check /> | <Check /> |
-| Fetch channel messages | <Check /> | <Check /> | <Check /> | <Check /> | <Warn /> Cached | <Check /> | <Cross /> | <Cross /> | <Warn /> Cached |
-| List threads | <Check /> | <Check /> | <Check /> | <Check /> | <Cross /> | <Check /> | <Cross /> | <Cross /> | <Cross /> |
-| Fetch channel info | <Check /> | <Check /> | <Check /> | <Check /> | <Check /> | <Check /> | <Cross /> | <Cross /> | <Check /> |
-| Post channel message | <Check /> | <Check /> | <Check /> | <Check /> | <Check /> | <Cross /> | <Cross /> | <Check /> | <Check /> |
+| Feature | Slack | Teams | Google Chat | Discord | Telegram | GitHub | Linear | WhatsApp | Messenger | Email |
+|---------|-------|-------|-------------|---------|----------|--------|--------|-----------|-----------|-------|
+| Fetch messages | <Check /> | <Check /> | <Check /> | <Check /> | <Warn /> Cached | <Check /> | <Check /> | <Warn /> Cached sent messages only | <Warn /> Cached sent messages only | <Cross /> |
+| Fetch single message | <Check /> | <Cross /> | <Cross /> | <Cross /> | <Warn /> Cached | <Cross /> | <Cross /> | <Cross /> | <Warn /> Cached | <Cross /> |
+| Fetch thread info | <Check /> | <Check /> | <Check /> | <Check /> | <Check /> | <Check /> | <Check /> | <Check /> | <Check /> | <Check /> |
+| Fetch channel messages | <Check /> | <Check /> | <Check /> | <Check /> | <Warn /> Cached | <Check /> | <Cross /> | <Cross /> | <Warn /> Cached | <Cross /> |
+| List threads | <Check /> | <Check /> | <Check /> | <Check /> | <Cross /> | <Check /> | <Cross /> | <Cross /> | <Cross /> | <Cross /> |
+| Fetch channel info | <Check /> | <Check /> | <Check /> | <Check /> | <Check /> | <Check /> | <Cross /> | <Cross /> | <Check /> | <Cross /> |
+| Post channel message | <Check /> | <Check /> | <Check /> | <Check /> | <Check /> | <Cross /> | <Cross /> | <Check /> | <Check /> | <Cross /> |
 
 <Callout type="info">
 <Warn /> indicates partial support — the feature works with limitations. See individual adapter pages for details.

--- a/apps/docs/lib/logos.tsx
+++ b/apps/docs/lib/logos.tsx
@@ -527,3 +527,27 @@ export const messenger = (props: ComponentProps<"svg">) => (
     />
   </svg>
 );
+
+export const email = (props: ComponentProps<"svg">) => (
+  <svg
+    fill="none"
+    viewBox="0 0 24 24"
+    xmlns="http://www.w3.org/2000/svg"
+    {...props}
+  >
+    <rect
+      height="14"
+      rx="2"
+      stroke="currentColor"
+      strokeWidth="1.5"
+      width="18"
+      x="3"
+      y="5"
+    />
+    <path
+      d="m3 7 8.4 6.3a1 1 0 0 0 1.2 0L21 7"
+      stroke="currentColor"
+      strokeWidth="1.5"
+    />
+  </svg>
+);

--- a/packages/adapter-email/CHANGELOG.md
+++ b/packages/adapter-email/CHANGELOG.md
@@ -1,0 +1,1 @@
+# @chat-adapter/email

--- a/packages/adapter-email/README.md
+++ b/packages/adapter-email/README.md
@@ -1,0 +1,149 @@
+# @chat-adapter/email
+
+[![npm version](https://img.shields.io/npm/v/@chat-adapter/email)](https://www.npmjs.com/package/@chat-adapter/email)
+[![npm downloads](https://img.shields.io/npm/dm/@chat-adapter/email)](https://www.npmjs.com/package/@chat-adapter/email)
+
+Email adapter for [Chat SDK](https://chat-sdk.dev). One adapter, multiple Email Service Providers.
+
+This package owns the email-shaped behavior — RFC-822 threading via `Message-ID` / `In-Reply-To` / `References`, MIME composition, HTML+text rendering of cards and markdown — and delegates outbound sending and inbound webhook parsing to pluggable ESP providers.
+
+## Installation
+
+```bash
+pnpm add @chat-adapter/email
+```
+
+## Usage
+
+Providers live on the `/providers` subpath. Import the one you need and pass it to `createEmailAdapter`:
+
+### Resend
+
+```typescript
+import { Chat } from "chat";
+import { createEmailAdapter } from "@chat-adapter/email";
+import { resend } from "@chat-adapter/email/providers";
+import { createRedisState } from "@chat-adapter/state-redis";
+
+const bot = new Chat({
+  userName: "support-bot",
+  adapters: {
+    email: createEmailAdapter({
+      fromAddress: "support@yourdomain.com",
+      fromName: "Acme Support",
+      provider: resend(),
+    }),
+  },
+  state: createRedisState(),
+});
+
+bot.onDirectMessage(async (thread, message) => {
+  await thread.subscribe();
+  await thread.post(`Thanks for emailing! You said: ${message.text}`);
+});
+```
+
+### Inbound
+
+```typescript
+import { Chat } from "chat";
+import { createEmailAdapter } from "@chat-adapter/email";
+import { inbound } from "@chat-adapter/email/providers";
+import { createRedisState } from "@chat-adapter/state-redis";
+
+const bot = new Chat({
+  userName: "support-bot",
+  adapters: {
+    email: createEmailAdapter({
+      fromAddress: "support@yourdomain.com",
+      provider: inbound(),
+    }),
+  },
+  state: createRedisState(),
+});
+
+bot.onDirectMessage(async (thread, message) => {
+  await thread.subscribe();
+  await thread.post(`Thanks for emailing! You said: ${message.text}`);
+});
+```
+
+### Mix and match
+
+You can wire one provider's `transport` to another's `inbound` when the easiest sender and the easiest inbound parser don't belong to the same ESP.
+
+```typescript
+import { createEmailAdapter } from "@chat-adapter/email";
+import { inbound, resend } from "@chat-adapter/email/providers";
+
+createEmailAdapter({
+  fromAddress: "support@yourdomain.com",
+  transport: resend().transport,
+  inbound: inbound().inbound,
+});
+```
+
+## Supported Email Service Providers
+
+| Provider | Send | Receive | Required env vars | Notes |
+|----------|:----:|:-------:|-------------------|-------|
+| [Resend](https://resend.com) (`resend`) | ✓ | ✓ | `RESEND_API_KEY`, `RESEND_WEBHOOK_SECRET` (receive only) | Svix HMAC-SHA256 webhook verification. Body and headers are fetched via the Receiving API after the webhook fires. |
+| [Inbound](https://inbound.new) (`inbound`) | ✓ | ✓ | `INBOUND_API_KEY`, `INBOUND_VERIFICATION_TOKEN` (receive only) | Constant-time `X-Webhook-Verification-Token` verification. Webhook payload is self-contained (body, headers, attachment metadata inline). Attachments are lazy-fetched via authenticated `downloadUrl`. |
+
+Capabilities are determined by the provider's API surface; receive-only or send-only setups are first-class — pass only the directions you need. Need another ESP? See [Adding a custom provider](#adding-a-custom-provider) below — the `EmailProvider` contract is intentionally tiny so anyone can wire up Postmark, SendGrid, Mailgun, SES, etc. against the same machinery.
+
+## Adding a custom provider
+
+A provider is a plain object with optional `transport` and `inbound` fields. Implement either (or both) and pass it to `createEmailAdapter`:
+
+```typescript
+import { defineEmailProvider } from "@chat-adapter/email";
+
+const myProvider = defineEmailProvider({
+  transport: {
+    name: "my-esp",
+    async send(email) {
+      // email.messageId / email.inReplyTo / email.references are already
+      // composed — forward them as RFC-822 headers on your wire format.
+      return { providerMessageId: "abc", raw: {} };
+    },
+  },
+  inbound: {
+    name: "my-esp",
+    verifySignature(request, body) {
+      // Return true if the request is authentic; false to reject with 401.
+    },
+    async parse(request, body) {
+      // Return a ParsedInboundEmail, or null to skip (e.g. delivery events).
+    },
+  },
+});
+```
+
+The main `@chat-adapter/email` entry also exports helpers for common provider needs:
+
+- `verifySvixSignature` / `verifySvixRequest` — Svix-style HMAC-SHA256 webhook verification.
+- `verifyConstantTimeToken` — shared-token verification (constant-time compare).
+- `throwForEspError` — maps HTTP responses to typed `AdapterError` subclasses.
+- `parseAddress` — RFC-822 `Name <addr@example.com>` parsing.
+- `normalizeHeaderKeys` — lowercase header keys for consistent lookup.
+
+See [`src/types.ts`](./src/types.ts) for the full `EmailTransport`, `EmailInbound`, `OutboundEmail`, and `ParsedInboundEmail` contracts.
+
+## Threading
+
+Email threads are rooted on the first message's `Message-ID`. Inbound messages walk the `References` and `In-Reply-To` headers to find the thread root; outbound replies always include the full `References` chain (capped at 10 entries) so mail clients group them correctly.
+
+The thread ID format is `email:<base64url(rootMessageId)>`.
+
+## Limitations
+
+- **No edit / delete / reactions** — email is immutable. Calling `editMessage`, `deleteMessage`, `addReaction`, or `removeReaction` throws `NotImplementedError`.
+- **No native streaming** — `stream()` buffers all chunks and sends one email at the end.
+- **No @-mentions** — every inbound message in an unsubscribed thread routes to `onDirectMessage`.
+- **Cards in email** — buttons render as anchor tags driven by `callbackUrl`. Inline button clicks back to the bot are not possible (no live channel).
+- **1:1 conversations** — group threads (multi-recipient) are not supported.
+
+## License
+
+MIT

--- a/packages/adapter-email/package.json
+++ b/packages/adapter-email/package.json
@@ -1,0 +1,61 @@
+{
+  "name": "@chat-adapter/email",
+  "version": "4.28.1",
+  "description": "Email adapter for chat, pluggable email service providers for your chatbot",
+  "type": "module",
+  "main": "./dist/index.js",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    },
+    "./providers": {
+      "types": "./dist/providers/index.d.ts",
+      "import": "./dist/providers/index.js"
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsup",
+    "dev": "tsup --watch",
+    "test": "vitest run --coverage",
+    "test:watch": "vitest",
+    "typecheck": "tsc --noEmit",
+    "clean": "rm -rf dist"
+  },
+  "dependencies": {
+    "@chat-adapter/shared": "workspace:*",
+    "chat": "workspace:*"
+  },
+  "devDependencies": {
+    "@types/node": "^25.3.2",
+    "tsup": "^8.3.5",
+    "typescript": "^5.7.2",
+    "vitest": "^4.0.18"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/vercel/chat.git",
+    "directory": "packages/adapter-email"
+  },
+  "homepage": "https://github.com/vercel/chat#readme",
+  "bugs": {
+    "url": "https://github.com/vercel/chat/issues"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "keywords": [
+    "chat",
+    "email",
+    "bot",
+    "adapter",
+    "resend",
+    "inbound"
+  ],
+  "license": "MIT"
+}

--- a/packages/adapter-email/src/adapter.test.ts
+++ b/packages/adapter-email/src/adapter.test.ts
@@ -1,0 +1,930 @@
+import { ConsoleLogger, NotImplementedError } from "chat";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const MESSAGE_ID_AT_DOMAIN = /@yourdomain\.com$/;
+const THREAD_ID_PREFIX = /^email:/;
+
+import { EmailAdapter } from "./adapter";
+import { decodeEmailThreadId, stripAngleBrackets } from "./threading";
+import type { EmailInbound, EmailTransport, ParsedInboundEmail } from "./types";
+
+interface MockChatInstance {
+  getLogger: ReturnType<typeof vi.fn>;
+  getState: ReturnType<typeof vi.fn>;
+  getUserName: ReturnType<typeof vi.fn>;
+  processAction: ReturnType<typeof vi.fn>;
+  processMessage: ReturnType<typeof vi.fn>;
+  processReaction: ReturnType<typeof vi.fn>;
+}
+
+function makeMockState() {
+  const store = new Map<string, unknown>();
+  return {
+    store,
+    state: {
+      get: vi.fn(async (key: string) => store.get(key) ?? null),
+      set: vi.fn(async (key: string, value: unknown) => {
+        store.set(key, value);
+      }),
+      delete: vi.fn(async (key: string) => {
+        store.delete(key);
+      }),
+      acquireLock: vi.fn(),
+      releaseLock: vi.fn(),
+      forceReleaseLock: vi.fn(),
+      extendLock: vi.fn(),
+      subscribe: vi.fn(),
+      unsubscribe: vi.fn(),
+      isSubscribed: vi.fn(async () => false),
+      connect: vi.fn(),
+      disconnect: vi.fn(),
+      enqueue: vi.fn(),
+      dequeue: vi.fn(),
+      queueDepth: vi.fn(),
+      setIfNotExists: vi.fn(),
+      appendToList: vi.fn(),
+      getList: vi.fn(),
+    },
+  };
+}
+
+function makeMockChat(stateStore: ReturnType<typeof makeMockState>) {
+  const chat: MockChatInstance = {
+    getState: vi.fn(() => stateStore.state),
+    getUserName: vi.fn(() => "test-bot"),
+    getLogger: vi.fn(() => new ConsoleLogger("silent")),
+    processMessage: vi.fn(async () => undefined),
+    processAction: vi.fn(async () => undefined),
+    processReaction: vi.fn(),
+  };
+  return chat;
+}
+
+function makeAdapter(
+  opts: { transport?: EmailTransport; inbound?: EmailInbound } = {}
+) {
+  return new EmailAdapter({
+    fromAddress: "bot@yourdomain.com",
+    fromName: "Test Bot",
+    messageIdDomain: "yourdomain.com",
+    transport: opts.transport,
+    inbound: opts.inbound,
+    userName: "test-bot",
+    logger: new ConsoleLogger("silent"),
+  });
+}
+
+describe("EmailAdapter#initialize", () => {
+  it("stores the chat reference", async () => {
+    const adapter = makeAdapter();
+    const stateStore = makeMockState();
+    const chat = makeMockChat(stateStore);
+    await adapter.initialize(chat as never);
+    expect(adapter.botUserId).toBe("bot@yourdomain.com");
+  });
+});
+
+describe("EmailAdapter#openDM", () => {
+  let stateStore: ReturnType<typeof makeMockState>;
+  let chat: MockChatInstance;
+
+  beforeEach(() => {
+    stateStore = makeMockState();
+    chat = makeMockChat(stateStore);
+  });
+
+  it("rejects malformed addresses", async () => {
+    const adapter = makeAdapter();
+    await adapter.initialize(chat as never);
+    await expect(adapter.openDM("not-an-email")).rejects.toThrow(
+      "Invalid email address"
+    );
+  });
+
+  it("returns a stable thread ID and pre-stashes thread state", async () => {
+    const adapter = makeAdapter();
+    await adapter.initialize(chat as never);
+    const threadId = await adapter.openDM("user@example.com");
+    const decoded = decodeEmailThreadId(threadId);
+    expect(decoded.participantAddress).toBe("user@example.com");
+    expect(decoded.rootMessageId).toMatch(MESSAGE_ID_AT_DOMAIN);
+    const stored = stateStore.store.get(
+      `email:thread:${decoded.rootMessageId}`
+    );
+    expect(stored).toEqual({
+      references: [],
+      participantAddress: "user@example.com",
+    });
+  });
+});
+
+describe("EmailAdapter#postMessage", () => {
+  let stateStore: ReturnType<typeof makeMockState>;
+  let chat: MockChatInstance;
+  let send: ReturnType<typeof vi.fn>;
+  let transport: EmailTransport;
+
+  beforeEach(() => {
+    stateStore = makeMockState();
+    chat = makeMockChat(stateStore);
+    send = vi.fn(async () => ({ providerMessageId: "p_1", raw: { ok: true } }));
+    transport = { name: "mock", send };
+  });
+
+  it("throws when no transport is configured", async () => {
+    const adapter = makeAdapter();
+    await adapter.initialize(chat as never);
+    const threadId = `email:${Buffer.from("root@x").toString("base64url")}`;
+    await expect(adapter.postMessage(threadId, "hi")).rejects.toThrow(
+      "No transport configured"
+    );
+  });
+
+  it("requires a participant address in the thread ID", async () => {
+    const adapter = makeAdapter({ transport });
+    await adapter.initialize(chat as never);
+    const threadId = `email:${Buffer.from("root@x").toString("base64url")}`;
+    await expect(adapter.postMessage(threadId, "hi")).rejects.toThrow(
+      "recipient address is unknown"
+    );
+  });
+
+  it("sends an outbound-initiated email reusing the reserved root as Message-ID", async () => {
+    const adapter = makeAdapter({ transport });
+    await adapter.initialize(chat as never);
+    const threadId = await adapter.openDM("user@example.com");
+    const decoded = decodeEmailThreadId(threadId);
+
+    const result = await adapter.postMessage(threadId, "Hello world");
+
+    expect(send).toHaveBeenCalledTimes(1);
+    const sent = send.mock.calls[0]?.[0];
+    expect(sent.from).toEqual({
+      address: "bot@yourdomain.com",
+      name: "Test Bot",
+    });
+    expect(sent.to).toEqual(["user@example.com"]);
+    expect(sent.subject).toBe("Hello world");
+    expect(sent.text).toBe("Hello world");
+    expect(sent.html).toContain("<p>Hello world</p>");
+    expect(sent.messageId).toBe(decoded.rootMessageId);
+    expect(sent.threadRootMessageId).toBe(decoded.rootMessageId);
+    expect(sent.inReplyTo).toBeUndefined();
+    expect(sent.references).toBeUndefined();
+
+    expect(result.threadId).toBe(threadId);
+    expect(result.id).toBe(decoded.rootMessageId);
+
+    const stored = stateStore.store.get(
+      `email:thread:${decoded.rootMessageId}`
+    ) as { references: string[] };
+    expect(stored.references).toEqual([decoded.rootMessageId]);
+  });
+
+  it("sends a reply with In-Reply-To and References when the thread already has messages", async () => {
+    const adapter = makeAdapter({ transport });
+    await adapter.initialize(chat as never);
+    // Simulate an inbound message landing first.
+    const inbound = makeInboundFixture({
+      messageId: "<inbound-1@example.com>",
+      from: "user@example.com",
+      subject: "Hello bot",
+      text: "Original message",
+    });
+    const inboundProvider: EmailInbound = {
+      name: "fixture",
+      verifySignature: () => true,
+      parse: () => inbound,
+    };
+    const adapterWithInbound = makeAdapter({
+      transport,
+      inbound: inboundProvider,
+    });
+    await adapterWithInbound.initialize(chat as never);
+
+    const req = new Request("https://example.com/wh", {
+      method: "POST",
+      body: "{}",
+    });
+    const response = await adapterWithInbound.handleWebhook(req);
+    expect(response.status).toBe(200);
+    expect(chat.processMessage).toHaveBeenCalledTimes(1);
+    const [, threadIdReceived] = chat.processMessage.mock.calls[0] ?? [];
+
+    // Now reply via postMessage.
+    await adapterWithInbound.postMessage(
+      threadIdReceived as string,
+      "Reply body"
+    );
+
+    const sent = send.mock.calls[0]?.[0];
+    expect(sent.subject).toBe("Re: Hello bot");
+    expect(sent.inReplyTo).toBe("inbound-1@example.com");
+    expect(sent.references).toEqual(["inbound-1@example.com"]);
+    expect(sent.threadRootMessageId).toBe("inbound-1@example.com");
+    expect(sent.messageId).not.toBe("inbound-1@example.com");
+  });
+
+  it("renders a card to HTML and falls back to plain text", async () => {
+    const adapter = makeAdapter({ transport });
+    await adapter.initialize(chat as never);
+    const threadId = await adapter.openDM("user@example.com");
+    await adapter.postMessage(threadId, {
+      card: {
+        type: "card",
+        title: "Hi",
+        children: [{ type: "text", content: "Body" }],
+      },
+    });
+    const sent = send.mock.calls[0]?.[0];
+    expect(sent.html).toContain("Hi");
+    expect(sent.html).toContain("Body");
+    expect(sent.text).toContain("Hi");
+    expect(sent.text).toContain("Body");
+    expect(sent.subject).toBe("Hi");
+  });
+});
+
+describe("EmailAdapter#handleWebhook", () => {
+  let stateStore: ReturnType<typeof makeMockState>;
+  let chat: MockChatInstance;
+
+  beforeEach(() => {
+    stateStore = makeMockState();
+    chat = makeMockChat(stateStore);
+  });
+
+  it("returns 404 when no inbound provider is configured", async () => {
+    const adapter = makeAdapter();
+    await adapter.initialize(chat as never);
+    const response = await adapter.handleWebhook(
+      new Request("https://example.com/wh", { method: "POST", body: "{}" })
+    );
+    expect(response.status).toBe(404);
+  });
+
+  it("returns 401 when signature verification fails", async () => {
+    const adapter = makeAdapter({
+      inbound: {
+        name: "mock",
+        verifySignature: () => false,
+        parse: () => null,
+      },
+    });
+    await adapter.initialize(chat as never);
+    const response = await adapter.handleWebhook(
+      new Request("https://example.com/wh", { method: "POST", body: "{}" })
+    );
+    expect(response.status).toBe(401);
+  });
+
+  it("returns 200 and skips dispatch when parse returns null", async () => {
+    const adapter = makeAdapter({
+      inbound: {
+        name: "mock",
+        verifySignature: () => true,
+        parse: () => null,
+      },
+    });
+    await adapter.initialize(chat as never);
+    const response = await adapter.handleWebhook(
+      new Request("https://example.com/wh", { method: "POST", body: "{}" })
+    );
+    expect(response.status).toBe(200);
+    expect(chat.processMessage).not.toHaveBeenCalled();
+  });
+
+  it("dispatches a parsed inbound message to chat.processMessage", async () => {
+    const inbound = makeInboundFixture({
+      messageId: "msg-1@example.com",
+      from: "user@example.com",
+      subject: "Hi",
+      text: "Test body",
+    });
+    const adapter = makeAdapter({
+      inbound: {
+        name: "mock",
+        verifySignature: () => true,
+        parse: () => inbound,
+      },
+    });
+    await adapter.initialize(chat as never);
+    const response = await adapter.handleWebhook(
+      new Request("https://example.com/wh", { method: "POST", body: "{}" })
+    );
+    expect(response.status).toBe(200);
+    expect(chat.processMessage).toHaveBeenCalledTimes(1);
+    const args = chat.processMessage.mock.calls[0];
+    if (!args) {
+      throw new Error("processMessage was not called");
+    }
+    const [adapterArg, threadId, message] = args as [
+      unknown,
+      string,
+      { text: string },
+    ];
+    expect(adapterArg).toBe(adapter);
+    expect(threadId).toMatch(THREAD_ID_PREFIX);
+    expect(message.text).toBe("Test body");
+  });
+
+  it("returns 400 when parse throws", async () => {
+    const adapter = makeAdapter({
+      inbound: {
+        name: "mock",
+        verifySignature: () => true,
+        parse: () => {
+          throw new Error("boom");
+        },
+      },
+    });
+    await adapter.initialize(chat as never);
+    const response = await adapter.handleWebhook(
+      new Request("https://example.com/wh", { method: "POST", body: "{}" })
+    );
+    expect(response.status).toBe(400);
+  });
+});
+
+describe("EmailAdapter#stream", () => {
+  it("buffers chunks and posts a single email at the end", async () => {
+    const send = vi.fn(async () => ({ providerMessageId: "p_1", raw: {} }));
+    const transport: EmailTransport = { name: "mock", send };
+    const adapter = makeAdapter({ transport });
+    const stateStore = makeMockState();
+    const chat = makeMockChat(stateStore);
+    await adapter.initialize(chat as never);
+    const threadId = await adapter.openDM("user@example.com");
+
+    async function* gen() {
+      yield "Hello ";
+      yield { type: "markdown_text" as const, text: "world" };
+      yield {
+        type: "task_update" as const,
+        status: "complete" as const,
+        id: "t",
+        title: "t",
+      };
+    }
+
+    await adapter.stream(threadId, gen());
+    expect(send).toHaveBeenCalledTimes(1);
+    const sent = send.mock.calls[0]?.[0];
+    expect(sent.text).toBe("Hello world");
+  });
+});
+
+describe("EmailAdapter unsupported operations", () => {
+  it("rejects edit/delete/reactions with NotImplementedError", async () => {
+    const adapter = makeAdapter();
+    await expect(
+      // @ts-expect-error: testing the runtime guard, not the type
+      adapter.editMessage("t", "m", "x")
+    ).rejects.toBeInstanceOf(NotImplementedError);
+    await expect(adapter.deleteMessage("t", "m")).rejects.toBeInstanceOf(
+      NotImplementedError
+    );
+    await expect(adapter.addReaction("t", "m", "x")).rejects.toBeInstanceOf(
+      NotImplementedError
+    );
+    await expect(adapter.removeReaction("t", "m", "x")).rejects.toBeInstanceOf(
+      NotImplementedError
+    );
+  });
+
+  it("startTyping resolves without doing anything", async () => {
+    const adapter = makeAdapter();
+    await expect(adapter.startTyping()).resolves.toBeUndefined();
+  });
+});
+
+describe("EmailAdapter#handleWebhook (additional)", () => {
+  it("returns 200 and skips processing when Chat is not yet initialized", async () => {
+    const adapter = makeAdapter({
+      inbound: {
+        name: "mock",
+        verifySignature: () => true,
+        parse: () => ({
+          messageId: "x@y",
+          from: { address: "a@b" },
+          to: ["bot@yourdomain.com"],
+          subject: "",
+          receivedAt: new Date(),
+          raw: {},
+        }),
+      },
+    });
+    // NOTE: deliberately NOT calling adapter.initialize()
+    const response = await adapter.handleWebhook(
+      new Request("https://x", { method: "POST", body: "{}" })
+    );
+    expect(response.status).toBe(200);
+  });
+
+  it("returns 500 when dispatch throws", async () => {
+    const stateStore = makeMockState();
+    const chat = makeMockChat(stateStore);
+    // Make state.set reject so dispatchInbound throws.
+    stateStore.state.set = vi.fn(async () => {
+      throw new Error("state explosion");
+    });
+    const adapter = makeAdapter({
+      inbound: {
+        name: "mock",
+        verifySignature: () => true,
+        parse: () => ({
+          messageId: "x@y",
+          from: { address: "a@b" },
+          to: ["bot@yourdomain.com"],
+          subject: "",
+          receivedAt: new Date(),
+          raw: {},
+        }),
+      },
+    });
+    await adapter.initialize(chat as never);
+    const response = await adapter.handleWebhook(
+      new Request("https://x", { method: "POST", body: "{}" })
+    );
+    expect(response.status).toBe(500);
+  });
+
+  it("attaches inbound attachments to the dispatched Message", async () => {
+    const stateStore = makeMockState();
+    const chat = makeMockChat(stateStore);
+    const fetchData = vi.fn(async () => Buffer.from("data"));
+    const adapter = makeAdapter({
+      inbound: {
+        name: "mock",
+        verifySignature: () => true,
+        parse: () => ({
+          messageId: "x@y",
+          from: { address: "a@b", name: "A" },
+          to: ["bot@yourdomain.com"],
+          subject: "Hi",
+          receivedAt: new Date(),
+          text: "body",
+          attachments: [
+            {
+              filename: "f.pdf",
+              contentType: "application/pdf",
+              size: 100,
+              url: "https://example.com/f.pdf",
+              fetchData,
+            },
+            {
+              filename: "img.png",
+              contentType: "image/png",
+            },
+            {
+              filename: "movie.mp4",
+              contentType: "video/mp4",
+            },
+            {
+              filename: "song.mp3",
+              contentType: "audio/mp3",
+            },
+            {
+              filename: "unknown.bin",
+              // no contentType -> infers "file"
+            },
+          ],
+          raw: {},
+        }),
+      },
+    });
+    await adapter.initialize(chat as never);
+    await adapter.handleWebhook(
+      new Request("https://x", { method: "POST", body: "{}" })
+    );
+    expect(chat.processMessage).toHaveBeenCalledTimes(1);
+    const [, , message] = chat.processMessage.mock.calls[0] as [
+      unknown,
+      string,
+      { attachments: Array<{ type: string; name: string }> },
+    ];
+    const types = message.attachments.map((a) => a.type).sort();
+    expect(types).toEqual(["audio", "file", "file", "image", "video"]);
+  });
+});
+
+describe("EmailAdapter#postMessage (additional)", () => {
+  it("rethrows transport errors after logging", async () => {
+    const send = vi.fn(async () => {
+      throw new Error("transport boom");
+    });
+    const transport: EmailTransport = { name: "mock", send };
+    const stateStore = makeMockState();
+    const chat = makeMockChat(stateStore);
+    const adapter = makeAdapter({ transport });
+    await adapter.initialize(chat as never);
+    const threadId = await adapter.openDM("user@example.com");
+    await expect(adapter.postMessage(threadId, "hi")).rejects.toThrow(
+      "transport boom"
+    );
+  });
+
+  describe("renderBodies (via postMessage)", () => {
+    function makeSendingAdapter() {
+      const send = vi.fn(async () => ({ providerMessageId: "x", raw: {} }));
+      const transport: EmailTransport = { name: "mock", send };
+      const stateStore = makeMockState();
+      const chat = makeMockChat(stateStore);
+      const adapter = makeAdapter({ transport });
+      return { adapter, send, chat };
+    }
+
+    it("renders the raw passthrough body", async () => {
+      const { adapter, send, chat } = makeSendingAdapter();
+      await adapter.initialize(chat as never);
+      const threadId = await adapter.openDM("user@example.com");
+      await adapter.postMessage(threadId, { raw: "raw body text" });
+      const sent = send.mock.calls[0]?.[0];
+      expect(sent.text).toBe("raw body text");
+      expect(sent.html).toContain("raw body text");
+    });
+
+    it("renders an AST postable body", async () => {
+      const { adapter, send, chat } = makeSendingAdapter();
+      await adapter.initialize(chat as never);
+      const threadId = await adapter.openDM("user@example.com");
+      await adapter.postMessage(threadId, {
+        ast: {
+          type: "root",
+          children: [
+            {
+              type: "paragraph",
+              children: [{ type: "text", value: "ast-body" }],
+            },
+          ],
+        },
+      });
+      const sent = send.mock.calls[0]?.[0];
+      expect(sent.text.trim()).toBe("ast-body");
+      expect(sent.html).toContain("ast-body");
+    });
+  });
+
+  describe("deriveInitialSubject", () => {
+    function makeSendingAdapter() {
+      const send = vi.fn(async () => ({ providerMessageId: "x", raw: {} }));
+      const transport: EmailTransport = { name: "mock", send };
+      const stateStore = makeMockState();
+      const chat = makeMockChat(stateStore);
+      const adapter = makeAdapter({ transport });
+      return { adapter, send, chat };
+    }
+
+    it("derives subject from the first line of a raw body", async () => {
+      const { adapter, send, chat } = makeSendingAdapter();
+      await adapter.initialize(chat as never);
+      const threadId = await adapter.openDM("user@example.com");
+      await adapter.postMessage(threadId, { raw: "first line\nsecond" });
+      expect(send.mock.calls[0]?.[0].subject).toBe("first line");
+    });
+
+    it("derives subject from the first line of a markdown body", async () => {
+      const { adapter, send, chat } = makeSendingAdapter();
+      await adapter.initialize(chat as never);
+      const threadId = await adapter.openDM("user@example.com");
+      await adapter.postMessage(threadId, {
+        markdown: "# Heading\n\nbody",
+      });
+      expect(send.mock.calls[0]?.[0].subject).toBe("Heading");
+    });
+
+    it("uses card.title from a PostableCard", async () => {
+      const { adapter, send, chat } = makeSendingAdapter();
+      await adapter.initialize(chat as never);
+      const threadId = await adapter.openDM("user@example.com");
+      await adapter.postMessage(threadId, {
+        card: { type: "card", title: "Card Title", children: [] },
+      });
+      expect(send.mock.calls[0]?.[0].subject).toBe("Card Title");
+    });
+
+    it("uses card.title from a direct CardElement", async () => {
+      const { adapter, send, chat } = makeSendingAdapter();
+      await adapter.initialize(chat as never);
+      const threadId = await adapter.openDM("user@example.com");
+      await adapter.postMessage(threadId, {
+        type: "card",
+        title: "Direct Card Title",
+        children: [],
+      });
+      expect(send.mock.calls[0]?.[0].subject).toBe("Direct Card Title");
+    });
+
+    it("falls back to `Message from <userName>` when no candidate is present", async () => {
+      const { adapter, send, chat } = makeSendingAdapter();
+      await adapter.initialize(chat as never);
+      const threadId = await adapter.openDM("user@example.com");
+      await adapter.postMessage(threadId, "   \n   ");
+      expect(send.mock.calls[0]?.[0].subject).toBe("Message from test-bot");
+    });
+
+    it("truncates subjects longer than 80 characters", async () => {
+      const { adapter, send, chat } = makeSendingAdapter();
+      await adapter.initialize(chat as never);
+      const threadId = await adapter.openDM("user@example.com");
+      const longText = "x".repeat(200);
+      await adapter.postMessage(threadId, longText);
+      const subject = send.mock.calls[0]?.[0].subject;
+      expect(subject).toHaveLength(80);
+      expect(subject.endsWith("...")).toBe(true);
+    });
+  });
+});
+
+describe("EmailAdapter thread / channel introspection", () => {
+  let stateStore: ReturnType<typeof makeMockState>;
+  let chat: MockChatInstance;
+
+  beforeEach(() => {
+    stateStore = makeMockState();
+    chat = makeMockChat(stateStore);
+  });
+
+  it("fetchMessages returns an empty result (server-side history not supported)", async () => {
+    const adapter = makeAdapter();
+    await adapter.initialize(chat as never);
+    const result = await adapter.fetchMessages("email:foo");
+    expect(result).toEqual({ messages: [] });
+  });
+
+  it("fetchThread returns a normalized ThreadInfo with stored subject", async () => {
+    const send = vi.fn(async () => ({ providerMessageId: "x", raw: {} }));
+    const transport: EmailTransport = { name: "mock", send };
+    const adapter = makeAdapter({ transport });
+    await adapter.initialize(chat as never);
+    const threadId = await adapter.openDM("user@example.com");
+    // Post once so the thread has subject state persisted.
+    await adapter.postMessage(threadId, "Hello topic");
+
+    const info = await adapter.fetchThread(threadId);
+    expect(info.id).toBe(threadId);
+    expect(info.isDM).toBe(true);
+    expect(info.channelName).toBe("Hello topic");
+  });
+
+  it("fetchThread defaults channelName when no subject is stored", async () => {
+    const adapter = makeAdapter();
+    await adapter.initialize(chat as never);
+    const root = Buffer.from("solo@x").toString("base64url");
+    const info = await adapter.fetchThread(`email:${root}`);
+    expect(info.channelName).toBe("Email conversation");
+  });
+
+  it("encodeThreadId / decodeThreadId roundtrip", () => {
+    const adapter = makeAdapter();
+    const data = {
+      rootMessageId: "abc@x.com",
+      participantAddress: "user@x.com",
+    };
+    const encoded = adapter.encodeThreadId(data);
+    expect(adapter.decodeThreadId(encoded)).toEqual(data);
+  });
+
+  it("channelIdFromThreadId returns the thread id unchanged", () => {
+    const adapter = makeAdapter();
+    expect(adapter.channelIdFromThreadId("email:foo")).toBe("email:foo");
+  });
+
+  it("isDM always returns true", () => {
+    const adapter = makeAdapter();
+    expect(adapter.isDM("anything")).toBe(true);
+  });
+
+  it("renderFormatted delegates to the format converter", () => {
+    const adapter = makeAdapter();
+    const out = adapter.renderFormatted({
+      type: "root",
+      children: [
+        {
+          type: "paragraph",
+          children: [{ type: "text", value: "hi" }],
+        },
+      ],
+    });
+    expect(out.trim()).toBe("hi");
+  });
+});
+
+describe("EmailAdapter#parseMessage", () => {
+  it("rebuilds an inbound Message from a raw payload", () => {
+    const adapter = makeAdapter();
+    const parsed = makeInboundFixture({
+      messageId: "<m@x>",
+      from: "alice@x.com",
+      subject: "Hi",
+      text: "Hello",
+      references: ["<root@x>"],
+    });
+    const msg = adapter.parseMessage({ direction: "inbound", email: parsed });
+    expect(msg.text).toBe("Hello");
+    expect(msg.author.userId).toBe("alice@x.com");
+    expect(msg.threadId).toMatch(THREAD_ID_PREFIX);
+  });
+
+  it("falls back to messageId as the thread root for inbound messages with no chain", () => {
+    const adapter = makeAdapter();
+    const parsed = makeInboundFixture({
+      messageId: "first@x",
+      from: "alice@x.com",
+    });
+    const msg = adapter.parseMessage({ direction: "inbound", email: parsed });
+    const decoded = decodeEmailThreadId(msg.threadId);
+    expect(decoded.rootMessageId).toBe("first@x");
+  });
+
+  it("rebuilds an outbound Message with isMe: true", () => {
+    const adapter = makeAdapter();
+    const out = {
+      from: { address: "bot@yourdomain.com", name: "Test Bot" },
+      to: ["user@example.com"],
+      subject: "Hi",
+      html: "<p>Hi</p>",
+      text: "Hi",
+      messageId: "out-1@yourdomain.com",
+      threadRootMessageId: "out-1@yourdomain.com",
+    };
+    const msg = adapter.parseMessage({
+      direction: "outbound",
+      email: out,
+      result: { providerMessageId: undefined, raw: {} },
+    });
+    expect(msg.author.isMe).toBe(true);
+    expect(msg.author.isBot).toBe(true);
+    expect(msg.text).toBe("Hi");
+  });
+
+  it("encodes an empty recipient when parseMessage gets an outbound with no `to`", () => {
+    const adapter = makeAdapter();
+    const out = {
+      from: { address: "bot@yourdomain.com" },
+      to: [] as string[],
+      subject: "x",
+      html: "",
+      text: "",
+      messageId: "out@x",
+      threadRootMessageId: "out@x",
+    };
+    const msg = adapter.parseMessage({
+      direction: "outbound",
+      email: out,
+      result: { raw: {} },
+    });
+    expect(msg.threadId).toMatch(THREAD_ID_PREFIX);
+  });
+
+  it("uses userName as the fullName when fromName is not configured", () => {
+    // Build an adapter without fromName via the public createEmailAdapter
+    // factory — the EmailAdapter ctor itself accepts fromName as optional.
+    const adapter = new EmailAdapter({
+      fromAddress: "bot@yourdomain.com",
+      messageIdDomain: "yourdomain.com",
+      transport: { name: "noop", send: vi.fn() },
+      userName: "test-bot",
+      logger: new ConsoleLogger("silent"),
+    });
+    const out = {
+      from: { address: "bot@yourdomain.com" },
+      to: ["user@example.com"],
+      subject: "x",
+      html: "",
+      text: "",
+      messageId: "m@x",
+      threadRootMessageId: "m@x",
+    };
+    const msg = adapter.parseMessage({
+      direction: "outbound",
+      email: out,
+      result: { raw: {} },
+    });
+    expect(msg.author.fullName).toBe("test-bot");
+  });
+
+  it("preserves inbound In-Reply-To when building the threadId for parseMessage", () => {
+    const adapter = makeAdapter();
+    const parsed: ParsedInboundEmail = {
+      messageId: "child@x",
+      inReplyTo: "<parent@x>",
+      from: { address: "alice@x.com" },
+      to: ["bot@yourdomain.com"],
+      subject: "Re",
+      receivedAt: new Date("2026-01-01T00:00:00Z"),
+      raw: {},
+    };
+    const msg = adapter.parseMessage({ direction: "inbound", email: parsed });
+    const decoded = decodeEmailThreadId(msg.threadId);
+    // findThreadRoot prefers In-Reply-To when references is empty/missing.
+    expect(decoded.rootMessageId).toBe("parent@x");
+  });
+
+  it("handles inbound messages where the sender has no display name", async () => {
+    const stateStore = makeMockState();
+    const chat = makeMockChat(stateStore);
+    const adapter = makeAdapter({
+      inbound: {
+        name: "mock",
+        verifySignature: () => true,
+        parse: () => ({
+          messageId: "x@y",
+          inReplyTo: "<parent@x>",
+          from: { address: "noname@x.com" }, // no `name`
+          to: ["bot@yourdomain.com"],
+          subject: "Hi",
+          receivedAt: new Date(),
+          raw: {},
+        }),
+      },
+    });
+    await adapter.initialize(chat as never);
+    await adapter.handleWebhook(
+      new Request("https://x", { method: "POST", body: "{}" })
+    );
+    const [, , msg] = chat.processMessage.mock.calls[0] as [
+      unknown,
+      string,
+      { author: { fullName: string } },
+    ];
+    // fullName falls back to the address when no name is provided.
+    expect(msg.author.fullName).toBe("noname@x.com");
+  });
+
+  it("detects isMe for an inbound message sent from the bot's own address", async () => {
+    const adapter = makeAdapter();
+    const stateStore = makeMockState();
+    const chat = makeMockChat(stateStore);
+    await adapter.initialize(chat as never);
+    const parsed = makeInboundFixture({
+      messageId: "self@x",
+      from: "BOT@yourdomain.com", // case-insensitive match
+    });
+    const msg = adapter.parseMessage({ direction: "inbound", email: parsed });
+    expect(msg.author.isMe).toBe(true);
+  });
+});
+
+describe("EmailAdapter state helpers when chat is null", () => {
+  it("loadThreadState returns empty state when chat is not initialized", async () => {
+    // Reach through a subclass to call the protected method without
+    // initializing chat first.
+    class TestAdapter extends EmailAdapter {
+      exposed(rootMessageId: string) {
+        return this.loadThreadState(rootMessageId);
+      }
+    }
+    const adapter = new TestAdapter({
+      fromAddress: "bot@yourdomain.com",
+      messageIdDomain: "yourdomain.com",
+      transport: NOOP_TRANSPORT_FOR_HELPERS,
+      userName: "test-bot",
+      logger: new ConsoleLogger("silent"),
+    });
+    const state = await adapter.exposed("any@x");
+    expect(state).toEqual({ references: [] });
+  });
+
+  it("persistThreadState is a no-op when chat is not initialized", async () => {
+    class TestAdapter extends EmailAdapter {
+      exposed(rootMessageId: string) {
+        return this.persistThreadState(rootMessageId, { references: [] });
+      }
+    }
+    const adapter = new TestAdapter({
+      fromAddress: "bot@yourdomain.com",
+      messageIdDomain: "yourdomain.com",
+      transport: NOOP_TRANSPORT_FOR_HELPERS,
+      userName: "test-bot",
+      logger: new ConsoleLogger("silent"),
+    });
+    await expect(adapter.exposed("any@x")).resolves.toBeUndefined();
+  });
+});
+
+const NOOP_TRANSPORT_FOR_HELPERS: EmailTransport = {
+  name: "noop",
+  send: vi.fn(async () => ({ providerMessageId: "x", raw: {} })),
+};
+
+function makeInboundFixture(args: {
+  messageId: string;
+  from: string;
+  subject?: string;
+  text?: string;
+  inReplyTo?: string;
+  references?: string[];
+}): ParsedInboundEmail {
+  return {
+    messageId: stripAngleBrackets(args.messageId),
+    from: { address: args.from, name: args.from },
+    to: ["bot@yourdomain.com"],
+    subject: args.subject ?? "",
+    text: args.text,
+    inReplyTo: args.inReplyTo,
+    references: args.references,
+    receivedAt: new Date("2026-01-01T00:00:00Z"),
+    raw: { fixture: true },
+  };
+}

--- a/packages/adapter-email/src/adapter.ts
+++ b/packages/adapter-email/src/adapter.ts
@@ -1,0 +1,809 @@
+/**
+ * Email adapter for Chat SDK.
+ *
+ * Owns the email-shaped behavior — RFC-822 threading, MIME composition,
+ * HTML/text rendering — and delegates outbound sending and inbound
+ * webhook parsing to a pluggable {@link EmailProvider}.
+ */
+
+import { extractCard, ValidationError } from "@chat-adapter/shared";
+import type {
+  Adapter,
+  AdapterPostableMessage,
+  Author,
+  ChatInstance,
+  FetchOptions,
+  FetchResult,
+  FormattedContent,
+  Logger,
+  PostableAst,
+  RawMessage,
+  StreamChunk,
+  StreamOptions,
+  ThreadInfo,
+  WebhookOptions,
+} from "chat";
+import {
+  Message,
+  NotImplementedError,
+  parseMarkdown,
+  stringifyMarkdown,
+} from "chat";
+import { EmailFormatConverter } from "./markdown";
+import { cardToHtml, cardToPlainText, markdownToHtml } from "./render";
+import {
+  buildReferencesChain,
+  decodeEmailThreadId,
+  encodeEmailThreadId,
+  findThreadRoot,
+  generateMessageId,
+  replySubject,
+  stripAngleBrackets,
+} from "./threading";
+import type {
+  EmailInbound,
+  EmailRawMessage,
+  EmailSendResult,
+  EmailThreadId,
+  EmailTransport,
+  OutboundEmail,
+  ParsedInboundEmail,
+} from "./types";
+
+/**
+ * Internal state stored per thread. Used to construct the `References`
+ * chain for outbound replies and to remember the original subject line.
+ */
+interface EmailThreadState {
+  /** Last known participant address. */
+  participantAddress?: string;
+  /** Message-IDs in chronological order (oldest first). */
+  references: string[];
+  /** Subject from the most recent message in the thread. */
+  subject?: string;
+}
+
+const STATE_TTL_MS = 30 * 24 * 60 * 60 * 1000; // 30 days
+
+/**
+ * Email implementation of the Chat SDK {@link Adapter} contract.
+ *
+ * Use {@link createEmailAdapter} to construct instances — the constructor
+ * deliberately takes a single fully-resolved options object so the factory
+ * can apply env-var lookups, default the `messageIdDomain` from the From
+ * address, and validate that at least one transport is configured.
+ *
+ * @template TThreadId - {@link EmailThreadId} — decoded `email:<root>:<addr>` thread IDs.
+ * @template TRawMessage - {@link EmailRawMessage} — discriminated union of the inbound or outbound payload for each {@link Message}.
+ *
+ * @see {@link createEmailAdapter} for the public factory.
+ * @see {@link EmailProvider} for the contract every ESP integration implements.
+ */
+export class EmailAdapter implements Adapter<EmailThreadId, EmailRawMessage> {
+  /** Adapter discriminator used by `chat.webhooks.<name>` routing. */
+  readonly name = "email";
+  /** Email is 1:1, so thread-level locking is correct. */
+  readonly lockScope = "thread" as const;
+  /** Bot username surfaced through {@link Adapter.userName}. */
+  readonly userName: string;
+
+  /** Reference to the host {@link ChatInstance}, set during {@link initialize}. */
+  protected chat: ChatInstance | null = null;
+  /** Namespaced logger; defaults to `ConsoleLogger("info").child("email")`. */
+  protected readonly logger: Logger;
+  /** Mailbox the bot sends from (the `From` address). */
+  protected readonly fromAddress: string;
+  /** Optional display name shown in the `From` header. */
+  protected readonly fromName?: string;
+  /** Optional `Reply-To` override for outbound messages. */
+  protected readonly replyToAddress?: string;
+  /** Domain used as the `@domain` suffix on generated `Message-ID` headers. */
+  protected readonly messageIdDomain: string;
+  /** Provider-supplied outbound transport. Undefined produces a send-disabled adapter. */
+  protected readonly transport?: EmailTransport;
+  /** Provider-supplied inbound parser. Undefined produces a receive-disabled adapter. */
+  protected readonly inbound?: EmailInbound;
+  /** Markdown ↔ AST converter; canonical outbound rendering happens in {@link cardToHtml} / {@link markdownToHtml}. */
+  protected readonly formatConverter = new EmailFormatConverter();
+
+  /**
+   * The bot's "user ID" is its From address — used for self-message
+   * detection when an inbound parser surfaces an outbound copy.
+   */
+  get botUserId(): string {
+    return this.fromAddress;
+  }
+
+  /**
+   * Construct an `EmailAdapter`. Prefer {@link createEmailAdapter} unless
+   * you need to bypass env-var lookups and the auto-derived messageIdDomain.
+   */
+  constructor(config: {
+    fromAddress: string;
+    fromName?: string;
+    replyToAddress?: string;
+    messageIdDomain: string;
+    transport?: EmailTransport;
+    inbound?: EmailInbound;
+    userName: string;
+    logger: Logger;
+  }) {
+    this.fromAddress = config.fromAddress;
+    this.fromName = config.fromName;
+    this.replyToAddress = config.replyToAddress;
+    this.messageIdDomain = config.messageIdDomain;
+    this.transport = config.transport;
+    this.inbound = config.inbound;
+    this.userName = config.userName;
+    this.logger = config.logger;
+  }
+
+  /**
+   * Wire the adapter to its host {@link ChatInstance}. Called once during
+   * `new Chat({...})` construction; not part of the public API.
+   */
+  async initialize(chat: ChatInstance): Promise<void> {
+    this.chat = chat;
+    this.logger.info("Email adapter initialized", {
+      fromAddress: this.fromAddress,
+      transport: this.transport?.name ?? null,
+      inbound: this.inbound?.name ?? null,
+    });
+    await Promise.resolve();
+  }
+
+  // ===========================================================================
+  // Webhook handling
+  // ===========================================================================
+
+  /**
+   * Handle an inbound webhook from the configured provider.
+   *
+   * Response codes:
+   * - `404` — no inbound provider is configured (the adapter is send-only).
+   * - `401` — signature verification failed.
+   * - `400` — provider's `parse` threw (malformed JSON, missing fields, etc.).
+   * - `500` — dispatch into the host {@link ChatInstance} failed (state error, etc.).
+   * - `200` — dispatched successfully, or the event was a non-message
+   *   notification that the provider chose to skip.
+   *
+   * Pre-`initialize()` calls return `200` so the platform doesn't retry
+   * during cold starts.
+   */
+  async handleWebhook(
+    request: Request,
+    options?: WebhookOptions
+  ): Promise<Response> {
+    if (!this.inbound) {
+      this.logger.debug(
+        "Inbound webhook received but no inbound provider configured"
+      );
+      return new Response("Not configured", { status: 404 });
+    }
+
+    if (!this.chat) {
+      this.logger.warn("Chat instance not initialized, ignoring email webhook");
+      return new Response("ok", { status: 200 });
+    }
+
+    const body = await request.text();
+    const verified = await this.inbound.verifySignature(request, body);
+    if (!verified) {
+      this.logger.warn("Email webhook rejected: invalid signature", {
+        provider: this.inbound.name,
+      });
+      return new Response("Invalid signature", { status: 401 });
+    }
+
+    let parsed: ParsedInboundEmail | null;
+    try {
+      parsed = await this.inbound.parse(request, body);
+    } catch (error) {
+      this.logger.error("Email inbound parse failed", {
+        error,
+        provider: this.inbound.name,
+      });
+      return new Response("Invalid payload", { status: 400 });
+    }
+
+    if (!parsed) {
+      // Provider chose to skip this event (e.g. delivery confirmations).
+      return new Response("ok", { status: 200 });
+    }
+
+    try {
+      await this.dispatchInbound(parsed, options);
+    } catch (error) {
+      this.logger.error("Email inbound dispatch failed", { error });
+      return new Response("Internal error", { status: 500 });
+    }
+
+    return new Response("ok", { status: 200 });
+  }
+
+  /**
+   * Persist thread state for a parsed inbound email and dispatch the
+   * resulting {@link Message} into the host {@link ChatInstance}.
+   *
+   * The thread root is resolved from RFC-822 `References` / `In-Reply-To`
+   * headers; if neither is present, the inbound message becomes the new
+   * thread root.
+   */
+  protected async dispatchInbound(
+    parsed: ParsedInboundEmail,
+    options: WebhookOptions | undefined
+  ): Promise<void> {
+    // handleWebhook guards against a null chat before reaching here, so
+    // we can assert non-null and treat any divergence as a programmer
+    // error rather than a runtime case to handle.
+    const chat = this.chat as ChatInstance;
+
+    const messageId = stripAngleBrackets(parsed.messageId);
+    const inReplyTo = parsed.inReplyTo
+      ? stripAngleBrackets(parsed.inReplyTo)
+      : undefined;
+    const references = (parsed.references ?? []).map(stripAngleBrackets);
+
+    // Find the thread root. If there's no prior thread context, this
+    // message becomes the new root.
+    const discoveredRoot = findThreadRoot({ references, inReplyTo });
+    const rootMessageId = discoveredRoot ?? messageId;
+
+    const participantAddress = parsed.from.address;
+    const threadId = encodeEmailThreadId({
+      rootMessageId,
+      participantAddress,
+    });
+
+    // Persist the latest reference chain + subject + participant for this
+    // thread so future outbound replies thread correctly.
+    const newState: EmailThreadState = {
+      references: [...references, messageId],
+      subject: parsed.subject,
+      participantAddress,
+    };
+    await chat
+      .getState()
+      .set(this.threadStateKey(rootMessageId), newState, STATE_TTL_MS);
+
+    const message = this.buildInboundMessage(parsed, threadId);
+    await chat.processMessage(this, threadId, message, options);
+  }
+
+  /**
+   * Build the normalized {@link Message} object from a parsed inbound
+   * email. Detects `isMe` case-insensitively against {@link fromAddress},
+   * preserves attachments verbatim (their `fetchData` is provider-supplied),
+   * and constructs the mdast `formatted` field from the plain-text body.
+   */
+  protected buildInboundMessage(
+    parsed: ParsedInboundEmail,
+    threadId: string
+  ): Message<EmailRawMessage> {
+    const text = parsed.text ?? "";
+    const author: Author = {
+      userId: parsed.from.address,
+      userName: parsed.from.address,
+      fullName: parsed.from.name ?? parsed.from.address,
+      isBot: false,
+      isMe:
+        parsed.from.address.toLowerCase() === this.fromAddress.toLowerCase(),
+    };
+
+    const formatted: FormattedContent = parseMarkdown(text);
+
+    return new Message<EmailRawMessage>({
+      id: stripAngleBrackets(parsed.messageId),
+      threadId,
+      text,
+      formatted,
+      author,
+      raw: { direction: "inbound", email: parsed },
+      attachments: (parsed.attachments ?? []).map((att) => ({
+        type: inferAttachmentType(att.contentType),
+        name: att.filename,
+        mimeType: att.contentType,
+        size: att.size,
+        url: att.url,
+        data: att.data,
+        fetchData: att.fetchData,
+      })),
+      metadata: {
+        dateSent: parsed.receivedAt,
+        edited: false,
+      },
+    });
+  }
+
+  // ===========================================================================
+  // Outbound
+  // ===========================================================================
+
+  /**
+   * Compose and send a single email through the configured transport.
+   *
+   * The first call on a thread (when no prior outbound or inbound has been
+   * stored) reuses the thread ID's reserved root as the outbound
+   * `Message-ID` so {@link openDM} → first `post()` round-trips correctly
+   * with replies. Subsequent calls generate a fresh `Message-ID`, set
+   * `In-Reply-To` to the parent, and extend the `References` chain.
+   *
+   * @throws {ValidationError} if the adapter has no transport, or if the
+   *   thread ID is missing a participant address (the latter happens only
+   *   when callers construct a thread ID by hand instead of using
+   *   {@link openDM}).
+   */
+  async postMessage(
+    threadId: string,
+    message: AdapterPostableMessage
+  ): Promise<RawMessage<EmailRawMessage>> {
+    if (!this.transport) {
+      throw new ValidationError(
+        "email",
+        "No transport configured. Pass `provider:` or `transport:` to createEmailAdapter() to send messages."
+      );
+    }
+
+    const decoded = decodeEmailThreadId(threadId);
+    const recipient = decoded.participantAddress;
+    if (!recipient) {
+      throw new ValidationError(
+        "email",
+        `Cannot send to thread ${threadId}: recipient address is unknown. Use openDM() to start a new conversation.`
+      );
+    }
+
+    const state = await this.loadThreadState(decoded.rootMessageId);
+    const isFirstMessage = state.references.length === 0;
+    const subject = isFirstMessage
+      ? this.deriveInitialSubject(message)
+      : replySubject(state.subject);
+
+    // For outbound-initiated threads (openDM → first post), the threadId's
+    // root was reserved upfront and we reuse it as this message's
+    // Message-ID so the encoded threadId stays stable between bot and
+    // recipient. For replies, generate a fresh Message-ID and chain it.
+    const messageId = isFirstMessage
+      ? decoded.rootMessageId
+      : generateMessageId(this.messageIdDomain);
+    const threadRootMessageId = decoded.rootMessageId;
+    const parentMessageId = state.references.at(-1);
+
+    const inReplyTo = parentMessageId;
+    const references = parentMessageId
+      ? buildReferencesChain(state.references.slice(0, -1), parentMessageId)
+      : undefined;
+
+    const { html, text } = this.renderBodies(message);
+
+    const outbound: OutboundEmail = {
+      from: { address: this.fromAddress, name: this.fromName },
+      to: [recipient],
+      replyTo: this.replyToAddress,
+      subject,
+      html,
+      text,
+      messageId,
+      inReplyTo,
+      references,
+      threadRootMessageId,
+    };
+
+    const result: EmailSendResult = await this.transport
+      .send(outbound)
+      .catch((error: unknown) => {
+        this.logger.error("Email transport send failed", {
+          error,
+          transport: this.transport?.name,
+        });
+        throw error;
+      });
+
+    // Update thread state to include this outbound message-id so the
+    // next reply can extend the References chain correctly.
+    await this.persistThreadState(threadRootMessageId, {
+      references: [...state.references, messageId],
+      subject,
+      participantAddress: recipient,
+    });
+
+    // If this was the first message, the canonical thread ID changes
+    // (root became this outbound message-id). The Chat instance still
+    // sees the original threadId for routing purposes; that's fine
+    // because openDM() callers receive the canonical ID.
+    return {
+      id: messageId,
+      threadId,
+      raw: { direction: "outbound", email: outbound, result },
+    };
+  }
+
+  /**
+   * Render an {@link AdapterPostableMessage} to a paired HTML body and
+   * plain-text fallback. Cards go through {@link cardToHtml} +
+   * {@link cardToPlainText}; markdown/raw/ast bodies share the
+   * {@link markdownToHtml} pipeline.
+   */
+  protected renderBodies(message: AdapterPostableMessage): {
+    html: string;
+    text: string;
+  } {
+    const card = extractCard(message);
+    if (card) {
+      return {
+        html: cardToHtml(card),
+        text: cardToPlainText(card),
+      };
+    }
+    if (typeof message === "string") {
+      return {
+        html: markdownToHtml(message),
+        text: message,
+      };
+    }
+    if ("raw" in message) {
+      return {
+        html: markdownToHtml(message.raw),
+        text: message.raw,
+      };
+    }
+    if ("markdown" in message) {
+      return {
+        html: markdownToHtml(message.markdown),
+        text: message.markdown,
+      };
+    }
+    // The remaining shape of AdapterPostableMessage is `PostableAst` —
+    // `extractCard` already handled both PostableCard and CardElement, and
+    // string / PostableRaw / PostableMarkdown were checked above. TypeScript
+    // can't see through `extractCard`, so we narrow explicitly here.
+    const md = stringifyMarkdown((message as PostableAst).ast);
+    return {
+      html: markdownToHtml(md),
+      text: md,
+    };
+  }
+
+  /**
+   * Heuristically derive a Subject line for the first message in a
+   * thread (replies always use `Re: <stored subject>` instead).
+   *
+   * Strategy, in order: first non-empty line of text/raw/markdown bodies,
+   * `card.title` for `PostableCard` and direct `CardElement`, fallback to
+   * `"Message from <userName>"`. Subjects longer than 80 characters are
+   * truncated with an ellipsis.
+   */
+  protected deriveInitialSubject(message: AdapterPostableMessage): string {
+    // First-line heuristic: take the first non-empty line of the text body
+    // up to 80 chars, falling back to "Message from <userName>".
+    let candidate: string | undefined;
+    if (typeof message === "string") {
+      candidate = firstLine(message);
+    } else if ("raw" in message) {
+      candidate = firstLine(message.raw);
+    } else if ("markdown" in message) {
+      candidate = firstLine(message.markdown);
+    } else if ("card" in message && message.card.title) {
+      candidate = message.card.title;
+    } else if ("type" in message && message.type === "card" && message.title) {
+      candidate = message.title;
+    }
+    if (!candidate) {
+      return `Message from ${this.userName}`;
+    }
+    return candidate.length > 80 ? `${candidate.slice(0, 77)}...` : candidate;
+  }
+
+  // ===========================================================================
+  // Streaming, edit, delete, reactions, typing — mostly unsupported
+  // ===========================================================================
+
+  /**
+   * Stream a message by buffering all chunks and sending one email at the
+   * end. Email has no live channel, so token-by-token rendering is
+   * impossible; this matches the WhatsApp/Telegram adapters' approach.
+   *
+   * Non-text `StreamChunk` types (e.g. `task_update`, `plan_update`) are
+   * silently dropped.
+   */
+  async stream(
+    threadId: string,
+    textStream: AsyncIterable<string | StreamChunk>,
+    _options?: StreamOptions
+  ): Promise<RawMessage<EmailRawMessage>> {
+    let accumulated = "";
+    for await (const chunk of textStream) {
+      if (typeof chunk === "string") {
+        accumulated += chunk;
+      } else if (chunk.type === "markdown_text") {
+        accumulated += chunk.text;
+      }
+    }
+    return this.postMessage(threadId, { markdown: accumulated });
+  }
+
+  /** Always throws {@link NotImplementedError} — email messages are immutable once sent. */
+  editMessage(): Promise<RawMessage<EmailRawMessage>> {
+    return Promise.reject(
+      new NotImplementedError(
+        "Email messages are immutable. Send a new message instead.",
+        "editMessage"
+      )
+    );
+  }
+
+  /** Always throws {@link NotImplementedError} — email has no delete API. */
+  deleteMessage(): Promise<void> {
+    return Promise.reject(
+      new NotImplementedError(
+        "Email messages cannot be deleted after sending.",
+        "deleteMessage"
+      )
+    );
+  }
+
+  /** Always throws {@link NotImplementedError} — email has no reaction primitive. */
+  addReaction(): Promise<void> {
+    return Promise.reject(
+      new NotImplementedError(
+        "Email does not support reactions.",
+        "addReaction"
+      )
+    );
+  }
+
+  /** Always throws {@link NotImplementedError} — email has no reaction primitive. */
+  removeReaction(): Promise<void> {
+    return Promise.reject(
+      new NotImplementedError(
+        "Email does not support reactions.",
+        "removeReaction"
+      )
+    );
+  }
+
+  /** No-op — email has no typing indicator. Provided for `Adapter` contract parity. */
+  async startTyping(): Promise<void> {
+    // No-op: email has no typing indicator.
+    await Promise.resolve();
+  }
+
+  // ===========================================================================
+  // Thread / channel introspection
+  // ===========================================================================
+
+  /**
+   * Returns an empty result — email has no server-side history API.
+   *
+   * If you need access to prior messages from a handler, opt in to the
+   * SDK's `persistThreadHistory` mechanism on your {@link ChatConfig};
+   * this adapter intentionally does not set `persistThreadHistory: true`
+   * so that durability is an explicit user-side decision.
+   */
+  async fetchMessages(
+    _threadId: string,
+    _options?: FetchOptions
+  ): Promise<FetchResult<EmailRawMessage>> {
+    await Promise.resolve();
+    return { messages: [] };
+  }
+
+  /**
+   * Resolve thread metadata from the persisted thread state. `channelName`
+   * falls back to `"Email conversation"` if no subject has been observed
+   * yet.
+   */
+  async fetchThread(threadId: string): Promise<ThreadInfo> {
+    const decoded = decodeEmailThreadId(threadId);
+    const state = await this.loadThreadState(decoded.rootMessageId);
+    return {
+      id: threadId,
+      channelId: this.channelIdFromThreadId(threadId),
+      channelName: state.subject ?? "Email conversation",
+      isDM: true,
+      metadata: {
+        rootMessageId: decoded.rootMessageId,
+        participantAddress: decoded.participantAddress,
+        subject: state.subject,
+      },
+    };
+  }
+
+  /** Encode `{ rootMessageId, participantAddress }` into the canonical `email:<root>:<addr>` thread ID. */
+  encodeThreadId(data: EmailThreadId): string {
+    return encodeEmailThreadId(data);
+  }
+
+  /**
+   * Decode an `email:<root>:<addr>` thread ID.
+   *
+   * @throws {ValidationError} on prefix mismatch, empty segments, or
+   *   base64url segments that decode to an empty string.
+   */
+  decodeThreadId(threadId: string): EmailThreadId {
+    return decodeEmailThreadId(threadId);
+  }
+
+  /**
+   * Email is inherently 1:1 — there's no distinct channel container,
+   * so the thread ID doubles as the channel ID.
+   */
+  channelIdFromThreadId(threadId: string): string {
+    return threadId;
+  }
+
+  /** Always `true` — every email thread is a direct conversation. */
+  isDM(_threadId: string): boolean {
+    return true;
+  }
+
+  /**
+   * Reconstruct a {@link Message} from a serialized {@link EmailRawMessage}.
+   *
+   * Used by the SDK during message rehydration for queue/debounce
+   * strategies. The discriminator on `raw.direction` selects whether to
+   * build an inbound or outbound message; `isMe` / `isBot` are wired
+   * accordingly.
+   */
+  parseMessage(raw: EmailRawMessage): Message<EmailRawMessage> {
+    if (raw.direction === "outbound") {
+      const out = raw.email;
+      const recipient = out.to[0] ?? "";
+      const threadId = encodeEmailThreadId({
+        rootMessageId: out.threadRootMessageId,
+        participantAddress: recipient,
+      });
+      const author: Author = {
+        userId: this.fromAddress,
+        userName: this.userName,
+        fullName: this.fromName ?? this.userName,
+        isBot: true,
+        isMe: true,
+      };
+      return new Message<EmailRawMessage>({
+        id: out.messageId,
+        threadId,
+        text: out.text,
+        formatted: parseMarkdown(out.text),
+        author,
+        raw,
+        attachments: [],
+        metadata: { dateSent: new Date(), edited: false },
+      });
+    }
+    const inbound = raw.email;
+    const threadId = encodeEmailThreadId({
+      rootMessageId:
+        findThreadRoot({
+          references: inbound.references?.map(stripAngleBrackets),
+          inReplyTo: inbound.inReplyTo
+            ? stripAngleBrackets(inbound.inReplyTo)
+            : undefined,
+        }) ?? stripAngleBrackets(inbound.messageId),
+      participantAddress: inbound.from.address,
+    });
+    return this.buildInboundMessage(inbound, threadId);
+  }
+
+  /**
+   * Render a chat-sdk {@link FormattedContent} (mdast) back to markdown.
+   * The canonical outbound HTML rendering lives in {@link renderBodies};
+   * this method satisfies the {@link Adapter} contract for downstream
+   * consumers like transcripts.
+   */
+  renderFormatted(content: FormattedContent): string {
+    return this.formatConverter.fromAst(content);
+  }
+
+  /**
+   * Open a 1:1 conversation with an email address. The returned thread ID
+   * uses a fresh root Message-ID; the first call to `postMessage` replaces
+   * that placeholder root with the actual outbound Message-ID via the
+   * stored thread state, but the encoded thread ID stays stable for the
+   * caller.
+   */
+  async openDM(emailAddress: string): Promise<string> {
+    if (!emailAddress.includes("@")) {
+      throw new ValidationError(
+        "email",
+        `Invalid email address: ${emailAddress}`
+      );
+    }
+    const rootMessageId = generateMessageId(this.messageIdDomain);
+    // Pre-stash empty thread state under the new root so that the first
+    // postMessage call uses the placeholder root as the canonical ID.
+    await this.persistThreadState(rootMessageId, {
+      references: [],
+      participantAddress: emailAddress,
+    });
+    return encodeEmailThreadId({
+      rootMessageId,
+      participantAddress: emailAddress,
+    });
+  }
+
+  // ===========================================================================
+  // State helpers
+  // ===========================================================================
+
+  /** State-adapter key namespace for per-thread metadata. */
+  protected threadStateKey(rootMessageId: string): string {
+    return `email:thread:${rootMessageId}`;
+  }
+
+  /**
+   * Read the per-thread metadata blob. Returns an empty references list
+   * when the thread has no prior state (new conversation or expired TTL).
+   */
+  protected async loadThreadState(
+    rootMessageId: string
+  ): Promise<EmailThreadState> {
+    if (!this.chat) {
+      return { references: [] };
+    }
+    const stored = await this.chat
+      .getState()
+      .get<EmailThreadState>(this.threadStateKey(rootMessageId));
+    return stored ?? { references: [] };
+  }
+
+  /**
+   * Persist per-thread metadata (references chain, last subject,
+   * participant address). TTL is 30 days, refreshed on every write.
+   */
+  protected async persistThreadState(
+    rootMessageId: string,
+    state: EmailThreadState
+  ): Promise<void> {
+    if (!this.chat) {
+      return;
+    }
+    await this.chat
+      .getState()
+      .set(this.threadStateKey(rootMessageId), state, STATE_TTL_MS);
+  }
+}
+
+// =============================================================================
+// Helpers
+// =============================================================================
+
+/**
+ * Map a MIME type to the chat-sdk {@link Attachment} kind. Unknown or
+ * missing content types default to `"file"`.
+ */
+function inferAttachmentType(
+  contentType: string | undefined
+): "image" | "file" | "video" | "audio" {
+  if (!contentType) {
+    return "file";
+  }
+  if (contentType.startsWith("image/")) {
+    return "image";
+  }
+  if (contentType.startsWith("video/")) {
+    return "video";
+  }
+  if (contentType.startsWith("audio/")) {
+    return "audio";
+  }
+  return "file";
+}
+
+const NEWLINE_PATTERN = /\r?\n/;
+const HEADING_HASH_PREFIX = /^#+\s*/;
+
+/**
+ * Return the first non-empty trimmed line of a text body, with any
+ * leading markdown heading hashes stripped. Returns `undefined` if every
+ * line is blank.
+ */
+function firstLine(text: string): string | undefined {
+  for (const line of text.split(NEWLINE_PATTERN)) {
+    const trimmed = line.trim().replace(HEADING_HASH_PREFIX, "");
+    if (trimmed) {
+      return trimmed;
+    }
+  }
+  return undefined;
+}

--- a/packages/adapter-email/src/index.test.ts
+++ b/packages/adapter-email/src/index.test.ts
@@ -1,0 +1,67 @@
+import { ConsoleLogger } from "chat";
+import { describe, expect, it, vi } from "vitest";
+import { createEmailAdapter, defineEmailProvider, EmailAdapter } from "./index";
+
+const NOOP_TRANSPORT = {
+  name: "noop",
+  send: vi.fn(async () => ({ providerMessageId: undefined, raw: {} })),
+};
+
+describe("createEmailAdapter", () => {
+  it("requires fromAddress", () => {
+    expect(() =>
+      // @ts-expect-error: testing the runtime guard
+      createEmailAdapter({ provider: { transport: NOOP_TRANSPORT } })
+    ).toThrow("fromAddress");
+  });
+
+  it("requires a transport", () => {
+    expect(() =>
+      createEmailAdapter({ fromAddress: "bot@yourdomain.com" })
+    ).toThrow("No transport configured");
+  });
+
+  it("accepts a provider with bundled transport", () => {
+    const adapter = createEmailAdapter({
+      fromAddress: "bot@yourdomain.com",
+      provider: { transport: NOOP_TRANSPORT },
+    });
+    expect(adapter).toBeInstanceOf(EmailAdapter);
+  });
+
+  it("accepts an explicit transport overriding the provider", () => {
+    const t1 = { ...NOOP_TRANSPORT, name: "p1" };
+    const t2 = { ...NOOP_TRANSPORT, name: "p2" };
+    const adapter = createEmailAdapter({
+      fromAddress: "bot@yourdomain.com",
+      provider: { transport: t1 },
+      transport: t2,
+    });
+    expect(adapter).toBeInstanceOf(EmailAdapter);
+  });
+
+  it("derives messageIdDomain from fromAddress when not provided", () => {
+    const adapter = createEmailAdapter({
+      fromAddress: "bot@yourdomain.com",
+      provider: { transport: NOOP_TRANSPORT },
+      logger: new ConsoleLogger("silent"),
+    });
+    expect(adapter.botUserId).toBe("bot@yourdomain.com");
+  });
+
+  it("rejects when fromAddress has no domain and messageIdDomain is unset", () => {
+    expect(() =>
+      createEmailAdapter({
+        fromAddress: "noatsign",
+        provider: { transport: NOOP_TRANSPORT },
+      })
+    ).toThrow("Cannot derive Message-ID domain");
+  });
+});
+
+describe("defineEmailProvider", () => {
+  it("is an identity function", () => {
+    const p = defineEmailProvider({ transport: NOOP_TRANSPORT });
+    expect(p.transport).toBe(NOOP_TRANSPORT);
+  });
+});

--- a/packages/adapter-email/src/index.ts
+++ b/packages/adapter-email/src/index.ts
@@ -1,0 +1,149 @@
+/**
+ * @chat-adapter/email
+ *
+ * Email adapter for Chat SDK with pluggable Email Service Provider (ESP)
+ * implementations.
+ */
+
+import { ValidationError } from "@chat-adapter/shared";
+import { ConsoleLogger, type Logger } from "chat";
+import { EmailAdapter } from "./adapter";
+import { emailDomainOf } from "./threading";
+import type {
+  EmailAdapterConfig,
+  EmailInbound,
+  EmailProvider,
+  EmailTransport,
+} from "./types";
+
+export { EmailAdapter } from "./adapter";
+export { EmailFormatConverter } from "./markdown";
+export {
+  normalizeHeaderKeys,
+  parseAddress,
+  throwForEspError,
+  verifySvixRequest,
+  verifySvixSignature,
+} from "./providers/utils";
+export {
+  astToHtml,
+  cardToHtml,
+  cardToPlainText,
+  markdownToHtml,
+} from "./render";
+export {
+  buildReferencesChain,
+  decodeEmailThreadId,
+  encodeEmailThreadId,
+  findThreadRoot,
+  generateMessageId,
+  MAX_REFERENCES_CHAIN,
+  parseReferencesHeader,
+  replySubject,
+  stripAngleBrackets,
+  wrapAngleBrackets,
+} from "./threading";
+export type {
+  EmailAdapterConfig,
+  EmailInbound,
+  EmailProvider,
+  EmailRawMessage,
+  EmailSendResult,
+  EmailThreadId,
+  EmailTransport,
+  OutboundEmail,
+  OutboundEmailAttachment,
+  ParsedInboundAttachment,
+  ParsedInboundEmail,
+} from "./types";
+
+/**
+ * Identity helper for authoring custom providers with full TypeScript
+ * inference. Equivalent to constructing the object literal directly, but
+ * future-proofs against any additional optional fields the contract may
+ * grow.
+ *
+ * @example
+ * ```ts
+ * const myProvider = defineEmailProvider({
+ *   transport: {
+ *     name: "my-esp",
+ *     async send(email) { ... },
+ *   },
+ * });
+ * ```
+ */
+export function defineEmailProvider(provider: EmailProvider): EmailProvider {
+  return provider;
+}
+
+/**
+ * Create an Email adapter.
+ *
+ * @example
+ * ```ts
+ * import { createEmailAdapter } from "@chat-adapter/email";
+ * import { resend } from "@chat-adapter/email/providers";
+ *
+ * createEmailAdapter({
+ *   fromAddress: "support@yourdomain.com",
+ *   provider: resend(),
+ * });
+ * ```
+ *
+ * @example Mix-and-match transports and inbound parsers
+ * ```ts
+ * import { createEmailAdapter } from "@chat-adapter/email";
+ * import { inbound, resend } from "@chat-adapter/email/providers";
+ *
+ * createEmailAdapter({
+ *   fromAddress: "support@yourdomain.com",
+ *   transport: resend().transport,
+ *   inbound: inbound().inbound,
+ * });
+ * ```
+ *
+ * @throws {ValidationError} when no transport is configured (proactive
+ *   `openDM()` and `thread.post()` both require send capability).
+ */
+export function createEmailAdapter(config: EmailAdapterConfig): EmailAdapter {
+  if (!config.fromAddress) {
+    throw new ValidationError("email", "`fromAddress` is required.");
+  }
+
+  const transport: EmailTransport | undefined =
+    config.transport ?? config.provider?.transport;
+  const inbound: EmailInbound | undefined =
+    config.inbound ?? config.provider?.inbound;
+
+  if (!transport) {
+    throw new ValidationError(
+      "email",
+      "No transport configured. Pass `provider:` or `transport:` to createEmailAdapter() — every email adapter must be able to send (proactive openDM() and thread.post() both require it)."
+    );
+  }
+
+  const messageIdDomain =
+    config.messageIdDomain ?? emailDomainOf(config.fromAddress);
+  if (!messageIdDomain) {
+    throw new ValidationError(
+      "email",
+      `Cannot derive Message-ID domain from fromAddress "${config.fromAddress}". Pass an explicit \`messageIdDomain\`.`
+    );
+  }
+
+  const logger: Logger =
+    config.logger ?? new ConsoleLogger("info").child("email");
+  const userName = config.userName ?? process.env.BOT_USERNAME ?? "email-bot";
+
+  return new EmailAdapter({
+    fromAddress: config.fromAddress,
+    fromName: config.fromName,
+    replyToAddress: config.replyToAddress,
+    messageIdDomain,
+    transport,
+    inbound,
+    userName,
+    logger,
+  });
+}

--- a/packages/adapter-email/src/markdown.test.ts
+++ b/packages/adapter-email/src/markdown.test.ts
@@ -1,0 +1,176 @@
+import type { Root } from "chat";
+import { describe, expect, it } from "vitest";
+import { EmailFormatConverter } from "./markdown";
+
+const converter = new EmailFormatConverter();
+const EMPHASIS_GLYPH = /[*_]italic[*_]/;
+
+describe("EmailFormatConverter#toAst", () => {
+  it("parses a plain paragraph into a Root AST", () => {
+    const ast = converter.toAst("Hello world");
+    expect(ast.type).toBe("root");
+    expect(ast.children).toHaveLength(1);
+    const para = ast.children[0] as { type: string };
+    expect(para.type).toBe("paragraph");
+  });
+
+  it("preserves inline formatting nodes", () => {
+    const ast = converter.toAst("**bold** and *italic* and [link](https://x)");
+    const para = ast.children[0] as { children: Array<{ type: string }> };
+    const types = para.children.map((c) => c.type);
+    expect(types).toContain("strong");
+    expect(types).toContain("emphasis");
+    expect(types).toContain("link");
+  });
+
+  it("parses lists, headings, and code blocks", () => {
+    const ast = converter.toAst(
+      "# Title\n\n- one\n- two\n\n```ts\nconst x = 1;\n```"
+    );
+    const types = ast.children.map((c) => (c as { type: string }).type);
+    expect(types).toEqual(["heading", "list", "code"]);
+  });
+
+  it("returns a root with no children for empty input", () => {
+    const ast = converter.toAst("");
+    expect(ast.type).toBe("root");
+    expect(ast.children).toEqual([]);
+  });
+
+  it("does not throw on email artefacts like quoted reply chevrons", () => {
+    // Email replies commonly include `> quoted line` and `--` signature
+    // separators; remark parses chevrons as blockquotes and that's fine.
+    const ast = converter.toAst(
+      "Reply text\n\n> Previous message\n> from sender\n\n-- \nSent from Foo"
+    );
+    expect(ast.children.length).toBeGreaterThan(0);
+    const types = ast.children.map((c) => (c as { type: string }).type);
+    expect(types).toContain("blockquote");
+  });
+});
+
+describe("EmailFormatConverter#fromAst", () => {
+  it("renders a Root AST back to markdown", () => {
+    const ast: Root = {
+      type: "root",
+      children: [
+        {
+          type: "paragraph",
+          children: [{ type: "text", value: "Hello" }],
+        },
+      ],
+    };
+    const md = converter.fromAst(ast);
+    expect(md.trim()).toBe("Hello");
+  });
+
+  it("preserves bold and emphasis", () => {
+    const ast = converter.toAst("**bold** and *italic*");
+    const md = converter.fromAst(ast);
+    // remark may pick `*` or `_` for emphasis; assert the bold and the
+    // word content survive rather than the exact glyph.
+    expect(md).toContain("**bold**");
+    expect(md).toMatch(EMPHASIS_GLYPH);
+  });
+
+  it("returns an empty string for an empty root", () => {
+    expect(converter.fromAst({ type: "root", children: [] }).trim()).toBe("");
+  });
+});
+
+describe("EmailFormatConverter round-trip", () => {
+  it("preserves headings, lists, and links across parse + stringify", () => {
+    const input = "# Title\n\n- one\n- two\n\n[link](https://x.example)";
+    const ast = converter.toAst(input);
+    const out = converter.fromAst(ast);
+    expect(out).toContain("# Title");
+    expect(out).toContain("one");
+    expect(out).toContain("two");
+    expect(out).toContain("[link](https://x.example)");
+  });
+});
+
+describe("EmailFormatConverter#fromMarkdown (inherited)", () => {
+  it("round-trips a markdown string back to canonical markdown", () => {
+    const out = converter.fromMarkdown("hello **world**");
+    expect(out).toContain("hello");
+    expect(out).toContain("**world**");
+  });
+});
+
+describe("EmailFormatConverter#toMarkdown (inherited)", () => {
+  it("parses platform text and re-stringifies it as markdown", () => {
+    const out = converter.toMarkdown("just text");
+    expect(out.trim()).toBe("just text");
+  });
+});
+
+describe("EmailFormatConverter#extractPlainText (inherited)", () => {
+  it("strips markdown formatting", () => {
+    expect(converter.extractPlainText("**bold** _italic_ text")).toBe(
+      "bold italic text"
+    );
+  });
+
+  it("returns text from links without the URL", () => {
+    expect(
+      converter.extractPlainText("Visit [our site](https://example.com)!")
+    ).toBe("Visit our site!");
+  });
+
+  it("returns empty string for empty input", () => {
+    expect(converter.extractPlainText("")).toBe("");
+  });
+});
+
+describe("EmailFormatConverter#renderPostable (inherited)", () => {
+  it("passes strings through verbatim", () => {
+    expect(converter.renderPostable("Hello")).toBe("Hello");
+  });
+
+  it("returns raw bodies untouched", () => {
+    expect(converter.renderPostable({ raw: "<not markdown>" })).toBe(
+      "<not markdown>"
+    );
+  });
+
+  it("converts markdown bodies through the converter", () => {
+    const out = converter.renderPostable({ markdown: "**bold**" });
+    expect(out).toContain("**bold**");
+  });
+
+  it("renders an ast body via fromAst", () => {
+    const ast: Root = {
+      type: "root",
+      children: [
+        {
+          type: "paragraph",
+          children: [{ type: "text", value: "from-ast" }],
+        },
+      ],
+    };
+    expect(converter.renderPostable({ ast }).trim()).toBe("from-ast");
+  });
+
+  it("falls back to card text for card postables", () => {
+    const card = {
+      type: "card" as const,
+      title: "Hello",
+      children: [{ type: "text" as const, content: "Body" }],
+    };
+    const out = converter.renderPostable({ card });
+    expect(out).toContain("Hello");
+    expect(out).toContain("Body");
+  });
+
+  it("uses the provided fallbackText when set on a card postable", () => {
+    const card = {
+      type: "card" as const,
+      title: "Hello",
+      children: [],
+    };
+    expect(
+      converter.renderPostable({ card, fallbackText: "PLAIN FALLBACK" })
+    ).toBe("PLAIN FALLBACK");
+  });
+});

--- a/packages/adapter-email/src/markdown.ts
+++ b/packages/adapter-email/src/markdown.ts
@@ -1,0 +1,47 @@
+/**
+ * Email format converter.
+ *
+ * The adapter speaks markdown internally (via mdast) and renders to HTML +
+ * plain-text at send time. The converter exists to satisfy the
+ * `Adapter.renderFormatted()` and the host `BaseFormatConverter` contract,
+ * but the canonical outbound rendering happens in
+ * {@link import("./render").cardToHtml}, {@link import("./render").markdownToHtml},
+ * etc. — the adapter pulls those directly when composing an email.
+ */
+
+import {
+  BaseFormatConverter,
+  parseMarkdown,
+  type Root,
+  stringifyMarkdown,
+} from "chat";
+
+/**
+ * Email-specific {@link BaseFormatConverter} implementation.
+ *
+ * Lives mostly to satisfy the {@link Adapter.renderFormatted} contract
+ * and the inherited `renderPostable` dispatch logic — the heavy lifting
+ * (Card → HTML, markdown → HTML, plain-text fallback) happens directly in
+ * {@link cardToHtml}, {@link markdownToHtml}, and {@link cardToPlainText}
+ * from `./render`, which the adapter calls without going through this
+ * class.
+ */
+export class EmailFormatConverter extends BaseFormatConverter {
+  /**
+   * Inbound text bodies are already markdown (or close to it), so the
+   * default markdown parser handles them as-is. Quoted reply chevrons,
+   * signatures, and other email artefacts are preserved verbatim — strip
+   * them in user-land if needed.
+   */
+  toAst(platformText: string): Root {
+    return parseMarkdown(platformText);
+  }
+
+  /**
+   * Stringify back to markdown so renderers downstream (e.g. transcripts)
+   * see consistent output.
+   */
+  fromAst(ast: Root): string {
+    return stringifyMarkdown(ast);
+  }
+}

--- a/packages/adapter-email/src/providers/inbound.test.ts
+++ b/packages/adapter-email/src/providers/inbound.test.ts
@@ -1,0 +1,608 @@
+import { describe, expect, it, vi } from "vitest";
+import { inbound } from "./inbound";
+
+describe("inbound", () => {
+  it("returns no transport or inbound when no credentials are set", () => {
+    const originalApi = process.env.INBOUND_API_KEY;
+    const originalToken = process.env.INBOUND_VERIFICATION_TOKEN;
+    process.env.INBOUND_API_KEY = "";
+    process.env.INBOUND_VERIFICATION_TOKEN = "";
+    try {
+      const p = inbound();
+      expect(p.transport).toBeUndefined();
+      expect(p.inbound).toBeUndefined();
+    } finally {
+      if (originalApi !== undefined) {
+        process.env.INBOUND_API_KEY = originalApi;
+      }
+      if (originalToken !== undefined) {
+        process.env.INBOUND_VERIFICATION_TOKEN = originalToken;
+      }
+    }
+  });
+
+  it("exports transport when apiKey is provided", () => {
+    const p = inbound({ apiKey: "test_key", fetch: vi.fn() });
+    expect(p.transport?.name).toBe("inbound");
+    expect(p.inbound).toBeUndefined();
+  });
+
+  it("exports inbound handler when verificationToken is provided", () => {
+    const p = inbound({
+      verificationToken: "tok_123",
+      fetch: vi.fn(),
+    });
+    expect(p.inbound?.name).toBe("inbound");
+    expect(p.transport).toBeUndefined();
+  });
+
+  it("exports both when apiKey and verificationToken are provided", () => {
+    const p = inbound({
+      apiKey: "k",
+      verificationToken: "tok",
+      fetch: vi.fn(),
+    });
+    expect(p.transport?.name).toBe("inbound");
+    expect(p.inbound?.name).toBe("inbound");
+  });
+
+  describe("transport.send", () => {
+    it("POSTs to /api/e2/emails with composed RFC-822 headers", async () => {
+      const fetchImpl = vi.fn(
+        async () =>
+          new Response(JSON.stringify({ id: "inbnd_1", message_id: "<m@x>" }), {
+            status: 200,
+          })
+      );
+      const p = inbound({
+        apiKey: "test_key",
+        fetch: fetchImpl as unknown as typeof globalThis.fetch,
+      });
+      const result = await p.transport?.send({
+        from: { address: "bot@x.com", name: "Bot" },
+        to: ["user@x.com"],
+        subject: "Hi",
+        html: "<p>Hi</p>",
+        text: "Hi",
+        messageId: "out-1@x.com",
+        threadRootMessageId: "out-1@x.com",
+        inReplyTo: "in-1@x.com",
+        references: ["root@x.com", "in-1@x.com"],
+      });
+      expect(result?.providerMessageId).toBe("inbnd_1");
+      expect(fetchImpl).toHaveBeenCalledTimes(1);
+      const [url, init] = fetchImpl.mock.calls[0] ?? [];
+      expect(url).toBe("https://inbound.new/api/e2/emails");
+      const init2 = init as {
+        method: string;
+        headers: Record<string, string>;
+        body: string;
+      };
+      expect(init2.method).toBe("POST");
+      expect(init2.headers.Authorization).toBe("Bearer test_key");
+      const body = JSON.parse(init2.body);
+      expect(body.from).toBe("Bot <bot@x.com>");
+      expect(body.to).toEqual(["user@x.com"]);
+      expect(body.subject).toBe("Hi");
+      expect(body.html).toBe("<p>Hi</p>");
+      expect(body.text).toBe("Hi");
+      expect(body.headers["Message-ID"]).toBe("<out-1@x.com>");
+      expect(body.headers["In-Reply-To"]).toBe("<in-1@x.com>");
+      expect(body.headers.References).toBe("<root@x.com> <in-1@x.com>");
+    });
+
+    it("omits optional headers when threading info is absent", async () => {
+      const fetchImpl = vi.fn(
+        async () => new Response(JSON.stringify({ id: "x" }), { status: 200 })
+      );
+      const p = inbound({
+        apiKey: "k",
+        fetch: fetchImpl as unknown as typeof globalThis.fetch,
+      });
+      await p.transport?.send({
+        from: { address: "bot@x.com" },
+        to: ["u@x.com"],
+        subject: "Hi",
+        html: "",
+        text: "",
+        messageId: "m@x",
+        threadRootMessageId: "m@x",
+      });
+      const body = JSON.parse(
+        (fetchImpl.mock.calls[0]?.[1] as { body: string }).body
+      );
+      expect(body.headers["In-Reply-To"]).toBeUndefined();
+      expect(body.headers.References).toBeUndefined();
+      expect(body.headers["Message-ID"]).toBe("<m@x>");
+    });
+
+    it("encodes attachments as base64 with content_type", async () => {
+      const fetchImpl = vi.fn(
+        async () => new Response(JSON.stringify({ id: "id" }), { status: 200 })
+      );
+      const p = inbound({
+        apiKey: "k",
+        fetch: fetchImpl as unknown as typeof globalThis.fetch,
+      });
+      await p.transport?.send({
+        from: { address: "bot@x.com" },
+        to: ["u@x.com"],
+        subject: "Hi",
+        html: "",
+        text: "",
+        messageId: "m@x",
+        threadRootMessageId: "m@x",
+        attachments: [
+          {
+            filename: "f.txt",
+            content: Buffer.from("hello", "utf8"),
+            contentType: "text/plain",
+          },
+        ],
+      });
+      const body = JSON.parse(
+        (fetchImpl.mock.calls[0]?.[1] as { body: string }).body
+      );
+      expect(body.attachments).toEqual([
+        {
+          filename: "f.txt",
+          content: Buffer.from("hello", "utf8").toString("base64"),
+          content_type: "text/plain",
+        },
+      ]);
+    });
+
+    it("throws AuthenticationError on 401", async () => {
+      const fetchImpl = vi.fn(
+        async () =>
+          new Response(JSON.stringify({ error: "no" }), { status: 401 })
+      );
+      const p = inbound({
+        apiKey: "k",
+        fetch: fetchImpl as unknown as typeof globalThis.fetch,
+      });
+      await expect(
+        p.transport?.send({
+          from: { address: "bot@x.com" },
+          to: ["u@x.com"],
+          subject: "x",
+          html: "",
+          text: "",
+          messageId: "m@x",
+          threadRootMessageId: "m@x",
+        })
+      ).rejects.toThrow("Inbound send email");
+    });
+  });
+
+  describe("inbound.verifySignature", () => {
+    it("returns false when token header is missing", () => {
+      const p = inbound({ verificationToken: "tok_123", fetch: vi.fn() });
+      expect(
+        p.inbound?.verifySignature(
+          new Request("https://x", { method: "POST", body: "{}" }),
+          "{}"
+        )
+      ).toBe(false);
+    });
+
+    it("returns false when token mismatches", () => {
+      const p = inbound({ verificationToken: "tok_123", fetch: vi.fn() });
+      const req = new Request("https://x", {
+        method: "POST",
+        headers: { "x-webhook-verification-token": "wrong" },
+        body: "{}",
+      });
+      expect(p.inbound?.verifySignature(req, "{}")).toBe(false);
+    });
+
+    it("returns true when token matches", () => {
+      const p = inbound({ verificationToken: "tok_123", fetch: vi.fn() });
+      const req = new Request("https://x", {
+        method: "POST",
+        headers: { "x-webhook-verification-token": "tok_123" },
+        body: "{}",
+      });
+      expect(p.inbound?.verifySignature(req, "{}")).toBe(true);
+    });
+  });
+
+  describe("inbound.parse", () => {
+    it("returns null for non email.received events", async () => {
+      const p = inbound({ verificationToken: "tok", fetch: vi.fn() });
+      const body = JSON.stringify({
+        event: "email.delivered",
+        timestamp: "2026-01-01T00:00:00Z",
+        email: { id: "x", messageId: "<x@y>" },
+      });
+      const out = await p.inbound?.parse(
+        new Request("https://x", { method: "POST", body }),
+        body
+      );
+      expect(out).toBeNull();
+    });
+
+    it("parses an email.received payload into the normalized shape", async () => {
+      const p = inbound({
+        apiKey: "k",
+        verificationToken: "tok",
+        fetch: vi.fn() as unknown as typeof globalThis.fetch,
+      });
+      const payload = {
+        event: "email.received",
+        timestamp: "2026-01-15T10:30:00Z",
+        email: {
+          id: "inbnd_abc",
+          messageId: "<inbound-1@sender.com>",
+          recipient: "support@yourdomain.com",
+          subject: "Help",
+          receivedAt: "2026-01-15T10:30:00Z",
+          parsedData: {
+            messageId: "<inbound-1@sender.com>",
+            date: "2026-01-15T10:30:00Z",
+            subject: "Help",
+            from: {
+              text: "Alice <alice@sender.com>",
+              addresses: [{ name: "Alice", address: "alice@sender.com" }],
+            },
+            to: {
+              text: "support@yourdomain.com",
+              addresses: [{ name: null, address: "support@yourdomain.com" }],
+            },
+            cc: null,
+            bcc: null,
+            replyTo: null,
+            textBody: "Plain body",
+            htmlBody: "<p>HTML</p>",
+            inReplyTo: "<root@x.com>",
+            references: "<root@x.com> <mid@x.com>",
+            attachments: [
+              {
+                filename: "doc.pdf",
+                contentType: "application/pdf",
+                size: 1234,
+                contentId: "<cid>",
+                contentDisposition: "attachment",
+                downloadUrl: "https://inbound.new/api/e2/attachments/x.pdf",
+              },
+            ],
+          },
+        },
+      };
+      const body = JSON.stringify(payload);
+      const result = await p.inbound?.parse(
+        new Request("https://x", { method: "POST", body }),
+        body
+      );
+      expect(result?.messageId).toBe("inbound-1@sender.com");
+      expect(result?.from).toEqual({
+        address: "alice@sender.com",
+        name: "Alice",
+      });
+      expect(result?.to).toEqual(["support@yourdomain.com"]);
+      expect(result?.subject).toBe("Help");
+      expect(result?.text).toBe("Plain body");
+      expect(result?.html).toBe("<p>HTML</p>");
+      expect(result?.inReplyTo).toBe("root@x.com");
+      expect(result?.references).toEqual(["root@x.com", "mid@x.com"]);
+      expect(result?.attachments).toHaveLength(1);
+      expect(result?.attachments?.[0]).toMatchObject({
+        filename: "doc.pdf",
+        contentType: "application/pdf",
+        size: 1234,
+        url: "https://inbound.new/api/e2/attachments/x.pdf",
+      });
+      expect(typeof result?.attachments?.[0]?.fetchData).toBe("function");
+    });
+
+    it("falls back to headers.references when parsedData.references is missing", async () => {
+      const p = inbound({ verificationToken: "tok", fetch: vi.fn() });
+      const body = JSON.stringify({
+        event: "email.received",
+        timestamp: "2026-01-15T10:30:00Z",
+        email: {
+          id: "inbnd_x",
+          messageId: "<m@x>",
+          parsedData: {
+            messageId: "<m@x>",
+            headers: {
+              "In-Reply-To": "<parent@x>",
+              References: "<root@x> <parent@x>",
+            },
+          },
+        },
+      });
+      const result = await p.inbound?.parse(
+        new Request("https://x", { method: "POST", body }),
+        body
+      );
+      expect(result?.inReplyTo).toBe("parent@x");
+      expect(result?.references).toEqual(["root@x", "parent@x"]);
+    });
+
+    it("handles a `references` array form", async () => {
+      const p = inbound({ verificationToken: "tok", fetch: vi.fn() });
+      const body = JSON.stringify({
+        event: "email.received",
+        timestamp: "2026-01-15T10:30:00Z",
+        email: {
+          id: "inbnd_x",
+          messageId: "<m@x>",
+          parsedData: {
+            messageId: "<m@x>",
+            references: ["<a@x>", "<b@x>"],
+          },
+        },
+      });
+      const result = await p.inbound?.parse(
+        new Request("https://x", { method: "POST", body }),
+        body
+      );
+      expect(result?.references).toEqual(["a@x", "b@x"]);
+    });
+
+    it("throws a ValidationError when the webhook body is not valid JSON", () => {
+      const p = inbound({ verificationToken: "tok", fetch: vi.fn() });
+      expect(() =>
+        p.inbound?.parse(
+          new Request("https://x", { method: "POST", body: "not json" }),
+          "not json"
+        )
+      ).toThrow("Inbound webhook body is not valid JSON");
+    });
+
+    it("parses cc addresses when present", async () => {
+      const p = inbound({ verificationToken: "tok", fetch: vi.fn() });
+      const body = JSON.stringify({
+        event: "email.received",
+        timestamp: "2026-01-15T10:30:00Z",
+        email: {
+          id: "inbnd_cc",
+          messageId: "<m@x>",
+          parsedData: {
+            messageId: "<m@x>",
+            cc: {
+              text: "manager@x.com",
+              addresses: [{ name: null, address: "manager@x.com" }],
+            },
+          },
+        },
+      });
+      const result = await p.inbound?.parse(
+        new Request("https://x", { method: "POST", body }),
+        body
+      );
+      expect(result?.cc).toEqual(["manager@x.com"]);
+    });
+
+    it("falls back to unknown@unknown when no usable from address is present", async () => {
+      const p = inbound({ verificationToken: "tok", fetch: vi.fn() });
+      const body = JSON.stringify({
+        event: "email.received",
+        timestamp: "2026-01-15T10:30:00Z",
+        email: {
+          id: "inbnd_x",
+          messageId: "<m@x>",
+          parsedData: {
+            messageId: "<m@x>",
+            from: {
+              text: "",
+              addresses: [{ name: "Display", address: "" }],
+            },
+          },
+        },
+      });
+      const result = await p.inbound?.parse(
+        new Request("https://x", { method: "POST", body }),
+        body
+      );
+      expect(result?.from).toEqual({ address: "unknown@unknown" });
+    });
+
+    it("surfaces errors from the attachment download endpoint", async () => {
+      const fetchImpl = vi.fn(
+        async () =>
+          new Response(JSON.stringify({ error: "forbidden" }), { status: 403 })
+      );
+      const p = inbound({
+        apiKey: "k",
+        verificationToken: "tok",
+        fetch: fetchImpl as unknown as typeof globalThis.fetch,
+      });
+      const body = JSON.stringify({
+        event: "email.received",
+        timestamp: "2026-01-15T10:30:00Z",
+        email: {
+          id: "inbnd_x",
+          messageId: "<m@x>",
+          parsedData: {
+            messageId: "<m@x>",
+            attachments: [
+              {
+                filename: "f.bin",
+                contentType: "application/octet-stream",
+                downloadUrl: "https://inbound.new/api/e2/attachments/f.bin",
+              },
+            ],
+          },
+        },
+      });
+      const result = await p.inbound?.parse(
+        new Request("https://x", { method: "POST", body }),
+        body
+      );
+      await expect(result?.attachments?.[0]?.fetchData?.()).rejects.toThrow(
+        "Inbound download attachment"
+      );
+    });
+
+    it("returns an empty messageId when both parsedData.messageId and email.messageId are missing", () => {
+      const p = inbound({ verificationToken: "tok", fetch: vi.fn() });
+      const body = JSON.stringify({
+        event: "email.received",
+        timestamp: "2026-01-15T10:30:00Z",
+        email: {
+          id: "inbnd_x",
+          // messageId omitted entirely
+          parsedData: {
+            // parsed.messageId omitted too
+            subject: "no msgid",
+          },
+        },
+      });
+      const result = p.inbound?.parse(
+        new Request("https://x", { method: "POST", body }),
+        body
+      );
+      expect(result?.messageId).toBe("");
+    });
+
+    it("falls back to top-level email.messageId when parsedData is absent", () => {
+      const p = inbound({ verificationToken: "tok", fetch: vi.fn() });
+      const body = JSON.stringify({
+        event: "email.received",
+        timestamp: "2026-01-15T10:30:00Z",
+        email: {
+          id: "inbnd_x",
+          messageId: "<from-top@x>",
+          // no parsedData at all
+        },
+      });
+      const result = p.inbound?.parse(
+        new Request("https://x", { method: "POST", body }),
+        body
+      );
+      expect(result?.messageId).toBe("from-top@x");
+    });
+
+    it("returns undefined fetchData when downloadUrl is missing", async () => {
+      const p = inbound({ verificationToken: "tok", fetch: vi.fn() });
+      const body = JSON.stringify({
+        event: "email.received",
+        timestamp: "2026-01-15T10:30:00Z",
+        email: {
+          id: "inbnd_x",
+          messageId: "<m@x>",
+          parsedData: {
+            messageId: "<m@x>",
+            attachments: [
+              {
+                filename: "f.bin",
+                contentType: "application/octet-stream",
+                // no downloadUrl
+              },
+            ],
+          },
+        },
+      });
+      const result = await p.inbound?.parse(
+        new Request("https://x", { method: "POST", body }),
+        body
+      );
+      expect(result?.attachments?.[0]?.fetchData).toBeUndefined();
+    });
+
+    it("downloads attachments without Authorization when apiKey is not configured", async () => {
+      const fetchImpl = vi.fn(
+        async () => new Response(new Uint8Array([7]).buffer, { status: 200 })
+      );
+      const p = inbound({
+        // no apiKey — only token configured (inbound-only setup)
+        verificationToken: "tok",
+        fetch: fetchImpl as unknown as typeof globalThis.fetch,
+      });
+      const body = JSON.stringify({
+        event: "email.received",
+        timestamp: "2026-01-15T10:30:00Z",
+        email: {
+          id: "inbnd_x",
+          messageId: "<m@x>",
+          parsedData: {
+            messageId: "<m@x>",
+            attachments: [
+              {
+                filename: "f.bin",
+                contentType: "application/octet-stream",
+                downloadUrl: "https://inbound.new/api/e2/attachments/f.bin",
+              },
+            ],
+          },
+        },
+      });
+      const result = await p.inbound?.parse(
+        new Request("https://x", { method: "POST", body }),
+        body
+      );
+      await result?.attachments?.[0]?.fetchData?.();
+      const init = fetchImpl.mock.calls[0]?.[1] as {
+        headers: Record<string, string>;
+      };
+      expect(init.headers.Authorization).toBeUndefined();
+    });
+
+    it("returns an unnamed first address when the address object has no name", () => {
+      const p = inbound({ verificationToken: "tok", fetch: vi.fn() });
+      const body = JSON.stringify({
+        event: "email.received",
+        timestamp: "2026-01-15T10:30:00Z",
+        email: {
+          id: "inbnd_x",
+          messageId: "<m@x>",
+          parsedData: {
+            messageId: "<m@x>",
+            from: {
+              text: "alice@x.com",
+              addresses: [{ name: null, address: "alice@x.com" }],
+            },
+          },
+        },
+      });
+      const result = p.inbound?.parse(
+        new Request("https://x", { method: "POST", body }),
+        body
+      );
+      expect(result?.from).toEqual({ address: "alice@x.com" });
+    });
+
+    it("attachment fetchData downloads with Authorization", async () => {
+      const fetchImpl = vi.fn(
+        async () =>
+          new Response(new Uint8Array([1, 2, 3]).buffer, { status: 200 })
+      );
+      const p = inbound({
+        apiKey: "k",
+        verificationToken: "tok",
+        fetch: fetchImpl as unknown as typeof globalThis.fetch,
+      });
+      const body = JSON.stringify({
+        event: "email.received",
+        timestamp: "2026-01-15T10:30:00Z",
+        email: {
+          id: "inbnd_x",
+          messageId: "<m@x>",
+          parsedData: {
+            messageId: "<m@x>",
+            attachments: [
+              {
+                filename: "f.bin",
+                contentType: "application/octet-stream",
+                downloadUrl: "https://inbound.new/api/e2/attachments/f.bin",
+              },
+            ],
+          },
+        },
+      });
+      const result = await p.inbound?.parse(
+        new Request("https://x", { method: "POST", body }),
+        body
+      );
+      const buf = await result?.attachments?.[0]?.fetchData?.();
+      expect(buf?.equals(Buffer.from([1, 2, 3]))).toBe(true);
+      const [url, init] = fetchImpl.mock.calls[0] ?? [];
+      expect(url).toBe("https://inbound.new/api/e2/attachments/f.bin");
+      expect(
+        (init as { headers: Record<string, string> }).headers.Authorization
+      ).toBe("Bearer k");
+    });
+  });
+});

--- a/packages/adapter-email/src/providers/inbound.ts
+++ b/packages/adapter-email/src/providers/inbound.ts
@@ -1,0 +1,366 @@
+/**
+ * Inbound (inbound.new) provider for {@link createEmailAdapter}.
+ *
+ * Implements:
+ * - {@link EmailTransport} via `POST /api/e2/emails`. The adapter's
+ *   composed `Message-ID`, `In-Reply-To`, and `References` are forwarded
+ *   through Inbound's `headers` passthrough so threading works the same
+ *   as Resend.
+ * - {@link EmailInbound} verifying the `X-Webhook-Verification-Token`
+ *   header (constant-time compare against the configured token) and
+ *   parsing `email.received` events. Inbound's payload is self-contained
+ *   — body text/HTML and attachment metadata arrive inline so the
+ *   provider does not need a follow-up API call.
+ *
+ * @see https://inbound.new/docs/api-reference/emails/send-an-email
+ * @see https://inbound.new/docs/api-reference/webhooks/email-received
+ */
+
+import { ValidationError } from "@chat-adapter/shared";
+import {
+  parseReferencesHeader,
+  stripAngleBrackets,
+  wrapAngleBrackets,
+} from "../threading";
+import type {
+  EmailInbound,
+  EmailProvider,
+  EmailSendResult,
+  EmailTransport,
+  OutboundEmail,
+  ParsedInboundAttachment,
+  ParsedInboundEmail,
+} from "../types";
+import {
+  normalizeHeaderKeys,
+  throwForEspError,
+  verifyConstantTimeToken,
+} from "./utils";
+
+const INBOUND_API_BASE_DEFAULT = "https://inbound.new/api/e2";
+
+/**
+ * Configuration for the {@link inbound} provider.
+ */
+export interface InboundProviderConfig {
+  /** API key for outbound and attachment download calls. Falls back to `INBOUND_API_KEY`. */
+  apiKey?: string;
+  /** Override the API base URL (defaults to `https://inbound.new/api/e2`). */
+  apiUrl?: string;
+  /** Custom fetch implementation (for testing). */
+  fetch?: typeof globalThis.fetch;
+  /**
+   * Verification token configured on the Inbound endpoint. Falls back to
+   * `INBOUND_VERIFICATION_TOKEN`. When omitted, no inbound handler is
+   * exported (the provider becomes send-only).
+   */
+  verificationToken?: string;
+}
+
+/**
+ * Build an Inbound provider bundle.
+ *
+ * Naming note: the function is named after the brand (`inbound`), not the
+ * direction. To avoid confusion in mix-and-match setups, use it as
+ * `provider: inbound()` rather than reaching into its fields.
+ *
+ * @example
+ * ```ts
+ * import { createEmailAdapter } from "@chat-adapter/email";
+ * import { inbound } from "@chat-adapter/email/providers";
+ *
+ * createEmailAdapter({
+ *   fromAddress: "support@yourdomain.com",
+ *   provider: inbound(),
+ * });
+ * ```
+ */
+export function inbound(config: InboundProviderConfig = {}): EmailProvider {
+  const fetchImpl = config.fetch ?? globalThis.fetch;
+  const apiUrl = config.apiUrl ?? INBOUND_API_BASE_DEFAULT;
+  const apiKey = config.apiKey ?? process.env.INBOUND_API_KEY;
+  const verificationToken =
+    config.verificationToken ?? process.env.INBOUND_VERIFICATION_TOKEN;
+
+  const transport: EmailTransport | undefined = apiKey
+    ? createTransport({ apiKey, apiUrl, fetch: fetchImpl })
+    : undefined;
+
+  const inboundHandler: EmailInbound | undefined = verificationToken
+    ? createInbound({ apiKey, verificationToken, fetch: fetchImpl })
+    : undefined;
+
+  return {
+    transport,
+    inbound: inboundHandler,
+  };
+}
+
+// =============================================================================
+// Outbound transport
+// =============================================================================
+
+interface InboundSendResponse {
+  id: string;
+  message_id?: string;
+  scheduled_at?: string;
+  status?: "sent" | "scheduled";
+}
+
+function createTransport(args: {
+  apiKey: string;
+  apiUrl: string;
+  fetch: typeof globalThis.fetch;
+}): EmailTransport {
+  return {
+    name: "inbound",
+    async send(email: OutboundEmail): Promise<EmailSendResult> {
+      const headers: Record<string, string> = {
+        "Message-ID": wrapAngleBrackets(email.messageId),
+      };
+      if (email.inReplyTo) {
+        headers["In-Reply-To"] = wrapAngleBrackets(email.inReplyTo);
+      }
+      if (email.references && email.references.length > 0) {
+        headers.References = email.references.map(wrapAngleBrackets).join(" ");
+      }
+
+      const body = {
+        from: email.from.name
+          ? `${email.from.name} <${email.from.address}>`
+          : email.from.address,
+        to: email.to,
+        cc: email.cc,
+        bcc: email.bcc,
+        reply_to: email.replyTo,
+        subject: email.subject,
+        html: email.html,
+        text: email.text,
+        headers,
+        attachments: email.attachments?.map((att) => ({
+          filename: att.filename,
+          content: att.content.toString("base64"),
+          content_type: att.contentType,
+        })),
+      };
+
+      const response = await args.fetch(`${args.apiUrl}/emails`, {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${args.apiKey}`,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify(body),
+      });
+
+      if (!response.ok) {
+        await throwForEspError({
+          response,
+          provider: "Inbound",
+          operation: "send email",
+        });
+      }
+
+      const json = (await response.json()) as InboundSendResponse;
+      return {
+        providerMessageId: json.id,
+        raw: json,
+      };
+    },
+  };
+}
+
+// =============================================================================
+// Inbound webhook
+// =============================================================================
+
+interface InboundAddress {
+  address: string;
+  name: string | null;
+}
+
+interface InboundAddressGroup {
+  addresses?: InboundAddress[];
+  text?: string;
+}
+
+interface InboundAttachmentPayload {
+  contentDisposition?: string;
+  contentId?: string;
+  contentType?: string;
+  downloadUrl?: string;
+  filename?: string;
+  size?: number;
+}
+
+interface InboundParsedData {
+  attachments?: InboundAttachmentPayload[];
+  bcc?: InboundAddressGroup | null;
+  cc?: InboundAddressGroup | null;
+  date?: string;
+  from?: InboundAddressGroup;
+  headers?: Record<string, string>;
+  htmlBody?: string | null;
+  inReplyTo?: string;
+  messageId?: string;
+  references?: string | string[];
+  replyTo?: InboundAddressGroup | null;
+  subject?: string;
+  textBody?: string | null;
+  to?: InboundAddressGroup;
+}
+
+interface InboundWebhookEmail {
+  from?: InboundAddressGroup;
+  id: string;
+  messageId: string;
+  parsedData?: InboundParsedData;
+  receivedAt?: string;
+  recipient?: string;
+  subject?: string;
+  to?: InboundAddressGroup;
+}
+
+interface InboundWebhookEnvelope {
+  email: InboundWebhookEmail;
+  event: string;
+  timestamp: string;
+}
+
+function createInbound(args: {
+  apiKey: string | undefined;
+  verificationToken: string;
+  fetch: typeof globalThis.fetch;
+}): EmailInbound {
+  return {
+    name: "inbound",
+    verifySignature(request: Request, _body: string): boolean {
+      return verifyConstantTimeToken(
+        request.headers.get("x-webhook-verification-token"),
+        args.verificationToken
+      );
+    },
+    parse(_request: Request, body: string): ParsedInboundEmail | null {
+      let envelope: InboundWebhookEnvelope;
+      try {
+        envelope = JSON.parse(body) as InboundWebhookEnvelope;
+      } catch (cause) {
+        throw new ValidationError(
+          "email",
+          `Inbound webhook body is not valid JSON: ${(cause as Error).message}`
+        );
+      }
+      if (envelope.event !== "email.received") {
+        return null;
+      }
+      return parseInboundEnvelope(envelope, {
+        apiKey: args.apiKey,
+        fetch: args.fetch,
+      });
+    },
+  };
+}
+
+function parseInboundEnvelope(
+  envelope: InboundWebhookEnvelope,
+  ctx: { apiKey: string | undefined; fetch: typeof globalThis.fetch }
+): ParsedInboundEmail {
+  const email = envelope.email;
+  const parsed = email.parsedData ?? {};
+
+  const messageId = stripAngleBrackets(
+    parsed.messageId ?? email.messageId ?? ""
+  );
+
+  // Inbound exposes `parsedData.inReplyTo` and `parsedData.references`
+  // when the parser surfaces them, plus a raw headers map. Try the
+  // structured fields first, then fall back to the headers map so we
+  // tolerate future schema changes.
+  const headers = normalizeHeaderKeys(parsed.headers);
+  const inReplyToRaw = parsed.inReplyTo ?? headers["in-reply-to"] ?? undefined;
+  const inReplyTo = inReplyToRaw ? stripAngleBrackets(inReplyToRaw) : undefined;
+
+  let references: string[] = [];
+  if (Array.isArray(parsed.references)) {
+    references = parsed.references.map(stripAngleBrackets).filter(Boolean);
+  } else if (typeof parsed.references === "string") {
+    references = parseReferencesHeader(parsed.references);
+  } else if (headers.references) {
+    references = parseReferencesHeader(headers.references);
+  }
+
+  const from = extractFirstAddress(parsed.from ?? email.from) ?? {
+    address: "unknown@unknown",
+  };
+  const to = (parsed.to?.addresses ?? email.to?.addresses ?? [])
+    .map((a) => a.address)
+    .filter(Boolean);
+  const cc = parsed.cc?.addresses?.map((a) => a.address).filter(Boolean);
+
+  const receivedAt = new Date(
+    parsed.date ?? email.receivedAt ?? envelope.timestamp
+  );
+
+  const attachments: ParsedInboundAttachment[] = (parsed.attachments ?? []).map(
+    (att) => ({
+      filename: att.filename,
+      contentType: att.contentType,
+      size: att.size,
+      url: att.downloadUrl,
+      fetchData: att.downloadUrl
+        ? () => fetchAttachment(att.downloadUrl as string, ctx)
+        : undefined,
+    })
+  );
+
+  return {
+    messageId,
+    inReplyTo,
+    references,
+    from,
+    to: to.length > 0 ? to : [email.recipient ?? ""].filter(Boolean),
+    cc,
+    subject: parsed.subject ?? email.subject ?? "",
+    text: parsed.textBody ?? undefined,
+    html: parsed.htmlBody ?? undefined,
+    attachments,
+    receivedAt,
+    raw: envelope,
+  };
+}
+
+function extractFirstAddress(
+  group: InboundAddressGroup | undefined | null
+): { address: string; name?: string } | null {
+  if (!group) {
+    return null;
+  }
+  const first = group.addresses?.[0];
+  if (!first?.address) {
+    return null;
+  }
+  return first.name
+    ? { address: first.address, name: first.name }
+    : {
+        address: first.address,
+      };
+}
+
+async function fetchAttachment(
+  downloadUrl: string,
+  ctx: { apiKey: string | undefined; fetch: typeof globalThis.fetch }
+): Promise<Buffer> {
+  const response = await ctx.fetch(downloadUrl, {
+    method: "GET",
+    headers: ctx.apiKey ? { Authorization: `Bearer ${ctx.apiKey}` } : {},
+  });
+  if (!response.ok) {
+    await throwForEspError({
+      response,
+      provider: "Inbound",
+      operation: "download attachment",
+    });
+  }
+  const arrayBuffer = await response.arrayBuffer();
+  return Buffer.from(arrayBuffer);
+}

--- a/packages/adapter-email/src/providers/index.ts
+++ b/packages/adapter-email/src/providers/index.ts
@@ -17,4 +17,5 @@
  * entry point and the {@link EmailProvider} contract in `types.ts`.
  */
 
+export { type InboundProviderConfig, inbound } from "./inbound";
 export { type ResendProviderConfig, resend } from "./resend";

--- a/packages/adapter-email/src/providers/index.ts
+++ b/packages/adapter-email/src/providers/index.ts
@@ -1,0 +1,20 @@
+/**
+ * Built-in providers for `@chat-adapter/email`.
+ *
+ * Import the providers you use here, then pass them to `createEmailAdapter`:
+ *
+ * ```ts
+ * import { createEmailAdapter } from "@chat-adapter/email";
+ * import { resend } from "@chat-adapter/email/providers";
+ *
+ * createEmailAdapter({
+ *   fromAddress: "support@yourdomain.com",
+ *   provider: resend(),
+ * });
+ * ```
+ *
+ * To build a custom provider, see {@link defineEmailProvider} on the main
+ * entry point and the {@link EmailProvider} contract in `types.ts`.
+ */
+
+export { type ResendProviderConfig, resend } from "./resend";

--- a/packages/adapter-email/src/providers/resend.test.ts
+++ b/packages/adapter-email/src/providers/resend.test.ts
@@ -1,0 +1,367 @@
+import { createHmac, randomBytes } from "node:crypto";
+import { describe, expect, it, vi } from "vitest";
+import { resend } from "./resend";
+
+const WHSEC_PREFIX = /^whsec_/;
+
+function makeSvixHeaders(
+  body: string,
+  secret: string,
+  overrides: { id?: string; timestamp?: string } = {}
+) {
+  const id = overrides.id ?? "msg_test";
+  const timestamp =
+    overrides.timestamp ?? String(Math.floor(Date.now() / 1000));
+  const secretBytes = Buffer.from(secret.replace(WHSEC_PREFIX, ""), "base64");
+  const signed = `${id}.${timestamp}.${body}`;
+  const sig = createHmac("sha256", secretBytes)
+    .update(signed, "utf8")
+    .digest("base64");
+  return {
+    "svix-id": id,
+    "svix-timestamp": timestamp,
+    "svix-signature": `v1,${sig}`,
+  };
+}
+
+const TEST_SECRET = `whsec_${randomBytes(24).toString("base64")}`;
+
+describe("resend", () => {
+  it("returns no transport or inbound when no credentials are set", () => {
+    const originalApi = process.env.RESEND_API_KEY;
+    const originalSecret = process.env.RESEND_WEBHOOK_SECRET;
+    process.env.RESEND_API_KEY = "";
+    process.env.RESEND_WEBHOOK_SECRET = "";
+    try {
+      const p = resend();
+      expect(p.transport).toBeUndefined();
+      expect(p.inbound).toBeUndefined();
+    } finally {
+      if (originalApi !== undefined) {
+        process.env.RESEND_API_KEY = originalApi;
+      }
+      if (originalSecret !== undefined) {
+        process.env.RESEND_WEBHOOK_SECRET = originalSecret;
+      }
+    }
+  });
+
+  it("exports both transport and inbound when credentials are present", () => {
+    const p = resend({
+      apiKey: "test_key",
+      webhookSecret: TEST_SECRET,
+      fetch: vi.fn(),
+    });
+    expect(p.transport?.name).toBe("resend");
+    expect(p.inbound?.name).toBe("resend");
+  });
+
+  describe("transport.send", () => {
+    it("posts to /emails with composed headers", async () => {
+      const fetchImpl = vi.fn(
+        async () =>
+          new Response(JSON.stringify({ id: "abc-123" }), { status: 200 })
+      );
+      const provider = resend({
+        apiKey: "test_key",
+        fetch: fetchImpl as unknown as typeof globalThis.fetch,
+      });
+      const result = await provider.transport?.send({
+        from: { address: "bot@x.com", name: "Bot" },
+        to: ["user@x.com"],
+        subject: "Hi",
+        html: "<p>Hi</p>",
+        text: "Hi",
+        messageId: "out-1@x.com",
+        threadRootMessageId: "out-1@x.com",
+        inReplyTo: "in-1@x.com",
+        references: ["root@x.com", "in-1@x.com"],
+      });
+      expect(result?.providerMessageId).toBe("abc-123");
+      expect(fetchImpl).toHaveBeenCalledTimes(1);
+      const [url, init] = fetchImpl.mock.calls[0] ?? [];
+      expect(url).toBe("https://api.resend.com/emails");
+      const init2 = init as {
+        method: string;
+        headers: Record<string, string>;
+        body: string;
+      };
+      expect(init2.method).toBe("POST");
+      expect(init2.headers.Authorization).toBe("Bearer test_key");
+      const body = JSON.parse(init2.body);
+      expect(body.from).toBe("Bot <bot@x.com>");
+      expect(body.to).toEqual(["user@x.com"]);
+      expect(body.headers["Message-ID"]).toBe("<out-1@x.com>");
+      expect(body.headers["In-Reply-To"]).toBe("<in-1@x.com>");
+      expect(body.headers.References).toBe("<root@x.com> <in-1@x.com>");
+    });
+
+    it("encodes attachments as base64", async () => {
+      const fetchImpl = vi.fn(
+        async () => new Response(JSON.stringify({ id: "id" }), { status: 200 })
+      );
+      const provider = resend({
+        apiKey: "k",
+        fetch: fetchImpl as unknown as typeof globalThis.fetch,
+      });
+      await provider.transport?.send({
+        from: { address: "bot@x.com" },
+        to: ["user@x.com"],
+        subject: "Hi",
+        html: "",
+        text: "",
+        messageId: "m@x",
+        threadRootMessageId: "m@x",
+        attachments: [
+          {
+            filename: "f.txt",
+            content: Buffer.from("hello", "utf8"),
+            contentType: "text/plain",
+          },
+        ],
+      });
+      const body = JSON.parse(
+        (fetchImpl.mock.calls[0]?.[1] as { body: string }).body
+      );
+      expect(body.attachments).toEqual([
+        {
+          filename: "f.txt",
+          content: Buffer.from("hello", "utf8").toString("base64"),
+          content_type: "text/plain",
+        },
+      ]);
+    });
+
+    it("throws AuthenticationError on 401", async () => {
+      const fetchImpl = vi.fn(
+        async () =>
+          new Response(JSON.stringify({ message: "bad key" }), {
+            status: 401,
+          })
+      );
+      const provider = resend({
+        apiKey: "k",
+        fetch: fetchImpl as unknown as typeof globalThis.fetch,
+      });
+      await expect(
+        provider.transport?.send({
+          from: { address: "bot@x.com" },
+          to: ["user@x.com"],
+          subject: "x",
+          html: "",
+          text: "",
+          messageId: "m@x",
+          threadRootMessageId: "m@x",
+        })
+      ).rejects.toThrow("bad key");
+    });
+  });
+
+  describe("inbound.parse", () => {
+    it("returns null for non email.received events", async () => {
+      const fetchImpl = vi.fn();
+      const provider = resend({
+        apiKey: "k",
+        webhookSecret: TEST_SECRET,
+        fetch: fetchImpl as unknown as typeof globalThis.fetch,
+      });
+      const body = JSON.stringify({ type: "email.delivered", data: {} });
+      const result = await provider.inbound?.parse(
+        new Request("https://x", { method: "POST", body }),
+        body
+      );
+      expect(result).toBeNull();
+    });
+
+    it("fetches the received email and returns a normalized payload", async () => {
+      const detail = {
+        id: "e1",
+        message_id: "<inbound-1@example.com>",
+        from: "Alice <alice@example.com>",
+        to: ["bot@yourdomain.com"],
+        cc: [],
+        bcc: [],
+        reply_to: [],
+        subject: "Hello",
+        created_at: "2026-04-01T00:00:00Z",
+        text: "Plain body",
+        html: "<p>HTML body</p>",
+        headers: {
+          "In-Reply-To": "<root@example.com>",
+          References: "<root@example.com> <prev@example.com>",
+        },
+        attachments: [
+          {
+            id: "a1",
+            filename: "doc.pdf",
+            content_type: "application/pdf",
+            content_disposition: null,
+            content_id: null,
+          },
+        ],
+      };
+      const fetchImpl = vi.fn(
+        async () => new Response(JSON.stringify(detail), { status: 200 })
+      );
+      const provider = resend({
+        apiKey: "k",
+        webhookSecret: TEST_SECRET,
+        fetch: fetchImpl as unknown as typeof globalThis.fetch,
+      });
+      const body = JSON.stringify({
+        type: "email.received",
+        created_at: "2026-04-01T00:00:00Z",
+        data: {
+          email_id: "e1",
+          message_id: "<inbound-1@example.com>",
+          from: "Alice <alice@example.com>",
+          to: ["bot@yourdomain.com"],
+          subject: "Hello",
+        },
+      });
+      const result = await provider.inbound?.parse(
+        new Request("https://x", { method: "POST", body }),
+        body
+      );
+      expect(result?.messageId).toBe("inbound-1@example.com");
+      expect(result?.inReplyTo).toBe("root@example.com");
+      expect(result?.references).toEqual([
+        "root@example.com",
+        "prev@example.com",
+      ]);
+      expect(result?.from).toEqual({
+        address: "alice@example.com",
+        name: "Alice",
+      });
+      expect(result?.subject).toBe("Hello");
+      expect(result?.text).toBe("Plain body");
+      expect(result?.html).toBe("<p>HTML body</p>");
+      expect(result?.attachments).toEqual([
+        { filename: "doc.pdf", contentType: "application/pdf" },
+      ]);
+    });
+
+    it("throws a ValidationError when the webhook body is not valid JSON", async () => {
+      const provider = resend({
+        apiKey: "k",
+        webhookSecret: TEST_SECRET,
+        fetch: vi.fn(),
+      });
+      await expect(
+        provider.inbound?.parse(
+          new Request("https://x", { method: "POST", body: "not json" }),
+          "not json"
+        )
+      ).rejects.toThrow("Resend webhook body is not valid JSON");
+    });
+
+    it("falls back to envelope.data when the Receiving API omits fields", async () => {
+      const detail = {
+        id: "e1",
+        message_id: "",
+        from: "",
+        to: ["bot@yourdomain.com"],
+        cc: [],
+        bcc: [],
+        reply_to: [],
+        subject: "Hello",
+        // omit created_at to test fallback to envelope.created_at
+        text: null,
+        html: null,
+        headers: {},
+        attachments: [],
+      };
+      const fetchImpl = vi.fn(
+        async () => new Response(JSON.stringify(detail), { status: 200 })
+      );
+      const provider = resend({
+        apiKey: "k",
+        webhookSecret: TEST_SECRET,
+        fetch: fetchImpl as unknown as typeof globalThis.fetch,
+      });
+      const body = JSON.stringify({
+        type: "email.received",
+        created_at: "2026-04-01T00:00:00Z",
+        data: {
+          email_id: "e1",
+          message_id: "<envelope-msg@x>",
+          from: "envelope@x",
+          to: ["bot@yourdomain.com"],
+          subject: "Hello",
+        },
+      });
+      const result = await provider.inbound?.parse(
+        new Request("https://x", { method: "POST", body }),
+        body
+      );
+      expect(result?.messageId).toBe("envelope-msg@x");
+      expect(result?.from).toEqual({ address: "envelope@x" });
+      expect(result?.text).toBeUndefined();
+      expect(result?.html).toBeUndefined();
+      expect(result?.receivedAt.toISOString()).toBe("2026-04-01T00:00:00.000Z");
+    });
+
+    it("surfaces errors from the Receiving API", async () => {
+      const fetchImpl = vi.fn(
+        async () =>
+          new Response(JSON.stringify({ message: "not found" }), {
+            status: 404,
+          })
+      );
+      const provider = resend({
+        apiKey: "k",
+        webhookSecret: TEST_SECRET,
+        fetch: fetchImpl as unknown as typeof globalThis.fetch,
+      });
+      const body = JSON.stringify({
+        type: "email.received",
+        created_at: "2026-04-01T00:00:00Z",
+        data: {
+          email_id: "missing",
+          message_id: "<m@x>",
+          from: "x@x",
+          to: ["bot@x"],
+          subject: "Hi",
+        },
+      });
+      await expect(
+        provider.inbound?.parse(
+          new Request("https://x", { method: "POST", body }),
+          body
+        )
+      ).rejects.toThrow("Resend retrieve received email");
+    });
+  });
+
+  describe("inbound.verifySignature", () => {
+    it("returns false when svix headers are missing", () => {
+      const provider = resend({
+        apiKey: "k",
+        webhookSecret: TEST_SECRET,
+        fetch: vi.fn(),
+      });
+      expect(
+        provider.inbound?.verifySignature(
+          new Request("https://x", { method: "POST", body: "{}" }),
+          "{}"
+        )
+      ).toBe(false);
+    });
+
+    it("returns true when signature is valid", () => {
+      const provider = resend({
+        apiKey: "k",
+        webhookSecret: TEST_SECRET,
+        fetch: vi.fn(),
+      });
+      const body = "{}";
+      const headers = makeSvixHeaders(body, TEST_SECRET);
+      const req = new Request("https://x", {
+        method: "POST",
+        headers,
+        body,
+      });
+      expect(provider.inbound?.verifySignature(req, body)).toBe(true);
+    });
+  });
+});

--- a/packages/adapter-email/src/providers/resend.ts
+++ b/packages/adapter-email/src/providers/resend.ts
@@ -1,0 +1,308 @@
+/**
+ * Resend provider for {@link createEmailAdapter}.
+ *
+ * Implements:
+ * - {@link EmailTransport} via POST /emails on api.resend.com.
+ * - {@link EmailInbound} verifying Svix-style HMAC-SHA256 signatures and
+ *   parsing `email.received` events. Resend's webhook delivers metadata
+ *   only, so we fetch the body and headers via the Retrieve Received Email
+ *   API to populate text/html and `In-Reply-To` / `References`.
+ *
+ * @see https://resend.com/docs/api-reference/emails/send-email
+ * @see https://resend.com/docs/api-reference/emails/retrieve-received-email
+ * @see https://resend.com/docs/webhooks/verify-webhooks-requests
+ */
+
+import { ValidationError } from "@chat-adapter/shared";
+import {
+  parseReferencesHeader,
+  stripAngleBrackets,
+  wrapAngleBrackets,
+} from "../threading";
+import type {
+  EmailInbound,
+  EmailProvider,
+  EmailSendResult,
+  EmailTransport,
+  OutboundEmail,
+  ParsedInboundAttachment,
+  ParsedInboundEmail,
+} from "../types";
+import {
+  normalizeHeaderKeys,
+  parseAddress,
+  throwForEspError,
+  verifySvixRequest,
+} from "./utils";
+
+const RESEND_API_BASE_DEFAULT = "https://api.resend.com";
+
+/**
+ * Configuration for the {@link resend} provider.
+ */
+export interface ResendProviderConfig {
+  /** API key used for outbound and Receiving API calls. Falls back to `RESEND_API_KEY`. */
+  apiKey?: string;
+  /** Override the API base URL (e.g. for staging). */
+  apiUrl?: string;
+  /** Custom fetch implementation (for testing). */
+  fetch?: typeof globalThis.fetch;
+  /** Webhook signing secret. Falls back to `RESEND_WEBHOOK_SECRET`. */
+  webhookSecret?: string;
+}
+
+/**
+ * Build a Resend provider bundle.
+ *
+ * @example
+ * ```ts
+ * import { createEmailAdapter } from "@chat-adapter/email";
+ * import { resend } from "@chat-adapter/email/providers";
+ *
+ * createEmailAdapter({
+ *   fromAddress: "support@yourdomain.com",
+ *   provider: resend(),
+ * });
+ * ```
+ */
+export function resend(config: ResendProviderConfig = {}): EmailProvider {
+  const fetchImpl = config.fetch ?? globalThis.fetch;
+  const apiUrl = config.apiUrl ?? RESEND_API_BASE_DEFAULT;
+  const apiKey = config.apiKey ?? process.env.RESEND_API_KEY;
+  const webhookSecret =
+    config.webhookSecret ?? process.env.RESEND_WEBHOOK_SECRET;
+
+  const transport: EmailTransport | undefined = apiKey
+    ? createTransport({ apiKey, apiUrl, fetch: fetchImpl })
+    : undefined;
+
+  const inbound: EmailInbound | undefined =
+    apiKey && webhookSecret
+      ? createInbound({ apiKey, webhookSecret, apiUrl, fetch: fetchImpl })
+      : undefined;
+
+  return {
+    transport,
+    inbound,
+  };
+}
+
+// =============================================================================
+// Outbound transport
+// =============================================================================
+
+interface ResendSendResponse {
+  id: string;
+}
+
+function createTransport(args: {
+  apiKey: string;
+  apiUrl: string;
+  fetch: typeof globalThis.fetch;
+}): EmailTransport {
+  return {
+    name: "resend",
+    async send(email: OutboundEmail): Promise<EmailSendResult> {
+      const headers: Record<string, string> = {
+        "Message-ID": wrapAngleBrackets(email.messageId),
+      };
+      if (email.inReplyTo) {
+        headers["In-Reply-To"] = wrapAngleBrackets(email.inReplyTo);
+      }
+      if (email.references && email.references.length > 0) {
+        headers.References = email.references.map(wrapAngleBrackets).join(" ");
+      }
+
+      const body = {
+        from: email.from.name
+          ? `${email.from.name} <${email.from.address}>`
+          : email.from.address,
+        to: email.to,
+        cc: email.cc,
+        bcc: email.bcc,
+        reply_to: email.replyTo,
+        subject: email.subject,
+        html: email.html,
+        text: email.text,
+        headers,
+        attachments: email.attachments?.map((att) => ({
+          filename: att.filename,
+          content: att.content.toString("base64"),
+          content_type: att.contentType,
+        })),
+      };
+
+      const response = await args.fetch(`${args.apiUrl}/emails`, {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${args.apiKey}`,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify(body),
+      });
+
+      if (!response.ok) {
+        await throwForEspError({
+          response,
+          provider: "Resend",
+          operation: "send email",
+        });
+      }
+
+      const json = (await response.json()) as ResendSendResponse;
+      return {
+        providerMessageId: json.id,
+        raw: json,
+      };
+    },
+  };
+}
+
+// =============================================================================
+// Inbound webhook
+// =============================================================================
+
+interface ResendWebhookEnvelope {
+  created_at: string;
+  data: ResendWebhookData;
+  type: string;
+}
+
+interface ResendWebhookData {
+  bcc?: string[];
+  cc?: string[];
+  created_at?: string;
+  email_id: string;
+  from: string;
+  message_id: string;
+  subject: string;
+  to: string[];
+}
+
+interface ResendReceivingResponse {
+  attachments: ResendReceivingAttachment[];
+  bcc: string[];
+  cc: string[];
+  created_at: string;
+  from: string;
+  headers: Record<string, string>;
+  html: string | null;
+  id: string;
+  message_id: string;
+  reply_to: string[];
+  subject: string;
+  text: string | null;
+  to: string[];
+}
+
+interface ResendReceivingAttachment {
+  content_disposition: string | null;
+  content_id: string | null;
+  content_type: string;
+  filename: string;
+  id: string;
+}
+
+function createInbound(args: {
+  apiKey: string;
+  webhookSecret: string;
+  apiUrl: string;
+  fetch: typeof globalThis.fetch;
+}): EmailInbound {
+  return {
+    name: "resend",
+    verifySignature(request: Request, body: string): boolean {
+      return verifySvixRequest({
+        request,
+        body,
+        secret: args.webhookSecret,
+      });
+    },
+    async parse(
+      _request: Request,
+      body: string
+    ): Promise<ParsedInboundEmail | null> {
+      let envelope: ResendWebhookEnvelope;
+      try {
+        envelope = JSON.parse(body) as ResendWebhookEnvelope;
+      } catch (cause) {
+        throw new ValidationError(
+          "email",
+          `Resend webhook body is not valid JSON: ${(cause as Error).message}`
+        );
+      }
+      if (envelope.type !== "email.received") {
+        return null;
+      }
+
+      const data = envelope.data;
+      const detail = await fetchReceivedEmail({
+        emailId: data.email_id,
+        apiKey: args.apiKey,
+        apiUrl: args.apiUrl,
+        fetch: args.fetch,
+      });
+
+      return parseResendDetail(envelope, detail);
+    },
+  };
+}
+
+function parseResendDetail(
+  envelope: ResendWebhookEnvelope,
+  detail: ResendReceivingResponse
+): ParsedInboundEmail {
+  const messageId = stripAngleBrackets(
+    detail.message_id || envelope.data.message_id
+  );
+  const headers = normalizeHeaderKeys(detail.headers);
+  const inReplyTo = headers["in-reply-to"]
+    ? stripAngleBrackets(headers["in-reply-to"])
+    : undefined;
+  const references = parseReferencesHeader(headers.references);
+  const from = parseAddress(detail.from || envelope.data.from);
+  const attachments: ParsedInboundAttachment[] = detail.attachments.map(
+    (att) => ({
+      filename: att.filename,
+      contentType: att.content_type,
+    })
+  );
+
+  return {
+    messageId,
+    inReplyTo,
+    references,
+    from,
+    to: detail.to,
+    cc: detail.cc,
+    subject: detail.subject,
+    text: detail.text ?? undefined,
+    html: detail.html ?? undefined,
+    attachments,
+    receivedAt: new Date(detail.created_at ?? envelope.created_at),
+    raw: { envelope, detail },
+  };
+}
+
+async function fetchReceivedEmail(args: {
+  emailId: string;
+  apiKey: string;
+  apiUrl: string;
+  fetch: typeof globalThis.fetch;
+}): Promise<ResendReceivingResponse> {
+  const response = await args.fetch(
+    `${args.apiUrl}/emails/receiving/${encodeURIComponent(args.emailId)}`,
+    {
+      method: "GET",
+      headers: { Authorization: `Bearer ${args.apiKey}` },
+    }
+  );
+  if (!response.ok) {
+    await throwForEspError({
+      response,
+      provider: "Resend",
+      operation: "retrieve received email",
+    });
+  }
+  return (await response.json()) as ResendReceivingResponse;
+}

--- a/packages/adapter-email/src/providers/utils.test.ts
+++ b/packages/adapter-email/src/providers/utils.test.ts
@@ -271,6 +271,42 @@ describe("parseAddress", () => {
       address: "alice@example.com",
     });
   });
+
+  it("uses the last `<` when the display name contains an angle bracket", () => {
+    expect(parseAddress('"weird <name" <addr@example.com>')).toEqual({
+      address: "addr@example.com",
+      name: "weird <name",
+    });
+  });
+
+  it("returns the trimmed input when the angle-bracket form is malformed", () => {
+    // Missing `>` — falls back to bare-address behavior.
+    expect(parseAddress("Alice <alice@example.com")).toEqual({
+      address: "Alice <alice@example.com",
+    });
+  });
+
+  it("returns just the trimmed input when the angle-bracket form has no `<`", () => {
+    expect(parseAddress("trailing-only>")).toEqual({
+      address: "trailing-only>",
+    });
+  });
+
+  it("returns just the trimmed input when the angle-bracket form has an empty address slice", () => {
+    expect(parseAddress("name<>")).toEqual({ address: "name<>" });
+  });
+
+  it("runs in linear time on adversarial whitespace input (ReDoS regression)", () => {
+    const adversarial = `${" ".repeat(100_000)}<alice@example.com>`;
+    const start = Date.now();
+    const result = parseAddress(adversarial);
+    const elapsed = Date.now() - start;
+    expect(result).toEqual({ address: "alice@example.com" });
+    // 100k chars of whitespace should parse in well under 100ms; allow
+    // slack for slow CI. Any quadratic / exponential implementation would
+    // be orders of magnitude slower.
+    expect(elapsed).toBeLessThan(100);
+  });
 });
 
 describe("normalizeHeaderKeys", () => {

--- a/packages/adapter-email/src/providers/utils.test.ts
+++ b/packages/adapter-email/src/providers/utils.test.ts
@@ -1,0 +1,293 @@
+import { createHmac, randomBytes } from "node:crypto";
+import {
+  AdapterRateLimitError,
+  AuthenticationError,
+  NetworkError,
+  ValidationError,
+} from "@chat-adapter/shared";
+import { describe, expect, it } from "vitest";
+import {
+  normalizeHeaderKeys,
+  parseAddress,
+  throwForEspError,
+  verifyConstantTimeToken,
+  verifySvixRequest,
+  verifySvixSignature,
+} from "./utils";
+
+const WHSEC_PREFIX = /^whsec_/;
+const TEST_SECRET = `whsec_${randomBytes(24).toString("base64")}`;
+
+function makeSvixHeaders(
+  body: string,
+  secret: string,
+  overrides: { id?: string; timestamp?: string } = {}
+) {
+  const id = overrides.id ?? "msg_test";
+  const timestamp =
+    overrides.timestamp ?? String(Math.floor(Date.now() / 1000));
+  const secretBytes = Buffer.from(secret.replace(WHSEC_PREFIX, ""), "base64");
+  const signed = `${id}.${timestamp}.${body}`;
+  const sig = createHmac("sha256", secretBytes)
+    .update(signed, "utf8")
+    .digest("base64");
+  return {
+    "svix-id": id,
+    "svix-timestamp": timestamp,
+    "svix-signature": `v1,${sig}`,
+  };
+}
+
+describe("verifySvixSignature", () => {
+  it("accepts a valid signature", () => {
+    const body = '{"hello":"world"}';
+    const headers = makeSvixHeaders(body, TEST_SECRET);
+    expect(
+      verifySvixSignature({
+        id: headers["svix-id"],
+        timestamp: headers["svix-timestamp"],
+        signatureHeader: headers["svix-signature"],
+        body,
+        secret: TEST_SECRET,
+      })
+    ).toBe(true);
+  });
+
+  it("rejects when the body is tampered", () => {
+    const body = '{"hello":"world"}';
+    const headers = makeSvixHeaders(body, TEST_SECRET);
+    expect(
+      verifySvixSignature({
+        id: headers["svix-id"],
+        timestamp: headers["svix-timestamp"],
+        signatureHeader: headers["svix-signature"],
+        body: '{"hello":"WORLD"}',
+        secret: TEST_SECRET,
+      })
+    ).toBe(false);
+  });
+
+  it("rejects an unknown signature version", () => {
+    expect(
+      verifySvixSignature({
+        id: "x",
+        timestamp: "y",
+        signatureHeader: "v0,abc",
+        body: "{}",
+        secret: TEST_SECRET,
+      })
+    ).toBe(false);
+  });
+
+  it("returns false when the secret cannot be decoded", () => {
+    expect(
+      verifySvixSignature({
+        id: "x",
+        timestamp: "y",
+        signatureHeader: "v1,abc",
+        body: "{}",
+        secret: "",
+      })
+    ).toBe(false);
+  });
+
+  it("accepts when one of multiple signatures matches", () => {
+    const body = "{}";
+    const headers = makeSvixHeaders(body, TEST_SECRET);
+    expect(
+      verifySvixSignature({
+        id: headers["svix-id"],
+        timestamp: headers["svix-timestamp"],
+        signatureHeader: `v1,xxx ${headers["svix-signature"]}`,
+        body,
+        secret: TEST_SECRET,
+      })
+    ).toBe(true);
+  });
+
+  it("tolerates a plain (non-prefixed) base64 secret", () => {
+    const plain = randomBytes(24).toString("base64");
+    const body = "{}";
+    const headers = makeSvixHeaders(body, plain);
+    expect(
+      verifySvixSignature({
+        id: headers["svix-id"],
+        timestamp: headers["svix-timestamp"],
+        signatureHeader: headers["svix-signature"],
+        body,
+        secret: plain,
+      })
+    ).toBe(true);
+  });
+});
+
+describe("verifyConstantTimeToken", () => {
+  it("returns true for matching tokens", () => {
+    expect(verifyConstantTimeToken("abc123", "abc123")).toBe(true);
+  });
+
+  it("returns false for mismatched tokens", () => {
+    expect(verifyConstantTimeToken("abc123", "abc124")).toBe(false);
+  });
+
+  it("returns false for length mismatches", () => {
+    expect(verifyConstantTimeToken("abc", "abcd")).toBe(false);
+  });
+
+  it("returns false for null/empty inputs", () => {
+    expect(verifyConstantTimeToken(null, "abc")).toBe(false);
+    expect(verifyConstantTimeToken(undefined, "abc")).toBe(false);
+    expect(verifyConstantTimeToken("", "abc")).toBe(false);
+    expect(verifyConstantTimeToken("abc", "")).toBe(false);
+  });
+});
+
+describe("verifySvixRequest", () => {
+  it("returns false when any svix header is missing", () => {
+    const req = new Request("https://x", { method: "POST", body: "{}" });
+    expect(
+      verifySvixRequest({ request: req, body: "{}", secret: TEST_SECRET })
+    ).toBe(false);
+  });
+
+  it("returns true when all headers are present and valid", () => {
+    const body = "{}";
+    const headers = makeSvixHeaders(body, TEST_SECRET);
+    const req = new Request("https://x", {
+      method: "POST",
+      headers,
+      body,
+    });
+    expect(verifySvixRequest({ request: req, body, secret: TEST_SECRET })).toBe(
+      true
+    );
+  });
+});
+
+describe("throwForEspError", () => {
+  it("maps 401 to AuthenticationError", async () => {
+    const response = new Response(JSON.stringify({ message: "no" }), {
+      status: 401,
+    });
+    await expect(
+      throwForEspError({ response, provider: "X", operation: "send" })
+    ).rejects.toBeInstanceOf(AuthenticationError);
+  });
+
+  it("maps 403 to AuthenticationError", async () => {
+    const response = new Response("{}", { status: 403 });
+    await expect(
+      throwForEspError({ response, provider: "X", operation: "send" })
+    ).rejects.toBeInstanceOf(AuthenticationError);
+  });
+
+  it("maps 429 to AdapterRateLimitError with retry-after", async () => {
+    const response = new Response("{}", {
+      status: 429,
+      headers: { "retry-after": "5" },
+    });
+    const err = await throwForEspError({
+      response,
+      provider: "X",
+      operation: "send",
+    }).catch((e) => e as AdapterRateLimitError);
+    expect(err).toBeInstanceOf(AdapterRateLimitError);
+    expect((err as AdapterRateLimitError).retryAfter).toBe(5);
+  });
+
+  it("maps 429 with no retry-after header to AdapterRateLimitError with undefined retry", async () => {
+    const response = new Response("{}", { status: 429 });
+    const err = await throwForEspError({
+      response,
+      provider: "X",
+      operation: "send",
+    }).catch((e) => e as AdapterRateLimitError);
+    expect(err).toBeInstanceOf(AdapterRateLimitError);
+    expect((err as AdapterRateLimitError).retryAfter).toBeUndefined();
+  });
+
+  it("maps 500+ to NetworkError", async () => {
+    const response = new Response("boom", { status: 502 });
+    await expect(
+      throwForEspError({ response, provider: "X", operation: "send" })
+    ).rejects.toBeInstanceOf(NetworkError);
+  });
+
+  it("maps 4xx to ValidationError by default", async () => {
+    const response = new Response(JSON.stringify({ message: "bad" }), {
+      status: 400,
+    });
+    await expect(
+      throwForEspError({ response, provider: "X", operation: "send" })
+    ).rejects.toBeInstanceOf(ValidationError);
+  });
+
+  it("includes provider and operation in the error message", async () => {
+    const response = new Response(JSON.stringify({ message: "nope" }), {
+      status: 400,
+    });
+    await expect(
+      throwForEspError({ response, provider: "Foo", operation: "send email" })
+    ).rejects.toThrow("Foo send email");
+  });
+
+  it("falls back to raw text when the body is not JSON", async () => {
+    const response = new Response("plain error text", { status: 400 });
+    await expect(
+      throwForEspError({ response, provider: "X", operation: "send" })
+    ).rejects.toThrow("plain error text");
+  });
+});
+
+describe("parseAddress", () => {
+  it("parses Name <addr@example.com>", () => {
+    expect(parseAddress("Alice <alice@example.com>")).toEqual({
+      address: "alice@example.com",
+      name: "Alice",
+    });
+  });
+
+  it("parses bare addresses", () => {
+    expect(parseAddress("alice@example.com")).toEqual({
+      address: "alice@example.com",
+    });
+  });
+
+  it("strips quotes around display names", () => {
+    expect(parseAddress('"Alice Smith" <alice@example.com>')).toEqual({
+      address: "alice@example.com",
+      name: "Alice Smith",
+    });
+  });
+
+  it("trims whitespace", () => {
+    expect(parseAddress("   alice@example.com  ")).toEqual({
+      address: "alice@example.com",
+    });
+  });
+
+  it("returns just the address when the angle-bracket form has an empty display name", () => {
+    expect(parseAddress("<alice@example.com>")).toEqual({
+      address: "alice@example.com",
+    });
+  });
+});
+
+describe("normalizeHeaderKeys", () => {
+  it("lowercases all keys", () => {
+    expect(
+      normalizeHeaderKeys({
+        "In-Reply-To": "<a@x>",
+        References: "<a@x> <b@x>",
+      })
+    ).toEqual({
+      "in-reply-to": "<a@x>",
+      references: "<a@x> <b@x>",
+    });
+  });
+
+  it("returns an empty object for null/undefined input", () => {
+    expect(normalizeHeaderKeys(null)).toEqual({});
+    expect(normalizeHeaderKeys(undefined)).toEqual({});
+  });
+});

--- a/packages/adapter-email/src/providers/utils.ts
+++ b/packages/adapter-email/src/providers/utils.ts
@@ -197,27 +197,40 @@ export async function throwForEspError(args: {
 // RFC-822 inbound parsing helpers
 // =============================================================================
 
-const ADDRESS_WITH_NAME_PATTERN = /^\s*"?([^"<>]*?)"?\s*<([^>]+)>\s*$/;
-
 /**
  * Parse an RFC-822 mailbox value into `{ address, name? }`.
  *
  * Handles both `Name <addr@example.com>` and bare `addr@example.com`.
  * Returns the input verbatim as `address` if no `<...>` envelope is
  * present; downstream code is responsible for validation.
+ *
+ * Implemented with plain string ops (no regex) so adversarial webhook
+ * inputs — like a long run of leading whitespace — can't trigger
+ * polynomial-time backtracking.
  */
 export function parseAddress(value: string): {
   address: string;
   name?: string;
 } {
-  const match = value.match(ADDRESS_WITH_NAME_PATTERN);
-  if (match) {
-    const name = match[1]?.trim();
-    // The regex `<([^>]+)>` guarantees match[2] when match is truthy.
-    const address = (match[2] as string).trim();
-    return name ? { address, name } : { address };
+  const trimmed = value.trim();
+  if (!trimmed.endsWith(">")) {
+    return { address: trimmed };
   }
-  return { address: value.trim() };
+  // Use the last `<` so a display name containing `<` doesn't confuse us.
+  const angleStart = trimmed.lastIndexOf("<");
+  if (angleStart === -1) {
+    return { address: trimmed };
+  }
+  const address = trimmed.slice(angleStart + 1, -1).trim();
+  if (!address) {
+    return { address: trimmed };
+  }
+  let name = trimmed.slice(0, angleStart).trim();
+  // Strip surrounding quotes on the display name if present.
+  if (name.length >= 2 && name.startsWith('"') && name.endsWith('"')) {
+    name = name.slice(1, -1).trim();
+  }
+  return name ? { address, name } : { address };
 }
 
 /**

--- a/packages/adapter-email/src/providers/utils.ts
+++ b/packages/adapter-email/src/providers/utils.ts
@@ -1,0 +1,237 @@
+/**
+ * Shared utilities for email providers.
+ *
+ * These helpers live here (rather than in every provider) so that adding
+ * a new ESP doesn't require reinventing webhook signature verification,
+ * HTTP error classification, or RFC-822 header parsing. Each helper is
+ * deliberately single-purpose so providers can opt in to whichever
+ * behaviors apply to their API.
+ */
+
+import { createHmac, timingSafeEqual } from "node:crypto";
+import {
+  AdapterRateLimitError,
+  AuthenticationError,
+  NetworkError,
+  ValidationError,
+} from "@chat-adapter/shared";
+
+// =============================================================================
+// Svix-style HMAC-SHA256 webhook verification
+// =============================================================================
+
+/**
+ * Verify a Svix-style webhook signature.
+ *
+ * The signed payload is `${id}.${timestamp}.${body}` and the signature is
+ * `v1,<base64(hmac_sha256(secret, payload))>`. The header may contain
+ * multiple space-separated signatures (one valid match is sufficient).
+ *
+ * Used by Resend, and any future provider that adopts the same standard
+ * (many ESPs delegate webhook signing to Svix).
+ *
+ * @see https://docs.svix.com/receiving/verifying-payloads/how-manual
+ */
+export function verifySvixSignature(args: {
+  id: string;
+  timestamp: string;
+  signatureHeader: string;
+  body: string;
+  secret: string;
+}): boolean {
+  const secretBytes = decodeSvixSecret(args.secret);
+  if (!secretBytes) {
+    return false;
+  }
+  const signedContent = `${args.id}.${args.timestamp}.${args.body}`;
+  const expected = createHmac("sha256", secretBytes)
+    .update(signedContent, "utf8")
+    .digest("base64");
+  const expectedBuf = Buffer.from(expected, "base64");
+
+  for (const candidate of args.signatureHeader.split(" ")) {
+    const [version, value] = candidate.split(",");
+    if (version !== "v1" || !value) {
+      continue;
+    }
+    // Buffer.from(string, "base64") never throws on invalid base64 — it
+    // produces a (possibly empty) buffer that simply won't match.
+    const actualBuf = Buffer.from(value, "base64");
+    if (
+      actualBuf.length === expectedBuf.length &&
+      timingSafeEqual(actualBuf, expectedBuf)
+    ) {
+      return true;
+    }
+  }
+  return false;
+}
+
+/**
+ * Constant-time comparison of two tokens.
+ *
+ * Use this for any provider whose webhook authentication is just "send
+ * back the secret token we configured" (e.g. Inbound's
+ * `X-Webhook-Verification-Token`). Falls back to `false` for null/empty
+ * inputs and length mismatches so callers don't need to guard.
+ *
+ * Do **not** use this for HMAC-based schemes — those need
+ * {@link verifySvixSignature} or a similar HMAC routine.
+ */
+export function verifyConstantTimeToken(
+  actual: string | null | undefined,
+  expected: string
+): boolean {
+  if (!(actual && expected)) {
+    return false;
+  }
+  const a = Buffer.from(actual);
+  const b = Buffer.from(expected);
+  if (a.length !== b.length) {
+    return false;
+  }
+  return timingSafeEqual(a, b);
+}
+
+/**
+ * Verify Svix headers from a `Request`. Returns `false` if any of the
+ * three required headers (`svix-id`, `svix-timestamp`, `svix-signature`)
+ * are missing.
+ */
+export function verifySvixRequest(args: {
+  request: Request;
+  body: string;
+  secret: string;
+}): boolean {
+  const id = args.request.headers.get("svix-id");
+  const timestamp = args.request.headers.get("svix-timestamp");
+  const signature = args.request.headers.get("svix-signature");
+  if (!(id && timestamp && signature)) {
+    return false;
+  }
+  return verifySvixSignature({
+    id,
+    timestamp,
+    signatureHeader: signature,
+    body: args.body,
+    secret: args.secret,
+  });
+}
+
+const SVIX_SECRET_PREFIX = "whsec_";
+
+/**
+ * Decode a Svix webhook secret. The format is `whsec_<base64>`. Plain
+ * base64 (no prefix) is also tolerated.
+ */
+function decodeSvixSecret(secret: string): Buffer | null {
+  const stripped = secret.startsWith(SVIX_SECRET_PREFIX)
+    ? secret.slice(SVIX_SECRET_PREFIX.length)
+    : secret;
+  if (!stripped) {
+    return null;
+  }
+  // Buffer.from(string, "base64") never throws on invalid input — at worst
+  // it returns a buffer that won't match the expected signature.
+  return Buffer.from(stripped, "base64");
+}
+
+// =============================================================================
+// HTTP error classification
+// =============================================================================
+
+/**
+ * Map an unsuccessful ESP HTTP response to a typed adapter error.
+ *
+ * Always throws — never returns. The `provider` and `operation` arguments
+ * are interpolated into the resulting error message so failures across
+ * providers stay diagnosable.
+ *
+ * Mapping:
+ * - `401` / `403` -> {@link AuthenticationError}
+ * - `429`         -> {@link AdapterRateLimitError} (with `retry-after`)
+ * - `5xx`         -> {@link NetworkError}
+ * - everything else -> {@link ValidationError}
+ */
+export async function throwForEspError(args: {
+  response: Response;
+  provider: string;
+  operation: string;
+}): Promise<never> {
+  const text = await args.response.text();
+  let parsed: { message?: string } | null = null;
+  try {
+    parsed = JSON.parse(text) as { message?: string };
+  } catch {
+    // ignore — providers may return non-JSON error bodies
+  }
+  const message = parsed?.message ?? text;
+  const prefix = `${args.provider} ${args.operation}`;
+
+  if (args.response.status === 401 || args.response.status === 403) {
+    throw new AuthenticationError("email", `${prefix}: ${message}`);
+  }
+  if (args.response.status === 429) {
+    const retryAfter = Number.parseInt(
+      args.response.headers.get("retry-after") ?? "",
+      10
+    );
+    throw new AdapterRateLimitError(
+      "email",
+      Number.isFinite(retryAfter) ? retryAfter : undefined
+    );
+  }
+  if (args.response.status >= 500) {
+    throw new NetworkError(
+      "email",
+      `${prefix} failed (${args.response.status}): ${message}`
+    );
+  }
+  throw new ValidationError(
+    "email",
+    `${prefix} failed (${args.response.status}): ${message}`
+  );
+}
+
+// =============================================================================
+// RFC-822 inbound parsing helpers
+// =============================================================================
+
+const ADDRESS_WITH_NAME_PATTERN = /^\s*"?([^"<>]*?)"?\s*<([^>]+)>\s*$/;
+
+/**
+ * Parse an RFC-822 mailbox value into `{ address, name? }`.
+ *
+ * Handles both `Name <addr@example.com>` and bare `addr@example.com`.
+ * Returns the input verbatim as `address` if no `<...>` envelope is
+ * present; downstream code is responsible for validation.
+ */
+export function parseAddress(value: string): {
+  address: string;
+  name?: string;
+} {
+  const match = value.match(ADDRESS_WITH_NAME_PATTERN);
+  if (match) {
+    const name = match[1]?.trim();
+    // The regex `<([^>]+)>` guarantees match[2] when match is truthy.
+    const address = (match[2] as string).trim();
+    return name ? { address, name } : { address };
+  }
+  return { address: value.trim() };
+}
+
+/**
+ * Lowercase all keys of a header object so callers can look up values by
+ * canonical name regardless of the source casing.
+ *
+ * Returns an empty object if `headers` is null/undefined.
+ */
+export function normalizeHeaderKeys(
+  headers: Record<string, string> | null | undefined
+): Record<string, string> {
+  const out: Record<string, string> = {};
+  for (const [k, v] of Object.entries(headers ?? {})) {
+    out[k.toLowerCase()] = v;
+  }
+  return out;
+}

--- a/packages/adapter-email/src/render.test.ts
+++ b/packages/adapter-email/src/render.test.ts
@@ -25,6 +25,7 @@ import {
 
 const TEXT_ALIGN_CENTER = /style="text-align:center/;
 const TEXT_ALIGN_RIGHT = /style="text-align:right/;
+const TABLE_CELL_OPEN_TAG = /<t[hd][\s>][^>]*>/g;
 
 describe("escapeHtml", () => {
   it("escapes the standard HTML character set", () => {
@@ -434,6 +435,79 @@ describe("astToHtml edge cases (manually constructed AST)", () => {
       ],
     };
     expect(astToHtml(ast)).toContain("no-align");
+  });
+});
+
+describe("cardToHtml table alignment", () => {
+  it("merges alignment into a single style attribute per cell", () => {
+    // Two `style=` attributes on the same tag would cause browsers to
+    // silently drop the second per the HTML spec, losing the padding /
+    // border styling whenever alignment is also present.
+    const card: CardElement = {
+      type: "card",
+      title: "Aligned",
+      children: [
+        {
+          type: "table",
+          headers: ["L", "C", "R"],
+          rows: [["1", "2", "3"]],
+          align: ["left", "center", "right"],
+        },
+      ],
+    };
+    const html = cardToHtml(card);
+
+    // Match opening <th> / <td> tags, but not <thead> / <tbody> wrappers.
+    // The `[\\s>]` requires whitespace or `>` immediately after the
+    // letter so `<thead>` and `<tbody>` are excluded.
+    const cells = html.match(TABLE_CELL_OPEN_TAG) ?? [];
+    expect(cells.length).toBeGreaterThan(0);
+    for (const cell of cells) {
+      // Exactly one `style=` attribute per cell. The split-on-`style=`
+      // count will be 2 (one before, one after) when there's exactly one.
+      expect(cell.split('style="').length).toBe(2);
+    }
+
+    // Padding and alignment both survive on the same cell.
+    expect(html).toContain(
+      '<th style="padding:8px;border-bottom:1px solid #e5e7eb;text-align:left">'
+    );
+    expect(html).toContain(
+      '<th style="padding:8px;border-bottom:1px solid #e5e7eb;text-align:center">'
+    );
+    expect(html).toContain(
+      '<th style="padding:8px;border-bottom:1px solid #e5e7eb;text-align:right">'
+    );
+    expect(html).toContain(
+      '<td style="padding:8px;border-bottom:1px solid #f3f4f6;text-align:left">'
+    );
+    expect(html).toContain(
+      '<td style="padding:8px;border-bottom:1px solid #f3f4f6;text-align:center">'
+    );
+    expect(html).toContain(
+      '<td style="padding:8px;border-bottom:1px solid #f3f4f6;text-align:right">'
+    );
+  });
+
+  it("omits text-align on body cells when no alignment is configured", () => {
+    const card: CardElement = {
+      type: "card",
+      children: [
+        {
+          type: "table",
+          headers: ["A", "B"],
+          rows: [["1", "2"]],
+        },
+      ],
+    };
+    const html = cardToHtml(card);
+    // Headers always include a default `text-align:left`...
+    expect(html).toContain("text-align:left");
+    // ...but body cells should not carry an explicit alignment when the
+    // table didn't request one (relies on the browser's default).
+    expect(html).toContain(
+      '<td style="padding:8px;border-bottom:1px solid #f3f4f6">'
+    );
   });
 });
 

--- a/packages/adapter-email/src/render.test.ts
+++ b/packages/adapter-email/src/render.test.ts
@@ -1,0 +1,619 @@
+import type { CardChild, CardElement, Root } from "chat";
+import {
+  Actions,
+  Button,
+  Card,
+  Image as CardImage,
+  CardLink,
+  CardText,
+  Divider,
+  Field,
+  Fields,
+  LinkButton,
+  Section,
+  Table,
+} from "chat";
+import { describe, expect, it } from "vitest";
+import {
+  astToHtml,
+  cardToHtml,
+  cardToPlainText,
+  escapeAttr,
+  escapeHtml,
+  markdownToHtml,
+} from "./render";
+
+const TEXT_ALIGN_CENTER = /style="text-align:center/;
+const TEXT_ALIGN_RIGHT = /style="text-align:right/;
+
+describe("escapeHtml", () => {
+  it("escapes the standard HTML character set", () => {
+    expect(escapeHtml(`<script>alert("x" & 'y')</script>`)).toBe(
+      "&lt;script&gt;alert(&quot;x&quot; &amp; &#39;y&#39;)&lt;/script&gt;"
+    );
+  });
+});
+
+describe("escapeAttr", () => {
+  it("strips control characters", () => {
+    expect(escapeAttr("https://example.com\u0007/path")).toBe(
+      "https://example.com/path"
+    );
+  });
+});
+
+describe("markdownToHtml", () => {
+  it("renders headings, bold, italic, and links", () => {
+    const html = markdownToHtml(
+      "# Hello\n\n**bold** and *italic* and [link](https://example.com)"
+    );
+    expect(html).toContain("<h1>Hello</h1>");
+    expect(html).toContain("<strong>bold</strong>");
+    expect(html).toContain("<em>italic</em>");
+    expect(html).toContain('<a href="https://example.com">link</a>');
+  });
+
+  it("renders ordered and unordered lists", () => {
+    const html = markdownToHtml("- one\n- two\n\n1. first\n2. second");
+    expect(html).toContain("<ul>");
+    expect(html).toContain("one");
+    expect(html).toContain("two");
+    expect(html).toContain("<ol>");
+    expect(html).toContain("first");
+    expect(html).toContain("second");
+  });
+
+  it("renders code blocks with language class", () => {
+    const html = markdownToHtml("```ts\nconst x = 1;\n```");
+    expect(html).toContain('<code class="language-ts">');
+    expect(html).toContain("const x = 1;");
+  });
+
+  it("renders inline code", () => {
+    const html = markdownToHtml("Use `foo` here.");
+    expect(html).toContain("<code>foo</code>");
+  });
+
+  it("renders thematic breaks", () => {
+    const html = markdownToHtml("a\n\n---\n\nb");
+    expect(html).toContain("<hr />");
+  });
+
+  it("renders GFM tables", () => {
+    const html = markdownToHtml(
+      "| H1 | H2 |\n| --- | --- |\n| a | b |\n| c | d |"
+    );
+    expect(html).toContain("<table");
+    expect(html).toContain("<th");
+    expect(html).toContain("<td");
+    expect(html).toContain("a");
+    expect(html).toContain("d");
+  });
+
+  it("escapes HTML in markdown text content", () => {
+    const html = markdownToHtml("Hello <script>x</script>");
+    expect(html).not.toContain("<script>");
+    expect(html).toContain("&lt;script&gt;");
+  });
+});
+
+describe("astToHtml", () => {
+  it("delegates to markdownToHtml result for trivial input", () => {
+    expect(astToHtml({ type: "root", children: [] })).toBe("");
+  });
+});
+
+describe("cardToHtml", () => {
+  it("renders title, subtitle, and text", () => {
+    const card = Card({
+      title: "Order #1234",
+      subtitle: "Submitted today",
+      children: [CardText("Total: $50.00")],
+    });
+    const html = cardToHtml(card);
+    expect(html).toContain("Order #1234");
+    expect(html).toContain("Submitted today");
+    expect(html).toContain("Total: $50.00");
+  });
+
+  it("escapes title and subtitle", () => {
+    const card = Card({
+      title: "<script>",
+      subtitle: '"x"',
+      children: [],
+    });
+    const html = cardToHtml(card);
+    expect(html).not.toContain("<script>");
+    expect(html).toContain("&lt;script&gt;");
+    expect(html).toContain("&quot;x&quot;");
+  });
+
+  it("renders a callback button as an anchor with actionId + value query params", () => {
+    const card = Card({
+      title: "Approve?",
+      children: [
+        Actions([
+          Button({
+            id: "approve",
+            label: "Approve",
+            style: "primary",
+            value: "order-1",
+            callbackUrl: "https://bot.example.com/cb",
+          }),
+        ]),
+      ],
+    });
+    const html = cardToHtml(card);
+    expect(html).toContain('<a href="https://bot.example.com/cb');
+    expect(html).toContain("actionId=approve");
+    expect(html).toContain("value=order-1");
+    expect(html).toContain("Approve");
+  });
+
+  it("renders a button without a callbackUrl as a disabled span", () => {
+    const card = Card({
+      children: [
+        Actions([Button({ id: "noop", label: "Noop", style: "default" })]),
+      ],
+    });
+    const html = cardToHtml(card);
+    expect(html).toContain("<span");
+    expect(html).toContain("Noop");
+    expect(html).toContain("opacity:0.5");
+  });
+
+  it("renders link buttons as anchors", () => {
+    const card = Card({
+      children: [
+        Actions([LinkButton({ url: "https://example.com", label: "Open" })]),
+      ],
+    });
+    const html = cardToHtml(card);
+    expect(html).toContain('<a href="https://example.com"');
+    expect(html).toContain("Open");
+  });
+
+  it("renders fields, images, dividers, sections, and tables", () => {
+    const card = Card({
+      imageUrl: "https://example.com/header.png",
+      children: [
+        Section([
+          CardText("Section text"),
+          Fields([
+            Field({ label: "Status", value: "Open" }),
+            Field({ label: "Owner", value: "Alice" }),
+          ]),
+        ]),
+        Divider(),
+        CardImage({ url: "https://example.com/inline.png", alt: "Inline" }),
+        Table({
+          headers: ["A", "B"],
+          rows: [
+            ["1", "2"],
+            ["3", "4"],
+          ],
+        }),
+      ],
+    });
+    const html = cardToHtml(card);
+    expect(html).toContain('src="https://example.com/header.png"');
+    expect(html).toContain("Section text");
+    expect(html).toContain("Status");
+    expect(html).toContain("Open");
+    expect(html).toContain("<hr");
+    expect(html).toContain('alt="Inline"');
+    expect(html).toContain("<table");
+  });
+});
+
+describe("cardToPlainText", () => {
+  it("includes title, subtitle, and text content", () => {
+    const card = Card({
+      title: "Hello",
+      subtitle: "Sub",
+      children: [CardText("Body text")],
+    });
+    const text = cardToPlainText(card);
+    expect(text).toContain("Hello");
+    expect(text).toContain("Sub");
+    expect(text).toContain("Body text");
+  });
+
+  it("includes link button URLs", () => {
+    const card = Card({
+      title: "Hi",
+      children: [
+        Actions([LinkButton({ url: "https://x.example", label: "Open" })]),
+      ],
+    });
+    const text = cardToPlainText(card);
+    expect(text).toContain("Open: https://x.example");
+  });
+
+  it("includes callbackUrl button URLs with query params", () => {
+    const card = Card({
+      title: "Hi",
+      children: [
+        Actions([
+          Button({
+            id: "yes",
+            label: "Yes",
+            value: "v",
+            callbackUrl: "https://bot.example.com/cb",
+          }),
+        ]),
+      ],
+    });
+    const text = cardToPlainText(card);
+    expect(text).toContain("Yes: https://bot.example.com/cb");
+    expect(text).toContain("actionId=yes");
+    expect(text).toContain("value=v");
+  });
+
+  it("omits action buttons that lack any URL", () => {
+    const card = Card({
+      title: "Hi",
+      children: [Actions([Button({ id: "x", label: "X" })])],
+    });
+    const text = cardToPlainText(card);
+    expect(text).not.toContain("X");
+    expect(text).toContain("Hi");
+  });
+
+  it("traverses section children", () => {
+    const card = Card({
+      title: "Hi",
+      children: [Section([CardText("inner-text"), Divider()])],
+    });
+    const text = cardToPlainText(card);
+    expect(text).toContain("inner-text");
+  });
+});
+
+// =============================================================================
+// Edge cases: AST nodes and CardChild variants not exercised by the
+// happy-path tests above. Some are constructed manually because the
+// markdown parser does not produce them, or because the AdapterPostable
+// builders don't expose the relevant config.
+// =============================================================================
+
+describe("markdownToHtml additional AST node coverage", () => {
+  it("renders blockquotes", () => {
+    expect(markdownToHtml("> quoted")).toContain("<blockquote>");
+  });
+
+  it("renders strikethrough (GFM delete) nodes", () => {
+    expect(markdownToHtml("~~strike~~")).toContain("<del>strike</del>");
+  });
+
+  it("renders inline images", () => {
+    const html = markdownToHtml("![alt text](https://example.com/img.png)");
+    expect(html).toContain('<img src="https://example.com/img.png"');
+    expect(html).toContain('alt="alt text"');
+  });
+
+  it("renders hard line breaks as <br />", () => {
+    // Two trailing spaces before a newline produce an mdast `break` node.
+    const html = markdownToHtml("foo  \nbar");
+    expect(html).toContain("<br />");
+  });
+
+  it("renders GFM tables with alignment", () => {
+    const html = markdownToHtml("| H1 | H2 |\n| :---: | ---: |\n| a | b |");
+    expect(html).toMatch(TEXT_ALIGN_CENTER);
+    expect(html).toMatch(TEXT_ALIGN_RIGHT);
+  });
+});
+
+describe("astToHtml edge cases (manually constructed AST)", () => {
+  it("falls through to children traversal for unknown node types", () => {
+    // mdast won't normally produce a node like this from markdown, but
+    // the default branch should still recurse through children.
+    const ast: Root = {
+      type: "root",
+      children: [
+        {
+          // Cast through unknown so TS allows a fabricated node type.
+          type: "totally-unknown",
+          children: [{ type: "text", value: "fallback-text" }],
+        } as unknown as Root["children"][number],
+      ],
+    };
+    expect(astToHtml(ast)).toContain("fallback-text");
+  });
+
+  it("renders an empty string for tables with no rows", () => {
+    const ast: Root = {
+      type: "root",
+      children: [
+        {
+          type: "table",
+          align: [],
+          children: [],
+        } as unknown as Root["children"][number],
+      ],
+    };
+    expect(astToHtml(ast)).toBe("");
+  });
+
+  it("renders headings without a depth as <h1>", () => {
+    const ast: Root = {
+      type: "root",
+      children: [
+        {
+          type: "heading",
+          children: [{ type: "text", value: "no-depth" }],
+        } as unknown as Root["children"][number],
+      ],
+    };
+    expect(astToHtml(ast)).toContain("<h1>no-depth</h1>");
+  });
+
+  it("renders fenced code blocks without a language", () => {
+    expect(markdownToHtml("```\nplain code\n```")).toContain(
+      "<pre><code>plain code</code></pre>"
+    );
+  });
+
+  it("renders ordered lists with a non-default start attribute", () => {
+    const html = markdownToHtml("3. third\n4. fourth");
+    expect(html).toContain('<ol start="3">');
+  });
+
+  it("renders links and images with empty url/alt fallbacks", () => {
+    const ast: Root = {
+      type: "root",
+      children: [
+        {
+          type: "paragraph",
+          children: [
+            {
+              // url omitted
+              type: "link",
+              children: [{ type: "text", value: "label" }],
+            } as unknown as Root["children"][number],
+            // image with no url and no alt
+            {
+              type: "image",
+            } as unknown as Root["children"][number],
+          ],
+        },
+      ],
+    };
+    const html = astToHtml(ast);
+    expect(html).toContain('<a href="">label</a>');
+    expect(html).toContain('<img src="" alt="" />');
+  });
+
+  it("renders tables that contain only a header row", () => {
+    const ast: Root = {
+      type: "root",
+      children: [
+        {
+          type: "table",
+          align: [],
+          children: [
+            {
+              type: "tableRow",
+              children: [
+                {
+                  type: "tableCell",
+                  children: [{ type: "text", value: "only-header" }],
+                },
+              ],
+            },
+          ],
+        } as unknown as Root["children"][number],
+      ],
+    };
+    const html = astToHtml(ast);
+    expect(html).toContain("<thead>");
+    expect(html).toContain("only-header");
+    expect(html).not.toContain("<tbody>");
+  });
+
+  it("renders tables that omit the `align` field", () => {
+    const ast: Root = {
+      type: "root",
+      children: [
+        {
+          type: "table",
+          // align intentionally omitted to exercise the `?? []` fallback
+          children: [
+            {
+              type: "tableRow",
+              children: [
+                {
+                  type: "tableCell",
+                  children: [{ type: "text", value: "no-align" }],
+                },
+              ],
+            },
+          ],
+        } as unknown as Root["children"][number],
+      ],
+    };
+    expect(astToHtml(ast)).toContain("no-align");
+  });
+});
+
+describe("cardToHtml minor element variants", () => {
+  it("renders an image element without alt", () => {
+    const card: CardElement = {
+      type: "card",
+      title: "x",
+      children: [
+        {
+          type: "image",
+          url: "https://example.com/pic.png",
+        } as CardChild,
+      ],
+    };
+    expect(cardToHtml(card)).toContain('alt=""');
+  });
+
+  it("renders a button without a `value` query param when value is undefined", () => {
+    const card: CardElement = {
+      type: "card",
+      title: "x",
+      children: [
+        {
+          type: "actions",
+          children: [
+            {
+              type: "button",
+              id: "approve",
+              label: "Approve",
+              // no `value`
+              callbackUrl: "https://bot/cb",
+            },
+          ],
+        },
+      ],
+    };
+    const html = cardToHtml(card);
+    expect(html).toContain("actionId=approve");
+    expect(html).not.toContain("value=");
+  });
+
+  it("falls back to the default button style when style is unrecognized", () => {
+    const card: CardElement = {
+      type: "card",
+      title: "x",
+      children: [
+        {
+          type: "actions",
+          children: [
+            {
+              type: "button",
+              id: "x",
+              label: "X",
+              // intentionally a style that BUTTON_STYLE_TO_CSS doesn't list
+              style: "totally-made-up" as unknown as "primary",
+              callbackUrl: "https://bot/cb",
+            },
+            {
+              type: "link-button",
+              url: "https://example.com",
+              label: "Open",
+              style: "totally-made-up" as unknown as "primary",
+            },
+          ],
+        },
+      ],
+    };
+    const html = cardToHtml(card);
+    // Neither bogus style maps; the inline style attribute should be empty
+    // (i.e., the anchor tag still renders without the BUTTON_STYLE_TO_CSS
+    // attributes baked in).
+    expect(html).toContain('style=""');
+    expect(html).toContain("Open");
+    expect(html).toContain("X");
+  });
+});
+
+describe("cardToPlainText minor variants", () => {
+  it("returns body content for cards without a title", () => {
+    const card = Card({
+      children: [CardText("body only")],
+    });
+    expect(cardToPlainText(card)).toContain("body only");
+  });
+
+  it("omits the value query param from callback button URLs when value is undefined", () => {
+    const card: CardElement = {
+      type: "card",
+      children: [
+        {
+          type: "actions",
+          children: [
+            {
+              type: "button",
+              id: "yes",
+              label: "Yes",
+              callbackUrl: "https://bot/cb",
+              // no `value`
+            },
+          ],
+        },
+      ],
+    };
+    const text = cardToPlainText(card);
+    expect(text).toContain("actionId=yes");
+    expect(text).not.toContain("value=");
+  });
+});
+
+describe("cardToHtml additional CardChild coverage", () => {
+  it("renders bold and muted text styles", () => {
+    // `CardText("...")` doesn't accept a style — build the element directly.
+    const boldChild: CardChild = {
+      type: "text",
+      content: "bold-text",
+      style: "bold",
+    };
+    const mutedChild: CardChild = {
+      type: "text",
+      content: "muted-text",
+      style: "muted",
+    };
+    const card: CardElement = {
+      type: "card",
+      title: "x",
+      children: [boldChild, mutedChild],
+    };
+    const html = cardToHtml(card);
+    expect(html).toContain("font-weight:600");
+    expect(html).toContain("color:#6b7280");
+    expect(html).toContain("bold-text");
+    expect(html).toContain("muted-text");
+  });
+
+  it("renders inline CardLink children", () => {
+    const card = Card({
+      title: "Hi",
+      children: [CardLink({ label: "Read more", url: "https://example.com" })],
+    });
+    const html = cardToHtml(card);
+    expect(html).toContain('<a href="https://example.com">Read more</a>');
+  });
+
+  it("renders nothing for unknown card child types (default branch)", () => {
+    const unknownChild = {
+      type: "totally-unknown",
+    } as unknown as CardChild;
+    const card: CardElement = {
+      type: "card",
+      title: "x",
+      children: [unknownChild],
+    };
+    const html = cardToHtml(card);
+    // The card frame still renders; the unknown child contributes nothing.
+    expect(html).toContain("x");
+    expect(html).toContain("max-width:600px");
+  });
+
+  it("renders no Actions block when all children are non-button/link-button", () => {
+    // Build an Actions element whose children are filtered out entirely;
+    // both the inner default branch and the outer empty-buttons guard
+    // need to be exercised.
+    const actionsChild = {
+      type: "actions",
+      children: [
+        {
+          type: "select",
+          id: "s",
+          options: [],
+        } as unknown as never,
+      ],
+    } as unknown as CardChild;
+    const card: CardElement = {
+      type: "card",
+      title: "x",
+      children: [actionsChild],
+    };
+    const html = cardToHtml(card);
+    // Should NOT contain the `<div style="margin:16px 0">` actions wrapper.
+    expect(html).not.toContain("margin:16px 0");
+  });
+});

--- a/packages/adapter-email/src/render.ts
+++ b/packages/adapter-email/src/render.ts
@@ -1,0 +1,504 @@
+/**
+ * HTML and plain-text rendering for outbound emails.
+ *
+ * Two pipelines live here:
+ *
+ * 1. {@link astToHtml} / {@link markdownToHtml} — render mdast to inline-styled
+ *    email-safe HTML. We hand-roll a small walker rather than pulling in
+ *    `remark-html` + `@react-email/components` because email layout
+ *    requirements are narrow (no client-side state, no CSS classes,
+ *    inline styles, table-based layouts) and a custom walker keeps the
+ *    package lean and matches how peer adapters (WhatsApp, Telegram) avoid
+ *    heavy framework deps.
+ *
+ * 2. {@link cardToHtml} / {@link cardToPlainText} — render `CardElement` to
+ *    HTML and a plain-text fallback. Buttons render as anchor tags driven
+ *    by `callbackUrl` (chat-sdk rewrites button values to `__cb:<token>`
+ *    before the adapter sees them; if there's no `callbackUrl` the button
+ *    becomes a `<button disabled>` to communicate intent).
+ */
+
+import type {
+  ActionsElement,
+  ButtonElement,
+  CardChild,
+  CardElement,
+  Content,
+  DividerElement,
+  FieldElement,
+  FieldsElement,
+  ImageElement,
+  LinkButtonElement,
+  LinkElement,
+  Root,
+  SectionElement,
+  TableElement,
+  TextElement,
+} from "chat";
+import {
+  cardChildToFallbackText,
+  getNodeChildren,
+  getNodeValue,
+  isTableNode,
+  parseMarkdown,
+} from "chat";
+
+// =============================================================================
+// HTML escaping
+// =============================================================================
+
+const HTML_ESCAPE_MAP: Record<string, string> = {
+  "&": "&amp;",
+  "<": "&lt;",
+  ">": "&gt;",
+  '"': "&quot;",
+  "'": "&#39;",
+};
+
+const HTML_ESCAPE_PATTERN = /[&<>"']/g;
+// biome-ignore lint/suspicious/noControlCharactersInRegex: removing actual control chars from URLs
+const CONTROL_CHAR_PATTERN = /[\u0000-\u001f\u007f]/g;
+
+/**
+ * Escape a string for safe embedding in HTML.
+ *
+ * Always called on user-controlled content (markdown bodies, card text,
+ * subjects) before injection into the rendered template.
+ */
+export function escapeHtml(value: string): string {
+  // HTML_ESCAPE_PATTERN only matches characters that exist in
+  // HTML_ESCAPE_MAP, so the lookup is guaranteed to return a string.
+  return value.replace(
+    HTML_ESCAPE_PATTERN,
+    (ch) => HTML_ESCAPE_MAP[ch] as string
+  );
+}
+
+/**
+ * Escape a string for safe embedding in an HTML attribute (URL, alt, etc.).
+ *
+ * URLs are also normalized to drop control characters that would break the
+ * surrounding `href="..."`.
+ */
+export function escapeAttr(value: string): string {
+  return escapeHtml(value.replace(CONTROL_CHAR_PATTERN, ""));
+}
+
+// =============================================================================
+// Markdown / mdast -> HTML
+// =============================================================================
+
+/**
+ * Convert a markdown string to HTML.
+ */
+export function markdownToHtml(markdown: string): string {
+  return astToHtml(parseMarkdown(markdown));
+}
+
+/**
+ * Convert an mdast `Root` to HTML.
+ */
+export function astToHtml(root: Root): string {
+  const parts: string[] = [];
+  for (const node of root.children) {
+    parts.push(nodeToHtml(node as Content));
+  }
+  return parts.filter(Boolean).join("\n");
+}
+
+/**
+ * Render a single mdast {@link Content} node to HTML. Dispatches on
+ * `node.type`; unknown types fall through to a children traversal so
+ * future mdast additions degrade gracefully.
+ */
+function nodeToHtml(node: Content): string {
+  switch (node.type) {
+    case "paragraph":
+      return `<p>${childrenToHtml(node)}</p>`;
+    case "heading": {
+      const level = Math.min(Math.max(node.depth ?? 1, 1), 6);
+      return `<h${level}>${childrenToHtml(node)}</h${level}>`;
+    }
+    case "thematicBreak":
+      return "<hr />";
+    case "blockquote":
+      return `<blockquote>${childrenToHtml(node)}</blockquote>`;
+    case "list":
+      return listToHtml(node);
+    case "code":
+      return `<pre><code${
+        node.lang ? ` class="language-${escapeAttr(node.lang)}"` : ""
+      }>${escapeHtml(getNodeValue(node))}</code></pre>`;
+    case "inlineCode":
+      return `<code>${escapeHtml(getNodeValue(node))}</code>`;
+    case "strong":
+      return `<strong>${childrenToHtml(node)}</strong>`;
+    case "emphasis":
+      return `<em>${childrenToHtml(node)}</em>`;
+    case "delete":
+      return `<del>${childrenToHtml(node)}</del>`;
+    case "link":
+      return `<a href="${escapeAttr(node.url ?? "")}">${childrenToHtml(node)}</a>`;
+    case "image":
+      return `<img src="${escapeAttr(node.url ?? "")}" alt="${escapeAttr(
+        node.alt ?? ""
+      )}" />`;
+    case "break":
+      return "<br />";
+    case "text":
+      return escapeHtml(getNodeValue(node));
+    case "html":
+      // Treat raw HTML embedded in markdown as untrusted text and escape it.
+      // This matches the behavior we want for email — bots should not
+      // inject arbitrary HTML through user-controlled content.
+      return escapeHtml(getNodeValue(node));
+    default:
+      if (isTableNode(node)) {
+        return tableNodeToHtml(node);
+      }
+      return childrenToHtml(node);
+  }
+}
+
+function childrenToHtml(node: Content): string {
+  return getNodeChildren(node)
+    .map((child) => nodeToHtml(child as Content))
+    .join("");
+}
+
+function listToHtml(node: Content): string {
+  // The `list` switch case routes here; mdast guarantees `ordered` and
+  // optionally provides `start` (defaulting to 1).
+  const listNode = node as Content & {
+    ordered?: boolean | null;
+    start?: number;
+  };
+  const ordered = Boolean(listNode.ordered);
+  const start = typeof listNode.start === "number" ? listNode.start : 1;
+  const tag = ordered ? "ol" : "ul";
+  const startAttr = ordered && start !== 1 ? ` start="${start}"` : "";
+  const items = getNodeChildren(node)
+    .map((child) => `<li>${childrenToHtml(child as Content)}</li>`)
+    .join("");
+  return `<${tag}${startAttr}>${items}</${tag}>`;
+}
+
+function tableNodeToHtml(node: Content): string {
+  const rows = getNodeChildren(node);
+  if (rows.length === 0) {
+    return "";
+  }
+  const tableNode = node as Content & { align?: (string | undefined)[] };
+  const align = tableNode.align ?? [];
+  const [headerRow, ...bodyRows] = rows;
+
+  // `headerRow` is always defined here because we returned early above
+  // when `rows.length === 0`. TypeScript can't see through the destructure.
+  const head = `<thead><tr>${getNodeChildren(headerRow as Content)
+    .map(
+      (cell, i) =>
+        `<th${alignAttr(align[i])}>${childrenToHtml(cell as Content)}</th>`
+    )
+    .join("")}</tr></thead>`;
+  const body =
+    bodyRows.length > 0
+      ? `<tbody>${bodyRows
+          .map(
+            (row) =>
+              `<tr>${getNodeChildren(row)
+                .map(
+                  (cell, i) =>
+                    `<td${alignAttr(align[i])}>${childrenToHtml(
+                      cell as Content
+                    )}</td>`
+                )
+                .join("")}</tr>`
+          )
+          .join("")}</tbody>`
+      : "";
+  return `<table border="1" cellpadding="6" cellspacing="0">${head}${body}</table>`;
+}
+
+function alignAttr(align: string | undefined): string {
+  if (!align) {
+    return "";
+  }
+  return ` style="text-align:${escapeAttr(align)}"`;
+}
+
+// =============================================================================
+// CardElement -> HTML
+// =============================================================================
+
+const BUTTON_STYLE_TO_CSS: Record<string, string> = {
+  primary:
+    "background:#2563eb;color:#fff;border:1px solid #1d4ed8;padding:8px 16px;border-radius:6px;text-decoration:none;display:inline-block;font-weight:600",
+  danger:
+    "background:#dc2626;color:#fff;border:1px solid #b91c1c;padding:8px 16px;border-radius:6px;text-decoration:none;display:inline-block;font-weight:600",
+  default:
+    "background:#f3f4f6;color:#111827;border:1px solid #d1d5db;padding:8px 16px;border-radius:6px;text-decoration:none;display:inline-block;font-weight:600",
+};
+
+/**
+ * Render a {@link CardElement} as inline-styled HTML suitable for email.
+ */
+export function cardToHtml(card: CardElement): string {
+  const parts: string[] = [];
+  parts.push(
+    `<div style="font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Helvetica,Arial,sans-serif;max-width:600px">`
+  );
+  if (card.imageUrl) {
+    parts.push(
+      `<img src="${escapeAttr(card.imageUrl)}" alt="${escapeAttr(
+        card.title ?? ""
+      )}" style="max-width:100%;border-radius:8px 8px 0 0;display:block" />`
+    );
+  }
+  parts.push(
+    `<div style="border:1px solid #e5e7eb;border-radius:${
+      card.imageUrl ? "0 0 8px 8px" : "8px"
+    };padding:24px">`
+  );
+  if (card.title) {
+    parts.push(
+      `<h2 style="margin:0 0 8px 0;font-size:20px;line-height:1.3">${escapeHtml(
+        card.title
+      )}</h2>`
+    );
+  }
+  if (card.subtitle) {
+    parts.push(
+      `<p style="margin:0 0 16px 0;color:#6b7280">${escapeHtml(card.subtitle)}</p>`
+    );
+  }
+  for (const child of card.children) {
+    parts.push(cardChildToHtml(child));
+  }
+  parts.push("</div></div>");
+  return parts.filter(Boolean).join("\n");
+}
+
+/** Dispatch a `CardChild` to its element-specific renderer. */
+function cardChildToHtml(child: CardChild): string {
+  switch (child.type) {
+    case "text":
+      return textElementToHtml(child);
+    case "image":
+      return imageElementToHtml(child);
+    case "divider":
+      return dividerElementToHtml(child);
+    case "actions":
+      return actionsElementToHtml(child);
+    case "section":
+      return sectionElementToHtml(child);
+    case "fields":
+      return fieldsElementToHtml(child);
+    case "link":
+      return linkElementToHtml(child);
+    case "table":
+      return tableElementToHtml(child);
+    default:
+      return "";
+  }
+}
+
+function textStyleToCss(style: TextElement["style"]): string {
+  if (style === "bold") {
+    return "font-weight:600";
+  }
+  if (style === "muted") {
+    return "color:#6b7280";
+  }
+  return "";
+}
+
+function textElementToHtml(el: TextElement): string {
+  const style = textStyleToCss(el.style);
+  // Render markdown inside text content for parity with other adapters
+  const inner = markdownToHtml(el.content);
+  if (style) {
+    return `<div style="${style};margin-bottom:12px">${inner}</div>`;
+  }
+  return `<div style="margin-bottom:12px">${inner}</div>`;
+}
+
+function imageElementToHtml(el: ImageElement): string {
+  return `<p style="margin:0 0 12px 0"><img src="${escapeAttr(
+    el.url
+  )}" alt="${escapeAttr(el.alt ?? "")}" style="max-width:100%;border-radius:6px" /></p>`;
+}
+
+function dividerElementToHtml(_el: DividerElement): string {
+  return `<hr style="border:none;border-top:1px solid #e5e7eb;margin:16px 0" />`;
+}
+
+/**
+ * Render an `Actions` container. Selects and radio selects are not
+ * actionable in email and are dropped; if every child is dropped the
+ * whole wrapper is omitted.
+ */
+function actionsElementToHtml(el: ActionsElement): string {
+  const buttons = el.children
+    .map((child) => {
+      switch (child.type) {
+        case "button":
+          return buttonElementToHtml(child);
+        case "link-button":
+          return linkButtonElementToHtml(child);
+        default:
+          // Selects/radio selects are not interactive in email - skip.
+          return "";
+      }
+    })
+    .filter(Boolean)
+    .join(" ");
+  if (!buttons) {
+    return "";
+  }
+  return `<div style="margin:16px 0">${buttons}</div>`;
+}
+
+function buttonElementToHtml(el: ButtonElement): string {
+  const style = BUTTON_STYLE_TO_CSS[el.style ?? "default"] ?? "";
+  if (el.callbackUrl) {
+    // chat-sdk has already rewritten button.value to a callback token by
+    // the time the adapter sees the postable. We render an anchor that
+    // GETs the callback URL with the actionId and value as query params.
+    const url = new URL(el.callbackUrl);
+    url.searchParams.set("actionId", el.id);
+    if (el.value !== undefined) {
+      url.searchParams.set("value", el.value);
+    }
+    return `<a href="${escapeAttr(url.toString())}" style="${style}">${escapeHtml(
+      el.label
+    )}</a>`;
+  }
+  // Without a callbackUrl, the button can't do anything actionable in
+  // email. Render a disabled-styled span so the intent is preserved.
+  return `<span style="${style};opacity:0.5;cursor:not-allowed">${escapeHtml(
+    el.label
+  )}</span>`;
+}
+
+function linkButtonElementToHtml(el: LinkButtonElement): string {
+  const style = BUTTON_STYLE_TO_CSS[el.style ?? "default"] ?? "";
+  return `<a href="${escapeAttr(el.url)}" style="${style}">${escapeHtml(
+    el.label
+  )}</a>`;
+}
+
+function sectionElementToHtml(el: SectionElement): string {
+  return `<div style="margin-bottom:16px">${el.children
+    .map((child) => cardChildToHtml(child))
+    .join("\n")}</div>`;
+}
+
+function fieldsElementToHtml(el: FieldsElement): string {
+  const cells = el.children.map((field) => fieldElementToHtml(field)).join("");
+  return `<table style="width:100%;border-collapse:collapse;margin:12px 0"><tbody><tr>${cells}</tr></tbody></table>`;
+}
+
+function fieldElementToHtml(el: FieldElement): string {
+  return `<td style="vertical-align:top;padding:0 12px 0 0"><div style="font-size:12px;color:#6b7280;text-transform:uppercase;letter-spacing:0.05em;margin-bottom:4px">${escapeHtml(
+    el.label
+  )}</div><div>${escapeHtml(el.value)}</div></td>`;
+}
+
+function linkElementToHtml(el: LinkElement): string {
+  return `<p style="margin:0 0 12px 0"><a href="${escapeAttr(el.url)}">${escapeHtml(
+    el.label
+  )}</a></p>`;
+}
+
+function tableElementToHtml(el: TableElement): string {
+  const align = el.align ?? [];
+  const head = `<thead><tr>${el.headers
+    .map(
+      (h, i) =>
+        `<th${alignAttr(align[i])} style="padding:8px;border-bottom:1px solid #e5e7eb;text-align:${escapeAttr(
+          align[i] ?? "left"
+        )}">${escapeHtml(h)}</th>`
+    )
+    .join("")}</tr></thead>`;
+  const body = `<tbody>${el.rows
+    .map(
+      (row) =>
+        `<tr>${row
+          .map(
+            (cell, i) =>
+              `<td${alignAttr(align[i])} style="padding:8px;border-bottom:1px solid #f3f4f6">${escapeHtml(
+                cell
+              )}</td>`
+          )
+          .join("")}</tr>`
+    )
+    .join("")}</tbody>`;
+  return `<table style="width:100%;border-collapse:collapse;margin:12px 0">${head}${body}</table>`;
+}
+
+// =============================================================================
+// Plain-text fallback
+// =============================================================================
+
+/**
+ * Render a {@link CardElement} as plain text using the chat-sdk's
+ * canonical fallback formatter.
+ *
+ * Email clients without HTML rendering (or in plain-text mode) see this
+ * version. Action buttons are excluded from the text fallback because they
+ * are not actionable; link buttons collapse to "label (url)".
+ */
+export function cardToPlainText(card: CardElement): string {
+  const parts: string[] = [];
+  if (card.title) {
+    parts.push(card.title);
+  }
+  if (card.subtitle) {
+    parts.push(card.subtitle);
+  }
+  for (const child of card.children) {
+    const text = cardChildToText(child);
+    if (text) {
+      parts.push(text);
+    }
+  }
+  return parts.join("\n\n");
+}
+
+/**
+ * Plain-text version of {@link cardChildToHtml}. Returns `null` for
+ * children that don't contribute any meaningful text (e.g. action
+ * containers with no actionable URLs).
+ */
+function cardChildToText(child: CardChild): string | null {
+  switch (child.type) {
+    case "actions": {
+      // Include only link-buttons (since action buttons need a callback URL
+      // to be useful in email — those still degrade to label-only here).
+      const lines = child.children
+        .map((c) => {
+          if (c.type === "link-button") {
+            return `- ${c.label}: ${c.url}`;
+          }
+          if (c.type === "button" && c.callbackUrl) {
+            const url = new URL(c.callbackUrl);
+            url.searchParams.set("actionId", c.id);
+            if (c.value !== undefined) {
+              url.searchParams.set("value", c.value);
+            }
+            return `- ${c.label}: ${url.toString()}`;
+          }
+          return null;
+        })
+        .filter(Boolean);
+      return lines.length > 0 ? lines.join("\n") : null;
+    }
+    case "section":
+      return child.children
+        .map((c) => cardChildToText(c))
+        .filter(Boolean)
+        .join("\n");
+    default:
+      return cardChildToFallbackText(child);
+  }
+}

--- a/packages/adapter-email/src/render.ts
+++ b/packages/adapter-email/src/render.ts
@@ -414,10 +414,7 @@ function tableElementToHtml(el: TableElement): string {
   const align = el.align ?? [];
   const head = `<thead><tr>${el.headers
     .map(
-      (h, i) =>
-        `<th${alignAttr(align[i])} style="padding:8px;border-bottom:1px solid #e5e7eb;text-align:${escapeAttr(
-          align[i] ?? "left"
-        )}">${escapeHtml(h)}</th>`
+      (h, i) => `<th style="${headerCellStyle(align[i])}">${escapeHtml(h)}</th>`
     )
     .join("")}</tr></thead>`;
   const body = `<tbody>${el.rows
@@ -426,14 +423,37 @@ function tableElementToHtml(el: TableElement): string {
         `<tr>${row
           .map(
             (cell, i) =>
-              `<td${alignAttr(align[i])} style="padding:8px;border-bottom:1px solid #f3f4f6">${escapeHtml(
-                cell
-              )}</td>`
+              `<td style="${bodyCellStyle(align[i])}">${escapeHtml(cell)}</td>`
           )
           .join("")}</tr>`
     )
     .join("")}</tbody>`;
   return `<table style="width:100%;border-collapse:collapse;margin:12px 0">${head}${body}</table>`;
+}
+
+const TABLE_HEADER_BASE_STYLE = "padding:8px;border-bottom:1px solid #e5e7eb";
+const TABLE_BODY_BASE_STYLE = "padding:8px;border-bottom:1px solid #f3f4f6";
+
+/**
+ * Build the inline `style` value for a table header cell as a single
+ * attribute. Emitting alignment as a separate `style="..."` attribute
+ * would shadow these declarations — per the HTML spec, browsers keep
+ * the first `style` attribute on a tag and silently drop any later ones.
+ */
+function headerCellStyle(align: string | undefined): string {
+  return `${TABLE_HEADER_BASE_STYLE};text-align:${escapeAttr(align ?? "left")}`;
+}
+
+/**
+ * Build the inline `style` value for a table body cell. Alignment is
+ * only emitted when explicitly set; `<td>` defaults to `text-align:left`
+ * already.
+ */
+function bodyCellStyle(align: string | undefined): string {
+  if (!align) {
+    return TABLE_BODY_BASE_STYLE;
+  }
+  return `${TABLE_BODY_BASE_STYLE};text-align:${escapeAttr(align)}`;
 }
 
 // =============================================================================

--- a/packages/adapter-email/src/threading.test.ts
+++ b/packages/adapter-email/src/threading.test.ts
@@ -1,0 +1,202 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildReferencesChain,
+  decodeEmailThreadId,
+  emailDomainOf,
+  encodeEmailThreadId,
+  findThreadRoot,
+  generateMessageId,
+  MAX_REFERENCES_CHAIN,
+  parseReferencesHeader,
+  replySubject,
+  stripAngleBrackets,
+  wrapAngleBrackets,
+} from "./threading";
+
+const UUID_AT_DOMAIN = /^[0-9a-f-]{36}@yourdomain\.com$/;
+
+describe("generateMessageId", () => {
+  it("produces uuid@domain", () => {
+    const id = generateMessageId("yourdomain.com");
+    expect(id).toMatch(UUID_AT_DOMAIN);
+  });
+
+  it("rejects empty domain", () => {
+    expect(() => generateMessageId("")).toThrow("messageIdDomain is required");
+  });
+});
+
+describe("stripAngleBrackets / wrapAngleBrackets", () => {
+  it("removes angle brackets when present", () => {
+    expect(stripAngleBrackets("<abc@example.com>")).toBe("abc@example.com");
+  });
+
+  it("leaves plain values untouched", () => {
+    expect(stripAngleBrackets("abc@example.com")).toBe("abc@example.com");
+  });
+
+  it("handles whitespace", () => {
+    expect(stripAngleBrackets("  <abc@example.com>  ")).toBe("abc@example.com");
+  });
+
+  it("wraps without double-wrapping", () => {
+    expect(wrapAngleBrackets("abc@example.com")).toBe("<abc@example.com>");
+    expect(wrapAngleBrackets("<abc@example.com>")).toBe("<abc@example.com>");
+  });
+});
+
+describe("parseReferencesHeader", () => {
+  it("returns empty for missing header", () => {
+    expect(parseReferencesHeader(undefined)).toEqual([]);
+    expect(parseReferencesHeader("")).toEqual([]);
+  });
+
+  it("parses a whitespace-separated chain of <id> tokens", () => {
+    const header = "<a@x>\r\n <b@x>\t<c@x>";
+    expect(parseReferencesHeader(header)).toEqual(["a@x", "b@x", "c@x"]);
+  });
+
+  it("falls back to whitespace splitting when angle brackets are missing", () => {
+    expect(parseReferencesHeader("a@x b@x")).toEqual(["a@x", "b@x"]);
+  });
+});
+
+describe("findThreadRoot", () => {
+  it("prefers the first References entry", () => {
+    expect(
+      findThreadRoot({
+        references: ["root@x", "second@x"],
+        inReplyTo: "different@x",
+      })
+    ).toBe("root@x");
+  });
+
+  it("falls back to In-Reply-To", () => {
+    expect(findThreadRoot({ inReplyTo: "parent@x" })).toBe("parent@x");
+  });
+
+  it("returns null when neither header is present", () => {
+    expect(findThreadRoot({})).toBeNull();
+  });
+
+  it("ignores empty References array", () => {
+    expect(findThreadRoot({ references: [], inReplyTo: "parent@x" })).toBe(
+      "parent@x"
+    );
+  });
+
+  it("skips an empty first entry in References and falls back to In-Reply-To", () => {
+    expect(findThreadRoot({ references: [""], inReplyTo: "parent@x" })).toBe(
+      "parent@x"
+    );
+  });
+});
+
+describe("buildReferencesChain", () => {
+  it("appends parent to previous chain", () => {
+    expect(buildReferencesChain(["root@x"], "parent@x")).toEqual([
+      "root@x",
+      "parent@x",
+    ]);
+  });
+
+  it("strips angle brackets from inputs", () => {
+    expect(buildReferencesChain(["<root@x>"], "<parent@x>")).toEqual([
+      "root@x",
+      "parent@x",
+    ]);
+  });
+
+  it("preserves root and tail when chain exceeds the cap", () => {
+    const previous = Array.from({ length: 30 }, (_, i) => `m${i}@x`);
+    const chain = buildReferencesChain(previous, "parent@x");
+    expect(chain).toHaveLength(MAX_REFERENCES_CHAIN);
+    expect(chain[0]).toBe("m0@x");
+    expect(chain.at(-1)).toBe("parent@x");
+    // Tail should be the last MAX-1 entries from combined
+    expect(chain[1]).toBe(`m${30 - (MAX_REFERENCES_CHAIN - 2)}@x`);
+  });
+});
+
+describe("encodeEmailThreadId / decodeEmailThreadId", () => {
+  it("roundtrips a root-only thread", () => {
+    const data = { rootMessageId: "abc:def@example.com" };
+    const encoded = encodeEmailThreadId(data);
+    expect(encoded.startsWith("email:")).toBe(true);
+    expect(decodeEmailThreadId(encoded)).toEqual(data);
+  });
+
+  it("roundtrips a thread with a participant address", () => {
+    const data = {
+      rootMessageId: "abc@example.com",
+      participantAddress: "user+tag@example.com",
+    };
+    const encoded = encodeEmailThreadId(data);
+    expect(decodeEmailThreadId(encoded)).toEqual(data);
+  });
+
+  it("rejects invalid prefixes", () => {
+    expect(() => decodeEmailThreadId("notemail:foo")).toThrow(
+      "Invalid email thread ID"
+    );
+    expect(() => decodeEmailThreadId("email:")).toThrow(
+      "Invalid email thread ID"
+    );
+  });
+
+  it("rejects an empty root segment after the prefix", () => {
+    expect(() => decodeEmailThreadId("email::xxx")).toThrow(
+      "Invalid email thread ID format"
+    );
+  });
+
+  it("rejects a root segment that base64url-decodes to empty", () => {
+    // `===` is valid base64url padding-only input that decodes to an
+    // empty string; the adapter rejects it as an unusable root.
+    expect(() => decodeEmailThreadId("email:===")).toThrow(
+      "Invalid email thread ID encoding"
+    );
+  });
+
+  it("rejects an empty participant segment", () => {
+    const root = Buffer.from("root@x.com").toString("base64url");
+    expect(() => decodeEmailThreadId(`email:${root}:`)).toThrow(
+      "Invalid email thread ID format"
+    );
+  });
+
+  it("rejects too many colon-separated segments", () => {
+    const root = Buffer.from("root@x.com").toString("base64url");
+    const addr = Buffer.from("user@x.com").toString("base64url");
+    expect(() => decodeEmailThreadId(`email:${root}:${addr}:extra`)).toThrow(
+      "Invalid email thread ID format"
+    );
+  });
+});
+
+describe("emailDomainOf", () => {
+  it("returns the domain portion", () => {
+    expect(emailDomainOf("user@example.com")).toBe("example.com");
+  });
+
+  it("returns null for malformed addresses", () => {
+    expect(emailDomainOf("noatsign")).toBeNull();
+    expect(emailDomainOf("user@")).toBeNull();
+  });
+});
+
+describe("replySubject", () => {
+  it("prepends Re: when missing", () => {
+    expect(replySubject("Hello")).toBe("Re: Hello");
+  });
+
+  it("does not double-prefix", () => {
+    expect(replySubject("Re: Hello")).toBe("Re: Hello");
+    expect(replySubject("RE: Hello")).toBe("RE: Hello");
+  });
+
+  it("handles empty input", () => {
+    expect(replySubject("")).toBe("Re:");
+    expect(replySubject(undefined)).toBe("Re:");
+  });
+});

--- a/packages/adapter-email/src/threading.test.ts
+++ b/packages/adapter-email/src/threading.test.ts
@@ -59,6 +59,20 @@ describe("parseReferencesHeader", () => {
   it("falls back to whitespace splitting when angle brackets are missing", () => {
     expect(parseReferencesHeader("a@x b@x")).toEqual(["a@x", "b@x"]);
   });
+
+  it("runs in linear time on adversarial bracket input (ReDoS regression)", () => {
+    // `<<<<...` with no closing `>` could trigger O(n^2) backtracking in
+    // a naive `<[^>]+>/g` implementation; the tightened pattern rejects
+    // nested `<` so the regex fails fast at every position.
+    const adversarial = "<".repeat(100_000);
+    const start = Date.now();
+    parseReferencesHeader(adversarial);
+    const elapsed = Date.now() - start;
+    // 100k chars should parse in well under 100ms; allow slack for slow
+    // CI. Any quadratic implementation would be orders of magnitude
+    // slower.
+    expect(elapsed).toBeLessThan(100);
+  });
 });
 
 describe("findThreadRoot", () => {

--- a/packages/adapter-email/src/threading.ts
+++ b/packages/adapter-email/src/threading.ts
@@ -1,0 +1,251 @@
+/**
+ * Email threading helpers.
+ *
+ * Email threading is governed by RFC-2822 / RFC-5322:
+ * - Each message has a `Message-ID` header (a globally unique opaque token).
+ * - Replies set `In-Reply-To` to the parent's Message-ID.
+ * - Replies set `References` to the parent's References chain plus its
+ *   Message-ID, so mail clients can reconstruct the thread.
+ *
+ * This module implements:
+ * - {@link generateMessageId}: a fresh Message-ID for outbound emails.
+ * - {@link stripAngleBrackets}: header value normalization.
+ * - {@link findThreadRoot}: resolve a thread root from References /
+ *   In-Reply-To headers.
+ * - {@link buildReferencesChain}: produce the References list for a reply,
+ *   capped at {@link MAX_REFERENCES_CHAIN} entries.
+ * - {@link encodeEmailThreadId} / {@link decodeEmailThreadId}: thread ID
+ *   marshalling that survives addresses with `:` characters.
+ *
+ * @see https://datatracker.ietf.org/doc/html/rfc5322#section-3.6.4
+ */
+
+import { randomUUID } from "node:crypto";
+import { ValidationError } from "@chat-adapter/shared";
+import type { EmailThreadId } from "./types";
+
+/**
+ * Maximum number of entries kept in the `References` header chain.
+ *
+ * Long chains can exceed the 998-character RFC-5322 line limit and are
+ * routinely truncated by mail relays, so we cap at a conservative number
+ * that comfortably fits in a single header line for typical Message-IDs.
+ */
+export const MAX_REFERENCES_CHAIN = 10;
+
+const ANGLE_TOKEN_PATTERN = /<[^>]+>/g;
+const REFERENCES_FALLBACK_SPLIT = /[\s,]+/;
+const RE_PREFIX_PATTERN = /^re:/i;
+
+/**
+ * Generate a fresh RFC-822 Message-ID without angle brackets.
+ *
+ * Format: `<random-uuid>@<domain>`. The `@<domain>` part is required by
+ * RFC-5322; the random UUID guarantees uniqueness without coordinating
+ * across processes or hosts.
+ *
+ * @example
+ * generateMessageId("yourdomain.com")
+ * // "550e8400-e29b-41d4-a716-446655440000@yourdomain.com"
+ */
+export function generateMessageId(domain: string): string {
+  if (!domain) {
+    throw new ValidationError(
+      "email",
+      "messageIdDomain is required to generate a Message-ID"
+    );
+  }
+  return `${randomUUID()}@${domain}`;
+}
+
+/**
+ * Remove angle brackets from a header value if present.
+ *
+ * RFC-5322 header values are wrapped in `<...>`, but providers handle this
+ * inconsistently. We always store and pass Message-IDs without brackets
+ * internally so comparisons are consistent.
+ */
+export function stripAngleBrackets(value: string): string {
+  const trimmed = value.trim();
+  if (trimmed.startsWith("<") && trimmed.endsWith(">")) {
+    return trimmed.slice(1, -1);
+  }
+  return trimmed;
+}
+
+/**
+ * Wrap a Message-ID in angle brackets for use as an outbound header value.
+ */
+export function wrapAngleBrackets(messageId: string): string {
+  return `<${stripAngleBrackets(messageId)}>`;
+}
+
+/**
+ * Parse a `References` header into an oldest-first array of Message-IDs
+ * without angle brackets.
+ *
+ * Tolerates both whitespace-separated and comma-separated input, since
+ * different ESPs/parsers normalize differently.
+ */
+export function parseReferencesHeader(header: string | undefined): string[] {
+  if (!header) {
+    return [];
+  }
+  // Match each <id> token. Fall back to whitespace split if no brackets.
+  const matches = header.match(ANGLE_TOKEN_PATTERN);
+  if (matches && matches.length > 0) {
+    return matches.map(stripAngleBrackets).filter(Boolean);
+  }
+  return header
+    .split(REFERENCES_FALLBACK_SPLIT)
+    .map(stripAngleBrackets)
+    .filter(Boolean);
+}
+
+/**
+ * Resolve the thread-root Message-ID from header values.
+ *
+ * Resolution order:
+ * 1. The first (oldest) entry in `References`, when present.
+ * 2. The `In-Reply-To` value, when present.
+ * 3. `null` — caller should treat the current message as a new root.
+ */
+export function findThreadRoot(args: {
+  references?: string[];
+  inReplyTo?: string;
+}): string | null {
+  if (args.references && args.references.length > 0) {
+    const first = args.references[0];
+    if (first) {
+      return first;
+    }
+  }
+  if (args.inReplyTo) {
+    return args.inReplyTo;
+  }
+  return null;
+}
+
+/**
+ * Build the outbound `References` chain for a reply.
+ *
+ * @param previousReferences - References chain on the message being replied
+ *   to (oldest-first). May be empty when replying to a thread root.
+ * @param parentMessageId - Message-ID of the message being replied to.
+ * @returns oldest-first chain capped at {@link MAX_REFERENCES_CHAIN}. When
+ *   trimming is required, the oldest entry (the thread root) is preserved
+ *   per the recommendation in RFC-5322 §3.6.4.
+ */
+export function buildReferencesChain(
+  previousReferences: string[],
+  parentMessageId: string
+): string[] {
+  const combined = [...previousReferences, parentMessageId]
+    .map(stripAngleBrackets)
+    .filter(Boolean);
+
+  if (combined.length <= MAX_REFERENCES_CHAIN) {
+    return combined;
+  }
+
+  // Preserve the thread root (first entry) and the most recent N-1 entries.
+  const root = combined[0] as string;
+  const tail = combined.slice(combined.length - (MAX_REFERENCES_CHAIN - 1));
+  return [root, ...tail];
+}
+
+/**
+ * Encode an email thread ID.
+ *
+ * Format: `email:<base64url(rootMessageId)>[:<base64url(participantAddress)>]`.
+ *
+ * Both segments are base64url-encoded because Message-IDs and email
+ * addresses can contain `:`, `@`, `+`, `=`, and other characters that
+ * conflict with the colon-delimited thread ID convention.
+ */
+export function encodeEmailThreadId(data: EmailThreadId): string {
+  const root = base64urlEncode(data.rootMessageId);
+  if (data.participantAddress) {
+    const addr = base64urlEncode(data.participantAddress);
+    return `email:${root}:${addr}`;
+  }
+  return `email:${root}`;
+}
+
+/**
+ * Decode an email thread ID produced by {@link encodeEmailThreadId}.
+ */
+export function decodeEmailThreadId(threadId: string): EmailThreadId {
+  if (!threadId.startsWith("email:")) {
+    throw new ValidationError("email", `Invalid email thread ID: ${threadId}`);
+  }
+  const remainder = threadId.slice("email:".length);
+  if (!remainder) {
+    throw new ValidationError(
+      "email",
+      `Invalid email thread ID format: ${threadId}`
+    );
+  }
+  const parts = remainder.split(":");
+  const rootSegment = parts[0];
+  if (!rootSegment) {
+    throw new ValidationError(
+      "email",
+      `Invalid email thread ID format: ${threadId}`
+    );
+  }
+  const rootMessageId = base64urlDecode(rootSegment);
+  if (!rootMessageId) {
+    throw new ValidationError(
+      "email",
+      `Invalid email thread ID encoding: ${threadId}`
+    );
+  }
+  if (parts.length === 1) {
+    return { rootMessageId };
+  }
+  if (parts.length !== 2 || !parts[1]) {
+    throw new ValidationError(
+      "email",
+      `Invalid email thread ID format: ${threadId}`
+    );
+  }
+  const participantAddress = base64urlDecode(parts[1]);
+  return { rootMessageId, participantAddress };
+}
+
+/**
+ * Extract the host portion of an email address (the part after the `@`).
+ *
+ * Returns `null` for malformed input rather than throwing so callers can
+ * decide whether to fall back or surface a validation error.
+ */
+export function emailDomainOf(address: string): string | null {
+  const idx = address.lastIndexOf("@");
+  if (idx === -1 || idx === address.length - 1) {
+    return null;
+  }
+  return address.slice(idx + 1);
+}
+
+/**
+ * Generate a default reply Subject by adding `Re: ` if not already present.
+ */
+export function replySubject(originalSubject: string | undefined): string {
+  const trimmed = (originalSubject ?? "").trim();
+  if (!trimmed) {
+    return "Re:";
+  }
+  if (RE_PREFIX_PATTERN.test(trimmed)) {
+    return trimmed;
+  }
+  return `Re: ${trimmed}`;
+}
+
+function base64urlEncode(value: string): string {
+  return Buffer.from(value, "utf8").toString("base64url");
+}
+
+function base64urlDecode(value: string): string {
+  return Buffer.from(value, "base64url").toString("utf8");
+}

--- a/packages/adapter-email/src/threading.ts
+++ b/packages/adapter-email/src/threading.ts
@@ -33,7 +33,11 @@ import type { EmailThreadId } from "./types";
  */
 export const MAX_REFERENCES_CHAIN = 10;
 
-const ANGLE_TOKEN_PATTERN = /<[^>]+>/g;
+// Forbid `<` and whitespace inside the token so the regex fails fast on
+// adversarial inputs like `<<<<<<...` (avoids polynomial-time backtracking
+// across global match attempts). Real RFC-5322 Message-IDs are dot-atom
+// strings and never contain either character.
+const ANGLE_TOKEN_PATTERN = /<[^<>\s]+>/g;
 const REFERENCES_FALLBACK_SPLIT = /[\s,]+/;
 const RE_PREFIX_PATTERN = /^re:/i;
 

--- a/packages/adapter-email/src/types.ts
+++ b/packages/adapter-email/src/types.ts
@@ -1,0 +1,265 @@
+/**
+ * Type definitions for the Email adapter.
+ *
+ * The adapter owns the email-shaped behavior (RFC-822 threading, MIME
+ * composition, HTML/text rendering). Email Service Provider (ESP) specific
+ * wire formats are delegated to pluggable providers conforming to the
+ * {@link EmailProvider} contract.
+ */
+
+import type { Logger } from "chat";
+
+// =============================================================================
+// Outbound email composed by the adapter and handed to a transport
+// =============================================================================
+
+/**
+ * An attachment to send with an outbound email.
+ */
+export interface OutboundEmailAttachment {
+  /** Binary contents. */
+  content: Buffer;
+  /** MIME type (e.g. "application/pdf"). Optional; provider may infer. */
+  contentType?: string;
+  /** Filename shown to the recipient. */
+  filename: string;
+}
+
+/**
+ * Outbound email composed by {@link EmailAdapter} before handoff to a transport.
+ *
+ * The adapter sets `messageId`, `inReplyTo`, and `references` so providers
+ * stay dumb — they just forward these as RFC-822 headers if their API
+ * supports header passthrough.
+ */
+export interface OutboundEmail {
+  /** Optional attachments. */
+  attachments?: OutboundEmailAttachment[];
+  /** Bcc recipients. */
+  bcc?: string[];
+  /** Cc recipients. */
+  cc?: string[];
+  /** From mailbox. */
+  from: { address: string; name?: string };
+  /** Pre-rendered HTML body. */
+  html: string;
+  /** RFC-822 In-Reply-To header (without angle brackets), if a reply. */
+  inReplyTo?: string;
+  /**
+   * RFC-822 Message-ID for this outbound email, without angle brackets.
+   * Adapters generate this so threading works even on providers that don't
+   * return their own Message-ID.
+   */
+  messageId: string;
+  /** RFC-822 References chain (without angle brackets), oldest-first. */
+  references?: string[];
+  /** Optional Reply-To override. */
+  replyTo?: string;
+  /** Subject line (already includes "Re: " prefix on replies). */
+  subject: string;
+  /** Plain-text fallback body. */
+  text: string;
+  /** Stable thread-root Message-ID. Equal to `messageId` for new threads. */
+  threadRootMessageId: string;
+  /** Primary recipients (typically a single address for 1:1 conversations). */
+  to: string[];
+}
+
+/**
+ * Result of {@link EmailTransport.send}.
+ */
+export interface EmailSendResult {
+  /** Provider's own message identifier, if returned. */
+  providerMessageId?: string;
+  /** Provider-specific raw response. Surfaced via `message.raw` on the bot side. */
+  raw: unknown;
+}
+
+// =============================================================================
+// Inbound email parsed from a webhook
+// =============================================================================
+
+/**
+ * A parsed inbound attachment.
+ */
+export interface ParsedInboundAttachment {
+  /** MIME type, if known. */
+  contentType?: string;
+  /** Inline binary, if the webhook delivered it. */
+  data?: Buffer;
+  /** Optional async fetcher (e.g., authenticated download). */
+  fetchData?: () => Promise<Buffer>;
+  /** Original filename, if present. */
+  filename?: string;
+  /** Size in bytes, if known. */
+  size?: number;
+  /** Download URL, if the provider hosts the attachment. */
+  url?: string;
+}
+
+/**
+ * Normalized inbound email shape produced by {@link EmailInbound.parse}.
+ */
+export interface ParsedInboundEmail {
+  /** Inbound attachments. */
+  attachments?: ParsedInboundAttachment[];
+  /** Cc addresses, if any. */
+  cc?: string[];
+  /** Sender mailbox. */
+  from: { address: string; name?: string };
+  /** HTML body. */
+  html?: string;
+  /** In-Reply-To header value (without angle brackets), if present. */
+  inReplyTo?: string;
+  /**
+   * RFC-822 Message-ID of this inbound message, without angle brackets.
+   * Required so the adapter can place the message in the correct thread.
+   */
+  messageId: string;
+  /** Provider-specific raw payload, surfaced via `message.raw`. */
+  raw: unknown;
+  /** Receive timestamp. */
+  receivedAt: Date;
+  /** References chain (without angle brackets), oldest-first, if present. */
+  references?: string[];
+  /** Subject line as received. */
+  subject: string;
+  /** Plain-text body. */
+  text?: string;
+  /** Resolved To addresses. */
+  to: string[];
+}
+
+// =============================================================================
+// Provider contract
+// =============================================================================
+
+/**
+ * Outbound side of an ESP integration.
+ *
+ * Implementations receive a fully composed {@link OutboundEmail} and forward
+ * it through their HTTP API.
+ */
+export interface EmailTransport {
+  /** Display name (e.g. "resend", "inbound"). Used for logs and errors. */
+  readonly name: string;
+  /** Send an outbound email. */
+  send(email: OutboundEmail): Promise<EmailSendResult>;
+}
+
+/**
+ * Inbound side of an ESP integration.
+ *
+ * Implementations verify the platform's webhook signature scheme and parse
+ * the platform-specific payload into a {@link ParsedInboundEmail}.
+ */
+export interface EmailInbound {
+  /** Display name (e.g. "resend"). Used for logs and errors. */
+  readonly name: string;
+  /**
+   * Parse the verified webhook body into a normalized inbound email.
+   *
+   * Return `null` to skip processing without an error (e.g. for delivery
+   * status events that aren't actually inbound messages).
+   */
+  parse(
+    request: Request,
+    body: string
+  ): Promise<ParsedInboundEmail | null> | ParsedInboundEmail | null;
+  /**
+   * Verify the webhook signature against the raw request body.
+   *
+   * Return `false` to reject the request with a 401.
+   */
+  verifySignature(request: Request, body: string): boolean | Promise<boolean>;
+}
+
+/**
+ * Bundle of optional transport and inbound implementations.
+ *
+ * Pass via `provider:` for the simple case where one ESP handles both
+ * directions, or pass `transport:` and/or `inbound:` directly for
+ * mix-and-match setups.
+ */
+export interface EmailProvider {
+  inbound?: EmailInbound;
+  transport?: EmailTransport;
+}
+
+// =============================================================================
+// Adapter configuration
+// =============================================================================
+
+/**
+ * Public configuration accepted by {@link createEmailAdapter}.
+ */
+export interface EmailAdapterConfig {
+  /** Mailbox the bot sends from. Required. */
+  fromAddress: string;
+  /** Display name shown in the From header. */
+  fromName?: string;
+  /** Override or supply the inbound webhook parser directly. */
+  inbound?: EmailInbound;
+  /** Logger instance. Defaults to a `ConsoleLogger` namespaced "email". */
+  logger?: Logger;
+  /**
+   * Domain used to generate `Message-ID` headers for outbound emails.
+   * Defaults to the domain part of `fromAddress`.
+   */
+  messageIdDomain?: string;
+  /**
+   * Bundled transport + inbound. Equivalent to setting `transport` and/or
+   * `inbound` to its respective fields, but easier when one ESP does both.
+   */
+  provider?: EmailProvider;
+  /** Optional Reply-To override. Defaults to `fromAddress`. */
+  replyToAddress?: string;
+  /** Override or supply the outbound transport directly. */
+  transport?: EmailTransport;
+  /** Bot username (defaults to chat's global `userName`). */
+  userName?: string;
+}
+
+// =============================================================================
+// Thread ID
+// =============================================================================
+
+/**
+ * Decoded email thread ID.
+ *
+ * Email threads are rooted on the first message's `Message-ID`. The thread
+ * ID encodes that root so that even if the state adapter is reset, the
+ * threading still works as long as the participant replies preserve the
+ * `References` chain.
+ */
+export interface EmailThreadId {
+  /**
+   * Email address of the human participant. Optional; included so the
+   * adapter can post replies to a thread it discovered during inbound
+   * parsing without re-fetching state.
+   */
+  participantAddress?: string;
+  /** RFC-822 Message-ID of the thread root, without angle brackets. */
+  rootMessageId: string;
+}
+
+// =============================================================================
+// Raw message type stored on Message.raw
+// =============================================================================
+
+/**
+ * Raw message payload exposed to user handlers via `message.raw`.
+ *
+ * Direction is preserved so handlers can distinguish inbound replies from
+ * outbound copies of their own posts.
+ */
+export type EmailRawMessage =
+  | {
+      direction: "inbound";
+      email: ParsedInboundEmail;
+    }
+  | {
+      direction: "outbound";
+      email: OutboundEmail;
+      result: EmailSendResult;
+    };

--- a/packages/adapter-email/tsconfig.json
+++ b/packages/adapter-email/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "strictNullChecks": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist", "**/*.test.ts"]
+}

--- a/packages/adapter-email/tsup.config.ts
+++ b/packages/adapter-email/tsup.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from "tsup";
+
+export default defineConfig({
+  entry: ["src/index.ts", "src/providers/index.ts"],
+  format: ["esm"],
+  dts: true,
+  clean: true,
+  sourcemap: false,
+});

--- a/packages/adapter-email/vitest.config.ts
+++ b/packages/adapter-email/vitest.config.ts
@@ -1,0 +1,14 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: "node",
+    coverage: {
+      provider: "v8",
+      reporter: ["text", "json-summary", "json"],
+      include: ["src/**/*.ts"],
+      exclude: ["src/**/*.test.ts", "src/types.ts", "src/providers/index.ts"],
+    },
+  },
+});

--- a/packages/integration-tests/src/documentation-test-utils.ts
+++ b/packages/integration-tests/src/documentation-test-utils.ts
@@ -18,6 +18,8 @@ export const VALID_PACKAGE_README_IMPORTS = [
   "@chat-adapter/linear",
   "@chat-adapter/whatsapp",
   "@chat-adapter/messenger",
+  "@chat-adapter/email",
+  "@chat-adapter/email/providers",
   "@chat-adapter/web",
   "@chat-adapter/web/react",
   "@chat-adapter/state-redis",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -316,6 +316,28 @@ importers:
         specifier: ^4.0.18
         version: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@25.3.2)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)
 
+  packages/adapter-email:
+    dependencies:
+      '@chat-adapter/shared':
+        specifier: workspace:*
+        version: link:../adapter-shared
+      chat:
+        specifier: workspace:*
+        version: link:../chat
+    devDependencies:
+      '@types/node':
+        specifier: ^25.3.2
+        version: 25.3.2
+      tsup:
+        specifier: ^8.3.5
+        version: 8.5.1(@swc/core@1.15.3)(jiti@2.6.1)(postcss@8.5.14)(tsx@4.21.0)(typescript@5.9.3)
+      typescript:
+        specifier: ^5.7.2
+        version: 5.9.3
+      vitest:
+        specifier: ^4.0.18
+        version: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@25.3.2)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)
+
   packages/adapter-gchat:
     dependencies:
       '@chat-adapter/shared':


### PR DESCRIPTION
## Summary

Adds `@chat-adapter/email`: a single Chat SDK adapter that owns email-shaped behavior (RFC-822 threading via `Message-ID` / `In-Reply-To` / `References`, MIME composition, HTML+text rendering of cards and markdown) and delegates outbound sending and inbound webhook parsing to pluggable Email Service Provider implementations.

```ts
import { createEmailAdapter } from "@chat-adapter/email";
import { resend } from "@chat-adapter/email/providers";

const bot = new Chat({
  userName: "support-bot",
  adapters: {
    email: createEmailAdapter({
      fromAddress: "support@yourdomain.com",
      provider: resend(),
    }),
  },
  state: createRedisState(),
});

bot.onDirectMessage(async (thread, message) => {
  await thread.subscribe();
  await thread.post(`Thanks for emailing! You said: ${message.text}`);
});
```

### Built-in providers (on the `/providers` subpath)

| Provider | Send | Receive | Required env vars | Notes |
|----------|:----:|:-------:|-------------------|-------|
| [Resend](https://resend.com) (`resend`) | ✓ | ✓ | `RESEND_API_KEY`, `RESEND_WEBHOOK_SECRET` (receive only) | Svix HMAC-SHA256 webhook verification. Body and headers are fetched via the Receiving API after the webhook fires. |
| [Inbound](https://inbound.new) (`inbound`) | ✓ | ✓ | `INBOUND_API_KEY`, `INBOUND_VERIFICATION_TOKEN` (receive only) | Constant-time token verification. Webhook payload is self-contained (body, headers, attachment metadata inline). Attachments are lazy-fetched via authenticated `downloadUrl`. |

Mix-and-match is first-class — pass `transport:` and `inbound:` separately to combine ESPs. The main `@chat-adapter/email` entry also exports `defineEmailProvider` plus the helpers any future provider would need (`verifySvixSignature`, `verifySvixRequest`, `verifyConstantTimeToken`, `throwForEspError`, `parseAddress`, `normalizeHeaderKeys`), so Postmark / SendGrid / Mailgun / SES providers can be published as drop-ins without forking machinery.

### Design choices worth flagging

- **Cards in email** — buttons render as anchor tags driven by `callbackUrl`. The chat-sdk rewrites `button.value` to a callback token before the adapter sees it, so this works without any per-button platform plumbing.
- **No native streaming** — `stream()` buffers chunks and sends one email at the end. Email has no live channel.
- **Edit / delete / reactions throw `NotImplementedError`** — email is immutable and has no reaction primitive.
- **1:1 only** — every conversation is a DM. Group threads (multi-recipient) would require `lockScope: "channel"` with a sorted-participant hash and are deferred.

### Commit structure

The 9 commits build up the package incrementally so each tree compiles and tests pass:

1. Scaffold package boilerplate, types, and entry point
2. RFC-822 threading helpers (Message-ID generation, References chain, thread ID encode/decode)
3. HTML and plain-text renderers (mdast → HTML, Card → HTML, EmailFormatConverter)
4. Shared provider utilities (Svix verification, constant-time tokens, HTTP error mapping, RFC-822 helpers)
5. EmailAdapter and `createEmailAdapter` factory
6. Resend provider
7. Inbound provider
8. README, docs-site registry entry, feature matrix, integration-test allowlist
9. Changeset (`minor` against the package's fixed-version line)

## Test plan

- [x] `pnpm validate` — passes
- [x] `pnpm --filter @chat-adapter/email test` — **208 tests passing**
- [x] **100% coverage** across `adapter.ts`, `markdown.ts`, `render.ts`, `threading.ts`, `index.ts`, `providers/utils.ts`, `providers/resend.ts`, `providers/inbound.ts` (statements, branches, functions, lines)
- [x] `pnpm --filter @chat-adapter/email typecheck` — clean (strict mode, `verbatimModuleSyntax`, no `any` / `@ts-ignore` / `as unknown as` in source)
- [x] `pnpm check` (ultracite / biome) — clean
- [x] `pnpm knip` — clean
- [x] `pnpm --filter @chat-adapter/email build` — emits `dist/index.js` + `dist/providers/index.js` with shared chunk
- [x] Provider subpath resolves at runtime: `import("@chat-adapter/email/providers")` → `{ inbound, resend }`
- [x] `pnpm --filter @chat-adapter/integration-tests test` — 396/396 (the `package-readmes.test.ts` allowlist accepts the new imports)