### PR TITLE
chore: remove .vercel.approvers files

### DIFF
--- a/.changeset/.vercel.approvers
+++ b/.changeset/.vercel.approvers
@@ -1,1 +1,0 @@
-config.json @cramforce

--- a/.github/.vercel.approvers
+++ b/.github/.vercel.approvers
@@ -1,1 +1,0 @@
-CODEOWNERS @cramforce

--- a/.github/workflows/.vercel.approvers
+++ b/.github/workflows/.vercel.approvers
@@ -1,1 +1,0 @@
-release.yml @cramforce

--- a/.vercel.approvers
+++ b/.vercel.approvers
@@ -1,1 +1,0 @@
-@vercel/chat-sdk


### PR DESCRIPTION
Code ownership is already governed by .github/CODEOWNERS.