### PR TITLE
feat(chat): strict reviver that errors on missing _type

### DIFF
--- a/packages/chat/src/index.ts
+++ b/packages/chat/src/index.ts
@@ -60,7 +60,7 @@ export type {
   PostableObjectContext,
 } from "./postable-object";
 export { isPostableObject } from "./postable-object";
-export { reviver } from "./reviver";
+export { reviver, strictReviver } from "./reviver";
 export { StreamingMarkdownRenderer } from "./streaming-markdown";
 export {
   StreamingPlan,

--- a/packages/chat/src/reviver.ts
+++ b/packages/chat/src/reviver.ts
@@ -31,3 +31,53 @@ export function reviver(_key: string, value: unknown): unknown {
   }
   return value;
 }
+
+/**
+ * Strict variant of {@link reviver}. Throws when a value looks like a
+ * Thread / Channel / Message (i.e. it carries the SDK's required keys)
+ * but is missing the `_type` discriminator the standard reviver needs.
+ *
+ * Use when you construct Thread/Message references by hand and pass
+ * them through `JSON.parse(..., reviver)` — the standard reviver
+ * silently returns the literal in that case, and downstream
+ * `thread.post()` then throws "thread.post is not a function" deep
+ * inside delivery code. `strictReviver()` surfaces the mistake at
+ * the parse boundary instead.
+ *
+ * @example
+ * ```typescript
+ * const data = JSON.parse(payload, strictReviver());
+ * // throws: "[chat-sdk] reviver: object with Thread-shaped keys
+ * //          (id, channelId, isDM) is missing `_type: 'chat:Thread'`."
+ * ```
+ */
+export function strictReviver(): (key: string, value: unknown) => unknown {
+  return (key, value) => {
+    if (value && typeof value === "object" && !("_type" in value)) {
+      const o = value as Record<string, unknown>;
+      // Thread-shaped: has SerializedThread's required keys.
+      if (
+        typeof o.id === "string" &&
+        typeof o.channelId === "string" &&
+        typeof o.isDM === "boolean"
+      ) {
+        throw new Error(
+          "[chat-sdk] reviver: object with Thread-shaped keys (id, channelId, isDM) is missing `_type: 'chat:Thread'`. " +
+            `Add the discriminator or construct via ThreadImpl.fromJSON / new ThreadImpl({...}). Key: ${JSON.stringify(key)}`
+        );
+      }
+      // Message-shaped.
+      if (
+        typeof o.id === "string" &&
+        typeof o.threadId === "string" &&
+        ("text" in o || "parts" in o)
+      ) {
+        throw new Error(
+          "[chat-sdk] reviver: object with Message-shaped keys (id, threadId, text/parts) is missing `_type: 'chat:Message'`. " +
+            `Add the discriminator or construct via Message.fromJSON. Key: ${JSON.stringify(key)}`
+        );
+      }
+    }
+    return reviver(key, value);
+  };
+}


### PR DESCRIPTION
## Summary

Adds an opt-in `strictReviver()` that throws when `JSON.parse(payload, strictReviver())` encounters a Thread- or Message-shaped object missing the `_type` discriminator.

The default `reviver` silently returns the literal in that case, so a downstream `thread.post(...)` call later throws `TypeError: thread.post is not a function` deep inside delivery code — far from the actual mistake.

We hit this in production after refactoring a delivery path that used the `JSON.stringify(...) + JSON.parse(..., bot.reviver())` pattern to construct Thread refs by hand. Missing `_type` meant the reviver returned a plain object, the type assertion lied, and `.post()` blew up on first delivery. This change makes that mistake fail loud at the parse boundary instead.

## Behaviour

- `reviver` — unchanged, backward compatible.
- `strictReviver()` — wraps `reviver`. Detects Thread-shaped values (`id` + `channelId` + `isDM`) and Message-shaped values (`id` + `threadId` + `text`/`parts`) without `_type` and throws a descriptive error.

## Test plan

- [ ] Existing reviver tests still pass (no change to `reviver`).
- [ ] New test: `strictReviver()` throws on `{ id, channelId, isDM }` without `_type`.
- [ ] New test: `strictReviver()` is a no-op for properly-typed payloads.

Happy to add the tests in this PR if the direction looks right — opening as a small surface-area proposal first.