### PR TITLE
feat(telegram): support slash commands

### DIFF
--- a/.changeset/new-walls-turn.md
+++ b/.changeset/new-walls-turn.md
@@ -1,0 +1,5 @@
+---
+"@chat-adapter/telegram": minor
+---
+
+Add support for routing Telegram bot commands to Chat SDK slash command handlers

--- a/apps/docs/content/adapters/official/telegram.mdx
+++ b/apps/docs/content/adapters/official/telegram.mdx
@@ -34,7 +34,7 @@ features:
   fields: yes
   imagesInCards: no
   modals: no
-  slashCommands: no
+  slashCommands: yes
   mentions: yes
   addReactions: yes
   removeReactions: yes
@@ -183,6 +183,10 @@ const telegram = createTelegramAdapter({ mode: "auto" });
 void bot.initialize();
 console.log(telegram.runtimeMode); // "webhook" | "polling"
 ```
+
+### Slash commands
+
+Use `bot.onSlashCommand` to handle Telegram bot commands such as `/status` and `/status@mybot`. Commands addressed to another bot are ignored.
 
 ### Markdown formatting
 

--- a/apps/docs/content/adapters/official/telegram.mdx
+++ b/apps/docs/content/adapters/official/telegram.mdx
@@ -186,7 +186,7 @@ console.log(telegram.runtimeMode); // "webhook" | "polling"
 
 ### Slash commands
 
-Use `bot.onSlashCommand` to handle Telegram bot commands such as `/status` and `/status@mybot`. Commands addressed to another bot are ignored.
+Use `bot.onSlashCommand` to handle Telegram bot commands such as `/status` and `/status@mybot`. Commands addressed to another bot are ignored as slash commands and continue through the normal message path.
 
 ### Markdown formatting
 

--- a/apps/docs/content/docs/slash-commands.mdx
+++ b/apps/docs/content/docs/slash-commands.mdx
@@ -8,11 +8,12 @@ related:
   - /docs/modals
   - /adapters/official/slack
   - /adapters/official/discord
+  - /adapters/official/telegram
 ---
 
 Slash commands let users invoke your bot with `/command` syntax. Register handlers with `onSlashCommand` to respond.
 
-Slash commands are supported on [Slack](/adapters/official/slack) and [Discord](/adapters/official/discord).
+Slash commands are supported on [Slack](/adapters/official/slack), [Discord](/adapters/official/discord), and [Telegram](/adapters/official/telegram).
 
 ## Handle a specific command
 
@@ -111,6 +112,10 @@ bot.onModalSubmit("feedback_form", async (event) => {
   }
 });
 ```
+
+## Telegram
+
+Telegram supports bot commands such as `/status` and `/status@mybot`. Register handlers with `onSlashCommand`; commands addressed to another bot are ignored.
 
 ## Discord
 

--- a/apps/docs/content/docs/slash-commands.mdx
+++ b/apps/docs/content/docs/slash-commands.mdx
@@ -115,7 +115,7 @@ bot.onModalSubmit("feedback_form", async (event) => {
 
 ## Telegram
 
-Telegram supports bot commands such as `/status` and `/status@mybot`. Register handlers with `onSlashCommand`; commands addressed to another bot are ignored.
+Telegram supports bot commands such as `/status` and `/status@mybot`. Register handlers with `onSlashCommand`; commands addressed to another bot are ignored as slash commands and continue through the normal message path.
 
 ## Discord
 

--- a/packages/adapter-telegram/src/index.test.ts
+++ b/packages/adapter-telegram/src/index.test.ts
@@ -403,6 +403,69 @@ describe("TelegramAdapter", () => {
     expect(event.user).toMatchObject({ fullName: "User", userId: "456" });
   });
 
+  it("routes bot command captions to slash command handlers", async () => {
+    mockFetch.mockResolvedValueOnce(
+      telegramOk({
+        id: 999,
+        is_bot: true,
+        first_name: "Bot",
+        username: "mybot",
+      })
+    );
+
+    const adapter = createTelegramAdapter({
+      botToken: "token",
+      mode: "webhook",
+      logger: mockLogger,
+      userName: "mybot",
+    });
+
+    const chat = createMockChat();
+    await adapter.initialize(chat);
+
+    const request = new Request("https://example.com/webhook", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        update_id: 3,
+        message: sampleMessage({
+          caption: "/ping hello world",
+          text: undefined,
+          caption_entities: [
+            { type: "bot_command", offset: 0, length: 5 },
+          ],
+          photo: [
+            {
+              file_id: "photo-1",
+              file_unique_id: "photo-unique-1",
+              height: 100,
+              width: 100,
+            },
+          ],
+        }),
+      }),
+    });
+
+    const response = await adapter.handleWebhook(request);
+    expect(response.status).toBe(200);
+
+    const processSlashCommand = chat.processSlashCommand as ReturnType<
+      typeof vi.fn
+    >;
+    expect(processSlashCommand).toHaveBeenCalledTimes(1);
+    expect(chat.processMessage).not.toHaveBeenCalled();
+
+    const [event] = processSlashCommand.mock.calls[0] as [
+      {
+        command: string;
+        text: string;
+      },
+    ];
+
+    expect(event.command).toBe("/ping");
+    expect(event.text).toBe("hello world");
+  });
+
   it("ignores bot commands addressed to another bot", async () => {
     mockFetch.mockResolvedValueOnce(
       telegramOk({

--- a/packages/adapter-telegram/src/index.test.ts
+++ b/packages/adapter-telegram/src/index.test.ts
@@ -347,6 +347,140 @@ describe("TelegramAdapter", () => {
     expect(parsedMessage.isMention).toBe(true);
   });
 
+  it("routes bot command messages to slash command handlers", async () => {
+    mockFetch.mockResolvedValueOnce(
+      telegramOk({
+        id: 999,
+        is_bot: true,
+        first_name: "Bot",
+        username: "mybot",
+      })
+    );
+
+    const adapter = createTelegramAdapter({
+      botToken: "token",
+      mode: "webhook",
+      logger: mockLogger,
+      userName: "mybot",
+    });
+
+    const chat = createMockChat();
+    await adapter.initialize(chat);
+
+    const request = new Request("https://example.com/webhook", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        update_id: 2,
+        message: sampleMessage({
+          text: "/ping@mybot hello world",
+          entities: [{ type: "bot_command", offset: 0, length: 11 }],
+        }),
+      }),
+    });
+
+    const response = await adapter.handleWebhook(request);
+    expect(response.status).toBe(200);
+
+    const processSlashCommand = chat.processSlashCommand as ReturnType<
+      typeof vi.fn
+    >;
+    expect(processSlashCommand).toHaveBeenCalledTimes(1);
+    expect(chat.processMessage).not.toHaveBeenCalled();
+
+    const [event] = processSlashCommand.mock.calls[0] as [
+      {
+        channelId: string;
+        command: string;
+        text: string;
+        user?: { fullName?: string; userId: string };
+      },
+    ];
+
+    expect(event.channelId).toBe("telegram:123");
+    expect(event.command).toBe("/ping");
+    expect(event.text).toBe("hello world");
+    expect(event.user).toMatchObject({ fullName: "User", userId: "456" });
+  });
+
+  it("ignores bot commands addressed to another bot", async () => {
+    mockFetch.mockResolvedValueOnce(
+      telegramOk({
+        id: 999,
+        is_bot: true,
+        first_name: "Bot",
+        username: "mybot",
+      })
+    );
+
+    const adapter = createTelegramAdapter({
+      botToken: "token",
+      mode: "webhook",
+      logger: mockLogger,
+      userName: "mybot",
+    });
+
+    const chat = createMockChat();
+    await adapter.initialize(chat);
+
+    const request = new Request("https://example.com/webhook", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        update_id: 3,
+        message: sampleMessage({
+          text: "/ping@otherbot hello world",
+          entities: [{ type: "bot_command", offset: 0, length: 14 }],
+        }),
+      }),
+    });
+
+    const response = await adapter.handleWebhook(request);
+    expect(response.status).toBe(200);
+
+    expect(chat.processSlashCommand).not.toHaveBeenCalled();
+    expect(chat.processMessage).toHaveBeenCalledTimes(1);
+  });
+
+  it("only treats leading bot command entities as slash commands", async () => {
+    mockFetch.mockResolvedValueOnce(
+      telegramOk({
+        id: 999,
+        is_bot: true,
+        first_name: "Bot",
+        username: "mybot",
+      })
+    );
+
+    const adapter = createTelegramAdapter({
+      botToken: "token",
+      mode: "webhook",
+      logger: mockLogger,
+      userName: "mybot",
+    });
+
+    const chat = createMockChat();
+    await adapter.initialize(chat);
+
+    const request = new Request("https://example.com/webhook", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        update_id: 4,
+        message: sampleMessage({
+          text: "please /ping",
+          entities: [{ type: "bot_command", offset: 7, length: 5 }],
+        }),
+      }),
+    });
+
+    const response = await adapter.handleWebhook(request);
+    expect(response.status).toBe(200);
+
+    expect(chat.processSlashCommand).not.toHaveBeenCalled();
+    expect(chat.processMessage).toHaveBeenCalledTimes(1);
+  });
+
   it("rejects webhook requests with invalid secret token", async () => {
     const adapter = createTelegramAdapter({
       botToken: "token",

--- a/packages/adapter-telegram/src/index.test.ts
+++ b/packages/adapter-telegram/src/index.test.ts
@@ -431,9 +431,7 @@ describe("TelegramAdapter", () => {
         message: sampleMessage({
           caption: "/ping hello world",
           text: undefined,
-          caption_entities: [
-            { type: "bot_command", offset: 0, length: 5 },
-          ],
+          caption_entities: [{ type: "bot_command", offset: 0, length: 5 }],
           photo: [
             {
               file_id: "photo-1",

--- a/packages/adapter-telegram/src/index.ts
+++ b/packages/adapter-telegram/src/index.ts
@@ -634,11 +634,17 @@ export class TelegramAdapter
   protected parseSlashCommand(
     telegramMessage: TelegramMessage
   ): { command: string; text: string } | null {
-    if (!telegramMessage.text) {
+    const hasText = telegramMessage.text !== undefined;
+    const text = hasText ? telegramMessage.text : telegramMessage.caption;
+    const entities = hasText
+      ? telegramMessage.entities ?? []
+      : telegramMessage.caption_entities ?? [];
+
+    if (!text) {
       return null;
     }
 
-    const commandEntity = (telegramMessage.entities ?? []).find(
+    const commandEntity = entities.find(
       (entity) => entity.type === "bot_command" && entity.offset === 0
     );
 
@@ -646,7 +652,7 @@ export class TelegramAdapter
       return null;
     }
 
-    const rawCommand = this.entityText(telegramMessage.text, commandEntity);
+    const rawCommand = this.entityText(text, commandEntity);
     if (!rawCommand.startsWith("/")) {
       return null;
     }
@@ -670,7 +676,7 @@ export class TelegramAdapter
 
     return {
       command: `/${commandName}`,
-      text: telegramMessage.text
+      text: text
         .slice(commandEntity.offset + commandEntity.length)
         .trimStart(),
     };

--- a/packages/adapter-telegram/src/index.ts
+++ b/packages/adapter-telegram/src/index.ts
@@ -559,7 +559,11 @@ export class TelegramAdapter
       update.channel_post ??
       update.edited_channel_post;
 
-    if (messageUpdate) {
+    const handledSlashCommand =
+      update.message !== undefined &&
+      this.handleSlashCommandUpdate(update.message, options);
+
+    if (messageUpdate && !handledSlashCommand) {
       this.handleIncomingMessageUpdate(messageUpdate, options);
     }
 
@@ -589,6 +593,87 @@ export class TelegramAdapter
     this.cacheMessage(parsedMessage);
 
     this.chat.processMessage(this, threadId, parsedMessage, options);
+  }
+
+  protected handleSlashCommandUpdate(
+    telegramMessage: TelegramMessage,
+    options?: WebhookOptions
+  ): boolean {
+    if (!this.chat) {
+      return false;
+    }
+
+    const slashCommand = this.parseSlashCommand(telegramMessage);
+    if (!slashCommand) {
+      return false;
+    }
+
+    const threadId = this.encodeThreadId({
+      chatId: String(telegramMessage.chat.id),
+      messageThreadId: telegramMessage.message_thread_id,
+    });
+
+    const parsedMessage = this.parseTelegramMessage(telegramMessage, threadId);
+    this.cacheMessage(parsedMessage);
+
+    this.chat.processSlashCommand(
+      {
+        adapter: this,
+        channelId: threadId,
+        command: slashCommand.command,
+        text: slashCommand.text,
+        user: parsedMessage.author,
+        raw: telegramMessage,
+      },
+      options
+    );
+
+    return true;
+  }
+
+  protected parseSlashCommand(
+    telegramMessage: TelegramMessage
+  ): { command: string; text: string } | null {
+    if (!telegramMessage.text) {
+      return null;
+    }
+
+    const commandEntity = (telegramMessage.entities ?? []).find(
+      (entity) => entity.type === "bot_command" && entity.offset === 0
+    );
+
+    if (!commandEntity) {
+      return null;
+    }
+
+    const rawCommand = this.entityText(telegramMessage.text, commandEntity);
+    if (!rawCommand.startsWith("/")) {
+      return null;
+    }
+
+    const commandWithoutSlash = rawCommand.slice(1);
+    const atIndex = commandWithoutSlash.indexOf("@");
+    const commandName =
+      atIndex === -1
+        ? commandWithoutSlash
+        : commandWithoutSlash.slice(0, atIndex);
+    const targetBot =
+      atIndex === -1 ? undefined : commandWithoutSlash.slice(atIndex + 1);
+
+    if (!commandName) {
+      return null;
+    }
+
+    if (targetBot && targetBot.toLowerCase() !== this.userName.toLowerCase()) {
+      return null;
+    }
+
+    return {
+      command: `/${commandName}`,
+      text: telegramMessage.text
+        .slice(commandEntity.offset + commandEntity.length)
+        .trimStart(),
+    };
   }
 
   protected handleCallbackQuery(

--- a/packages/adapter-telegram/src/index.ts
+++ b/packages/adapter-telegram/src/index.ts
@@ -637,8 +637,8 @@ export class TelegramAdapter
     const hasText = telegramMessage.text !== undefined;
     const text = hasText ? telegramMessage.text : telegramMessage.caption;
     const entities = hasText
-      ? telegramMessage.entities ?? []
-      : telegramMessage.caption_entities ?? [];
+      ? (telegramMessage.entities ?? [])
+      : (telegramMessage.caption_entities ?? []);
 
     if (!text) {
       return null;
@@ -676,9 +676,7 @@ export class TelegramAdapter
 
     return {
       command: `/${commandName}`,
-      text: text
-        .slice(commandEntity.offset + commandEntity.length)
-        .trimStart(),
+      text: text.slice(commandEntity.offset + commandEntity.length).trimStart(),
     };
   }
 


### PR DESCRIPTION
   ## Summary

   Adds Telegram bot command support for Chat SDK slash command handlers.

   - Routes Telegram `/command` and `/command@botusername` messages to `bot.onSlashCommand`
   - Ignores commands addressed to another bot
   - Keeps non-command messages on the existing normal message path

   ## Test plan

   - `pnpm validate`
   - Tested locally against a real Telegram bot

   ## Checklist

   - [x] All commits are signed and verified
   - [x] `pnpm validate` passes
   - [x] Changeset added
   - [x] Documentation updated