### PR TITLE
fix(slack): pass token through native stream stop

### DIFF
--- a/.changeset/tough-vans-shout.md
+++ b/.changeset/tough-vans-shout.md
@@ -1,0 +1,5 @@
+---
+"@chat-adapter/slack": patch
+---
+
+pass the Slack bot token through native stream append and stop calls

--- a/packages/adapter-slack/src/index.test.ts
+++ b/packages/adapter-slack/src/index.test.ts
@@ -7583,7 +7583,7 @@ describe("stream with empty threadTs", () => {
     ).rejects.toThrow(ValidationError);
   });
 
-  it("passes token to stop when markdown remains buffered", async () => {
+  it("passes token on stream stop", async () => {
     const adapter = createSlackAdapter({
       botToken: "xoxb-test-token",
       signingSecret: "test-signing-secret",

--- a/packages/adapter-slack/src/index.test.ts
+++ b/packages/adapter-slack/src/index.test.ts
@@ -7582,6 +7582,86 @@ describe("stream with empty threadTs", () => {
       })
     ).rejects.toThrow(ValidationError);
   });
+
+  it("passes token to stop when markdown remains buffered", async () => {
+    const adapter = createSlackAdapter({
+      botToken: "xoxb-test-token",
+      signingSecret: "test-signing-secret",
+      logger: mockLogger,
+    });
+    const append = vi.fn().mockResolvedValue(null);
+    const stop = vi.fn().mockResolvedValue({
+      ok: true,
+      ts: "1234567890.111111",
+    });
+    const chatStream = vi.fn().mockReturnValue({ append, stop });
+    mockClientMethod(adapter, "chatStream", chatStream);
+
+    async function* shortStream() {
+      yield "hello";
+    }
+
+    await adapter.stream("slack:C123:1234567890.000000", shortStream(), {
+      recipientUserId: "U123",
+      recipientTeamId: "T123",
+    });
+
+    expect(stop).toHaveBeenCalledWith(
+      expect.objectContaining({
+        token: "xoxb-test-token",
+      })
+    );
+  });
+
+  it("passes token on every stream append", async () => {
+    const adapter = createSlackAdapter({
+      botToken: "xoxb-test-token",
+      signingSecret: "test-signing-secret",
+      logger: mockLogger,
+    });
+    const append = vi.fn().mockResolvedValue({ ok: true });
+    const stop = vi.fn().mockResolvedValue({
+      ok: true,
+      ts: "1234567890.111111",
+    });
+    mockClientMethod(
+      adapter,
+      "chatStream",
+      vi.fn().mockReturnValue({ append, stop })
+    );
+
+    async function* chunkStream() {
+      yield {
+        details: "first",
+        id: "task-1",
+        status: "in_progress" as const,
+        title: "Task one",
+        type: "task_update" as const,
+      };
+      yield {
+        details: "second",
+        id: "task-2",
+        status: "in_progress" as const,
+        title: "Task two",
+        type: "task_update" as const,
+      };
+    }
+
+    await adapter.stream("slack:C123:1234567890.000000", chunkStream(), {
+      recipientUserId: "U123",
+      recipientTeamId: "T123",
+    });
+
+    expect(append).toHaveBeenCalledTimes(2);
+    expect(append).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({ token: "xoxb-test-token" })
+    );
+    expect(append).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({ token: "xoxb-test-token" })
+    );
+  });
 });
 
 describe("scheduleMessage with empty threadTs", () => {

--- a/packages/adapter-slack/src/index.ts
+++ b/packages/adapter-slack/src/index.ts
@@ -10,7 +10,7 @@ import {
   ValidationError,
 } from "@chat-adapter/shared";
 import { SocketModeClient } from "@slack/socket-mode";
-import { WebClient } from "@slack/web-api";
+import { type ChatStopStreamArguments, WebClient } from "@slack/web-api";
 import type {
   ActionEvent,
   Adapter,
@@ -3979,28 +3979,16 @@ export class SlackAdapter implements Adapter<SlackThreadId, unknown> {
       }),
     });
 
-    let first = true;
     let lastAppended = "";
     const renderer = new StreamingMarkdownRenderer({
       wrapTablesForAppend: false,
     });
 
-    /**
-     * Helper to flush markdown text delta to the stream.
-     * Handles first-append token passing and empty-delta skipping.
-     */
     const flushMarkdownDelta = async (delta: string): Promise<void> => {
       if (delta.length === 0) {
         return;
       }
-      if (first) {
-        // Pass token on first append so the streamer uses it for all subsequent calls
-        // biome-ignore lint/suspicious/noExplicitAny: ChatStreamer types don't include token
-        await streamer.append({ markdown_text: delta, token } as any);
-        first = false;
-      } else {
-        await streamer.append({ markdown_text: delta });
-      }
+      await streamer.append({ markdown_text: delta, token });
     };
 
     /**
@@ -4026,15 +4014,8 @@ export class SlackAdapter implements Adapter<SlackThreadId, unknown> {
       lastAppended = committable;
 
       try {
-        // Send the chunk directly — Slack's API accepts chunks array
-        if (first) {
-          // biome-ignore lint/suspicious/noExplicitAny: ChatStreamer types don't include token or chunks
-          await streamer.append({ chunks: [chunk], token } as any);
-          first = false;
-        } else {
-          // biome-ignore lint/suspicious/noExplicitAny: chunks not in ChatAppendStreamArguments for older @slack/web-api
-          await streamer.append({ chunks: [chunk] } as any);
-        }
+        // biome-ignore lint/suspicious/noExplicitAny: chunks not in ChatAppendStreamArguments for older @slack/web-api
+        await streamer.append({ chunks: [chunk], token } as any);
       } catch (error) {
         // Structured chunks may fail if the app doesn't have the required
         // Assistant scopes/features. Disable for the rest of this stream
@@ -4074,10 +4055,14 @@ export class SlackAdapter implements Adapter<SlackThreadId, unknown> {
     const finalDelta = finalCommittable.slice(lastAppended.length);
     await flushMarkdownDelta(finalDelta);
 
-    const result = await streamer.stop(
-      // biome-ignore lint/suspicious/noExplicitAny: stopBlocks are platform-specific Block Kit elements
-      options?.stopBlocks ? { blocks: options.stopBlocks as any[] } : undefined
-    );
+    const result = await streamer.stop({
+      token,
+      ...(options?.stopBlocks
+        ? {
+            blocks: options.stopBlocks as ChatStopStreamArguments["blocks"],
+          }
+        : {}),
+    });
     const messageTs = (result.message?.ts ?? result.ts) as string;
 
     this.logger.debug("Slack: stream complete", { messageId: messageTs });


### PR DESCRIPTION
## summary

fixes #570

fixes Slack native streaming when the stream reaches `stop()` before a token-bearing append has flushed

`SlackAdapter.stream()` now passes the resolved bot token on every `streamer.append()` and on `streamer.stop()`, matching Slack's auth requirements and avoiding `not_authed` responses from `chat.startStream` / `chat.stopStream`

adds regression coverage for buffered markdown streams and repeated structured chunk appends