### PR TITLE
ci: promote release branch on successful publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,3 +49,7 @@ jobs:
         env:
           NPM_CONFIG_PROVENANCE: "true"
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Promote release branch
+        if: steps.changesets.outputs.published == 'true'
+        run: git push origin HEAD:refs/heads/release


### PR DESCRIPTION
Adds a step to `release.yml` that pushes the just-published commit to a `release` branch when `changeset publish` succeeds.

This lets the docs site and example app Vercel projects use `release` as their production branch, so they only deploy after a release is actually published — avoiding the current behaviour where every merge to `main` (and the changesets version-bump commit) triggers a production deploy.