### PR TITLE
docs: list QQ Bot community adapter

### DIFF
--- a/apps/docs/adapters.json
+++ b/apps/docs/adapters.json
@@ -170,6 +170,16 @@
     "readme": "https://github.com/DivyanshGolyan/chat-state-mysql/tree/26502f2c43e2aee16b0b58f2066a81e01b2c289b"
   },
   {
+    "name": "QQ Bot",
+    "slug": "qq-bot",
+    "type": "platform",
+    "community": true,
+    "description": "Community QQ Bot adapter for Chat SDK with OpenAPI v2 webhooks, Gateway WebSocket events, c2c messaging, buttons, rich media, and live verification tooling.",
+    "packageName": "@youglin/adapter-qq-bot",
+    "author": "YougLin",
+    "readme": "https://github.com/YougLin-dev/adapter-qq-bot/tree/46e76e8e6965d5dc1ee1446bbea76feb23cf7733"
+  },
+  {
     "name": "Liveblocks",
     "slug": "liveblocks",
     "type": "platform",


### PR DESCRIPTION
## Summary

- Add the QQ Bot community platform adapter to `apps/docs/adapters.json`
- Point the listing at the published npm package `@youglin/adapter-qq-bot`
- Pin the rendered README to the adapter repository commit `46e76e8e6965d5dc1ee1446bbea76feb23cf7733`

## Verification

- Parsed `apps/docs/adapters.json` and checked unique `slug` / `packageName` values
- Verified the `readme` field is pinned to a 40-character commit SHA
- Verified GitHub API can fetch `README.md` at the pinned adapter commit
