### PR TITLE
fix(release): safely promote release branch

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,4 +52,7 @@ jobs:
 
       - name: Promote release branch
         if: steps.changesets.outputs.published == 'true'
-        run: git push origin HEAD:refs/heads/release
+        run: |
+          git fetch origin release
+          expected=$(git rev-parse origin/release)
+          git push --force-with-lease=refs/heads/release:$expected origin HEAD:refs/heads/release


### PR DESCRIPTION
## summary

updates the release workflow to promote the `release` branch with `--force-with-lease`

the previous plain push could fail when `release` had remote history that was not present in the workflow checkout, even after packages published successfully

this fetches the current `release` ref first, then updates it only if it still matches the fetched commit
