### PR TITLE
fix(release): prevent accidental major bumps

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -7,6 +7,9 @@
   "access": "public",
   "baseBranch": "main",
   "updateInternalDependencies": "patch",
+  "___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH": {
+    "onlyUpdatePeerDependentsWhenOutOfRange": true
+  },
   "ignore": [
     "example-nextjs-chat",
     "example-telegram-chat",

--- a/packages/tests/package.json
+++ b/packages/tests/package.json
@@ -32,7 +32,7 @@
     "clean": "rm -rf dist"
   },
   "peerDependencies": {
-    "chat": "workspace:*",
+    "chat": "^4.28.1",
     "vitest": "^4.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
## summary

fixes the release plan so peer-dependent packages only trigger major bumps when the next dependency version falls outside their supported range

this keeps the current release on `4.29.0` instead of accidentally bumping the fixed `chat` and `@chat-adapter/*` group to `5.0.0`

also changes `@chat-adapter/tests` to use a real `chat` peer range while keeping `workspace:*` for local development
