### PR TITLE
fix(web): exclude framework wrappers from coverage

### DIFF
--- a/packages/adapter-web/vitest.config.ts
+++ b/packages/adapter-web/vitest.config.ts
@@ -8,7 +8,12 @@ export default defineProject({
       provider: "v8",
       reporter: ["text", "json-summary"],
       include: ["src/**/*.ts"],
-      exclude: ["src/**/*.test.ts", "src/react/**"],
+      exclude: [
+        "src/**/*.test.ts",
+        "src/react/**",
+        "src/vue/**",
+        "src/svelte/**",
+      ],
     },
   },
 });


### PR DESCRIPTION
## summary

excludes the Web adapter React, Vue, and Svelte wrapper entry points from coverage collection

these files are thin framework-specific `useChat` wrappers that are already validated by build and typecheck, and excluding them avoids Vitest coverage trying to parse the Svelte wrapper as plain TypeScript
