### PR TITLE
docs(chat): clarify isMe semantics for adapter authors

### DIFF
--- a/apps/docs/content/docs/api/message.mdx
+++ b/apps/docs/content/docs/api/message.mdx
@@ -90,7 +90,11 @@ import { Message } from "chat";
 
 ### How `isMe` works
 
-Each adapter detects whether a message came from the bot itself. The detection logic varies by platform:
+Each adapter detects whether a message came from the bot itself. Chat SDK filters `isMe: true` messages before handlers run so bot replies do not loop back into `onNewMessage`, `onNewMention`, or subscribed-thread handlers.
+
+`isMe` means "sent by this bot/runtime", not "sent by the authenticated user or account". For adapters backed by a user-owned account, do not blindly map platform fields like `fromMe` to `isMe`. Only set `isMe: true` for messages the adapter sent itself. If the platform echoes sent messages back through the webhook, track sent message IDs and mark only those echoes as `isMe: true`.
+
+The detection logic varies by platform:
 
 | Platform | Detection method |
 |----------|-----------------|

--- a/apps/docs/content/docs/contributing/building.mdx
+++ b/apps/docs/content/docs/contributing/building.mdx
@@ -339,6 +339,8 @@ async handleWebhook(
 
 Convert the raw platform message into a normalized `Message` instance. The `author` fields use `userId` and `userName`, and `isBot` accepts `boolean | "unknown"`. Include a `metadata` object with `dateSent` and `edited` instead of a top-level `createdAt`.
 
+Set `author.isMe` only when the message was sent by this adapter runtime and should be ignored by Chat SDK's handler dispatch. Do not map a platform "sent from my account" flag directly to `isMe` unless that account is the bot identity. For user-owned account adapters, keep user-authored messages as `isMe: false` and track message IDs returned by `postMessage`; if the platform echoes one of those IDs through the webhook, mark that echo as `isMe: true` and `isBot: true`.
+
 ```typescript title="src/adapter.ts" lineNumbers
 parseMessage(raw: unknown): Message<unknown> {
   const payload = raw as Record<string, unknown>;

--- a/packages/chat/src/types.ts
+++ b/packages/chat/src/types.ts
@@ -1427,7 +1427,7 @@ export interface Author {
   fullName: string;
   /** Whether the author is a bot */
   isBot: boolean | "unknown";
-  /** Whether the author is this bot */
+  /** Whether this message was sent by this bot/runtime */
   isMe: boolean;
   /** Unique user ID */
   userId: string;


### PR DESCRIPTION
## summary

clarifies that `author.isMe` means the message was sent by the current bot runtime and should be filtered from handler dispatch

documents that adapters backed by user-owned accounts should not map platform fields like `fromMe` directly to `isMe`

recommends tracking message ids returned by `postMessage` so webhook echoes can be identified without filtering legitimate user-authored messages