### PR TITLE
feat(chat): add queue-debounce concurrency strategy

### DIFF
--- a/.changeset/soft-jars-cover.md
+++ b/.changeset/soft-jars-cover.md
@@ -1,0 +1,5 @@
+---
+"chat": minor
+---
+
+add queue-debounce concurrency strategy

--- a/.changeset/soft-jars-cover.md
+++ b/.changeset/soft-jars-cover.md
@@ -2,4 +2,4 @@
 "chat": minor
 ---
 
-add queue-debounce concurrency strategy
+add burst concurrency strategy

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Browse official, vendor-official, and community adapters on [chat-sdk.dev/adapte
 - [**File uploads**](https://chat-sdk.dev/docs/files) — send and receive file attachments
 - [**Direct messages**](https://chat-sdk.dev/docs/direct-messages) — initiate DMs programmatically
 - [**Ephemeral messages**](https://chat-sdk.dev/docs/ephemeral-messages) — user-only visible messages with DM fallback
-- [**Overlapping messages**](https://chat-sdk.dev/docs/concurrency) — queue, debounce, drop, or process concurrent messages on the same thread
+- [**Overlapping messages**](https://chat-sdk.dev/docs/concurrency) - queue-debounce, queue, debounce, drop, or process concurrent messages on the same thread
 
 ## AI coding agent support
 

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Browse official, vendor-official, and community adapters on [chat-sdk.dev/adapte
 - [**File uploads**](https://chat-sdk.dev/docs/files) — send and receive file attachments
 - [**Direct messages**](https://chat-sdk.dev/docs/direct-messages) — initiate DMs programmatically
 - [**Ephemeral messages**](https://chat-sdk.dev/docs/ephemeral-messages) — user-only visible messages with DM fallback
-- [**Overlapping messages**](https://chat-sdk.dev/docs/concurrency) - queue-debounce, queue, debounce, drop, or process concurrent messages on the same thread
+- [**Overlapping messages**](https://chat-sdk.dev/docs/concurrency) - burst, queue, debounce, drop, or process concurrent messages on the same thread
 
 ## AI coding agent support
 

--- a/apps/docs/content/docs/concurrency.mdx
+++ b/apps/docs/content/docs/concurrency.mdx
@@ -1,6 +1,6 @@
 ---
 title: Overlapping Messages
-description: Control how overlapping messages on the same thread are handled — queue, debounce, drop, or process concurrently.
+description: Control how overlapping messages on the same thread are handled - queue-debounce, queue, debounce, drop, or process concurrently.
 type: guide
 prerequisites:
   - /docs/handling-events
@@ -57,11 +57,47 @@ A done     → drain: [B, C, D] → handler(D, { skipped: [B, C] })
 D done     → queue empty → release lock
 ```
 
+### Queue debounce
+
+Waits once before the first handler on an idle thread, then drains the queued burst like `queue`. The latest message is dispatched, and earlier messages in the burst are available as `context.skipped`.
+
+Use this for assistant-style bots where users often send one logical turn as several short messages inside a small window and you want one response with full context. The tradeoff is that even a lone message waits for `debounceMs` before the handler runs.
+
+```typescript title="lib/bot.ts" lineNumbers
+const bot = new Chat({
+  concurrency: { strategy: "queue-debounce", debounceMs: 1000 },
+  // ...
+});
+
+bot.onNewMention(async (thread, message, context) => {
+  const turn = [...(context?.skipped ?? []), message]
+    .map((m) => m.text)
+    .join("\n\n");
+
+  const response = await generateAIResponse(turn);
+  await thread.post(response);
+});
+```
+
+**Flow:**
+
+```
+A arrives  → acquire lock → enqueue A → sleep(debounceMs)
+B arrives  → lock busy → enqueue B
+C arrives  → lock busy → enqueue C
+             ... debounceMs elapses ...
+           → drain: [A, B, C] → handler(C, { skipped: [A, B] })
+D arrives while C is running → lock busy → enqueue D
+E arrives while C is running → lock busy → enqueue E
+C done     → drain: [D, E] → handler(E, { skipped: [D] })
+E done     → queue empty → release lock
+```
+
 ### Debounce
 
-Every message starts or resets a debounce timer. Only the **final message in a burst** is processed.
+The first message waits for `debounceMs`. Messages that arrive during that window replace the pending message, so only the **final message in the burst window** is processed.
 
-This is particularly useful for platforms like **WhatsApp** and **Telegram** where users tend to send a flurry of short messages in quick succession instead of composing a single message — "hey", "quick question", "how do I reset my password?" arriving as three separate webhooks within a few seconds. Without debounce, the bot would respond to "hey" before the actual question even arrives. With debounce, the SDK waits for a pause in the conversation and processes only the final message.
+This is particularly useful for platforms like **WhatsApp** and **Telegram** where users tend to send a flurry of short messages in quick succession instead of composing a single message - "hey", "quick question", "how do I reset my password?" arriving as three separate webhooks within a few seconds. Without debounce, the bot would respond to "hey" before the actual question even arrives. With debounce, the SDK waits briefly and processes only the final message in the window.
 
 ```typescript title="lib/bot.ts" lineNumbers
 const bot = new Chat({
@@ -118,10 +154,10 @@ const bot = new Chat({
 | Option | Strategies | Default | Description |
 |--------|-----------|---------|-------------|
 | `strategy` | all | `"drop"` | The concurrency strategy to use |
-| `maxQueueSize` | queue, debounce | `10` | Maximum queued messages per thread |
-| `onQueueFull` | queue, debounce | `"drop-oldest"` | Whether to evict the oldest or reject the newest message when the queue is full |
-| `queueEntryTtlMs` | queue, debounce | `90000` | TTL for queued entries in milliseconds. Expired entries are discarded on dequeue |
-| `debounceMs` | debounce | `1500` | Debounce window in milliseconds |
+| `maxQueueSize` | queue, queue-debounce | `10` | Maximum queued messages per thread |
+| `onQueueFull` | queue, queue-debounce | `"drop-oldest"` | Whether to evict the oldest or reject the newest message when the queue is full |
+| `queueEntryTtlMs` | queue, debounce, queue-debounce | `90000` | TTL for queued entries in milliseconds. Expired entries are discarded on dequeue |
+| `debounceMs` | debounce, queue-debounce | `1500` | Debounce window in milliseconds |
 | `maxConcurrent` | concurrent | `Infinity` | Max concurrent handlers per thread |
 
 <Callout type="warn">
@@ -130,7 +166,7 @@ const bot = new Chat({
 
 ## MessageContext
 
-All handler types (`onNewMention`, `onSubscribedMessage`, `onNewMessage`) accept an optional `MessageContext` as their last parameter. It is only populated when using the `queue` strategy and messages were skipped.
+All handler types (`onNewMention`, `onSubscribedMessage`, `onNewMessage`) accept an optional `MessageContext` as their last parameter. It is populated when using the `queue` strategy for queued messages, and when using `queue-debounce` for a collapsed turn. A lone `queue-debounce` message receives `skipped: []` and `totalSinceLastHandler: 1`.
 
 ```typescript
 interface MessageContext {
@@ -186,7 +222,7 @@ const bot = new Chat({
 
 ## State adapter requirements
 
-The `queue` and `debounce` strategies require three additional methods on your state adapter:
+The `queue`, `debounce`, and `queue-debounce` strategies require three additional methods on your state adapter:
 
 | Method | Description |
 |--------|-------------|
@@ -202,12 +238,12 @@ All strategies emit structured log events at `info` level:
 
 | Event | Strategy | Data |
 |-------|----------|------|
-| `message-queued` | queue | threadId, messageId, queueDepth |
-| `message-dequeued` | queue, debounce | threadId, messageId, skippedCount |
-| `message-dropped` | drop, queue | threadId, messageId, reason |
-| `message-expired` | queue, debounce | threadId, messageId |
+| `message-queued` | queue, queue-debounce | threadId, messageId, queueDepth |
+| `message-dequeued` | queue, debounce, queue-debounce | threadId, messageId, skippedCount for queue/queue-debounce |
+| `message-dropped` | drop, queue, queue-debounce | threadId, messageId, reason |
+| `message-expired` | queue, debounce, queue-debounce | threadId, messageId |
 | `message-superseded` | debounce | threadId, droppedId |
-| `message-debouncing` | debounce | threadId, messageId, debounceMs |
+| `message-debouncing` | debounce, queue-debounce | threadId, messageId, debounceMs |
 | `message-debounce-reset` | debounce | threadId, messageId |
 
 ## Choosing a strategy
@@ -216,7 +252,8 @@ All strategies emit structured log events at `info` level:
 |----------|----------|-----|
 | Simple bots, one-shot commands | `drop` | No complexity, no queue overhead |
 | AI chatbots, customer support | `queue` | Never lose messages; handler sees full conversation context |
-| WhatsApp/Telegram bots, rapid corrections | `debounce` | Users send many short messages in quick succession; wait for a pause before responding |
+| AI chatbots with multi-message user turns | `queue-debounce` | Wait for the idle burst window, then respond once with every message in that window |
+| WhatsApp/Telegram bots, rapid corrections | `debounce` | Users send many short messages in quick succession; wait briefly and keep only the latest |
 | Stateless lookups, translations | `concurrent` | Maximum throughput, no ordering needed |
 
 ## Backward compatibility

--- a/apps/docs/content/docs/concurrency.mdx
+++ b/apps/docs/content/docs/concurrency.mdx
@@ -1,6 +1,6 @@
 ---
 title: Overlapping Messages
-description: Control how overlapping messages on the same thread are handled - queue-debounce, queue, debounce, drop, or process concurrently.
+description: Control how overlapping messages on the same thread are handled - burst, queue, debounce, drop, or process concurrently.
 type: guide
 prerequisites:
   - /docs/handling-events
@@ -57,15 +57,17 @@ A done     → drain: [B, C, D] → handler(D, { skipped: [B, C] })
 D done     → queue empty → release lock
 ```
 
-### Queue debounce
+### Burst
 
-Waits once before the first handler on an idle thread, then drains the queued burst like `queue`. The latest message is dispatched, and earlier messages in the burst are available as `context.skipped`.
+Waits for `debounceMs` before the first handler on an idle thread, then drains the collected burst like `queue`. The latest message is dispatched, and earlier messages in the burst are available as `context.skipped`.
 
-Use this for assistant-style bots where users often send one logical turn as several short messages inside a small window and you want one response with full context. The tradeoff is that even a lone message waits for `debounceMs` before the handler runs.
+Use this for assistant-style bots where users often send one logical turn as several short messages inside a small window and you want one response with full context. Compared to `debounce`, `burst` keeps the earlier messages in `context.skipped` instead of dropping them, and it flushes queued messages that arrive while the handler is running.
+
+Choose `debounce` when the latest message replaces earlier ones, like rapid corrections. Choose `burst` when earlier messages still matter, like "hey", "quick question", and then the actual question. The tradeoff is that even a lone message waits for `debounceMs` before the handler runs.
 
 ```typescript title="lib/bot.ts" lineNumbers
 const bot = new Chat({
-  concurrency: { strategy: "queue-debounce", debounceMs: 1000 },
+  concurrency: { strategy: "burst", debounceMs: 1000 },
   // ...
 });
 
@@ -154,10 +156,10 @@ const bot = new Chat({
 | Option | Strategies | Default | Description |
 |--------|-----------|---------|-------------|
 | `strategy` | all | `"drop"` | The concurrency strategy to use |
-| `maxQueueSize` | queue, queue-debounce | `10` | Maximum queued messages per thread |
-| `onQueueFull` | queue, queue-debounce | `"drop-oldest"` | Whether to evict the oldest or reject the newest message when the queue is full |
-| `queueEntryTtlMs` | queue, debounce, queue-debounce | `90000` | TTL for queued entries in milliseconds. Expired entries are discarded on dequeue |
-| `debounceMs` | debounce, queue-debounce | `1500` | Debounce window in milliseconds |
+| `maxQueueSize` | queue, burst | `10` | Maximum queued messages per thread |
+| `onQueueFull` | queue, burst | `"drop-oldest"` | Whether to evict the oldest or reject the newest message when the queue is full |
+| `queueEntryTtlMs` | queue, debounce, burst | `90000` | TTL for queued entries in milliseconds. Expired entries are discarded on dequeue |
+| `debounceMs` | debounce, burst | `1500` | Debounce window in milliseconds |
 | `maxConcurrent` | concurrent | `Infinity` | Max concurrent handlers per thread |
 
 <Callout type="warn">
@@ -166,7 +168,7 @@ const bot = new Chat({
 
 ## MessageContext
 
-All handler types (`onNewMention`, `onSubscribedMessage`, `onNewMessage`) accept an optional `MessageContext` as their last parameter. It is populated when using the `queue` strategy for queued messages, and when using `queue-debounce` for a collapsed turn. A lone `queue-debounce` message receives `skipped: []` and `totalSinceLastHandler: 1`.
+All handler types (`onNewMention`, `onSubscribedMessage`, `onNewMessage`) accept an optional `MessageContext` as their last parameter. It is populated when using the `queue` strategy for queued messages, and when using `burst` for a collapsed turn. A lone `burst` message receives `skipped: []` and `totalSinceLastHandler: 1`.
 
 ```typescript
 interface MessageContext {
@@ -222,7 +224,7 @@ const bot = new Chat({
 
 ## State adapter requirements
 
-The `queue`, `debounce`, and `queue-debounce` strategies require three additional methods on your state adapter:
+The `queue`, `debounce`, and `burst` strategies require three additional methods on your state adapter:
 
 | Method | Description |
 |--------|-------------|
@@ -238,12 +240,12 @@ All strategies emit structured log events at `info` level:
 
 | Event | Strategy | Data |
 |-------|----------|------|
-| `message-queued` | queue, queue-debounce | threadId, messageId, queueDepth |
-| `message-dequeued` | queue, debounce, queue-debounce | threadId, messageId, skippedCount for queue/queue-debounce |
-| `message-dropped` | drop, queue, queue-debounce | threadId, messageId, reason |
-| `message-expired` | queue, debounce, queue-debounce | threadId, messageId |
+| `message-queued` | queue, burst | threadId, messageId, queueDepth |
+| `message-dequeued` | queue, debounce, burst | threadId, messageId, skippedCount for queue/burst |
+| `message-dropped` | drop, queue, burst | threadId, messageId, reason |
+| `message-expired` | queue, debounce, burst | threadId, messageId |
 | `message-superseded` | debounce | threadId, droppedId |
-| `message-debouncing` | debounce, queue-debounce | threadId, messageId, debounceMs |
+| `message-debouncing` | debounce, burst | threadId, messageId, debounceMs |
 | `message-debounce-reset` | debounce | threadId, messageId |
 
 ## Choosing a strategy
@@ -252,7 +254,7 @@ All strategies emit structured log events at `info` level:
 |----------|----------|-----|
 | Simple bots, one-shot commands | `drop` | No complexity, no queue overhead |
 | AI chatbots, customer support | `queue` | Never lose messages; handler sees full conversation context |
-| AI chatbots with multi-message user turns | `queue-debounce` | Wait for the idle burst window, then respond once with every message in that window |
+| AI chatbots with multi-message user turns | `burst` | Wait for the idle burst window, then respond once with every message in that window |
 | WhatsApp/Telegram bots, rapid corrections | `debounce` | Users send many short messages in quick succession; wait briefly and keep only the latest |
 | Stateless lookups, translations | `concurrent` | Maximum throughput, no ordering needed |
 

--- a/apps/docs/content/docs/usage.mdx
+++ b/apps/docs/content/docs/usage.mdx
@@ -72,6 +72,7 @@ Your event handlers work identically across all registered adapters — the SDK 
 | `state` | `StateAdapter` | *required* | State adapter for subscriptions and locking |
 | `logger` | `Logger \| LogLevel` | `"info"` | Logger instance or log level (`"debug"`, `"info"`, `"warn"`, `"error"`, `"silent"`) |
 | `dedupeTtlMs` | `number` | `300000` | TTL in ms for message deduplication (5 minutes) |
+| `concurrency` | `"drop" \| "queue" \| "debounce" \| "queue-debounce" \| "concurrent" \| ConcurrencyConfig` | `"drop"` | Strategy for overlapping messages on the same thread |
 | `streamingUpdateIntervalMs` | `number` | `500` | Update interval in ms for post+edit streaming |
 | `fallbackStreamingPlaceholderText` | `string \| null` | `"..."` | Placeholder text while streaming starts. Set to `null` to skip |
 | `onLockConflict` | `'drop' \| 'force' \| (threadId, message) => 'drop' \| 'force'` | `"drop"` | Behavior when a thread lock is already held. `'force'` releases the existing lock and re-acquires it, enabling interrupt/steerability for long-running handlers |

--- a/apps/docs/content/docs/usage.mdx
+++ b/apps/docs/content/docs/usage.mdx
@@ -72,7 +72,7 @@ Your event handlers work identically across all registered adapters — the SDK 
 | `state` | `StateAdapter` | *required* | State adapter for subscriptions and locking |
 | `logger` | `Logger \| LogLevel` | `"info"` | Logger instance or log level (`"debug"`, `"info"`, `"warn"`, `"error"`, `"silent"`) |
 | `dedupeTtlMs` | `number` | `300000` | TTL in ms for message deduplication (5 minutes) |
-| `concurrency` | `"drop" \| "queue" \| "debounce" \| "queue-debounce" \| "concurrent" \| ConcurrencyConfig` | `"drop"` | Strategy for overlapping messages on the same thread |
+| `concurrency` | `"drop" \| "queue" \| "debounce" \| "burst" \| "concurrent" \| ConcurrencyConfig` | `"drop"` | Strategy for overlapping messages on the same thread |
 | `streamingUpdateIntervalMs` | `number` | `500` | Update interval in ms for post+edit streaming |
 | `fallbackStreamingPlaceholderText` | `string \| null` | `"..."` | Placeholder text while streaming starts. Set to `null` to skip |
 | `onLockConflict` | `'drop' \| 'force' \| (threadId, message) => 'drop' \| 'force'` | `"drop"` | Behavior when a thread lock is already held. `'force'` releases the existing lock and re-acquires it, enabling interrupt/steerability for long-running handlers |

--- a/packages/chat/src/chat.test.ts
+++ b/packages/chat/src/chat.test.ts
@@ -4034,25 +4034,25 @@ describe("Chat", () => {
     });
   });
 
-  describe("concurrency: queue-debounce", () => {
+  describe("concurrency: burst", () => {
     it("should collapse an idle burst into the latest message with skipped context", async () => {
       vi.useFakeTimers();
       try {
         const state = createMockState();
         const adapter = createMockAdapter("slack");
 
-        const queueDebounceChat = new Chat({
+        const burstChat = new Chat({
           userName: "testbot",
           adapters: { slack: adapter },
           state,
           logger: mockLogger,
           concurrency: {
-            strategy: "queue-debounce",
+            strategy: "burst",
             debounceMs: 100,
           },
         });
 
-        await queueDebounceChat.webhooks.slack(
+        await burstChat.webhooks.slack(
           new Request("http://test.com", { method: "POST" })
         );
 
@@ -4061,7 +4061,7 @@ describe("Chat", () => {
           { skipped: string[]; totalSinceLastHandler: number } | undefined
         > = [];
 
-        queueDebounceChat.onNewMention(
+        burstChat.onNewMention(
           vi.fn().mockImplementation(async (_thread, message, context) => {
             receivedMessages.push(message.text);
             receivedContexts.push(
@@ -4077,22 +4077,22 @@ describe("Chat", () => {
           })
         );
 
-        const msg1 = createTestMessage("msg-qd-1", "Hey @slack-bot first");
-        const promise = queueDebounceChat.handleIncomingMessage(
+        const msg1 = createTestMessage("msg-burst-1", "Hey @slack-bot first");
+        const promise = burstChat.handleIncomingMessage(
           adapter,
           "slack:C123:1234.5678",
           msg1
         );
 
-        const msg2 = createTestMessage("msg-qd-2", "Hey @slack-bot second");
-        await queueDebounceChat.handleIncomingMessage(
+        const msg2 = createTestMessage("msg-burst-2", "Hey @slack-bot second");
+        await burstChat.handleIncomingMessage(
           adapter,
           "slack:C123:1234.5678",
           msg2
         );
 
-        const msg3 = createTestMessage("msg-qd-3", "Hey @slack-bot third");
-        await queueDebounceChat.handleIncomingMessage(
+        const msg3 = createTestMessage("msg-burst-3", "Hey @slack-bot third");
+        await burstChat.handleIncomingMessage(
           adapter,
           "slack:C123:1234.5678",
           msg3
@@ -4121,26 +4121,26 @@ describe("Chat", () => {
         const state = createMockState();
         const adapter = createMockAdapter("slack");
 
-        const queueDebounceChat = new Chat({
+        const burstChat = new Chat({
           userName: "testbot",
           adapters: { slack: adapter },
           state,
           logger: mockLogger,
           concurrency: {
-            strategy: "queue-debounce",
+            strategy: "burst",
             debounceMs: 100,
           },
         });
 
-        await queueDebounceChat.webhooks.slack(
+        await burstChat.webhooks.slack(
           new Request("http://test.com", { method: "POST" })
         );
 
         const handler = vi.fn().mockResolvedValue(undefined);
-        queueDebounceChat.onNewMention(handler);
+        burstChat.onNewMention(handler);
 
-        const msg = createTestMessage("msg-qd-4", "Hey @slack-bot solo");
-        const promise = queueDebounceChat.handleIncomingMessage(
+        const msg = createTestMessage("msg-burst-4", "Hey @slack-bot solo");
+        const promise = burstChat.handleIncomingMessage(
           adapter,
           "slack:C123:1234.5678",
           msg
@@ -4168,18 +4168,18 @@ describe("Chat", () => {
         const state = createMockState();
         const adapter = createMockAdapter("slack");
 
-        const queueDebounceChat = new Chat({
+        const burstChat = new Chat({
           userName: "testbot",
           adapters: { slack: adapter },
           state,
           logger: mockLogger,
           concurrency: {
-            strategy: "queue-debounce",
+            strategy: "burst",
             debounceMs: 100,
           },
         });
 
-        await queueDebounceChat.webhooks.slack(
+        await burstChat.webhooks.slack(
           new Request("http://test.com", { method: "POST" })
         );
 
@@ -4189,7 +4189,7 @@ describe("Chat", () => {
         > = [];
         let releaseFirstHandler: (() => void) | undefined;
 
-        queueDebounceChat.onNewMention(
+        burstChat.onNewMention(
           vi.fn().mockImplementation(async (_thread, message, context) => {
             receivedMessages.push(message.text);
             receivedContexts.push(
@@ -4203,7 +4203,7 @@ describe("Chat", () => {
                 : undefined
             );
 
-            if (message.id === "msg-qd-drain-2") {
+            if (message.id === "msg-burst-drain-2") {
               await new Promise<void>((resolve) => {
                 releaseFirstHandler = resolve;
               });
@@ -4211,31 +4211,31 @@ describe("Chat", () => {
           })
         );
 
-        const firstPromise = queueDebounceChat.handleIncomingMessage(
+        const firstPromise = burstChat.handleIncomingMessage(
           adapter,
           "slack:C123:1234.5678",
-          createTestMessage("msg-qd-drain-1", "Hey @slack-bot first")
+          createTestMessage("msg-burst-drain-1", "Hey @slack-bot first")
         );
 
-        await queueDebounceChat.handleIncomingMessage(
+        await burstChat.handleIncomingMessage(
           adapter,
           "slack:C123:1234.5678",
-          createTestMessage("msg-qd-drain-2", "Hey @slack-bot second")
+          createTestMessage("msg-burst-drain-2", "Hey @slack-bot second")
         );
 
         await vi.advanceTimersByTimeAsync(150);
 
         expect(receivedMessages).toEqual(["Hey @slack-bot second"]);
 
-        await queueDebounceChat.handleIncomingMessage(
+        await burstChat.handleIncomingMessage(
           adapter,
           "slack:C123:1234.5678",
-          createTestMessage("msg-qd-drain-3", "Hey @slack-bot third")
+          createTestMessage("msg-burst-drain-3", "Hey @slack-bot third")
         );
-        await queueDebounceChat.handleIncomingMessage(
+        await burstChat.handleIncomingMessage(
           adapter,
           "slack:C123:1234.5678",
-          createTestMessage("msg-qd-drain-4", "Hey @slack-bot fourth")
+          createTestMessage("msg-burst-drain-4", "Hey @slack-bot fourth")
         );
 
         releaseFirstHandler?.();
@@ -4266,20 +4266,20 @@ describe("Chat", () => {
         const state = createMockState();
         const adapter = createMockAdapter("slack");
 
-        const queueDebounceChat = new Chat({
+        const burstChat = new Chat({
           userName: "testbot",
           adapters: { slack: adapter },
           state,
           logger: mockLogger,
           concurrency: {
-            strategy: "queue-debounce",
+            strategy: "burst",
             debounceMs: 100,
             maxQueueSize: 2,
             onQueueFull: "drop-newest",
           },
         });
 
-        await queueDebounceChat.webhooks.slack(
+        await burstChat.webhooks.slack(
           new Request("http://test.com", { method: "POST" })
         );
 
@@ -4288,7 +4288,7 @@ describe("Chat", () => {
           { skipped: string[]; totalSinceLastHandler: number } | undefined
         > = [];
 
-        queueDebounceChat.onNewMention(
+        burstChat.onNewMention(
           vi.fn().mockImplementation(async (_thread, message, context) => {
             receivedMessages.push(message.text);
             receivedContexts.push(
@@ -4304,20 +4304,20 @@ describe("Chat", () => {
           })
         );
 
-        const promise = queueDebounceChat.handleIncomingMessage(
+        const promise = burstChat.handleIncomingMessage(
           adapter,
           "slack:C123:1234.5678",
-          createTestMessage("msg-qd-drop-1", "Hey @slack-bot one")
+          createTestMessage("msg-burst-drop-1", "Hey @slack-bot one")
         );
-        await queueDebounceChat.handleIncomingMessage(
+        await burstChat.handleIncomingMessage(
           adapter,
           "slack:C123:1234.5678",
-          createTestMessage("msg-qd-drop-2", "Hey @slack-bot two")
+          createTestMessage("msg-burst-drop-2", "Hey @slack-bot two")
         );
-        await queueDebounceChat.handleIncomingMessage(
+        await burstChat.handleIncomingMessage(
           adapter,
           "slack:C123:1234.5678",
-          createTestMessage("msg-qd-drop-3", "Hey @slack-bot three")
+          createTestMessage("msg-burst-drop-3", "Hey @slack-bot three")
         );
 
         expect(await state.queueDepth("slack:C123:1234.5678")).toBe(2);
@@ -4356,44 +4356,44 @@ describe("Chat", () => {
         const mockSubject = {
           type: "issue",
           id: "ENG-414",
-          title: "Queue debounce test",
+          title: "Burst test",
           raw: {},
         };
         adapter.fetchSubject = vi.fn().mockResolvedValue(mockSubject);
 
-        const queueDebounceChat = new Chat({
+        const burstChat = new Chat({
           userName: "testbot",
           adapters: { slack: adapter },
           state,
           logger: mockLogger,
           concurrency: {
-            strategy: "queue-debounce",
+            strategy: "burst",
             debounceMs: 100,
           },
         });
 
-        await queueDebounceChat.webhooks.slack(
+        await burstChat.webhooks.slack(
           new Request("http://test.com", { method: "POST" })
         );
 
         let receivedSubject: unknown = "not-called";
         let receivedSkippedSubject: unknown = "not-called";
-        queueDebounceChat.onNewMention(
+        burstChat.onNewMention(
           vi.fn().mockImplementation(async (_thread, message, context) => {
             receivedSubject = await message.subject;
             receivedSkippedSubject = await context?.skipped[0]?.subject;
           })
         );
 
-        const promise = queueDebounceChat.handleIncomingMessage(
+        const promise = burstChat.handleIncomingMessage(
           adapter,
           "slack:C123:1234.5678",
-          createTestMessage("msg-qd-json-1", "Hey @slack-bot one")
+          createTestMessage("msg-burst-json-1", "Hey @slack-bot one")
         );
-        await queueDebounceChat.handleIncomingMessage(
+        await burstChat.handleIncomingMessage(
           adapter,
           "slack:C123:1234.5678",
-          createTestMessage("msg-qd-json-2", "Hey @slack-bot two")
+          createTestMessage("msg-burst-json-2", "Hey @slack-bot two")
         );
 
         await vi.advanceTimersByTimeAsync(150);

--- a/packages/chat/src/chat.test.ts
+++ b/packages/chat/src/chat.test.ts
@@ -4034,6 +4034,380 @@ describe("Chat", () => {
     });
   });
 
+  describe("concurrency: queue-debounce", () => {
+    it("should collapse an idle burst into the latest message with skipped context", async () => {
+      vi.useFakeTimers();
+      try {
+        const state = createMockState();
+        const adapter = createMockAdapter("slack");
+
+        const queueDebounceChat = new Chat({
+          userName: "testbot",
+          adapters: { slack: adapter },
+          state,
+          logger: mockLogger,
+          concurrency: {
+            strategy: "queue-debounce",
+            debounceMs: 100,
+          },
+        });
+
+        await queueDebounceChat.webhooks.slack(
+          new Request("http://test.com", { method: "POST" })
+        );
+
+        const receivedMessages: string[] = [];
+        const receivedContexts: Array<
+          { skipped: string[]; totalSinceLastHandler: number } | undefined
+        > = [];
+
+        queueDebounceChat.onNewMention(
+          vi.fn().mockImplementation(async (_thread, message, context) => {
+            receivedMessages.push(message.text);
+            receivedContexts.push(
+              context
+                ? {
+                    skipped: context.skipped.map(
+                      (m: { text: string }) => m.text
+                    ),
+                    totalSinceLastHandler: context.totalSinceLastHandler,
+                  }
+                : undefined
+            );
+          })
+        );
+
+        const msg1 = createTestMessage("msg-qd-1", "Hey @slack-bot first");
+        const promise = queueDebounceChat.handleIncomingMessage(
+          adapter,
+          "slack:C123:1234.5678",
+          msg1
+        );
+
+        const msg2 = createTestMessage("msg-qd-2", "Hey @slack-bot second");
+        await queueDebounceChat.handleIncomingMessage(
+          adapter,
+          "slack:C123:1234.5678",
+          msg2
+        );
+
+        const msg3 = createTestMessage("msg-qd-3", "Hey @slack-bot third");
+        await queueDebounceChat.handleIncomingMessage(
+          adapter,
+          "slack:C123:1234.5678",
+          msg3
+        );
+
+        expect(receivedMessages).toEqual([]);
+
+        await vi.advanceTimersByTimeAsync(150);
+        await promise;
+
+        expect(receivedMessages).toEqual(["Hey @slack-bot third"]);
+        expect(receivedContexts).toEqual([
+          {
+            skipped: ["Hey @slack-bot first", "Hey @slack-bot second"],
+            totalSinceLastHandler: 3,
+          },
+        ]);
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it("should process a lone idle message after the debounce window", async () => {
+      vi.useFakeTimers();
+      try {
+        const state = createMockState();
+        const adapter = createMockAdapter("slack");
+
+        const queueDebounceChat = new Chat({
+          userName: "testbot",
+          adapters: { slack: adapter },
+          state,
+          logger: mockLogger,
+          concurrency: {
+            strategy: "queue-debounce",
+            debounceMs: 100,
+          },
+        });
+
+        await queueDebounceChat.webhooks.slack(
+          new Request("http://test.com", { method: "POST" })
+        );
+
+        const handler = vi.fn().mockResolvedValue(undefined);
+        queueDebounceChat.onNewMention(handler);
+
+        const msg = createTestMessage("msg-qd-4", "Hey @slack-bot solo");
+        const promise = queueDebounceChat.handleIncomingMessage(
+          adapter,
+          "slack:C123:1234.5678",
+          msg
+        );
+
+        expect(handler).not.toHaveBeenCalled();
+
+        await vi.advanceTimersByTimeAsync(150);
+        await promise;
+
+        expect(handler).toHaveBeenCalledTimes(1);
+        expect(handler.mock.calls[0][1].text).toBe("Hey @slack-bot solo");
+        expect(handler.mock.calls[0][2]).toEqual({
+          skipped: [],
+          totalSinceLastHandler: 1,
+        });
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it("should drain messages that arrive while the debounced handler is running", async () => {
+      vi.useFakeTimers();
+      try {
+        const state = createMockState();
+        const adapter = createMockAdapter("slack");
+
+        const queueDebounceChat = new Chat({
+          userName: "testbot",
+          adapters: { slack: adapter },
+          state,
+          logger: mockLogger,
+          concurrency: {
+            strategy: "queue-debounce",
+            debounceMs: 100,
+          },
+        });
+
+        await queueDebounceChat.webhooks.slack(
+          new Request("http://test.com", { method: "POST" })
+        );
+
+        const receivedMessages: string[] = [];
+        const receivedContexts: Array<
+          { skipped: string[]; totalSinceLastHandler: number } | undefined
+        > = [];
+        let releaseFirstHandler: (() => void) | undefined;
+
+        queueDebounceChat.onNewMention(
+          vi.fn().mockImplementation(async (_thread, message, context) => {
+            receivedMessages.push(message.text);
+            receivedContexts.push(
+              context
+                ? {
+                    skipped: context.skipped.map(
+                      (m: { text: string }) => m.text
+                    ),
+                    totalSinceLastHandler: context.totalSinceLastHandler,
+                  }
+                : undefined
+            );
+
+            if (message.id === "msg-qd-drain-2") {
+              await new Promise<void>((resolve) => {
+                releaseFirstHandler = resolve;
+              });
+            }
+          })
+        );
+
+        const firstPromise = queueDebounceChat.handleIncomingMessage(
+          adapter,
+          "slack:C123:1234.5678",
+          createTestMessage("msg-qd-drain-1", "Hey @slack-bot first")
+        );
+
+        await queueDebounceChat.handleIncomingMessage(
+          adapter,
+          "slack:C123:1234.5678",
+          createTestMessage("msg-qd-drain-2", "Hey @slack-bot second")
+        );
+
+        await vi.advanceTimersByTimeAsync(150);
+
+        expect(receivedMessages).toEqual(["Hey @slack-bot second"]);
+
+        await queueDebounceChat.handleIncomingMessage(
+          adapter,
+          "slack:C123:1234.5678",
+          createTestMessage("msg-qd-drain-3", "Hey @slack-bot third")
+        );
+        await queueDebounceChat.handleIncomingMessage(
+          adapter,
+          "slack:C123:1234.5678",
+          createTestMessage("msg-qd-drain-4", "Hey @slack-bot fourth")
+        );
+
+        releaseFirstHandler?.();
+        await firstPromise;
+
+        expect(receivedMessages).toEqual([
+          "Hey @slack-bot second",
+          "Hey @slack-bot fourth",
+        ]);
+        expect(receivedContexts).toEqual([
+          {
+            skipped: ["Hey @slack-bot first"],
+            totalSinceLastHandler: 2,
+          },
+          {
+            skipped: ["Hey @slack-bot third"],
+            totalSinceLastHandler: 2,
+          },
+        ]);
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it("should respect drop-newest when the queue fills during debounce", async () => {
+      vi.useFakeTimers();
+      try {
+        const state = createMockState();
+        const adapter = createMockAdapter("slack");
+
+        const queueDebounceChat = new Chat({
+          userName: "testbot",
+          adapters: { slack: adapter },
+          state,
+          logger: mockLogger,
+          concurrency: {
+            strategy: "queue-debounce",
+            debounceMs: 100,
+            maxQueueSize: 2,
+            onQueueFull: "drop-newest",
+          },
+        });
+
+        await queueDebounceChat.webhooks.slack(
+          new Request("http://test.com", { method: "POST" })
+        );
+
+        const receivedMessages: string[] = [];
+        const receivedContexts: Array<
+          { skipped: string[]; totalSinceLastHandler: number } | undefined
+        > = [];
+
+        queueDebounceChat.onNewMention(
+          vi.fn().mockImplementation(async (_thread, message, context) => {
+            receivedMessages.push(message.text);
+            receivedContexts.push(
+              context
+                ? {
+                    skipped: context.skipped.map(
+                      (m: { text: string }) => m.text
+                    ),
+                    totalSinceLastHandler: context.totalSinceLastHandler,
+                  }
+                : undefined
+            );
+          })
+        );
+
+        const promise = queueDebounceChat.handleIncomingMessage(
+          adapter,
+          "slack:C123:1234.5678",
+          createTestMessage("msg-qd-drop-1", "Hey @slack-bot one")
+        );
+        await queueDebounceChat.handleIncomingMessage(
+          adapter,
+          "slack:C123:1234.5678",
+          createTestMessage("msg-qd-drop-2", "Hey @slack-bot two")
+        );
+        await queueDebounceChat.handleIncomingMessage(
+          adapter,
+          "slack:C123:1234.5678",
+          createTestMessage("msg-qd-drop-3", "Hey @slack-bot three")
+        );
+
+        expect(await state.queueDepth("slack:C123:1234.5678")).toBe(2);
+
+        await vi.advanceTimersByTimeAsync(150);
+        await promise;
+
+        expect(receivedMessages).toEqual(["Hey @slack-bot two"]);
+        expect(receivedContexts).toEqual([
+          {
+            skipped: ["Hey @slack-bot one"],
+            totalSinceLastHandler: 2,
+          },
+        ]);
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it("should rehydrate queued messages after JSON roundtrip", async () => {
+      vi.useFakeTimers();
+      try {
+        const state = createMockState();
+        const realEnqueue = state.enqueue.getMockImplementation();
+        if (!realEnqueue) {
+          throw new Error("Expected enqueue mock");
+        }
+        vi.mocked(state.enqueue).mockImplementation(
+          async (threadId, entry, maxSize) => {
+            const serialized = JSON.parse(JSON.stringify(entry));
+            return realEnqueue(threadId, serialized, maxSize);
+          }
+        );
+
+        const adapter = createMockAdapter("slack");
+        const mockSubject = {
+          type: "issue",
+          id: "ENG-414",
+          title: "Queue debounce test",
+          raw: {},
+        };
+        adapter.fetchSubject = vi.fn().mockResolvedValue(mockSubject);
+
+        const queueDebounceChat = new Chat({
+          userName: "testbot",
+          adapters: { slack: adapter },
+          state,
+          logger: mockLogger,
+          concurrency: {
+            strategy: "queue-debounce",
+            debounceMs: 100,
+          },
+        });
+
+        await queueDebounceChat.webhooks.slack(
+          new Request("http://test.com", { method: "POST" })
+        );
+
+        let receivedSubject: unknown = "not-called";
+        let receivedSkippedSubject: unknown = "not-called";
+        queueDebounceChat.onNewMention(
+          vi.fn().mockImplementation(async (_thread, message, context) => {
+            receivedSubject = await message.subject;
+            receivedSkippedSubject = await context?.skipped[0]?.subject;
+          })
+        );
+
+        const promise = queueDebounceChat.handleIncomingMessage(
+          adapter,
+          "slack:C123:1234.5678",
+          createTestMessage("msg-qd-json-1", "Hey @slack-bot one")
+        );
+        await queueDebounceChat.handleIncomingMessage(
+          adapter,
+          "slack:C123:1234.5678",
+          createTestMessage("msg-qd-json-2", "Hey @slack-bot two")
+        );
+
+        await vi.advanceTimersByTimeAsync(150);
+        await promise;
+
+        expect(receivedSubject).toEqual(mockSubject);
+        expect(receivedSkippedSubject).toEqual(mockSubject);
+        expect(adapter.fetchSubject).toHaveBeenCalledTimes(2);
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+  });
+
   describe("concurrency: concurrent", () => {
     it("should process messages without acquiring a lock", async () => {
       const state = createMockState();

--- a/packages/chat/src/chat.ts
+++ b/packages/chat/src/chat.ts
@@ -1975,7 +1975,7 @@ export class Chat<
    * - Deduplication: Same message may arrive multiple times (e.g., Slack sends
    *   both `message` and `app_mention` events, GChat sends direct webhook + Pub/Sub)
    * - Bot filtering: Messages from the bot itself are skipped
-   * - Concurrency: Controlled by `concurrency` config (drop, queue, debounce, concurrent)
+   * - Concurrency: Controlled by `concurrency` config (drop, queue, debounce, queue-debounce, concurrent)
    */
   async handleIncomingMessage(
     adapter: Adapter,
@@ -2044,7 +2044,11 @@ export class Chat<
       return;
     }
 
-    if (strategy === "queue" || strategy === "debounce") {
+    if (
+      strategy === "queue" ||
+      strategy === "debounce" ||
+      strategy === "queue-debounce"
+    ) {
       await this.handleQueueOrDebounce(
         adapter,
         threadId,
@@ -2122,7 +2126,7 @@ export class Chat<
     threadId: string,
     lockKey: string,
     message: Message,
-    strategy: "queue" | "debounce"
+    strategy: "queue" | "debounce" | "queue-debounce"
   ): Promise<void> {
     const { maxQueueSize, queueEntryTtlMs, onQueueFull, debounceMs } =
       this._concurrencyConfig;
@@ -2200,6 +2204,25 @@ export class Chat<
           debounceMs,
         });
         await this.debounceLoop(lock, adapter, threadId, lockKey);
+      } else if (strategy === "queue-debounce") {
+        await this._stateAdapter.enqueue(
+          lockKey,
+          {
+            message,
+            enqueuedAt: Date.now(),
+            expiresAt: Date.now() + queueEntryTtlMs,
+          },
+          maxQueueSize
+        );
+        this.logger.info("message-debouncing", {
+          threadId,
+          lockKey,
+          messageId: message.id,
+          debounceMs,
+        });
+        await sleep(debounceMs);
+        await this._stateAdapter.extendLock(lock, DEFAULT_LOCK_TTL_MS);
+        await this.drainQueue(lock, adapter, threadId, lockKey);
       } else {
         // Queue: process our message immediately, then drain any queued messages
         await this.dispatchToHandlers(adapter, threadId, message);

--- a/packages/chat/src/chat.ts
+++ b/packages/chat/src/chat.ts
@@ -1975,7 +1975,7 @@ export class Chat<
    * - Deduplication: Same message may arrive multiple times (e.g., Slack sends
    *   both `message` and `app_mention` events, GChat sends direct webhook + Pub/Sub)
    * - Bot filtering: Messages from the bot itself are skipped
-   * - Concurrency: Controlled by `concurrency` config (drop, queue, debounce, queue-debounce, concurrent)
+   * - Concurrency: Controlled by `concurrency` config (drop, queue, debounce, burst, concurrent)
    */
   async handleIncomingMessage(
     adapter: Adapter,
@@ -2047,7 +2047,7 @@ export class Chat<
     if (
       strategy === "queue" ||
       strategy === "debounce" ||
-      strategy === "queue-debounce"
+      strategy === "burst"
     ) {
       await this.handleQueueOrDebounce(
         adapter,
@@ -2126,7 +2126,7 @@ export class Chat<
     threadId: string,
     lockKey: string,
     message: Message,
-    strategy: "queue" | "debounce" | "queue-debounce"
+    strategy: "queue" | "debounce" | "burst"
   ): Promise<void> {
     const { maxQueueSize, queueEntryTtlMs, onQueueFull, debounceMs } =
       this._concurrencyConfig;
@@ -2204,7 +2204,7 @@ export class Chat<
           debounceMs,
         });
         await this.debounceLoop(lock, adapter, threadId, lockKey);
-      } else if (strategy === "queue-debounce") {
+      } else if (strategy === "burst") {
         await this._stateAdapter.enqueue(
           lockKey,
           {

--- a/packages/chat/src/types.ts
+++ b/packages/chat/src/types.ts
@@ -64,8 +64,10 @@ export interface ChatConfig<
    * - `'queue'` — queue the message; when the current handler finishes,
    *   process only the latest queued message with `context.skipped` containing
    *   all intermediate messages
-   * - `'debounce'` — all messages start/reset a debounce timer; only the
-   *   final message in a burst is processed
+   * - `'debounce'` — messages inside the debounce window replace the pending
+   *   message; only the final message in that window is processed
+   * - `'queue-debounce'` — wait once before the first handler, then process the
+   *   latest message with `context.skipped` containing earlier burst messages
    * - `'concurrent'` — no locking; all messages processed in parallel
    * - `ConcurrencyConfig` — fine-grained control over strategy and parameters
    */
@@ -755,15 +757,20 @@ export interface LockScopeContext {
 }
 
 /** Concurrency strategy for overlapping messages on the same thread. */
-export type ConcurrencyStrategy = "drop" | "queue" | "debounce" | "concurrent";
+export type ConcurrencyStrategy =
+  | "drop"
+  | "queue"
+  | "debounce"
+  | "queue-debounce"
+  | "concurrent";
 
 /** Fine-grained concurrency configuration. */
 export interface ConcurrencyConfig {
-  /** Debounce window in milliseconds (debounce strategy). Default: 1500. */
+  /** Debounce window in milliseconds (debounce/queue-debounce strategies). Default: 1500. */
   debounceMs?: number;
   /** Max concurrent handlers per thread (concurrent strategy). Default: Infinity. */
   maxConcurrent?: number;
-  /** Max queued messages per thread (queue/debounce strategy). Default: 10. */
+  /** Max queued messages per thread (queue/queue-debounce strategy). Default: 10. */
   maxQueueSize?: number;
   /** What to do when queue is full. Default: 'drop-oldest'. */
   onQueueFull?: "drop-oldest" | "drop-newest";
@@ -775,7 +782,7 @@ export interface ConcurrencyConfig {
 
 /**
  * An entry in the per-thread message queue.
- * Used by the `queue` and `debounce` concurrency strategies.
+ * Used by the `queue`, `debounce`, and `queue-debounce` concurrency strategies.
  */
 export interface QueueEntry {
   /** When this entry was enqueued (Unix ms). */
@@ -788,7 +795,7 @@ export interface QueueEntry {
 
 /**
  * Context provided to message handlers when messages were queued
- * while a previous handler was running.
+ * while a previous handler was running or while waiting for queue-debounce.
  */
 export interface MessageContext {
   /**

--- a/packages/chat/src/types.ts
+++ b/packages/chat/src/types.ts
@@ -66,7 +66,7 @@ export interface ChatConfig<
    *   all intermediate messages
    * - `'debounce'` — messages inside the debounce window replace the pending
    *   message; only the final message in that window is processed
-   * - `'queue-debounce'` — wait once before the first handler, then process the
+   * - `'burst'` — wait once before the first handler, then process the
    *   latest message with `context.skipped` containing earlier burst messages
    * - `'concurrent'` — no locking; all messages processed in parallel
    * - `ConcurrencyConfig` — fine-grained control over strategy and parameters
@@ -761,16 +761,16 @@ export type ConcurrencyStrategy =
   | "drop"
   | "queue"
   | "debounce"
-  | "queue-debounce"
+  | "burst"
   | "concurrent";
 
 /** Fine-grained concurrency configuration. */
 export interface ConcurrencyConfig {
-  /** Debounce window in milliseconds (debounce/queue-debounce strategies). Default: 1500. */
+  /** Debounce window in milliseconds (debounce/burst strategies). Default: 1500. */
   debounceMs?: number;
   /** Max concurrent handlers per thread (concurrent strategy). Default: Infinity. */
   maxConcurrent?: number;
-  /** Max queued messages per thread (queue/queue-debounce strategy). Default: 10. */
+  /** Max queued messages per thread (queue/burst strategy). Default: 10. */
   maxQueueSize?: number;
   /** What to do when queue is full. Default: 'drop-oldest'. */
   onQueueFull?: "drop-oldest" | "drop-newest";
@@ -782,7 +782,7 @@ export interface ConcurrencyConfig {
 
 /**
  * An entry in the per-thread message queue.
- * Used by the `queue`, `debounce`, and `queue-debounce` concurrency strategies.
+ * Used by the `queue`, `debounce`, and `burst` concurrency strategies.
  */
 export interface QueueEntry {
   /** When this entry was enqueued (Unix ms). */
@@ -795,7 +795,7 @@ export interface QueueEntry {
 
 /**
  * Context provided to message handlers when messages were queued
- * while a previous handler was running or while waiting for queue-debounce.
+ * while a previous handler was running or while waiting for burst.
  */
 export interface MessageContext {
   /**


### PR DESCRIPTION
## summary

adds an opt-in `burst` concurrency strategy for #414

when a thread is idle, the first message waits for `debounceMs`, messages that arrive during that window are queued, and the handler runs once with the latest message plus earlier burst messages in `context.skipped`

after the handler finishes, messages that arrived while it was running are drained like `queue`, so the latest queued message is processed with earlier queued messages in `context.skipped`

keeps existing `drop`, `queue`, `debounce`, and `concurrent` behavior unchanged

updates docs to cover `burst`, explain when to choose it over `debounce`, and document the related `MessageContext` behavior
