### PR TITLE
feat(chat): add multi-tenant adapter connections

### DIFF
--- a/.changeset/cuddly-mugs-sneeze.md
+++ b/.changeset/cuddly-mugs-sneeze.md
@@ -1,0 +1,14 @@
+---
+"chat": minor
+"@chat-adapter/slack": minor
+"@chat-adapter/telegram": minor
+"@chat-adapter/discord": minor
+"@chat-adapter/whatsapp": minor
+"@chat-adapter/messenger": minor
+"@chat-adapter/github": minor
+"@chat-adapter/linear": minor
+"@chat-adapter/gchat": minor
+"@chat-adapter/teams": minor
+---
+
+add multi-tenant connection support for BYOK chat adapters


### PR DESCRIPTION
## summary

adds first-class multi-tenant connection support for BYOK chat bots

this pr introduces a shared connection model in core, makes webhook handling and state identity connection-aware, and updates adapters so credentials can be resolved per customer connection instead of requiring one Chat instance per bot

the goal is to support platforms where users bring their own bot credentials while the app still runs through one stable Chat SDK runtime

closes #496

planned scope:
- add connection metadata to inbound messages, threads, and serialized workflow payloads
- make dedupe, locks, queues, subscriptions, and history safe across connections
- add adapter-level connection providers for webhook credential resolution
- add proactive connection APIs like withConnection
- support webhook-mode BYOK across the existing chat adapters
- document the multi-tenant BYOK setup and adapter-specific caveats

## test plan

draft pr, tests will be added as implementation lands
