### PR TITLE
feat(telegram): support typed attachment uploads

### DIFF
--- a/.changeset/light-sails-beg.md
+++ b/.changeset/light-sails-beg.md
@@ -1,0 +1,6 @@
+---
+"@chat-adapter/telegram": minor
+"@chat-adapter/shared": minor
+---
+
+support typed Telegram attachment uploads

--- a/apps/docs/content/docs/adapters.mdx
+++ b/apps/docs/content/docs/adapters.mdx
@@ -21,7 +21,7 @@ Ready to build your own? Follow the [building](/docs/contributing/building) guid
 | Post message | <Check /> | <Check /> | <Check /> | <Check /> | <Check /> | <Check /> | <Check /> | <Check /> | <Check /> |
 | Edit message | <Check /> | <Check /> | <Check /> | <Check /> | <Check /> | <Check /> | <Warn /> Partial | <Cross /> | <Cross /> |
 | Delete message | <Check /> | <Check /> | <Check /> | <Check /> | <Check /> | <Check /> | <Warn /> Partial | <Cross /> | <Cross /> |
-| File uploads | <Check /> | <Check /> | <Cross /> | <Check /> | <Warn /> Single file | <Cross /> | <Cross /> | <Check /> Images, audio, docs | <Cross /> |
+| File uploads | <Check /> | <Check /> | <Cross /> | <Check /> | <Warn /> Single file/media | <Cross /> | <Cross /> | <Check /> Images, audio, docs | <Cross /> |
 | Streaming | <Check /> Native | <Warn /> Native (DMs) / Buffered | <Warn /> Post+Edit | <Warn /> Post+Edit | <Warn /> Post+Edit | <Warn /> Buffered | <Warn /> Agent sessions / Post+Edit | <Warn /> Buffered | <Warn /> Buffered |
 | Scheduled messages | <Check /> Native | <Cross /> | <Cross /> | <Cross /> | <Cross /> | <Cross /> | <Cross /> | <Cross /> | <Cross /> |
 

--- a/apps/docs/content/docs/api/postable-message.mdx
+++ b/apps/docs/content/docs/api/postable-message.mdx
@@ -38,7 +38,7 @@ await thread.post({ raw: "Hello world" });
       type: 'string',
     },
     attachments: {
-      description: 'File/image attachments.',
+      description: 'Typed media attachments for adapters that support outgoing attachments.',
       type: 'Attachment[]',
     },
     files: {
@@ -63,7 +63,7 @@ await thread.post({ markdown: "**Bold** and _italic_" });
       type: 'string',
     },
     attachments: {
-      description: 'File/image attachments.',
+      description: 'Typed media attachments for adapters that support outgoing attachments.',
       type: 'Attachment[]',
     },
     files: {
@@ -92,7 +92,7 @@ await thread.post({
       type: 'Root',
     },
     attachments: {
-      description: 'File/image attachments.',
+      description: 'Typed media attachments for adapters that support outgoing attachments.',
       type: 'Attachment[]',
     },
     files: {

--- a/apps/docs/content/docs/contributing/building.mdx
+++ b/apps/docs/content/docs/contributing/building.mdx
@@ -370,7 +370,7 @@ parseMessage(raw: unknown): Message<unknown> {
 
 ### Sending messages
 
-Use `extractCard()` and `extractFiles()` from `@chat-adapter/shared` to check for rich content. Use your format converter's `renderPostable()` to convert the message to platform format.
+Use `extractCard()` and `extractFiles()` from `@chat-adapter/shared` to check for rich content. Use `extractPostableAttachments()` if your adapter maps normalized `Attachment` objects to platform-native media uploads. Use your format converter's `renderPostable()` to convert the message to platform format.
 
 ```typescript title="src/adapter.ts" lineNumbers
 async postMessage(

--- a/apps/docs/content/docs/files.mdx
+++ b/apps/docs/content/docs/files.mdx
@@ -43,7 +43,7 @@ await thread.post({
 });
 ```
 
-Outgoing `attachments` are available on `{ raw }`, `{ markdown }`, and `{ ast }` messages. Card messages use `files` for uploads. Use `files` for generic uploads. On Telegram, `files` always upload as documents, while `attachments` preserve image, audio, video, or file media type.
+Outgoing `attachments` are available on `{ raw }`, `{ markdown }`, and `{ ast }` messages. Card messages use `files` for uploads. Use `files` for generic uploads. On Telegram, `files` always upload as documents, while `attachments` preserve image, audio, video, or file media type. Use `data` or `fetchData` for private/authenticated files; URL-only attachments must be public URLs Telegram can fetch directly.
 
 ### Multiple files
 

--- a/apps/docs/content/docs/files.mdx
+++ b/apps/docs/content/docs/files.mdx
@@ -25,6 +25,26 @@ await thread.post({
 });
 ```
 
+### Typed attachments
+
+Use `attachments` when you already have normalized `Attachment` objects and the adapter supports typed outgoing media. Telegram supports one outgoing attachment per message and uses the native media method for the attachment type:
+
+```typescript title="lib/bot.ts" lineNumbers
+await thread.post({
+  markdown: "Here's the image:",
+  attachments: [
+    {
+      data: imageBuffer,
+      name: "diagram.png",
+      mimeType: "image/png",
+      type: "image",
+    },
+  ],
+});
+```
+
+Outgoing `attachments` are available on `{ raw }`, `{ markdown }`, and `{ ast }` messages. Card messages use `files` for uploads. Use `files` for generic uploads. On Telegram, `files` always upload as documents, while `attachments` preserve image, audio, video, or file media type.
+
 ### Multiple files
 
 ```typescript title="lib/bot.ts" lineNumbers

--- a/apps/docs/content/docs/posting-messages.mdx
+++ b/apps/docs/content/docs/posting-messages.mdx
@@ -168,6 +168,8 @@ await thread.post({
 });
 ```
 
+Use `attachments` on `{ raw }`, `{ markdown }`, or `{ ast }` when an adapter supports typed media uploads, such as Telegram's single image/audio/video/file upload support.
+
 See the [Files](/docs/files) page for more on attachments.
 
 ## Choosing a format

--- a/packages/adapter-shared/README.md
+++ b/packages/adapter-shared/README.md
@@ -17,6 +17,7 @@ pnpm add @chat-adapter/shared
 
 - `extractCard(message)` - extract a `CardElement` from an `AdapterPostableMessage`
 - `extractFiles(message)` - extract `FileUpload[]` from an `AdapterPostableMessage`
+- `extractPostableAttachments(message)` - extract `Attachment[]` from an `AdapterPostableMessage`
 
 ### Buffer conversion
 

--- a/packages/adapter-shared/src/adapter-utils.test.ts
+++ b/packages/adapter-shared/src/adapter-utils.test.ts
@@ -2,10 +2,14 @@
  * Tests for shared adapter utility functions.
  */
 
-import type { AdapterPostableMessage, FileUpload } from "chat";
+import type { AdapterPostableMessage, Attachment, FileUpload } from "chat";
 import { Card, CardText } from "chat";
 import { describe, expect, it } from "vitest";
-import { extractCard, extractFiles } from "./adapter-utils";
+import {
+  extractCard,
+  extractFiles,
+  extractPostableAttachments,
+} from "./adapter-utils";
 
 describe("extractCard", () => {
   describe("with CardElement", () => {
@@ -224,6 +228,107 @@ describe("extractFiles", () => {
     it("returns empty array for undefined input", () => {
       // @ts-expect-error testing invalid input
       const result = extractFiles(undefined);
+      expect(result).toEqual([]);
+    });
+  });
+});
+
+describe("extractPostableAttachments", () => {
+  describe("with attachments present", () => {
+    it("extracts attachments array from PostableRaw", () => {
+      const attachments: Attachment[] = [
+        { data: Buffer.from("content1"), name: "file1.txt", type: "file" },
+        { data: Buffer.from("content2"), name: "file2.txt", type: "file" },
+      ];
+      const message: AdapterPostableMessage = { raw: "Text", attachments };
+      const result = extractPostableAttachments(message);
+      expect(result).toBe(attachments);
+      expect(result).toHaveLength(2);
+    });
+
+    it("extracts attachments array from PostableMarkdown", () => {
+      const attachments: Attachment[] = [
+        {
+          data: Buffer.from("image"),
+          name: "image.png",
+          mimeType: "image/png",
+          type: "image",
+        },
+      ];
+      const message: AdapterPostableMessage = {
+        markdown: "**Text**",
+        attachments,
+      };
+      const result = extractPostableAttachments(message);
+      expect(result).toEqual(attachments);
+      expect(result[0]?.mimeType).toBe("image/png");
+    });
+
+    it("extracts attachments array from PostableAst", () => {
+      const attachments: Attachment[] = [
+        { data: Buffer.from("doc"), name: "doc.pdf", type: "file" },
+      ];
+      const message: AdapterPostableMessage = {
+        ast: { type: "root", children: [] },
+        attachments,
+      };
+      const result = extractPostableAttachments(message);
+      expect(result).toBe(attachments);
+    });
+  });
+
+  describe("with empty or missing attachments", () => {
+    it("returns empty array when attachments property is empty array", () => {
+      const message: AdapterPostableMessage = { raw: "Text", attachments: [] };
+      const result = extractPostableAttachments(message);
+      expect(result).toEqual([]);
+    });
+
+    it("returns empty array when attachments property is undefined", () => {
+      const message = {
+        raw: "Text",
+        attachments: undefined,
+      } as AdapterPostableMessage;
+      const result = extractPostableAttachments(message);
+      expect(result).toEqual([]);
+    });
+
+    it("returns empty array for PostableRaw without attachments", () => {
+      const message: AdapterPostableMessage = { raw: "Just text" };
+      const result = extractPostableAttachments(message);
+      expect(result).toEqual([]);
+    });
+
+    it("returns empty array for PostableMarkdown without attachments", () => {
+      const message: AdapterPostableMessage = { markdown: "**Bold**" };
+      const result = extractPostableAttachments(message);
+      expect(result).toEqual([]);
+    });
+  });
+
+  describe("with non-object messages", () => {
+    it("returns empty array for plain string", () => {
+      const result = extractPostableAttachments("Hello world");
+      expect(result).toEqual([]);
+    });
+
+    it("returns empty array for CardElement", () => {
+      const card = Card({ title: "Test" });
+      const result = extractPostableAttachments(card);
+      expect(result).toEqual([]);
+    });
+
+    it("returns empty array for null input", () => {
+      const result = extractPostableAttachments(
+        null as unknown as AdapterPostableMessage
+      );
+      expect(result).toEqual([]);
+    });
+
+    it("returns empty array for undefined input", () => {
+      const result = extractPostableAttachments(
+        undefined as unknown as AdapterPostableMessage
+      );
       expect(result).toEqual([]);
     });
   });

--- a/packages/adapter-shared/src/adapter-utils.ts
+++ b/packages/adapter-shared/src/adapter-utils.ts
@@ -5,7 +5,12 @@
  * to reduce code duplication and ensure consistent behavior.
  */
 
-import type { AdapterPostableMessage, CardElement, FileUpload } from "chat";
+import type {
+  AdapterPostableMessage,
+  Attachment,
+  CardElement,
+  FileUpload,
+} from "chat";
 import { isCardElement } from "chat";
 
 /**
@@ -71,6 +76,19 @@ export function extractCard(
 export function extractFiles(message: AdapterPostableMessage): FileUpload[] {
   if (typeof message === "object" && message !== null && "files" in message) {
     return (message as { files?: FileUpload[] }).files ?? [];
+  }
+  return [];
+}
+
+export function extractPostableAttachments(
+  message: AdapterPostableMessage
+): Attachment[] {
+  if (
+    typeof message === "object" &&
+    message !== null &&
+    "attachments" in message
+  ) {
+    return (message as { attachments?: Attachment[] }).attachments ?? [];
   }
   return [];
 }

--- a/packages/adapter-shared/src/index.ts
+++ b/packages/adapter-shared/src/index.ts
@@ -6,7 +6,11 @@
  */
 
 // Adapter utilities
-export { extractCard, extractFiles } from "./adapter-utils";
+export {
+  extractCard,
+  extractFiles,
+  extractPostableAttachments,
+} from "./adapter-utils";
 
 // Buffer conversion utilities
 export {

--- a/packages/adapter-telegram/README.md
+++ b/packages/adapter-telegram/README.md
@@ -199,7 +199,7 @@ Behavior change in 4.27.0: previous versions used Telegram's legacy `Markdown` p
 - If `getWebhookInfo` fails in `mode: "auto"`, the adapter stays in webhook mode (safe fallback).
 - `Button` and `LinkButton` in card `Actions` render as inline keyboard buttons.
 - Telegram callback data is limited to 64 bytes. Keep button `id`/`value` payloads short.
-- `files` upload as Telegram documents. `attachments` preserve the normalized media type for single image, audio, video, or file uploads.
+- `files` upload as Telegram documents. `attachments` preserve the normalized media type for single image, audio, video, or file uploads. Use `data` or `fetchData` for private/authenticated files; URL-only attachments must be public URLs Telegram can fetch directly.
 - Other rich card elements (images/select menus/radios) render as fallback text only.
 
 ## License

--- a/packages/adapter-telegram/README.md
+++ b/packages/adapter-telegram/README.md
@@ -143,6 +143,7 @@ TELEGRAM_API_BASE_URL=https://api.telegram.org
 | Edit message | Yes |
 | Delete message | Yes |
 | File uploads | Single file (`sendDocument`) |
+| Attachment uploads | Single image/audio/video/file (`sendPhoto`, `sendAudio`, `sendVideo`, `sendDocument`) |
 | Streaming | Post+Edit fallback |
 
 ### Rich content
@@ -198,6 +199,7 @@ Behavior change in 4.27.0: previous versions used Telegram's legacy `Markdown` p
 - If `getWebhookInfo` fails in `mode: "auto"`, the adapter stays in webhook mode (safe fallback).
 - `Button` and `LinkButton` in card `Actions` render as inline keyboard buttons.
 - Telegram callback data is limited to 64 bytes. Keep button `id`/`value` payloads short.
+- `files` upload as Telegram documents. `attachments` preserve the normalized media type for single image, audio, video, or file uploads.
 - Other rich card elements (images/select menus/radios) render as fallback text only.
 
 ## License

--- a/packages/adapter-telegram/src/index.test.ts
+++ b/packages/adapter-telegram/src/index.test.ts
@@ -127,6 +127,14 @@ function sampleMessage(overrides?: Partial<TelegramMessage>): TelegramMessage {
   };
 }
 
+function readFormData(callIndex: number): FormData {
+  const body = mockFetch.mock.calls[callIndex]?.[1]?.body;
+  if (!(body instanceof FormData)) {
+    throw new Error("Expected request body to be FormData");
+  }
+  return body as FormData;
+}
+
 function createAbortError(): Error {
   const fallback = new Error("Aborted");
   fallback.name = "AbortError";
@@ -971,6 +979,226 @@ describe("TelegramAdapter", () => {
 
     expect(sendMessageBody.chat_id).toBe("123");
     expect(sendMessageBody.text).toBe("raw id message");
+  });
+
+  it.each([
+    {
+      field: "photo",
+      method: "sendPhoto",
+      mimeType: "image/png",
+      name: "image.png",
+      type: "image",
+    },
+    {
+      field: "audio",
+      method: "sendAudio",
+      mimeType: "audio/mpeg",
+      name: "track.mp3",
+      type: "audio",
+    },
+    {
+      field: "video",
+      method: "sendVideo",
+      mimeType: "video/mp4",
+      name: "clip.mp4",
+      type: "video",
+    },
+    {
+      field: "document",
+      method: "sendDocument",
+      mimeType: "application/pdf",
+      name: "report.pdf",
+      type: "file",
+    },
+  ] as const)("posts $type attachments with Telegram $method uploads", async ({
+    field,
+    method,
+    mimeType,
+    name,
+    type,
+  }) => {
+    mockFetch
+      .mockResolvedValueOnce(
+        telegramOk({
+          id: 999,
+          is_bot: true,
+          first_name: "Bot",
+          username: "mybot",
+        })
+      )
+      .mockResolvedValueOnce(telegramOk(sampleMessage()));
+
+    const adapter = createTelegramAdapter({
+      botToken: "token",
+      mode: "webhook",
+      logger: mockLogger,
+      userName: "mybot",
+    });
+
+    await adapter.initialize(createMockChat());
+
+    await adapter.postMessage("telegram:-100123:42", {
+      markdown: "attached **media**",
+      attachments: [
+        {
+          data: Buffer.from("payload"),
+          height: type === "video" ? 720 : undefined,
+          mimeType,
+          name,
+          type,
+          width: type === "video" ? 1280 : undefined,
+        },
+      ],
+    });
+
+    expect(String(mockFetch.mock.calls[1]?.[0])).toContain(`/${method}`);
+
+    const formData = readFormData(1);
+    const upload = formData.get(field);
+
+    expect(formData.get("chat_id")).toBe("-100123");
+    expect(formData.get("message_thread_id")).toBe("42");
+    expect(formData.get("caption")).toBe("attached *media*");
+    expect(formData.get("parse_mode")).toBe("MarkdownV2");
+    expect(upload).toBeInstanceOf(Blob);
+    expect((upload as { name?: string }).name).toBe(name);
+    expect((upload as Blob).type).toBe(mimeType);
+
+    if (type === "video") {
+      expect(formData.get("width")).toBe("1280");
+      expect(formData.get("height")).toBe("720");
+    }
+  });
+
+  it("posts attachment data loaded through fetchData", async () => {
+    mockFetch
+      .mockResolvedValueOnce(
+        telegramOk({
+          id: 999,
+          is_bot: true,
+          first_name: "Bot",
+          username: "mybot",
+        })
+      )
+      .mockResolvedValueOnce(telegramOk(sampleMessage()));
+
+    const adapter = createTelegramAdapter({
+      botToken: "token",
+      mode: "webhook",
+      logger: mockLogger,
+      userName: "mybot",
+    });
+    const fetchData = vi.fn().mockResolvedValue(Buffer.from("payload"));
+
+    await adapter.initialize(createMockChat());
+
+    await adapter.postMessage("telegram:123", {
+      raw: "",
+      attachments: [
+        {
+          fetchData,
+          mimeType: "application/pdf",
+          name: "report.pdf",
+          type: "file",
+        },
+      ],
+    });
+
+    const formData = readFormData(1);
+
+    expect(fetchData).toHaveBeenCalledOnce();
+    expect(String(mockFetch.mock.calls[1]?.[0])).toContain("/sendDocument");
+    expect(formData.get("caption")).toBeNull();
+    expect(formData.get("parse_mode")).toBeNull();
+    expect(formData.get("document")).toBeInstanceOf(Blob);
+  });
+
+  it("rejects multiple Telegram attachments in one message", async () => {
+    mockFetch.mockResolvedValueOnce(
+      telegramOk({
+        id: 999,
+        is_bot: true,
+        first_name: "Bot",
+        username: "mybot",
+      })
+    );
+
+    const adapter = createTelegramAdapter({
+      botToken: "token",
+      mode: "webhook",
+      logger: mockLogger,
+      userName: "mybot",
+    });
+
+    await adapter.initialize(createMockChat());
+
+    await expect(
+      adapter.postMessage("telegram:123", {
+        raw: "attachments",
+        attachments: [
+          { data: Buffer.from("one"), type: "image" },
+          { data: Buffer.from("two"), type: "image" },
+        ],
+      })
+    ).rejects.toThrow("single attachment upload");
+    expect(mockFetch.mock.calls).toHaveLength(1);
+  });
+
+  it("rejects mixed file uploads and attachments", async () => {
+    mockFetch.mockResolvedValueOnce(
+      telegramOk({
+        id: 999,
+        is_bot: true,
+        first_name: "Bot",
+        username: "mybot",
+      })
+    );
+
+    const adapter = createTelegramAdapter({
+      botToken: "token",
+      mode: "webhook",
+      logger: mockLogger,
+      userName: "mybot",
+    });
+
+    await adapter.initialize(createMockChat());
+
+    await expect(
+      adapter.postMessage("telegram:123", {
+        raw: "mixed",
+        attachments: [{ data: Buffer.from("one"), type: "image" }],
+        files: [{ data: Buffer.from("two"), filename: "two.txt" }],
+      })
+    ).rejects.toThrow("mixing file uploads and attachments");
+    expect(mockFetch.mock.calls).toHaveLength(1);
+  });
+
+  it("rejects attachments without upload data", async () => {
+    mockFetch.mockResolvedValueOnce(
+      telegramOk({
+        id: 999,
+        is_bot: true,
+        first_name: "Bot",
+        username: "mybot",
+      })
+    );
+
+    const adapter = createTelegramAdapter({
+      botToken: "token",
+      mode: "webhook",
+      logger: mockLogger,
+      userName: "mybot",
+    });
+
+    await adapter.initialize(createMockChat());
+
+    await expect(
+      adapter.postMessage("telegram:123", {
+        raw: "",
+        attachments: [{ type: "image" }],
+      })
+    ).rejects.toThrow("Attachment data required for image");
+    expect(mockFetch.mock.calls).toHaveLength(1);
   });
 
   it("sets parse_mode for markdown messages", async () => {
@@ -2271,6 +2499,35 @@ describe("message length limits", () => {
     expect((caption as string).length).toBeLessThanOrEqual(
       TELEGRAM_CAPTION_LIMIT
     );
+  });
+
+  it("MarkdownV2 attachment captions use the Telegram caption limit", async () => {
+    const adapter = await createInitializedAdapter();
+    mockFetch.mockResolvedValueOnce(telegramOk(sampleMessage()));
+
+    const longMarkdown = "a".repeat(1500);
+    await adapter.postMessage("telegram:123", {
+      markdown: longMarkdown,
+      attachments: [
+        {
+          data: Buffer.from("payload"),
+          mimeType: "image/png",
+          name: "image.png",
+          type: "image",
+        },
+      ],
+    });
+
+    const formData = readFormData(1);
+    const caption = formData.get("caption");
+    const parseMode = formData.get("parse_mode");
+
+    expect(typeof caption).toBe("string");
+    expect((caption as string).length).toBeLessThanOrEqual(
+      TELEGRAM_CAPTION_LIMIT
+    );
+    expect(parseMode).toBe("MarkdownV2");
+    expect((caption as string).endsWith("\\.\\.\\.")).toBe(true);
   });
 });
 

--- a/packages/adapter-telegram/src/index.test.ts
+++ b/packages/adapter-telegram/src/index.test.ts
@@ -1113,6 +1113,52 @@ describe("TelegramAdapter", () => {
     expect(formData.get("document")).toBeInstanceOf(Blob);
   });
 
+  it("posts URL-only attachments through Telegram URL fields", async () => {
+    mockFetch
+      .mockResolvedValueOnce(
+        telegramOk({
+          id: 999,
+          is_bot: true,
+          first_name: "Bot",
+          username: "mybot",
+        })
+      )
+      .mockResolvedValueOnce(telegramOk(sampleMessage()));
+
+    const adapter = createTelegramAdapter({
+      botToken: "token",
+      mode: "webhook",
+      logger: mockLogger,
+      userName: "mybot",
+    });
+
+    await adapter.initialize(createMockChat());
+
+    await adapter.postMessage("telegram:-100123:42", {
+      markdown: "public **image**",
+      attachments: [
+        {
+          mimeType: "image/png",
+          name: "image.png",
+          type: "image",
+          url: "https://cdn.example.com/image.png",
+        },
+      ],
+    });
+
+    expect(String(mockFetch.mock.calls[1]?.[0])).toContain("/sendPhoto");
+    expect(mockFetch.mock.calls[1]?.[1]?.headers).toEqual({
+      "Content-Type": "application/json",
+    });
+    expect(JSON.parse(String(mockFetch.mock.calls[1]?.[1]?.body))).toEqual({
+      caption: "public *image*",
+      chat_id: "-100123",
+      message_thread_id: 42,
+      parse_mode: "MarkdownV2",
+      photo: "https://cdn.example.com/image.png",
+    });
+  });
+
   it("rejects multiple Telegram attachments in one message", async () => {
     mockFetch.mockResolvedValueOnce(
       telegramOk({
@@ -1197,7 +1243,7 @@ describe("TelegramAdapter", () => {
         raw: "",
         attachments: [{ type: "image" }],
       })
-    ).rejects.toThrow("Attachment data required for image");
+    ).rejects.toThrow("Attachment data or URL required for image");
     expect(mockFetch.mock.calls).toHaveLength(1);
   });
 

--- a/packages/adapter-telegram/src/index.ts
+++ b/packages/adapter-telegram/src/index.ts
@@ -5,6 +5,7 @@ import {
   cardToFallbackText,
   extractCard,
   extractFiles,
+  extractPostableAttachments,
   NetworkError,
   PermissionError,
   ResourceNotFoundError,
@@ -78,6 +79,15 @@ const trimTrailingSlashes = (url: string): string => {
   return url.slice(0, end);
 };
 const MESSAGE_SEQUENCE_PATTERN = /:(\d+)$/;
+const ATTACHMENT_UPLOADS = {
+  audio: { field: "audio", method: "sendAudio" },
+  file: { field: "document", method: "sendDocument" },
+  image: { field: "photo", method: "sendPhoto" },
+  video: { field: "video", method: "sendVideo" },
+} as const satisfies Record<
+  Attachment["type"],
+  { field: string; method: string }
+>;
 const LEADING_AT_PATTERN = /^@+/;
 const EMOJI_PLACEHOLDER_PATTERN = /^\{\{emoji:([a-z0-9_]+)\}\}$/i;
 const EMOJI_NAME_PATTERN = /^[a-z0-9_+-]+$/i;
@@ -717,6 +727,21 @@ export class TelegramAdapter
       );
     }
 
+    const attachments = extractPostableAttachments(message);
+    if (attachments.length > 1) {
+      throw new ValidationError(
+        "telegram",
+        "Telegram adapter supports a single attachment upload per message"
+      );
+    }
+
+    if (files.length > 0 && attachments.length > 0) {
+      throw new ValidationError(
+        "telegram",
+        "Telegram adapter does not support mixing file uploads and attachments in one message"
+      );
+    }
+
     let rawMessage: TelegramMessage;
 
     if (files.length === 1) {
@@ -727,6 +752,21 @@ export class TelegramAdapter
       rawMessage = await this.sendDocument(
         parsedThread,
         file,
+        text,
+        replyMarkup,
+        parseMode
+      );
+    } else if (attachments.length === 1) {
+      const [attachment] = attachments;
+      if (!attachment) {
+        throw new ValidationError(
+          "telegram",
+          "Attachment upload payload is empty"
+        );
+      }
+      rawMessage = await this.sendAttachment(
+        parsedThread,
+        attachment,
         text,
         replyMarkup,
         parseMode
@@ -1299,6 +1339,64 @@ export class TelegramAdapter
     }
 
     return this.telegramFetch<TelegramMessage>("sendDocument", formData);
+  }
+
+  protected async sendAttachment(
+    thread: TelegramThreadId,
+    attachment: Attachment,
+    text: string,
+    replyMarkup?: TelegramInlineKeyboardMarkup,
+    parseMode: TelegramParseMode = "plain"
+  ): Promise<TelegramMessage> {
+    const data =
+      attachment.data ??
+      (attachment.fetchData ? await attachment.fetchData() : undefined);
+
+    if (!data) {
+      throw new ValidationError(
+        "telegram",
+        `Attachment data required for ${attachment.type}`
+      );
+    }
+
+    const buffer = await this.toTelegramBuffer(data);
+    const formData = new FormData();
+    const upload = ATTACHMENT_UPLOADS[attachment.type];
+
+    formData.append("chat_id", thread.chatId);
+    if (typeof thread.messageThreadId === "number") {
+      formData.append("message_thread_id", String(thread.messageThreadId));
+    }
+
+    if (text.trim()) {
+      formData.append(
+        "caption",
+        truncateForTelegram(text, TELEGRAM_CAPTION_LIMIT, parseMode)
+      );
+      const botApiParseMode = toBotApiParseMode(parseMode);
+      if (botApiParseMode) {
+        formData.append("parse_mode", botApiParseMode);
+      }
+    }
+
+    if (attachment.type === "video") {
+      if (Number.isInteger(attachment.width)) {
+        formData.append("width", String(attachment.width));
+      }
+      if (Number.isInteger(attachment.height)) {
+        formData.append("height", String(attachment.height));
+      }
+    }
+
+    const blob = new Blob([new Uint8Array(buffer)], {
+      type: attachment.mimeType ?? "application/octet-stream",
+    });
+    formData.append(upload.field, blob, attachment.name ?? "attachment");
+    if (replyMarkup) {
+      formData.append("reply_markup", JSON.stringify(replyMarkup));
+    }
+
+    return this.telegramFetch<TelegramMessage>(upload.method, formData);
   }
 
   protected async toTelegramBuffer(

--- a/packages/adapter-telegram/src/index.ts
+++ b/packages/adapter-telegram/src/index.ts
@@ -1348,20 +1348,58 @@ export class TelegramAdapter
     replyMarkup?: TelegramInlineKeyboardMarkup,
     parseMode: TelegramParseMode = "plain"
   ): Promise<TelegramMessage> {
+    const upload = ATTACHMENT_UPLOADS[attachment.type];
     const data =
       attachment.data ??
       (attachment.fetchData ? await attachment.fetchData() : undefined);
 
-    if (!data) {
+    if (!(data || attachment.url)) {
       throw new ValidationError(
         "telegram",
-        `Attachment data required for ${attachment.type}`
+        `Attachment data or URL required for ${attachment.type}`
       );
+    }
+
+    if (!data) {
+      const payload: Record<string, unknown> = {
+        chat_id: thread.chatId,
+        [upload.field]: attachment.url,
+      };
+
+      if (typeof thread.messageThreadId === "number") {
+        payload.message_thread_id = thread.messageThreadId;
+      }
+
+      if (text.trim()) {
+        payload.caption = truncateForTelegram(
+          text,
+          TELEGRAM_CAPTION_LIMIT,
+          parseMode
+        );
+        const botApiParseMode = toBotApiParseMode(parseMode);
+        if (botApiParseMode) {
+          payload.parse_mode = botApiParseMode;
+        }
+      }
+
+      if (attachment.type === "video") {
+        if (Number.isInteger(attachment.width)) {
+          payload.width = attachment.width;
+        }
+        if (Number.isInteger(attachment.height)) {
+          payload.height = attachment.height;
+        }
+      }
+
+      if (replyMarkup) {
+        payload.reply_markup = replyMarkup;
+      }
+
+      return this.telegramFetch<TelegramMessage>(upload.method, payload);
     }
 
     const buffer = await this.toTelegramBuffer(data);
     const formData = new FormData();
-    const upload = ATTACHMENT_UPLOADS[attachment.type];
 
     formData.append("chat_id", thread.chatId);
     if (typeof thread.messageThreadId === "number") {


### PR DESCRIPTION
## summary

- add Telegram support for outgoing `attachments` on `{ raw }`, `{ markdown }`, and `{ ast }` messages
- map normalized attachment types to native Telegram Bot API methods: `sendPhoto`, `sendAudio`, `sendVideo`, and `sendDocument`
- upload `data` and `fetchData` attachments with multipart form data
- send URL-only attachments through Telegram URL fields when the URL is public and Telegram-fetchable
- keep existing `files` behavior as document uploads
- reject multiple attachment uploads and mixed `files` plus `attachments` with validation errors
- export `extractPostableAttachments` from `@chat-adapter/shared`
- update docs to clarify `files` vs typed `attachments`
