### PR TITLE
feat(docs): add JSON-LD structured data to adapter pages

### DIFF
--- a/apps/docs/app/[lang]/(home)/page.tsx
+++ b/apps/docs/app/[lang]/(home)/page.tsx
@@ -95,7 +95,7 @@ const jsonLd = {
   codeRepository: "https://github.com/vercel/chat",
   programmingLanguage: "TypeScript",
   runtimePlatform: "Node.js",
-  license: "https://opensource.org/licenses/Apache-2.0",
+  license: "https://opensource.org/licenses/MIT",
   author: {
     "@type": "Organization",
     name: "Vercel",

--- a/apps/docs/app/[lang]/adapters/(detail)/community/[slug]/page.tsx
+++ b/apps/docs/app/[lang]/adapters/(detail)/community/[slug]/page.tsx
@@ -8,6 +8,7 @@ import { FeatureSupport } from "@/components/geistdocs/feature-support";
 import { getMDXComponents } from "@/components/geistdocs/mdx-components";
 import { Upsell } from "@/components/geistdocs/upsell";
 import type { AdapterFeatureValue } from "@/lib/adapter-features";
+import { getAdapterJsonLd } from "@/lib/geistdocs/adapter-jsonld";
 import {
   type Adapter,
   getAdapter,
@@ -99,6 +100,14 @@ const Page = async ({ params }: { params: Promise<PageParams> }) => {
   const data = page.data as unknown as AdapterFrontmatter;
   const adapter = getAdapter(slug);
   const markdownPath = `/adapters/community/${slug}.md`;
+  const jsonLd = getAdapterJsonLd({
+    adapter,
+    group: "community",
+    packageName: data.packageName,
+    slug,
+    tagline: data.tagline,
+    title: data.title,
+  });
   const useMdxBody = data.mdxBody === true;
   let readme: string | undefined;
   if (!useMdxBody && adapter) {
@@ -158,6 +167,11 @@ const Page = async ({ params }: { params: Promise<PageParams> }) => {
       toc={page.data.toc}
     >
       <DocsBody>
+        <script
+          // biome-ignore lint/security/noDangerouslySetInnerHtml: static JSON-LD, not user input
+          dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
+          type="application/ld+json"
+        />
         {/* biome-ignore lint/a11y/useAnchorContent: intentionally aria-hidden hint surfacing the markdown URL for AI/LLM crawlers, not for screen readers */}
         <a
           aria-hidden="true"

--- a/apps/docs/app/[lang]/adapters/(detail)/official/[slug]/page.tsx
+++ b/apps/docs/app/[lang]/adapters/(detail)/official/[slug]/page.tsx
@@ -7,6 +7,8 @@ import { FeatureSupport } from "@/components/geistdocs/feature-support";
 import { getMDXComponents } from "@/components/geistdocs/mdx-components";
 import { Upsell } from "@/components/geistdocs/upsell";
 import type { AdapterFeatureValue } from "@/lib/adapter-features";
+import { getAdapterJsonLd } from "@/lib/geistdocs/adapter-jsonld";
+import { getAdapter } from "@/lib/geistdocs/adapter-readme";
 import { adaptersSource } from "@/lib/geistdocs/adapters-source";
 
 interface AdapterFrontmatter {
@@ -46,6 +48,14 @@ const Page = async ({ params }: { params: Promise<PageParams> }) => {
   const data = page.data as unknown as AdapterFrontmatter;
   const MDX = page.data.body;
   const markdownPath = `/adapters/official/${slug}.md`;
+  const jsonLd = getAdapterJsonLd({
+    adapter: getAdapter(slug),
+    group: "official",
+    packageName: data.packageName,
+    slug,
+    tagline: data.tagline,
+    title: data.title,
+  });
   const BoundFeatureSupport = renderBoundFeatureSupport(
     data.features,
     data.type
@@ -65,6 +75,11 @@ const Page = async ({ params }: { params: Promise<PageParams> }) => {
       toc={page.data.toc}
     >
       <DocsBody>
+        <script
+          // biome-ignore lint/security/noDangerouslySetInnerHtml: static JSON-LD, not user input
+          dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
+          type="application/ld+json"
+        />
         {/* biome-ignore lint/a11y/useAnchorContent: intentionally aria-hidden hint surfacing the markdown URL for AI/LLM crawlers, not for screen readers */}
         <a
           aria-hidden="true"

--- a/apps/docs/app/[lang]/adapters/(detail)/vendor-official/[slug]/page.tsx
+++ b/apps/docs/app/[lang]/adapters/(detail)/vendor-official/[slug]/page.tsx
@@ -7,6 +7,7 @@ import { FeatureSupport } from "@/components/geistdocs/feature-support";
 import { getMDXComponents } from "@/components/geistdocs/mdx-components";
 import { Upsell } from "@/components/geistdocs/upsell";
 import type { AdapterFeatureValue } from "@/lib/adapter-features";
+import { getAdapterJsonLd } from "@/lib/geistdocs/adapter-jsonld";
 import {
   type Adapter,
   getAdapter,
@@ -91,6 +92,14 @@ const Page = async ({ params }: { params: Promise<PageParams> }) => {
   const data = page.data as unknown as AdapterFrontmatter;
   const adapter = getAdapter(slug);
   const markdownPath = `/adapters/vendor-official/${slug}.md`;
+  const jsonLd = getAdapterJsonLd({
+    adapter,
+    group: "vendor-official",
+    packageName: data.packageName,
+    slug,
+    tagline: data.tagline,
+    title: data.title,
+  });
   const useMdxBody = data.mdxBody === true;
   let readme: string | undefined;
   if (!useMdxBody && adapter) {
@@ -150,6 +159,11 @@ const Page = async ({ params }: { params: Promise<PageParams> }) => {
       toc={page.data.toc}
     >
       <DocsBody>
+        <script
+          // biome-ignore lint/security/noDangerouslySetInnerHtml: static JSON-LD, not user input
+          dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
+          type="application/ld+json"
+        />
         {/* biome-ignore lint/a11y/useAnchorContent: intentionally aria-hidden hint surfacing the markdown URL for AI/LLM crawlers, not for screen readers */}
         <a
           aria-hidden="true"

--- a/apps/docs/lib/geistdocs/adapter-jsonld.ts
+++ b/apps/docs/lib/geistdocs/adapter-jsonld.ts
@@ -1,0 +1,73 @@
+import { type Adapter, getAuthor } from "./adapter-readme";
+
+const BASE_URL = "https://chat-sdk.dev";
+
+type AdapterGroup = "official" | "community" | "vendor-official";
+
+const VERCEL_AUTHOR = {
+  "@type": "Organization",
+  name: "Vercel",
+  url: "https://vercel.com",
+};
+
+interface AdapterJsonLdInput {
+  adapter?: Adapter;
+  group: AdapterGroup;
+  packageName: string;
+  slug: string;
+  tagline: string;
+  title: string;
+}
+
+/**
+ * Build JSON-LD for an adapter detail page: a `SoftwareSourceCode` node
+ * describing the adapter package and a `BreadcrumbList` for the page's
+ * position in the site hierarchy.
+ */
+export const getAdapterJsonLd = ({
+  adapter,
+  group,
+  packageName,
+  slug,
+  tagline,
+  title,
+}: AdapterJsonLdInput) => {
+  const pageUrl = `${BASE_URL}/adapters/${group}/${slug}`;
+  const authorName = adapter ? getAuthor(adapter) : undefined;
+  const author =
+    group === "official" || !authorName
+      ? VERCEL_AUTHOR
+      : { "@type": "Organization", name: authorName };
+
+  const softwareSourceCode = {
+    "@context": "https://schema.org",
+    "@type": "SoftwareSourceCode",
+    name: packageName,
+    description: tagline,
+    url: pageUrl,
+    programmingLanguage: "TypeScript",
+    runtimePlatform: "Node.js",
+    author,
+    ...(adapter?.readme ? { codeRepository: adapter.readme } : {}),
+    ...(group === "official"
+      ? { license: "https://opensource.org/licenses/Apache-2.0" }
+      : {}),
+  };
+
+  const breadcrumb = {
+    "@context": "https://schema.org",
+    "@type": "BreadcrumbList",
+    itemListElement: [
+      { "@type": "ListItem", position: 1, name: "Chat SDK", item: BASE_URL },
+      {
+        "@type": "ListItem",
+        position: 2,
+        name: "Adapters",
+        item: `${BASE_URL}/adapters`,
+      },
+      { "@type": "ListItem", position: 3, name: title, item: pageUrl },
+    ],
+  };
+
+  return [softwareSourceCode, breadcrumb];
+};

--- a/apps/docs/lib/geistdocs/adapter-jsonld.ts
+++ b/apps/docs/lib/geistdocs/adapter-jsonld.ts
@@ -34,10 +34,16 @@ export const getAdapterJsonLd = ({
 }: AdapterJsonLdInput) => {
   const pageUrl = `${BASE_URL}/adapters/${group}/${slug}`;
   const authorName = adapter ? getAuthor(adapter) : undefined;
-  const author =
-    group === "official" || !authorName
-      ? VERCEL_AUTHOR
-      : { "@type": "Organization", name: authorName };
+
+  // Only official adapters are authored by Vercel. Community/vendor-official
+  // adapters use their declared author, and omit the field entirely when none
+  // is declared — never fall back to Vercel.
+  let author: Record<string, string> | undefined;
+  if (group === "official") {
+    author = VERCEL_AUTHOR;
+  } else if (authorName) {
+    author = { "@type": "Organization", name: authorName };
+  }
 
   const softwareSourceCode = {
     "@context": "https://schema.org",
@@ -47,7 +53,7 @@ export const getAdapterJsonLd = ({
     url: pageUrl,
     programmingLanguage: "TypeScript",
     runtimePlatform: "Node.js",
-    author,
+    ...(author ? { author } : {}),
     ...(adapter?.readme ? { codeRepository: adapter.readme } : {}),
     ...(group === "official"
       ? { license: "https://opensource.org/licenses/Apache-2.0" }

--- a/apps/docs/lib/geistdocs/adapter-jsonld.ts
+++ b/apps/docs/lib/geistdocs/adapter-jsonld.ts
@@ -56,7 +56,7 @@ export const getAdapterJsonLd = ({
     ...(author ? { author } : {}),
     ...(adapter?.readme ? { codeRepository: adapter.readme } : {}),
     ...(group === "official"
-      ? { license: "https://opensource.org/licenses/Apache-2.0" }
+      ? { license: "https://opensource.org/licenses/MIT" }
       : {}),
   };
 


### PR DESCRIPTION
Adds Schema.org JSON-LD to every adapter detail page (official, community, vendor-official):

- `SoftwareSourceCode` describing the package — name (package), description (tagline), repository, `programmingLanguage: TypeScript`, `runtimePlatform: Node.js`, and author (Vercel for official adapters, the vendor/community author otherwise). License is only emitted for official adapters; no fabricated ratings/offers.
- `BreadcrumbList` for the `Chat SDK › Adapters › <name>` hierarchy.

Built from existing frontmatter + `adapters.json` via a shared `getAdapterJsonLd` helper, injected with the same `<script type="application/ld+json">` pattern already used on the home page. Primarily a classic-SEO/rich-result and entity-linking improvement, complementing the markdown/llms.txt AEO work.