### PR TITLE
feat: docs: add Lark / Feishu adapter

### DIFF
--- a/apps/docs/adapters.json
+++ b/apps/docs/adapters.json
@@ -273,5 +273,16 @@
     "packageName": "chat-adapter-mattermost",
     "author": "thiagoferolla",
     "readme": "https://github.com/thiagoferolla/chat-adapter-mattermost/tree/70eb85321cba65d511f6e158b9a2f5aac2aa922c"
+  },
+  {
+    "name": "Lark / Feishu",
+    "slug": "lark",
+    "type": "platform",
+    "community": true,
+    "description": "Lark / Feishu adapter for Chat SDK with native cardkit streaming, interactive cards, and reactions.",
+    "packageName": "@larksuite/vercel-chat-adapter",
+    "author": "Lark / Feishu",
+    "readme": "https://github.com/larksuite/node-sdk/tree/cbc4adf13cbcb93b389db01faf428e3b3cef053c/docs/vercel-chat-adapter",
+    "vendorOfficial": true
   }
 ]

--- a/apps/docs/app/[lang]/(home)/adapters/for/[messenger]/page.tsx
+++ b/apps/docs/app/[lang]/(home)/adapters/for/[messenger]/page.tsx
@@ -164,6 +164,13 @@ const messengerConfig: Record<
     adapterSlugs: ["mattermost"],
     keywords: ["mattermost"],
   },
+  lark: {
+    name: "Lark / Feishu",
+    description:
+      "Build bots for Lark / Feishu with Chat SDK. Browse official and community adapters that support Lark integration.",
+    adapterSlugs: ["lark"],
+    keywords: ["lark", "feishu"],
+  },
 };
 
 const getMessengerAdapters = (messengerSlug: string) => {

--- a/apps/docs/app/[lang]/(home)/adapters/page.tsx
+++ b/apps/docs/app/[lang]/(home)/adapters/page.tsx
@@ -30,6 +30,7 @@ const messengerLinks = [
   { name: "Google Chat", slug: "google-chat" },
   { name: "Zalo", slug: "zalo" },
   { name: "Mattermost", slug: "mattermost" },
+  { name: "Lark / Feishu", slug: "lark" },
 ];
 
 const AdaptersPage = () => (


### PR DESCRIPTION
## Summary

Adds [`@larksuite/vercel-chat-adapter`](https://www.npmjs.com/package/@larksuite/vercel-chat-adapter), the Lark / Feishu adapter for Chat SDK, as a **vendor-official community adapter**.

- **Package**: `@larksuite/vercel-chat-adapter` — published on npm under the official `larksuite` scope
- **Built on**: [`@larksuiteoapi/node-sdk`](https://www.npmjs.com/package/@larksuiteoapi/node-sdk)'s `LarkChannel`, the official Lark Node SDK
- **README**: hosted in [`larksuite/node-sdk`](https://github.com/larksuite/node-sdk/tree/cbc4adf13cbcb93b389db01faf428e3b3cef053c/docs/vercel-chat-adapter) — the Lark vendor-owned GitHub org, pinned at commit `cbc4adf1`
- **Capabilities**: native cardkit typewriter streaming, interactive cards, reactions, edit / delete, message history (via SDK `normalize()`), DM detection, mention handling, and scan-to-create app onboarding through `registerLarkApp`

## Changes

| File | Change |
|---|---|
| `apps/docs/adapters.json` | Add Lark / Feishu entry (`community: true`, `vendorOfficial: true`) |
| `apps/docs/app/[lang]/(home)/adapters/page.tsx` | Add "Lark / Feishu" chip to the browse-by-messenger list |
| `apps/docs/app/[lang]/(home)/adapters/for/[messenger]/page.tsx` | Add `lark` messenger config (keywords: `lark`, `feishu`) |

No icon registered in `iconMap` / `adapterLogos` — matches the existing pattern for community / vendor-official adapters (Beeper, Resend, Liveblocks, Zernio, Photon).

## Vendor Official tier

Per `docs/contributing/building.mdx` (Qualifications for vendor official tier):

- ✅ **Commitment for continued maintenance** — owned by the Lark / Feishu team
- ✅ **GitHub hosting in official vendor-owned org** — README lives in [`larksuite/node-sdk`](https://github.com/larksuite/node-sdk), the official Lark org
- ✅ **Documentation in primary vendor docs** — will be cross-linked from the official Lark Open Platform developer documentation
- ✅ **Announcement** — will be announced through Lark developer changelog / channels

## A note on source visibility

The adapter source is not currently open-sourced due to internal release-process requirements. What is public:

- The npm package itself (consumable by any user)
- The README, hosted in `larksuite/node-sdk` (official Lark org)
- The underlying [`@larksuiteoapi/node-sdk`](https://github.com/larksuite/node-sdk) on which it is built — this *is* fully open-source

## Test plan

- [x] `pnpm --filter docs build` — docs app builds cleanly
- [x] `pnpm typecheck` — passes
- [x] `pnpm check` (Ultracite / Biome) — passes
- [x] Manual: `/adapters` shows the Lark / Feishu card in the **Vendor Official** section, `/adapters/lark` renders the README pinned at `cbc4adf1`, `/adapters/for/lark` renders the messenger landing
