### PR TITLE
fix(packages): support require for esm package exports

### DIFF
--- a/.changeset/slow-books-speak.md
+++ b/.changeset/slow-books-speak.md
@@ -1,0 +1,21 @@
+---
+"@chat-adapter/messenger": patch
+"@chat-adapter/telegram": patch
+"@chat-adapter/whatsapp": patch
+"@chat-adapter/discord": patch
+"@chat-adapter/github": patch
+"@chat-adapter/linear": patch
+"@chat-adapter/shared": patch
+"@chat-adapter/gchat": patch
+"@chat-adapter/slack": patch
+"@chat-adapter/teams": patch
+"@chat-adapter/state-ioredis": patch
+"@chat-adapter/state-memory": patch
+"@chat-adapter/web": patch
+"@chat-adapter/state-redis": patch
+"@chat-adapter/state-pg": patch
+"@chat-adapter/tests": patch
+"chat": patch
+---
+
+support require for esm package exports on supported node versions

--- a/packages/adapter-discord/package.json
+++ b/packages/adapter-discord/package.json
@@ -12,7 +12,8 @@
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "import": "./dist/index.js"
+      "import": "./dist/index.js",
+      "module-sync": "./dist/index.js"
     }
   },
   "files": [

--- a/packages/adapter-gchat/package.json
+++ b/packages/adapter-gchat/package.json
@@ -12,7 +12,8 @@
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "import": "./dist/index.js"
+      "import": "./dist/index.js",
+      "module-sync": "./dist/index.js"
     }
   },
   "files": [

--- a/packages/adapter-github/package.json
+++ b/packages/adapter-github/package.json
@@ -12,7 +12,8 @@
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "import": "./dist/index.js"
+      "import": "./dist/index.js",
+      "module-sync": "./dist/index.js"
     }
   },
   "files": [

--- a/packages/adapter-linear/package.json
+++ b/packages/adapter-linear/package.json
@@ -12,7 +12,8 @@
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "import": "./dist/index.js"
+      "import": "./dist/index.js",
+      "module-sync": "./dist/index.js"
     }
   },
   "files": [

--- a/packages/adapter-messenger/package.json
+++ b/packages/adapter-messenger/package.json
@@ -12,7 +12,8 @@
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "import": "./dist/index.js"
+      "import": "./dist/index.js",
+      "module-sync": "./dist/index.js"
     }
   },
   "files": [

--- a/packages/adapter-shared/package.json
+++ b/packages/adapter-shared/package.json
@@ -9,7 +9,8 @@
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "import": "./dist/index.js"
+      "import": "./dist/index.js",
+      "module-sync": "./dist/index.js"
     }
   },
   "main": "./dist/index.js",

--- a/packages/adapter-slack/package.json
+++ b/packages/adapter-slack/package.json
@@ -12,7 +12,8 @@
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "import": "./dist/index.js"
+      "import": "./dist/index.js",
+      "module-sync": "./dist/index.js"
     }
   },
   "files": [

--- a/packages/adapter-teams/package.json
+++ b/packages/adapter-teams/package.json
@@ -12,7 +12,8 @@
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "import": "./dist/index.js"
+      "import": "./dist/index.js",
+      "module-sync": "./dist/index.js"
     }
   },
   "files": [

--- a/packages/adapter-telegram/package.json
+++ b/packages/adapter-telegram/package.json
@@ -12,7 +12,8 @@
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "import": "./dist/index.js"
+      "import": "./dist/index.js",
+      "module-sync": "./dist/index.js"
     }
   },
   "files": [

--- a/packages/adapter-web/package.json
+++ b/packages/adapter-web/package.json
@@ -12,11 +12,13 @@
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "import": "./dist/index.js"
+      "import": "./dist/index.js",
+      "module-sync": "./dist/index.js"
     },
     "./react": {
       "types": "./dist/react/index.d.ts",
-      "import": "./dist/react/index.js"
+      "import": "./dist/react/index.js",
+      "module-sync": "./dist/react/index.js"
     }
   },
   "files": [

--- a/packages/adapter-whatsapp/package.json
+++ b/packages/adapter-whatsapp/package.json
@@ -12,7 +12,8 @@
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "import": "./dist/index.js"
+      "import": "./dist/index.js",
+      "module-sync": "./dist/index.js"
     }
   },
   "files": [

--- a/packages/chat/package.json
+++ b/packages/chat/package.json
@@ -12,15 +12,18 @@
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "import": "./dist/index.js"
+      "import": "./dist/index.js",
+      "module-sync": "./dist/index.js"
     },
     "./jsx-runtime": {
       "types": "./dist/jsx-runtime.d.ts",
-      "import": "./dist/jsx-runtime.js"
+      "import": "./dist/jsx-runtime.js",
+      "module-sync": "./dist/jsx-runtime.js"
     },
     "./jsx-dev-runtime": {
       "types": "./dist/jsx-runtime.d.ts",
-      "import": "./dist/jsx-runtime.js"
+      "import": "./dist/jsx-runtime.js",
+      "module-sync": "./dist/jsx-runtime.js"
     }
   },
   "files": [

--- a/packages/state-ioredis/package.json
+++ b/packages/state-ioredis/package.json
@@ -12,7 +12,8 @@
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "import": "./dist/index.js"
+      "import": "./dist/index.js",
+      "module-sync": "./dist/index.js"
     }
   },
   "files": [

--- a/packages/state-memory/package.json
+++ b/packages/state-memory/package.json
@@ -12,7 +12,8 @@
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "import": "./dist/index.js"
+      "import": "./dist/index.js",
+      "module-sync": "./dist/index.js"
     }
   },
   "files": [

--- a/packages/state-pg/package.json
+++ b/packages/state-pg/package.json
@@ -12,7 +12,8 @@
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "import": "./dist/index.js"
+      "import": "./dist/index.js",
+      "module-sync": "./dist/index.js"
     }
   },
   "files": [

--- a/packages/state-redis/package.json
+++ b/packages/state-redis/package.json
@@ -12,7 +12,8 @@
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "import": "./dist/index.js"
+      "import": "./dist/index.js",
+      "module-sync": "./dist/index.js"
     }
   },
   "files": [

--- a/packages/tests/package.json
+++ b/packages/tests/package.json
@@ -9,15 +9,18 @@
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "import": "./dist/index.js"
+      "import": "./dist/index.js",
+      "module-sync": "./dist/index.js"
     },
     "./matchers": {
       "types": "./dist/matchers.d.ts",
-      "import": "./dist/matchers.js"
+      "import": "./dist/matchers.js",
+      "module-sync": "./dist/matchers.js"
     },
     "./setup": {
       "types": "./dist/setup.d.ts",
-      "import": "./dist/setup.js"
+      "import": "./dist/setup.js",
+      "module-sync": "./dist/setup.js"
     }
   },
   "files": [


### PR DESCRIPTION
## summary

add `module-sync` export conditions to published package entrypoints so CommonJS consumers on supported Node versions can `require()` Chat SDK packages without `ERR_PACKAGE_PATH_NOT_EXPORTED`

keeps existing ESM `import` targets unchanged and applies the same export shape across core, adapters, state packages, and test helpers

fixes #480

## test plan

- recreated the reported `ERR_PACKAGE_PATH_NOT_EXPORTED` failure against `chat`, `@chat-adapter/shared`, and `@chat-adapter/state-redis` before the fix
- verified `require()` and `import()` for all exported package entrypoints and subpaths after a fresh build
- verified the reported packages on Node 20.19, Node 22.12, and Node 25.9
