### PR TITLE
docs(chat): clarify direct message routing precedence

### DIFF
--- a/apps/docs/content/docs/api/chat.mdx
+++ b/apps/docs/content/docs/api/chat.mdx
@@ -74,9 +74,36 @@ bot.onNewMention(async (thread, message) => {
   }}
 />
 
+### onDirectMessage
+
+Fires for every direct message when registered. Direct message handlers run before `onSubscribedMessage`, `onNewMention`, and pattern handlers. If no direct message handler is registered, unsubscribed DMs fall through to `onNewMention` for backward compatibility.
+
+```typescript
+bot.onDirectMessage(async (thread, message, channel) => {
+  await thread.post(`Got your DM in ${channel.id}: ${message.text}`);
+});
+```
+
+<TypeTable
+  type={{
+    thread: {
+      description: 'The DM thread where the message occurred.',
+      type: 'Thread',
+    },
+    message: {
+      description: 'The direct message.',
+      type: 'Message',
+    },
+    channel: {
+      description: 'The DM channel.',
+      type: 'Channel',
+    },
+  }}
+/>
+
 ### onSubscribedMessage
 
-Fires for every new message in a subscribed thread. Once subscribed, all messages (including @-mentions) route here instead of `onNewMention`.
+Fires for every new message in a subscribed non-DM thread. Once subscribed, messages (including @-mentions) route here instead of `onNewMention`. DM threads route to `onDirectMessage` first when a direct message handler is registered.
 
 ```typescript
 bot.onSubscribedMessage(async (thread, message) => {

--- a/apps/docs/content/docs/api/thread.mdx
+++ b/apps/docs/content/docs/api/thread.mdx
@@ -146,7 +146,7 @@ if (participants.length > 1) {
 
 ## subscribe / unsubscribe
 
-Manage thread subscriptions. Subscribed threads route all messages to `onSubscribedMessage` handlers.
+Manage thread subscriptions. Subscribed non-DM threads route all messages to `onSubscribedMessage` handlers. DM threads route to `onDirectMessage` first when a direct message handler is registered.
 
 ```typescript
 await thread.subscribe();

--- a/apps/docs/content/docs/direct-messages.mdx
+++ b/apps/docs/content/docs/direct-messages.mdx
@@ -12,8 +12,17 @@ Open direct message conversations with users using `bot.openDM()`. For globally 
 
 DMs behave slightly differently from channel messages:
 
-- **Implicit mentions** — DM messages automatically set `isMention=true`, so your `onNewMention` handler fires without the user needing to @-mention the bot. This feels natural for 1:1 conversations.
+- **Direct message handlers** — if you register `onDirectMessage`, every incoming DM routes there before `onSubscribedMessage`, `onNewMention`, and pattern handlers. This keeps DM-centric flows like WhatsApp conversations, Telegram DMs, and web chat on one consistent handler.
+- **Mention fallback** — if no `onDirectMessage` handlers are registered, DMs continue through normal routing. Unsubscribed DMs are treated as mentions, so existing `onNewMention` bots keep working without requiring the user to @-mention the bot.
 - **Per-conversation threading** — Each top-level DM starts a new conversation. Thread replies within a DM continue the same conversation, giving you the same per-thread isolation as channels.
+
+## Handle incoming DMs
+
+```typescript title="lib/bot.ts" lineNumbers
+bot.onDirectMessage(async (thread, message) => {
+  await thread.post(`You said: ${message.text}`);
+});
+```
 
 ## Open a DM
 

--- a/apps/docs/content/docs/handling-events.mdx
+++ b/apps/docs/content/docs/handling-events.mdx
@@ -16,9 +16,10 @@ Chat SDK uses an event-driven architecture. You register handlers for different 
 
 When a message arrives, the SDK evaluates handlers in this order:
 
-1. **Subscribed threads** — if the thread is subscribed, `onSubscribedMessage` fires and no other message handler runs.
-2. **Mentions** — if the bot is @-mentioned in an unsubscribed thread, `onNewMention` fires.
-3. **Pattern matches** — if the message text matches any `onNewMessage` regex patterns, those handlers fire.
+1. **Direct messages** — if the thread is a DM and any `onDirectMessage` handlers are registered, they fire before `onSubscribedMessage`, `onNewMention`, and pattern handlers.
+2. **Subscribed threads** — if the thread is subscribed, `onSubscribedMessage` fires and no other message handler runs. DMs only reach this step when no `onDirectMessage` handlers are registered.
+3. **Mentions** — if the bot is @-mentioned in an unsubscribed thread, `onNewMention` fires. Unsubscribed DMs without direct handlers are treated as mentions for backward compatibility.
+4. **Pattern matches** — if the message text matches any `onNewMessage` regex patterns, those handlers fire.
 
 Reactions, slash commands, actions, and modals have their own dedicated routing and are not affected by subscription state.
 
@@ -68,7 +69,9 @@ bot.onNewMention(async (thread, message) => {
 
 ## Handling subscribed messages
 
-`onSubscribedMessage` fires for every new message in a thread your bot has subscribed to. Once subscribed, all messages (including @-mentions) route here instead of `onNewMention`.
+`onSubscribedMessage` fires for every new message in a non-DM thread your bot has subscribed to. Once subscribed, messages (including @-mentions) route here instead of `onNewMention`.
+
+If an `onDirectMessage` handler is registered, DM messages route there before subscription routing. Without a direct handler, subscribed DMs route to `onSubscribedMessage`.
 
 ```typescript title="lib/bot.ts" lineNumbers
 bot.onSubscribedMessage(async (thread, message) => {

--- a/apps/docs/content/docs/threads-messages-channels.mdx
+++ b/apps/docs/content/docs/threads-messages-channels.mdx
@@ -40,7 +40,7 @@ await thread.post({
 
 ### Subscribe and unsubscribe
 
-Subscriptions persist across restarts (stored in your state adapter). When a thread is subscribed, all messages route to `onSubscribedMessage`.
+Subscriptions persist across restarts (stored in your state adapter). When a non-DM thread is subscribed, all messages route to `onSubscribedMessage`. DM threads route to `onDirectMessage` first when a direct message handler is registered.
 
 ```typescript title="lib/bot.ts" lineNumbers
 await thread.subscribe();

--- a/packages/chat/src/chat.ts
+++ b/packages/chat/src/chat.ts
@@ -514,9 +514,13 @@ export class Chat<
   /**
    * Register a handler for direct messages.
    *
-   * Called when a message is received in a DM thread that is not subscribed.
-   * If no `onDirectMessage` handlers are registered, DMs fall through to
-   * `onNewMention` for backward compatibility.
+   * Called for every message received in a DM thread when at least one
+   * direct message handler is registered. Direct message handlers run before
+   * `onSubscribedMessage`, `onNewMention`, and pattern handlers.
+   *
+   * If no `onDirectMessage` handlers are registered, DMs continue through
+   * normal routing. Unsubscribed DMs fall through to `onNewMention` for
+   * backward compatibility.
    *
    * @param handler - Handler called for DM messages
    *

--- a/packages/chat/src/types.ts
+++ b/packages/chat/src/types.ts
@@ -1248,7 +1248,9 @@ export interface Thread<TState = Record<string, unknown>, TRawMessage = unknown>
   /**
    * Subscribe to future messages in this thread.
    *
-   * Once subscribed, all messages in this thread will trigger `onSubscribedMessage` handlers.
+   * Once subscribed, messages in non-DM threads trigger `onSubscribedMessage`
+   * handlers. DM threads route to `onDirectMessage` first when a direct
+   * message handler is registered.
    * The initial message that triggered subscription will NOT fire the handler.
    *
    * @example
@@ -1708,9 +1710,13 @@ export type MentionHandler<TState = Record<string, unknown>> = (
 /**
  * Handler for direct messages (1:1 conversations with the bot).
  *
- * Registered via `chat.onDirectMessage(handler)`. Called when a message
- * is received in a DM thread that is not subscribed. If no `onDirectMessage`
- * handlers are registered, DMs fall through to `onNewMention` for backward
+ * Registered via `chat.onDirectMessage(handler)`. Called for every message
+ * received in a DM thread when at least one direct message handler is
+ * registered. Direct message handlers run before `onSubscribedMessage`,
+ * `onNewMention`, and pattern handlers.
+ *
+ * If no `onDirectMessage` handlers are registered, DMs continue through normal
+ * routing. Unsubscribed DMs fall through to `onNewMention` for backward
  * compatibility.
  */
 export type DirectMessageHandler<TState = Record<string, unknown>> = (


### PR DESCRIPTION
## summary

clarifies that registered `onDirectMessage` handlers take precedence for incoming DM messages before subscribed-message, mention, and pattern routing

updates the direct messages, event handling, thread subscription, and API docs so they match the current runtime behavior

adds `onDirectMessage` to the Chat API docs

fixes #432
