### PR TITLE
fix(slack): return uploaded file ids from postMessage

### DIFF
--- a/.changeset/itchy-wolves-jump.md
+++ b/.changeset/itchy-wolves-jump.md
@@ -1,0 +1,5 @@
+---
+"@chat-adapter/slack": patch
+---
+
+surface Slack file upload confirmation ids in postMessage results

--- a/packages/adapter-slack/src/index.test.ts
+++ b/packages/adapter-slack/src/index.test.ts
@@ -3918,7 +3918,10 @@ describe("postMessage", () => {
     mockClientMethod(
       adapter,
       "files.uploadV2",
-      vi.fn().mockResolvedValue({ ok: true })
+      vi.fn().mockResolvedValue({
+        files: [{ files: [{ id: "F123" }] }],
+        ok: true,
+      })
     );
 
     const chatPostMessage = vi.fn();
@@ -3930,7 +3933,48 @@ describe("postMessage", () => {
     } as AdapterPostableMessage);
 
     expect(result.id).toMatch(FILE_ID_PATTERN);
+    expect(result.raw).toEqual({
+      files: [{ data: Buffer.from("hello"), filename: "test.txt" }],
+      uploadedFileIds: ["F123"],
+    });
     expect(chatPostMessage).not.toHaveBeenCalled();
+  });
+
+  it("adds uploaded file ids to text posts with files", async () => {
+    const adapter = createSlackAdapter({
+      botToken: "xoxb-test-token",
+      signingSecret: "test-signing-secret",
+      logger: mockLogger,
+    });
+
+    mockClientMethod(
+      adapter,
+      "files.uploadV2",
+      vi.fn().mockResolvedValue({
+        files: [{ files: [{ id: "F123" }, { id: "F456" }] }],
+        ok: true,
+      })
+    );
+    mockClientMethod(
+      adapter,
+      "chat.postMessage",
+      vi.fn().mockResolvedValue({ ok: true, ts: "1234567890.999999" })
+    );
+
+    const result = await adapter.postMessage("slack:C123:1234567890.000000", {
+      markdown: "uploaded files",
+      files: [
+        { data: Buffer.from("one"), filename: "one.txt" },
+        { data: Buffer.from("two"), filename: "two.txt" },
+      ],
+    } as AdapterPostableMessage);
+
+    expect(result.id).toBe("1234567890.999999");
+    expect(result.raw).toEqual({
+      ok: true,
+      ts: "1234567890.999999",
+      uploadedFileIds: ["F123", "F456"],
+    });
   });
 });
 

--- a/packages/adapter-slack/src/index.ts
+++ b/packages/adapter-slack/src/index.ts
@@ -3123,11 +3123,13 @@ export class SlackAdapter implements Adapter<SlackThreadId, unknown> {
     const threadTs = rawThreadTs || undefined;
 
     try {
+      let uploadedFileIds: string[] | undefined;
+
       // Check for files to upload
       const files = extractFiles(message);
       if (files.length > 0) {
         // Upload files first (they're shared to the channel automatically)
-        await this.uploadFiles(files, channel, threadTs);
+        uploadedFileIds = await this.uploadFiles(files, channel, threadTs);
 
         // If message only has files (no text/card), return early
         const hasText =
@@ -3144,7 +3146,7 @@ export class SlackAdapter implements Adapter<SlackThreadId, unknown> {
           return {
             id: `file-${Date.now()}`,
             threadId,
-            raw: { files },
+            raw: { files, uploadedFileIds },
           };
         }
       }
@@ -3182,7 +3184,10 @@ export class SlackAdapter implements Adapter<SlackThreadId, unknown> {
         return {
           id: result.ts as string,
           threadId,
-          raw: result,
+          raw:
+            uploadedFileIds === undefined
+              ? result
+              : { ...result, uploadedFileIds },
         };
       }
 
@@ -3212,7 +3217,10 @@ export class SlackAdapter implements Adapter<SlackThreadId, unknown> {
       return {
         id: result.ts as string,
         threadId,
-        raw: result,
+        raw:
+          uploadedFileIds === undefined
+            ? result
+            : { ...result, uploadedFileIds },
       };
     } catch (error) {
       this.handleSlackError(error);


### PR DESCRIPTION
## summary

fixes #564

preserves Slack `files.uploadV2` confirmation IDs on `postMessage` results when a message includes uploaded files

file-only Slack posts now keep the existing synthetic raw payload and add `uploadedFileIds`, while text/card posts with files augment the normal `chat.postMessage` raw response with the same IDs

this lets callers confirm which files Slack accepted without replacing existing `raw` data