### PR TITLE
fix(slack): resolve reaction user display names

### DIFF
--- a/.changeset/slack-reaction-display-names.md
+++ b/.changeset/slack-reaction-display-names.md
@@ -1,0 +1,9 @@
+---
+"@chat-adapter/slack": patch
+---
+
+fix(slack): resolve reaction user display names
+
+Slack reaction events now resolve the reacting user's display name and real name
+through the existing cached user lookup path. If lookup fails, the adapter falls
+back to the Slack user ID.

--- a/packages/adapter-slack/src/index.test.ts
+++ b/packages/adapter-slack/src/index.test.ts
@@ -650,10 +650,16 @@ describe("handleWebhook - event_callback", () => {
         messages: [{ ts: replyTs, thread_ts: parentTs }],
       })
     );
+    mockClientMethod(
+      adapter,
+      "users.info",
+      vi.fn().mockResolvedValue({
+        ok: true,
+        user: { name: "user", profile: { display_name: "User" } },
+      })
+    );
 
-    const mockChat = {
-      processReaction: vi.fn(),
-    } as unknown as ChatInstance;
+    const mockChat = createMockChatInstance(createMockState());
     (adapter as unknown as { chat: ChatInstance }).chat = mockChat;
 
     const body = JSON.stringify({
@@ -679,6 +685,62 @@ describe("handleWebhook - event_callback", () => {
       expect.objectContaining({
         threadId: `slack:C456:${parentTs}`,
         messageId: replyTs,
+      }),
+      undefined
+    );
+  });
+
+  it("resolves reaction user display name", async () => {
+    mockClientMethod(
+      adapter,
+      "conversations.replies",
+      vi.fn().mockResolvedValue({
+        ok: true,
+        messages: [{ ts: "1234567890.123456" }],
+      })
+    );
+    const usersInfoMock = vi.fn().mockResolvedValue({
+      ok: true,
+      user: {
+        id: "U123",
+        name: "alice",
+        real_name: "Alice Example",
+        profile: { display_name: "Alice", real_name: "Alice Example" },
+      },
+    });
+    mockClientMethod(adapter, "users.info", usersInfoMock);
+
+    const mockChat = createMockChatInstance(createMockState());
+    (adapter as unknown as { chat: ChatInstance }).chat = mockChat;
+
+    const body = JSON.stringify({
+      type: "event_callback",
+      event: {
+        type: "reaction_added",
+        user: "U123",
+        reaction: "thumbsup",
+        item: {
+          type: "message",
+          channel: "C456",
+          ts: "1234567890.123456",
+        },
+      },
+    });
+    const request = createWebhookRequest(body, secret);
+
+    await adapter.handleWebhook(request);
+    await new Promise((r) => setTimeout(r, 50));
+
+    expect(usersInfoMock).toHaveBeenCalledWith(
+      expect.objectContaining({ user: "U123" })
+    );
+    expect(mockChat.processReaction).toHaveBeenCalledWith(
+      expect.objectContaining({
+        user: expect.objectContaining({
+          userId: "U123",
+          userName: "Alice",
+          fullName: "Alice Example",
+        }),
       }),
       undefined
     );

--- a/packages/adapter-slack/src/index.ts
+++ b/packages/adapter-slack/src/index.ts
@@ -2306,6 +2306,10 @@ export class SlackAdapter implements Adapter<SlackThreadId, unknown> {
       (this._botUserId !== null && event.user === this._botUserId) ||
       (this._botId !== null && event.user === this._botId);
 
+    const userInfo = await this.lookupUser(event.user);
+    const userName = userInfo?.displayName ?? event.user;
+    const fullName = userInfo?.realName ?? userName;
+
     // Build reaction event
     const reactionEvent: Omit<ReactionEvent, "adapter" | "thread"> = {
       emoji: normalizedEmoji,
@@ -2313,9 +2317,9 @@ export class SlackAdapter implements Adapter<SlackThreadId, unknown> {
       added: event.type === "reaction_added",
       user: {
         userId: event.user,
-        userName: event.user, // Will be resolved below if possible
-        fullName: event.user,
-        isBot: false, // Users add reactions, not bots typically
+        userName,
+        fullName,
+        isBot: userInfo?.isBot ?? false,
         isMe,
       },
       messageId,


### PR DESCRIPTION
## Summary

Fixes Slack reaction events so `event.user.userName` and `event.user.fullName` are resolved from Slack user profile data instead of always being the raw Slack user ID.

This reuses the Slack adapter's existing cached `lookupUser()` path and falls back to the user ID when lookup fails.

Fixes #521

## Test plan

- Manually verified in Slack that `chat.onReaction()` receives the reacting user's display name in `event.user.userName` instead of the raw Slack user ID.
- Manually verified in Slack that `chat.onReaction()` receives the reacting user's real name in `event.user.fullName` instead of the raw Slack user ID.
- Manually verified that `event.user.userId` still contains the raw Slack user ID.
- `pnpm --filter @chat-adapter/slack exec vitest run src/index.test.ts -t "resolves reaction user display name|resolves parent thread_ts"`
- `pnpm --filter @chat-adapter/slack typecheck`
- `pnpm --filter @chat-adapter/slack build`
- `pnpm validate`

## Checklist

- [x] All commits are signed and verified
- [x] `pnpm validate` passes
- [x] Changeset added (or N/A — see [CONTRIBUTING.md](./CONTRIBUTING.md))
- [x] Documentation updated (or N/A)
