### PR TITLE
refactor(slack): share provider helpers

### DIFF
--- a/.changeset/strict-moons-sneeze.md
+++ b/.changeset/strict-moons-sneeze.md
@@ -1,0 +1,5 @@
+---
+"@chat-adapter/slack": patch
+---
+
+reuse low-level Slack formatting helpers in the adapter

--- a/packages/adapter-slack/src/blocks/index.ts
+++ b/packages/adapter-slack/src/blocks/index.ts
@@ -1,3 +1,4 @@
+import { markdownBoldToSlackMrkdwn } from "../format";
 import { SlackBlockError } from "./errors";
 import { LIMITS } from "./limits";
 import type {
@@ -451,10 +452,6 @@ function rawText(
     text: nonemptyText(convertEmoji(text)),
     type: "raw_text",
   };
-}
-
-function markdownBoldToSlackMrkdwn(text: string): string {
-  return text.replace(/\*\*(.+?)\*\*/g, "*$1*");
 }
 
 function mapButtonStyle(

--- a/packages/adapter-slack/src/cards.ts
+++ b/packages/adapter-slack/src/cards.ts
@@ -27,6 +27,7 @@ import type {
   TextElement,
 } from "chat";
 import { cardChildToFallbackText, tableElementToAscii } from "chat";
+import { markdownBoldToSlackMrkdwn } from "./format";
 
 /**
  * Convert emoji placeholders in text to Slack format.
@@ -168,14 +169,8 @@ function convertChildToBlocks(
   }
 }
 
-/** Convert standard Markdown formatting to Slack mrkdwn */
-function markdownToMrkdwn(text: string): string {
-  // **bold** → *bold*
-  return text.replace(/\*\*(.+?)\*\*/g, "*$1*");
-}
-
 export function convertTextToBlock(element: TextElement): SlackBlock {
-  const text = markdownToMrkdwn(convertEmoji(element.content));
+  const text = markdownBoldToSlackMrkdwn(convertEmoji(element.content));
   let formattedText = text;
 
   // Apply style
@@ -437,7 +432,7 @@ export function convertFieldsToBlock(element: FieldsElement): SlackBlock {
     // Add label and value as separate field items
     fields.push({
       type: "mrkdwn",
-      text: `*${markdownToMrkdwn(convertEmoji(field.label))}*\n${markdownToMrkdwn(convertEmoji(field.value))}`,
+      text: `*${markdownBoldToSlackMrkdwn(convertEmoji(field.label))}*\n${markdownBoldToSlackMrkdwn(convertEmoji(field.value))}`,
     });
   }
 

--- a/packages/adapter-slack/src/markdown.ts
+++ b/packages/adapter-slack/src/markdown.ts
@@ -32,11 +32,9 @@ import {
   stringifyMarkdown,
   tableToAscii,
 } from "chat";
+import { linkBareSlackMentions, slackMrkdwnToMarkdown } from "./format";
 
-// Match bare @mentions (e.g. "@george") to rewrite as Slack's `<@george>`.
-// The lookbehind excludes `<` (already-formatted mentions like `<@U123>`) and
-// any word character, so email addresses like `user@example.com` are left alone.
-const BARE_MENTION_REGEX = /(?<![<\w])@(\w+)/g;
+const BARE_MENTION_PATTERN = /(?<![<\w])@(\w+)/g;
 
 export type SlackTextPayload = { text: string } | { markdown_text: string };
 
@@ -53,32 +51,7 @@ export class SlackFormatConverter extends BaseFormatConverter {
    * Parse Slack mrkdwn into an AST. Used for incoming `message` events.
    */
   toAst(mrkdwn: string): Root {
-    let markdown = mrkdwn;
-
-    // User mentions: <@U123|name> -> @name or <@U123> -> @U123
-    markdown = markdown.replace(/<@([A-Z0-9_]+)\|([^<>]+)>/g, "@$2");
-    markdown = markdown.replace(/<@([A-Z0-9_]+)>/g, "@$1");
-
-    // Channel mentions: <#C123|name> -> #name
-    markdown = markdown.replace(/<#[A-Z0-9_]+\|([^<>]+)>/g, "#$1");
-    markdown = markdown.replace(/<#([A-Z0-9_]+)>/g, "#$1");
-
-    // Links: <url|text> -> [text](url)
-    markdown = markdown.replace(
-      /<(https?:\/\/[^|<>]+)\|([^<>]+)>/g,
-      "[$2]($1)"
-    );
-
-    // Bare links: <url> -> url
-    markdown = markdown.replace(/<(https?:\/\/[^<>]+)>/g, "$1");
-
-    // Bold: *text* -> **text** (Slack uses single * for bold)
-    markdown = markdown.replace(/(?<![_*\\])\*([^*\n]+)\*(?![_*])/g, "**$1**");
-
-    // Strikethrough: ~text~ -> ~~text~~
-    markdown = markdown.replace(/(?<!~)~([^~\n]+)~(?!~)/g, "~~$1~~");
-
-    return parseMarkdown(markdown);
+    return parseMarkdown(slackMrkdwnToMarkdown(mrkdwn));
   }
 
   /**
@@ -136,7 +109,7 @@ export class SlackFormatConverter extends BaseFormatConverter {
 
   private finalize(text: string): string {
     return convertEmojiPlaceholders(
-      text.replace(BARE_MENTION_REGEX, "<@$1>"),
+      linkBareMentionNames(linkBareSlackMentions(text)),
       "slack"
     );
   }
@@ -155,7 +128,7 @@ export class SlackFormatConverter extends BaseFormatConverter {
     }
 
     if (isTextNode(node)) {
-      return node.value.replace(BARE_MENTION_REGEX, "<@$1>");
+      return linkBareMentionNames(linkBareSlackMentions(node.value));
     }
 
     if (isStrongNode(node)) {
@@ -218,4 +191,8 @@ export class SlackFormatConverter extends BaseFormatConverter {
 
     return this.defaultNodeToText(node, (child) => this.nodeToMrkdwn(child));
   }
+}
+
+function linkBareMentionNames(text: string): string {
+  return text.replace(BARE_MENTION_PATTERN, "<@$1>");
 }


### PR DESCRIPTION
## summary

reuses the low-level Slack formatting helpers inside the high-level Slack adapter without changing adapter behavior

this removes duplicated mrkdwn-to-markdown and markdown-bold conversion logic by sharing `slackMrkdwnToMarkdown`, `linkBareSlackMentions`, and `markdownBoldToSlackMrkdwn` across the format converter, card converter, and blocks subpath

the low-level mention helper remains ID-based to match Slack docs, while the high-level adapter keeps its existing bare-name mention compatibility privately