### PR TITLE
fix(gchat): collapse redundant autolink formatting for email links

### DIFF
--- a/.changeset/sour-pans-stop.md
+++ b/.changeset/sour-pans-stop.md
@@ -1,0 +1,6 @@
+---
+"@chat-adapter/gchat": patch
+---
+
+- Fix redundant mailto link rendering in Google Chat adapter
+- Google Chat adapter was emitting redundant `<mailto:...|...>` tokens when rendering autolinked email addresses. This change collapses `mailto:` URLs when the visible text equals the email address, ensuring cleaner output consistent with plain text rendering in Google Chat.

--- a/packages/adapter-gchat/src/markdown.test.ts
+++ b/packages/adapter-gchat/src/markdown.test.ts
@@ -51,9 +51,9 @@ describe("GoogleChatFormatConverter", () => {
 
     it("collapses mailto autolink for plain email text", () => {
       const ast = converter.toAst("hello@example.com");
-      
+
       const result = converter.fromAst(ast);
-      
+
       expect(result).toBe("hello@example.com");
     });
 

--- a/packages/adapter-gchat/src/markdown.test.ts
+++ b/packages/adapter-gchat/src/markdown.test.ts
@@ -49,6 +49,40 @@ describe("GoogleChatFormatConverter", () => {
       expect(result).toContain("<https://example.com|click here>");
     });
 
+    it("collapses mailto autolink for plain email text", () => {
+      const ast = converter.toAst("hello@example.com");
+      
+      const result = converter.fromAst(ast);
+      
+      expect(result).toBe("hello@example.com");
+    });
+
+    it("preserves custom label for mailto links", () => {
+      const ast = converter.toAst("[contact](mailto:hello@example.com)");
+
+      const result = converter.fromAst(ast);
+
+      expect(result).toBe("<mailto:hello@example.com|contact>");
+    });
+
+    it("formats http links correctly", () => {
+      const input = "https://example.com";
+
+      const ast = converter.toAst(input);
+      const output = converter.fromAst(ast);
+
+      expect(output).toBe("https://example.com");
+    });
+
+    it("keeps phone numbers as plain text", () => {
+      const input = "+1555123456";
+
+      const ast = converter.toAst(input);
+      const output = converter.fromAst(ast);
+
+      expect(output).toBe("+1555123456");
+    });
+
     it("should handle blockquotes", () => {
       const ast = converter.toAst("> quoted text");
       const result = converter.fromAst(ast);

--- a/packages/adapter-gchat/src/markdown.test.ts
+++ b/packages/adapter-gchat/src/markdown.test.ts
@@ -83,6 +83,14 @@ describe("GoogleChatFormatConverter", () => {
       expect(output).toBe("+1555123456");
     });
 
+    it("collapses tel autolink for plain phone text", () => {
+      const ast = converter.toAst("[+1555123456](tel:+1555123456)");
+
+      const result = converter.fromAst(ast);
+
+      expect(result).toBe("+1555123456");
+    });
+
     it("should handle blockquotes", () => {
       const ast = converter.toAst("> quoted text");
       const result = converter.fromAst(ast);

--- a/packages/adapter-gchat/src/markdown.ts
+++ b/packages/adapter-gchat/src/markdown.ts
@@ -113,6 +113,17 @@ export class GoogleChatFormatConverter extends BaseFormatConverter {
       if (linkText === node.url) {
         return node.url;
       }
+      // Collapse redundant mailto:/tel: autolinks when the visible
+      const collapsibleSchemes = ["mailto:", "tel:"];
+      for (const scheme of collapsibleSchemes) {
+        if (!node.url.startsWith(scheme)) {
+          continue;
+        }
+        const bareValue = node.url.slice(scheme.length);
+        if (bareValue === linkText) {
+          return bareValue;
+        }
+      }
       return `<${node.url}|${linkText}>`;
     }
 

--- a/packages/adapter-gchat/src/markdown.ts
+++ b/packages/adapter-gchat/src/markdown.ts
@@ -113,7 +113,6 @@ export class GoogleChatFormatConverter extends BaseFormatConverter {
       if (linkText === node.url) {
         return node.url;
       }
-      // Collapse redundant mailto:/tel: autolinks when the visible
       const collapsibleSchemes = ["mailto:", "tel:"];
       for (const scheme of collapsibleSchemes) {
         if (!node.url.startsWith(scheme)) {


### PR DESCRIPTION
## Description

Fix redundant autolink rendering for email addresses in the Google Chat adapter.

Previously, autolinked email addresses were rendered as `<mailto:...|...>` even when the visible text already matched the email address. This resulted in unnecessary verbose output. This change collapses such cases to plain text for cleaner and more consistent rendering.

While testing, it was observed that `tel:` links are not currently generated from plain phone number inputs in the existing parsing pipeline. However, support for `tel:` handling has still been added in the implementation for future compatibility as referenced in the issue.

<img width="757" height="107" alt="image" src="https://github.com/user-attachments/assets/a8ccfd6c-6669-4535-b733-5f2c185d9e2f" />


Additionally, new test cases have been added to cover email autolinks, labeled mailto links, and general markdown link behavior.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Related Issues

Fixes #516

## Changes Made

- Collapsed redundant `mailto:` autolinks when visible text matches the email address  
- Added support for `tel:` scheme handling for future compatibility  
- Updated link rendering logic in Google Chat adapter markdown converter  
- Added and updated unit tests for email and link conversion cases  

## Testing

- [x] All existing tests pass
- [x] Added new tests for the changes
- [x] Manually tested the changes

### Test Coverage

- Email autolink collapsing verified
- Custom labeled mailto links verified
- HTTP link formatting verified
- Edge cases for link conversion verified via unit tests

## Screenshots/Demos

N/A

## Checklist

- [x] My code follows the project's code style
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have created a changeset (`pnpm changeset`)

## Changeset

- [x] I have created a changeset for these changes

## Additional Notes

During testing, `tel:` links were not observed in the current markdown parsing pipeline for plain phone numbers. However, support for `tel:` has been included to align with the issue description and for future-proofing the adapter behavior.