### PR TITLE
fix(ci): use supported node versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,7 +91,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.0.0
         with:
-          node-version: 20
+          node-version-file: .nvmrc
           cache: "pnpm"
 
       - name: Install dependencies
@@ -126,7 +126,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [20, 24]
+        node-version: [22, 24]
     name: build-and-test (Node ${{ matrix.node-version }})
     env:
       SLACK_BOT_TOKEN: xoxb-mock


### PR DESCRIPTION
## summary

updates CI jobs that install pnpm to use Node versions compatible with the current repo package manager

`Code Consistency` now follows `.nvmrc`, and the build/test matrix now runs on Node 22 and 24 instead of Node 20 and 24

this fixes the `node:sqlite` setup failure from running `pnpm@10.30.3` on Node 20