### PR TITLE
docs: use stable Teams CLI package

### DIFF
--- a/apps/docs/content/adapters/official/teams.mdx
+++ b/apps/docs/content/adapters/official/teams.mdx
@@ -133,7 +133,7 @@ The [Teams CLI](https://microsoft.github.io/teams-sdk/cli) handles AAD app regis
 ### Install the CLI
 
 ```bash
-npm install -g @microsoft/teams.cli@preview
+npm install -g @microsoft/teams.cli
 ```
 
 ### 1. Create the app

--- a/packages/adapter-teams/README.md
+++ b/packages/adapter-teams/README.md
@@ -38,7 +38,7 @@ bot.onNewMention(async (thread, message) => {
 The [Teams CLI](https://microsoft.github.io/teams-sdk/cli) handles AAD app registration, client secret generation, bot registration, and Teams channel setup in one command.
 
 ```bash
-npm install -g @microsoft/teams.cli@preview
+npm install -g @microsoft/teams.cli
 ```
 
 ### 1. Create the app


### PR DESCRIPTION
## Summary
- Updates Teams setup docs to install `@microsoft/teams.cli` instead of the old `@preview` tag.

## Why
- Teams CLI is stable now, so the docs should point folks at the stable package. Nice and tidy.

## Interesting bits
- This touches both the public docs page and the adapter README so they don't disagree.

## Test plan
- Not run; docs-only change.
