### PR TITLE
fix(docs): allow Velt adapter examples

### DIFF
--- a/packages/integration-tests/src/docs-adapters.test.ts
+++ b/packages/integration-tests/src/docs-adapters.test.ts
@@ -118,6 +118,7 @@ describe("Vendor-Official adapter MDX", () => {
         "liveblocks",
         "matrix",
         "resend",
+        "velt",
         "zernio",
       ].sort()
     );

--- a/packages/integration-tests/src/documentation-test-utils.ts
+++ b/packages/integration-tests/src/documentation-test-utils.ts
@@ -98,6 +98,7 @@ export const VALID_DOC_PACKAGES = [
   "chat-adapter-imessage",
   "@liveblocks/chat-sdk-adapter",
   "@resend/chat-sdk-adapter",
+  "@veltdev/chat-sdk-adapter",
   "@zernio/chat-sdk-adapter",
   "@agentphone/chat-sdk-adapter",
   "chat-adapter-baileys",


### PR DESCRIPTION
## summary

fixes the release-blocking docs validation failures from the Velt vendor-official adapter page

this updates the docs integration-test allowlists so `velt` is an expected vendor-official adapter slug and `@veltdev/chat-sdk-adapter` is accepted in docs code examples

no changeset needed because this only updates test expectations for existing docs content
