### PR TITLE
test(slack): expand emulator coverage for emulate.dev 0.6.0 APIs

### DIFF
--- a/packages/integration-tests/package.json
+++ b/packages/integration-tests/package.json
@@ -10,9 +10,9 @@
     "typecheck": "tsc --noEmit"
   },
   "devDependencies": {
-    "@emulators/core": "^0.5.0",
-    "@emulators/github": "^0.5.0",
-    "@emulators/slack": "^0.5.0",
+    "@emulators/core": "^0.6.0",
+    "@emulators/github": "^0.6.0",
+    "@emulators/slack": "^0.6.0",
     "@hono/node-server": "^2.0.2",
     "@types/node": "^25.3.2",
     "typescript": "^5.7.2",

--- a/packages/integration-tests/src/emulator/slack/block-actions.test.ts
+++ b/packages/integration-tests/src/emulator/slack/block-actions.test.ts
@@ -1,0 +1,143 @@
+/**
+ * Inbound `block_actions` interactivity: a user clicks a Block Kit button, the
+ * signed form-urlencoded payload is routed through `chat.webhooks.slack(...)`
+ * to `chat.handleAction`, and `onAction` handlers run with a live Thread so the
+ * bot can post a threaded reply that lands in the emulator store.
+ *
+ * Complements views.test.ts (view_submission) — this is the other half of
+ * Slack interactivity and was previously only exercised by the mock-client
+ * replay tests, never against the real HTTP webhook path.
+ */
+
+import type { ActionEvent } from "chat";
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vitest";
+import { createSlackBlockActionsRequest } from "../../slack-utils";
+import {
+  createEmulatorChatHarness,
+  createSlackEmulator,
+  EMULATOR_BOT_USER_ID,
+  type EmulatorChatHarness,
+  type SlackEmulatorHandle,
+} from "./utils";
+
+describe("Slack emulator: inbound block_actions flow", () => {
+  let emulator: SlackEmulatorHandle;
+  let harness: EmulatorChatHarness;
+
+  beforeAll(async () => {
+    emulator = await createSlackEmulator();
+  });
+
+  afterAll(async () => {
+    await emulator.close();
+  });
+
+  beforeEach(async () => {
+    harness = await createEmulatorChatHarness(emulator);
+  });
+
+  afterEach(async () => {
+    await harness.teardown();
+  });
+
+  /**
+   * Deliver a signed block_actions button click for the seeded human user in
+   * the seeded channel, assert the webhook returned 200, and drain the tracker
+   * so the `onAction` handler's `waitUntil` work has settled.
+   */
+  async function deliverAction(options: {
+    actionId: string;
+    actionValue?: string;
+    messageTs: string;
+    triggerId?: string;
+  }): Promise<void> {
+    const req = createSlackBlockActionsRequest(
+      {
+        actionId: options.actionId,
+        actionValue: options.actionValue,
+        channel: emulator.channelId,
+        messageTs: options.messageTs,
+        userId: emulator.humanUserId,
+        triggerId: options.triggerId,
+      },
+      emulator.signingSecret
+    );
+    const res = await harness.chat.webhooks.slack(req, {
+      waitUntil: harness.tracker.waitUntil,
+    });
+    if (res.status !== 200) {
+      throw new Error(`block_actions webhook returned ${res.status}`);
+    }
+    await harness.tracker.waitForAll();
+  }
+
+  it("delivers a button click to onAction and posts a threaded reply", async () => {
+    const captured = vi.fn<(event: ActionEvent) => void>();
+    harness.chat.onAction(async (event) => {
+      captured(event);
+      await event.thread?.post(`approved ${event.value}`);
+    });
+
+    const messageTs = "1700000000.700001";
+    await deliverAction({
+      actionId: "approve",
+      actionValue: "ticket-42",
+      messageTs,
+      triggerId: "trigger-abc",
+    });
+
+    expect(captured).toHaveBeenCalledTimes(1);
+    expect(captured.mock.calls[0]?.[0]).toMatchObject({
+      actionId: "approve",
+      value: "ticket-42",
+      triggerId: "trigger-abc",
+      threadId: `slack:${emulator.channelId}:${messageTs}`,
+      user: expect.objectContaining({ userId: emulator.humanUserId }),
+    });
+
+    // The handler's reply posted through the real chat.postMessage path and
+    // landed in the emulator store, threaded under the clicked message.
+    const replies = emulator.slackStore.messages
+      .all()
+      .filter(
+        (m) =>
+          m.channel_id === emulator.channelId &&
+          m.user === EMULATOR_BOT_USER_ID &&
+          m.thread_ts === messageTs
+      );
+    expect(replies.map((r) => r.text)).toEqual(["approved ticket-42"]);
+  });
+
+  it("routes only matching action IDs to a filtered onAction handler", async () => {
+    const onConfirm = vi.fn<(event: ActionEvent) => void>();
+    harness.chat.onAction(["confirm"], (event) => {
+      onConfirm(event);
+    });
+
+    // A non-matching action id must not trigger the filtered handler, but the
+    // webhook still acknowledges with 200.
+    await deliverAction({ actionId: "cancel", messageTs: "1700000000.700002" });
+    expect(onConfirm).not.toHaveBeenCalled();
+
+    // The matching action id fires the handler exactly once.
+    await deliverAction({
+      actionId: "confirm",
+      actionValue: "yes",
+      messageTs: "1700000000.700003",
+    });
+    expect(onConfirm).toHaveBeenCalledTimes(1);
+    expect(onConfirm.mock.calls[0]?.[0]).toMatchObject({
+      actionId: "confirm",
+      value: "yes",
+    });
+  });
+});

--- a/packages/integration-tests/src/emulator/slack/bookmarks.test.ts
+++ b/packages/integration-tests/src/emulator/slack/bookmarks.test.ts
@@ -1,0 +1,56 @@
+/**
+ * Bookmarks API round-trip via the emulator HTTP surface.
+ * The Slack adapter does not expose bookmarks yet; this verifies the
+ * emulator store and scopes used by integration tests.
+ */
+
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
+import {
+  addBookmarkViaApi,
+  createSlackEmulator,
+  listBookmarksViaApi,
+  type SlackEmulatorHandle,
+} from "./utils";
+
+describe("Slack emulator: bookmarks API", () => {
+  let emulator: SlackEmulatorHandle;
+
+  beforeAll(async () => {
+    emulator = await createSlackEmulator();
+  });
+
+  afterAll(async () => {
+    await emulator.close();
+  });
+
+  afterEach(() => {
+    emulator.reset();
+  });
+
+  it("adds and lists channel bookmarks in the emulator store", async () => {
+    const { bookmarkId } = await addBookmarkViaApi(emulator, {
+      channelId: emulator.channelId,
+      title: "Runbook",
+      link: "https://example.com/runbook",
+    });
+
+    const stored = emulator.slackStore.bookmarks.findOneBy(
+      "bookmark_id",
+      bookmarkId
+    );
+    expect(stored?.title).toBe("Runbook");
+    expect(stored?.link).toBe("https://example.com/runbook");
+    expect(stored?.channel_id).toBe(emulator.channelId);
+
+    const listed = await listBookmarksViaApi(emulator, emulator.channelId);
+    expect(listed).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          id: bookmarkId,
+          title: "Runbook",
+          link: "https://example.com/runbook",
+        }),
+      ])
+    );
+  });
+});

--- a/packages/integration-tests/src/emulator/slack/dm-events.test.ts
+++ b/packages/integration-tests/src/emulator/slack/dm-events.test.ts
@@ -1,0 +1,120 @@
+/**
+ * DM flow via conversations.open + inbound message events forwarded through
+ * the emulator webhook bridge.
+ */
+
+import { createSlackAdapter, type SlackAdapter } from "@chat-adapter/slack";
+import { createMemoryState } from "@chat-adapter/state-memory";
+import { Chat, type Message, type Thread } from "chat";
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vitest";
+import { createWaitUntilTracker } from "../../test-scenarios";
+import {
+  createSlackEmulator,
+  EMULATOR_BOT_NAME,
+  EMULATOR_BOT_TOKEN,
+  postAsHuman,
+  type SlackEmulatorHandle,
+  type SlackWebhookForwarder,
+  silentLogger,
+  startSlackWebhookForwarder,
+  waitForDelivery,
+} from "./utils";
+
+describe("Slack emulator: DM inbound flow", () => {
+  let emulator: SlackEmulatorHandle;
+  let chat: Chat<{ slack: SlackAdapter }>;
+  let adapter: SlackAdapter;
+  let forwarder: SlackWebhookForwarder;
+  let tracker: ReturnType<typeof createWaitUntilTracker>;
+  let dmChannelId: string;
+  let dmThreadId: string;
+
+  beforeAll(async () => {
+    emulator = await createSlackEmulator();
+  });
+
+  afterAll(async () => {
+    await emulator.close();
+  });
+
+  beforeEach(async () => {
+    adapter = createSlackAdapter({
+      apiUrl: emulator.apiUrl,
+      botToken: EMULATOR_BOT_TOKEN,
+      signingSecret: emulator.signingSecret,
+      userName: EMULATOR_BOT_NAME,
+      logger: silentLogger,
+    });
+    chat = new Chat({
+      userName: EMULATOR_BOT_NAME,
+      adapters: { slack: adapter },
+      state: createMemoryState(),
+      logger: silentLogger,
+    });
+    tracker = createWaitUntilTracker();
+    await chat.initialize();
+
+    dmThreadId = await adapter.openDM(emulator.humanUserId);
+    dmChannelId = adapter.decodeThreadId(dmThreadId).channel;
+
+    forwarder = await startSlackWebhookForwarder({
+      signingSecret: emulator.signingSecret,
+      teamId: emulator.teamId,
+      webhooks: emulator.webhooks,
+      onWebhook: (request) =>
+        chat.webhooks.slack(request, { waitUntil: tracker.waitUntil }),
+    });
+  });
+
+  afterEach(async () => {
+    if (forwarder) {
+      await forwarder.close();
+    }
+    if (chat) {
+      await chat.shutdown();
+    }
+    emulator.reset();
+  });
+
+  it("opens a DM channel via conversations.open", () => {
+    expect(dmChannelId.startsWith("D")).toBe(true);
+    expect(adapter.isDM(dmThreadId)).toBe(true);
+  });
+
+  it("delivers a human DM to onDirectMessage and posts a reply", async () => {
+    const captured = vi.fn<(thread: Thread, message: Message) => void>();
+    chat.onDirectMessage(async (thread, message) => {
+      captured(thread, message);
+      await thread.post("DM reply from bot");
+    });
+
+    await postAsHuman(emulator, {
+      channel: dmChannelId,
+      text: "hello in dm",
+    });
+
+    await waitForDelivery(emulator, (d) => d.event === "message" && d.success);
+    await tracker.waitForAll();
+
+    expect(captured).toHaveBeenCalledTimes(1);
+    const [thread, message] = captured.mock.calls[0] ?? [];
+    expect(adapter.decodeThreadId(thread.id).channel).toBe(dmChannelId);
+    expect(message.text).toBe("hello in dm");
+
+    const replies = emulator.slackStore.messages
+      .all()
+      .filter(
+        (m) => m.channel_id === dmChannelId && m.user === emulator.botUserId
+      );
+    expect(replies.map((r) => r.text)).toEqual(["DM reply from bot"]);
+  });
+});

--- a/packages/integration-tests/src/emulator/slack/dm-events.test.ts
+++ b/packages/integration-tests/src/emulator/slack/dm-events.test.ts
@@ -3,9 +3,7 @@
  * the emulator webhook bridge.
  */
 
-import { createSlackAdapter, type SlackAdapter } from "@chat-adapter/slack";
-import { createMemoryState } from "@chat-adapter/state-memory";
-import { Chat, type Message, type Thread } from "chat";
+import type { Message, Thread } from "chat";
 import {
   afterAll,
   afterEach,
@@ -16,25 +14,18 @@ import {
   it,
   vi,
 } from "vitest";
-import { createWaitUntilTracker } from "../../test-scenarios";
 import {
+  createEmulatorChatHarness,
   createSlackEmulator,
-  EMULATOR_BOT_NAME,
-  EMULATOR_BOT_TOKEN,
+  type EmulatorChatHarness,
   postAsHuman,
   type SlackEmulatorHandle,
-  type SlackWebhookForwarder,
-  silentLogger,
-  startSlackWebhookForwarder,
   waitForDelivery,
 } from "./utils";
 
 describe("Slack emulator: DM inbound flow", () => {
   let emulator: SlackEmulatorHandle;
-  let chat: Chat<{ slack: SlackAdapter }> | undefined;
-  let adapter!: SlackAdapter;
-  let forwarder: SlackWebhookForwarder | undefined;
-  let tracker!: ReturnType<typeof createWaitUntilTracker>;
+  let harness: EmulatorChatHarness;
   let dmChannelId!: string;
   let dmThreadId!: string;
 
@@ -47,59 +38,25 @@ describe("Slack emulator: DM inbound flow", () => {
   });
 
   beforeEach(async () => {
-    adapter = createSlackAdapter({
-      apiUrl: emulator.apiUrl,
-      botToken: EMULATOR_BOT_TOKEN,
-      signingSecret: emulator.signingSecret,
-      userName: EMULATOR_BOT_NAME,
-      logger: silentLogger,
+    harness = await createEmulatorChatHarness(emulator, {
+      withForwarder: true,
     });
-    chat = new Chat({
-      userName: EMULATOR_BOT_NAME,
-      adapters: { slack: adapter },
-      state: createMemoryState(),
-      logger: silentLogger,
-    });
-    tracker = createWaitUntilTracker();
-    await chat.initialize();
-
-    dmThreadId = await adapter.openDM(emulator.humanUserId);
-    dmChannelId = adapter.decodeThreadId(dmThreadId).channel;
-
-    const activeChat = chat;
-    forwarder = await startSlackWebhookForwarder({
-      signingSecret: emulator.signingSecret,
-      teamId: emulator.teamId,
-      webhooks: emulator.webhooks,
-      onWebhook: (request) =>
-        activeChat.webhooks.slack(request, { waitUntil: tracker.waitUntil }),
-    });
+    dmThreadId = await harness.adapter.openDM(emulator.humanUserId);
+    dmChannelId = harness.adapter.decodeThreadId(dmThreadId).channel;
   });
 
   afterEach(async () => {
-    if (forwarder) {
-      await forwarder.close();
-      forwarder = undefined;
-    }
-    if (chat) {
-      await chat.shutdown();
-      chat = undefined;
-    }
-    emulator.reset();
+    await harness.teardown();
   });
 
   it("opens a DM channel via conversations.open", () => {
     expect(dmChannelId.startsWith("D")).toBe(true);
-    expect(adapter.isDM(dmThreadId)).toBe(true);
+    expect(harness.adapter.isDM(dmThreadId)).toBe(true);
   });
 
   it("delivers a human DM to onDirectMessage and posts a reply", async () => {
-    if (!chat) {
-      throw new Error("chat not initialized");
-    }
-
     const captured = vi.fn<(thread: Thread, message: Message) => void>();
-    chat.onDirectMessage(async (thread, message) => {
+    harness.chat.onDirectMessage(async (thread, message) => {
       captured(thread, message);
       await thread.post("DM reply from bot");
     });
@@ -110,11 +67,11 @@ describe("Slack emulator: DM inbound flow", () => {
     });
 
     await waitForDelivery(emulator, (d) => d.event === "message" && d.success);
-    await tracker.waitForAll();
+    await harness.tracker.waitForAll();
 
     expect(captured).toHaveBeenCalledTimes(1);
     const [thread, message] = captured.mock.calls[0] ?? [];
-    expect(adapter.decodeThreadId(thread.id).channel).toBe(dmChannelId);
+    expect(harness.adapter.decodeThreadId(thread.id).channel).toBe(dmChannelId);
     expect(message.text).toBe("hello in dm");
 
     const replies = emulator.slackStore.messages

--- a/packages/integration-tests/src/emulator/slack/dm-events.test.ts
+++ b/packages/integration-tests/src/emulator/slack/dm-events.test.ts
@@ -31,12 +31,12 @@ import {
 
 describe("Slack emulator: DM inbound flow", () => {
   let emulator: SlackEmulatorHandle;
-  let chat: Chat<{ slack: SlackAdapter }>;
-  let adapter: SlackAdapter;
-  let forwarder: SlackWebhookForwarder;
-  let tracker: ReturnType<typeof createWaitUntilTracker>;
-  let dmChannelId: string;
-  let dmThreadId: string;
+  let chat: Chat<{ slack: SlackAdapter }> | undefined;
+  let adapter!: SlackAdapter;
+  let forwarder: SlackWebhookForwarder | undefined;
+  let tracker!: ReturnType<typeof createWaitUntilTracker>;
+  let dmChannelId!: string;
+  let dmThreadId!: string;
 
   beforeAll(async () => {
     emulator = await createSlackEmulator();
@@ -66,21 +66,24 @@ describe("Slack emulator: DM inbound flow", () => {
     dmThreadId = await adapter.openDM(emulator.humanUserId);
     dmChannelId = adapter.decodeThreadId(dmThreadId).channel;
 
+    const activeChat = chat;
     forwarder = await startSlackWebhookForwarder({
       signingSecret: emulator.signingSecret,
       teamId: emulator.teamId,
       webhooks: emulator.webhooks,
       onWebhook: (request) =>
-        chat.webhooks.slack(request, { waitUntil: tracker.waitUntil }),
+        activeChat.webhooks.slack(request, { waitUntil: tracker.waitUntil }),
     });
   });
 
   afterEach(async () => {
     if (forwarder) {
       await forwarder.close();
+      forwarder = undefined;
     }
     if (chat) {
       await chat.shutdown();
+      chat = undefined;
     }
     emulator.reset();
   });
@@ -91,6 +94,10 @@ describe("Slack emulator: DM inbound flow", () => {
   });
 
   it("delivers a human DM to onDirectMessage and posts a reply", async () => {
+    if (!chat) {
+      throw new Error("chat not initialized");
+    }
+
     const captured = vi.fn<(thread: Thread, message: Message) => void>();
     chat.onDirectMessage(async (thread, message) => {
       captured(thread, message);

--- a/packages/integration-tests/src/emulator/slack/fetch-messages.test.ts
+++ b/packages/integration-tests/src/emulator/slack/fetch-messages.test.ts
@@ -4,26 +4,27 @@
  * than mock WebClient calls.
  */
 
-import { createSlackAdapter, type SlackAdapter } from "@chat-adapter/slack";
-import { createMemoryState } from "@chat-adapter/state-memory";
-import { Chat } from "chat";
-import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
-import { createSlackEvent, createSlackWebhookRequest } from "../../slack-utils";
-import { createWaitUntilTracker } from "../../test-scenarios";
 import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+} from "vitest";
+import {
+  createEmulatorChatHarness,
   createSlackEmulator,
-  EMULATOR_BOT_NAME,
-  EMULATOR_BOT_TOKEN,
-  EMULATOR_BOT_USER_ID,
+  deliverMention,
+  type EmulatorChatHarness,
   postAsHuman,
   type SlackEmulatorHandle,
-  silentLogger,
 } from "./utils";
 
 describe("Slack emulator: fetchMessages round-trip", () => {
   let emulator: SlackEmulatorHandle;
-  let chat: Chat<{ slack: SlackAdapter }> | undefined;
-  let adapter!: SlackAdapter;
+  let harness: EmulatorChatHarness;
 
   beforeAll(async () => {
     emulator = await createSlackEmulator();
@@ -33,47 +34,23 @@ describe("Slack emulator: fetchMessages round-trip", () => {
     await emulator.close();
   });
 
-  afterEach(async () => {
-    if (chat) {
-      await chat.shutdown();
-      chat = undefined;
-    }
-    emulator.reset();
+  beforeEach(async () => {
+    harness = await createEmulatorChatHarness(emulator);
   });
 
-  async function setupChat(): Promise<Chat<{ slack: SlackAdapter }>> {
-    adapter = createSlackAdapter({
-      apiUrl: emulator.apiUrl,
-      botToken: EMULATOR_BOT_TOKEN,
-      signingSecret: emulator.signingSecret,
-      userName: EMULATOR_BOT_NAME,
-      logger: silentLogger,
-    });
-    const instance = new Chat({
-      userName: EMULATOR_BOT_NAME,
-      adapters: { slack: adapter },
-      state: createMemoryState(),
-      logger: silentLogger,
-    });
-    chat = instance;
-    await instance.initialize();
-    return instance;
-  }
+  afterEach(async () => {
+    await harness.teardown();
+  });
 
   it("returns channel history seeded via the emulator store", async () => {
-    await setupChat();
-
     await postAsHuman(emulator, { text: "older human note" });
     await postAsHuman(emulator, { text: "newer human note" });
 
-    const channelId = adapter.channelIdFromThreadId(
-      adapter.encodeThreadId({
-        channel: emulator.channelId,
-        threadTs: "",
-      })
+    // fetchChannelMessages takes the channel-level id (`slack:CHANNEL`).
+    const result = await harness.adapter.fetchChannelMessages(
+      `slack:${emulator.channelId}`,
+      { limit: 10 }
     );
-
-    const result = await adapter.fetchChannelMessages(channelId, { limit: 10 });
 
     expect(result.messages.length).toBeGreaterThanOrEqual(2);
     expect(result.messages.map((m) => m.text)).toEqual(
@@ -82,33 +59,19 @@ describe("Slack emulator: fetchMessages round-trip", () => {
   });
 
   it("returns threaded replies via conversations.replies", async () => {
-    const activeChat = await setupChat();
-    const tracker = createWaitUntilTracker();
-
-    activeChat.onNewMention(async (thread) => {
+    harness.chat.onNewMention(async (thread) => {
       await thread.post("bot reply one");
       await thread.post("bot reply two");
     });
 
     const threadTs = "1700000000.300001";
-    const event = createSlackEvent({
-      type: "app_mention",
-      text: `<@${EMULATOR_BOT_USER_ID}> thread please`,
-      userId: emulator.humanUserId,
-      messageTs: threadTs,
-      threadTs,
-      channel: emulator.channelId,
-      teamId: emulator.teamId,
-    });
-    const req = createSlackWebhookRequest(event, emulator.signingSecret);
-    await activeChat.webhooks.slack(req, { waitUntil: tracker.waitUntil });
-    await tracker.waitForAll();
+    await deliverMention(emulator, harness, threadTs, "thread please");
 
-    const threadId = adapter.encodeThreadId({
+    const threadId = harness.adapter.encodeThreadId({
       channel: emulator.channelId,
       threadTs,
     });
-    const result = await adapter.fetchMessages(threadId, { limit: 10 });
+    const result = await harness.adapter.fetchMessages(threadId, { limit: 10 });
 
     expect(result.messages.map((m) => m.text)).toEqual(
       expect.arrayContaining(["bot reply one", "bot reply two"])

--- a/packages/integration-tests/src/emulator/slack/fetch-messages.test.ts
+++ b/packages/integration-tests/src/emulator/slack/fetch-messages.test.ts
@@ -22,8 +22,8 @@ import {
 
 describe("Slack emulator: fetchMessages round-trip", () => {
   let emulator: SlackEmulatorHandle;
-  let chat: Chat<{ slack: SlackAdapter }>;
-  let adapter: SlackAdapter;
+  let chat: Chat<{ slack: SlackAdapter }> | undefined;
+  let adapter!: SlackAdapter;
 
   beforeAll(async () => {
     emulator = await createSlackEmulator();
@@ -36,11 +36,12 @@ describe("Slack emulator: fetchMessages round-trip", () => {
   afterEach(async () => {
     if (chat) {
       await chat.shutdown();
+      chat = undefined;
     }
     emulator.reset();
   });
 
-  async function setupChat() {
+  async function setupChat(): Promise<Chat<{ slack: SlackAdapter }>> {
     adapter = createSlackAdapter({
       apiUrl: emulator.apiUrl,
       botToken: EMULATOR_BOT_TOKEN,
@@ -48,13 +49,15 @@ describe("Slack emulator: fetchMessages round-trip", () => {
       userName: EMULATOR_BOT_NAME,
       logger: silentLogger,
     });
-    chat = new Chat({
+    const instance = new Chat({
       userName: EMULATOR_BOT_NAME,
       adapters: { slack: adapter },
       state: createMemoryState(),
       logger: silentLogger,
     });
-    await chat.initialize();
+    chat = instance;
+    await instance.initialize();
+    return instance;
   }
 
   it("returns channel history seeded via the emulator store", async () => {
@@ -79,10 +82,10 @@ describe("Slack emulator: fetchMessages round-trip", () => {
   });
 
   it("returns threaded replies via conversations.replies", async () => {
-    await setupChat();
+    const activeChat = await setupChat();
     const tracker = createWaitUntilTracker();
 
-    chat.onNewMention(async (thread) => {
+    activeChat.onNewMention(async (thread) => {
       await thread.post("bot reply one");
       await thread.post("bot reply two");
     });
@@ -98,7 +101,7 @@ describe("Slack emulator: fetchMessages round-trip", () => {
       teamId: emulator.teamId,
     });
     const req = createSlackWebhookRequest(event, emulator.signingSecret);
-    await chat.webhooks.slack(req, { waitUntil: tracker.waitUntil });
+    await activeChat.webhooks.slack(req, { waitUntil: tracker.waitUntil });
     await tracker.waitForAll();
 
     const threadId = adapter.encodeThreadId({

--- a/packages/integration-tests/src/emulator/slack/fetch-messages.test.ts
+++ b/packages/integration-tests/src/emulator/slack/fetch-messages.test.ts
@@ -1,0 +1,114 @@
+/**
+ * Verifies `fetchChannelMessages` and `fetchMessages` against the emulator's
+ * conversations.history and conversations.replies APIs using real HTTP rather
+ * than mock WebClient calls.
+ */
+
+import { createSlackAdapter, type SlackAdapter } from "@chat-adapter/slack";
+import { createMemoryState } from "@chat-adapter/state-memory";
+import { Chat } from "chat";
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
+import { createSlackEvent, createSlackWebhookRequest } from "../../slack-utils";
+import { createWaitUntilTracker } from "../../test-scenarios";
+import {
+  createSlackEmulator,
+  EMULATOR_BOT_NAME,
+  EMULATOR_BOT_TOKEN,
+  EMULATOR_BOT_USER_ID,
+  postAsHuman,
+  type SlackEmulatorHandle,
+  silentLogger,
+} from "./utils";
+
+describe("Slack emulator: fetchMessages round-trip", () => {
+  let emulator: SlackEmulatorHandle;
+  let chat: Chat<{ slack: SlackAdapter }>;
+  let adapter: SlackAdapter;
+
+  beforeAll(async () => {
+    emulator = await createSlackEmulator();
+  });
+
+  afterAll(async () => {
+    await emulator.close();
+  });
+
+  afterEach(async () => {
+    if (chat) {
+      await chat.shutdown();
+    }
+    emulator.reset();
+  });
+
+  async function setupChat() {
+    adapter = createSlackAdapter({
+      apiUrl: emulator.apiUrl,
+      botToken: EMULATOR_BOT_TOKEN,
+      signingSecret: emulator.signingSecret,
+      userName: EMULATOR_BOT_NAME,
+      logger: silentLogger,
+    });
+    chat = new Chat({
+      userName: EMULATOR_BOT_NAME,
+      adapters: { slack: adapter },
+      state: createMemoryState(),
+      logger: silentLogger,
+    });
+    await chat.initialize();
+  }
+
+  it("returns channel history seeded via the emulator store", async () => {
+    await setupChat();
+
+    await postAsHuman(emulator, { text: "older human note" });
+    await postAsHuman(emulator, { text: "newer human note" });
+
+    const channelId = adapter.channelIdFromThreadId(
+      adapter.encodeThreadId({
+        channel: emulator.channelId,
+        threadTs: "",
+      })
+    );
+
+    const result = await adapter.fetchChannelMessages(channelId, { limit: 10 });
+
+    expect(result.messages.length).toBeGreaterThanOrEqual(2);
+    expect(result.messages.map((m) => m.text)).toEqual(
+      expect.arrayContaining(["older human note", "newer human note"])
+    );
+  });
+
+  it("returns threaded replies via conversations.replies", async () => {
+    await setupChat();
+    const tracker = createWaitUntilTracker();
+
+    chat.onNewMention(async (thread) => {
+      await thread.post("bot reply one");
+      await thread.post("bot reply two");
+    });
+
+    const threadTs = "1700000000.300001";
+    const event = createSlackEvent({
+      type: "app_mention",
+      text: `<@${EMULATOR_BOT_USER_ID}> thread please`,
+      userId: emulator.humanUserId,
+      messageTs: threadTs,
+      threadTs,
+      channel: emulator.channelId,
+      teamId: emulator.teamId,
+    });
+    const req = createSlackWebhookRequest(event, emulator.signingSecret);
+    await chat.webhooks.slack(req, { waitUntil: tracker.waitUntil });
+    await tracker.waitForAll();
+
+    const threadId = adapter.encodeThreadId({
+      channel: emulator.channelId,
+      threadTs,
+    });
+    const result = await adapter.fetchMessages(threadId, { limit: 10 });
+
+    expect(result.messages.map((m) => m.text)).toEqual(
+      expect.arrayContaining(["bot reply one", "bot reply two"])
+    );
+  });
+});

--- a/packages/integration-tests/src/emulator/slack/file-upload.test.ts
+++ b/packages/integration-tests/src/emulator/slack/file-upload.test.ts
@@ -11,16 +11,6 @@ import {
   type SlackEmulatorHandle,
 } from "./utils";
 
-function resolveFetchUrl(input: RequestInfo | URL): string {
-  if (typeof input === "string") {
-    return input;
-  }
-  if (input instanceof URL) {
-    return input.href;
-  }
-  return input.url;
-}
-
 describe("Slack emulator: external file upload", () => {
   let emulator: SlackEmulatorHandle;
 
@@ -38,20 +28,9 @@ describe("Slack emulator: external file upload", () => {
 
   it("uploads a file and shares it to a channel", async () => {
     const content = "hello from emulator upload test";
-    // The emulator builds upload URLs from its configured baseUrl, which is
-    // `http://localhost:0` when the server binds to port 0. Rewrite upload
-    // requests to the actual listening origin from createSlackEmulator().
-    const fetchWithUploadHostFix: typeof fetch = (input, init) => {
-      const url = resolveFetchUrl(input);
-      if (url.includes("/upload/v1/")) {
-        const fileId = url.split("/upload/v1/").pop()?.split("?")[0];
-        if (fileId) {
-          return fetch(`${emulator.baseUrl}/upload/v1/${fileId}`, init);
-        }
-      }
-      return fetch(input, init);
-    };
-
+    // The emulator builds upload URLs from its configured baseUrl, which
+    // createSlackEmulator now sets to the real listening origin, so the upload
+    // requests reach the server directly without any host rewriting.
     const { fileIds } = await uploadSlackFiles(
       [
         {
@@ -65,7 +44,6 @@ describe("Slack emulator: external file upload", () => {
         token: EMULATOR_BOT_TOKEN,
         channelId: emulator.channelId,
         initialComment: "Uploaded via external flow",
-        fetch: fetchWithUploadHostFix,
       }
     );
 

--- a/packages/integration-tests/src/emulator/slack/file-upload.test.ts
+++ b/packages/integration-tests/src/emulator/slack/file-upload.test.ts
@@ -1,0 +1,97 @@
+/**
+ * External file upload flow via files.getUploadURLExternal and
+ * files.completeUploadExternal against the emulator store.
+ */
+
+import { uploadSlackFiles } from "@chat-adapter/slack/api";
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
+import {
+  createSlackEmulator,
+  EMULATOR_BOT_TOKEN,
+  type SlackEmulatorHandle,
+} from "./utils";
+
+function resolveFetchUrl(input: RequestInfo | URL): string {
+  if (typeof input === "string") {
+    return input;
+  }
+  if (input instanceof URL) {
+    return input.href;
+  }
+  return input.url;
+}
+
+describe("Slack emulator: external file upload", () => {
+  let emulator: SlackEmulatorHandle;
+
+  beforeAll(async () => {
+    emulator = await createSlackEmulator();
+  });
+
+  afterAll(async () => {
+    await emulator.close();
+  });
+
+  afterEach(() => {
+    emulator.reset();
+  });
+
+  it("uploads a file and shares it to a channel", async () => {
+    const content = "hello from emulator upload test";
+    // The emulator builds upload URLs from its configured baseUrl, which is
+    // `http://localhost:0` when the server binds to port 0. Rewrite upload
+    // requests to the actual listening origin from createSlackEmulator().
+    const fetchWithUploadHostFix: typeof fetch = (input, init) => {
+      const url = resolveFetchUrl(input);
+      if (url.includes("/upload/v1/")) {
+        const fileId = url.split("/upload/v1/").pop()?.split("?")[0];
+        if (fileId) {
+          return fetch(`${emulator.baseUrl}/upload/v1/${fileId}`, init);
+        }
+      }
+      return fetch(input, init);
+    };
+
+    const { fileIds } = await uploadSlackFiles(
+      [
+        {
+          data: Buffer.from(content),
+          filename: "notes.txt",
+          title: "Release notes",
+        },
+      ],
+      {
+        apiUrl: emulator.apiUrl,
+        token: EMULATOR_BOT_TOKEN,
+        channelId: emulator.channelId,
+        initialComment: "Uploaded via external flow",
+        fetch: fetchWithUploadHostFix,
+      }
+    );
+
+    expect(fileIds).toHaveLength(1);
+    const fileId = fileIds[0];
+    expect(fileId).toBeTruthy();
+
+    const file = emulator.slackStore.files.findOneBy("file_id", fileId);
+    expect(file?.name).toBe("notes.txt");
+    expect(file?.user).toBe(emulator.botUserId);
+
+    const session = emulator.slackStore.fileUploadSessions.findOneBy(
+      "file_id",
+      fileId
+    );
+    expect(session?.uploaded).toBe(true);
+    expect(session?.completed).toBe(true);
+
+    const shared = emulator.slackStore.messages
+      .all()
+      .filter(
+        (m) =>
+          m.channel_id === emulator.channelId &&
+          m.subtype === "file_share" &&
+          m.files?.some((f) => f.file_id === fileId)
+      );
+    expect(shared.length).toBeGreaterThan(0);
+  });
+});

--- a/packages/integration-tests/src/emulator/slack/member-joined-channel.test.ts
+++ b/packages/integration-tests/src/emulator/slack/member-joined-channel.test.ts
@@ -3,9 +3,7 @@
  * the bot has not yet joined.
  */
 
-import { createSlackAdapter, type SlackAdapter } from "@chat-adapter/slack";
-import { createMemoryState } from "@chat-adapter/state-memory";
-import { Chat, type MemberJoinedChannelEvent } from "chat";
+import type { MemberJoinedChannelEvent } from "chat";
 import {
   afterAll,
   afterEach,
@@ -16,17 +14,13 @@ import {
   it,
   vi,
 } from "vitest";
-import { createWaitUntilTracker } from "../../test-scenarios";
 import {
+  createEmulatorChatHarness,
   createSlackEmulator,
-  EMULATOR_BOT_NAME,
-  EMULATOR_BOT_TOKEN,
+  type EmulatorChatHarness,
   joinChannelAsBot,
   type SlackEmulatorHandle,
-  type SlackWebhookForwarder,
   seedChannelWithoutBot,
-  silentLogger,
-  startSlackWebhookForwarder,
   waitForDelivery,
 } from "./utils";
 
@@ -35,10 +29,7 @@ const UNJOINED_CHANNEL_NAME = "unjoined-channel";
 
 describe("Slack emulator: member_joined_channel flow", () => {
   let emulator: SlackEmulatorHandle;
-  let chat: Chat<{ slack: SlackAdapter }> | undefined;
-  let adapter!: SlackAdapter;
-  let forwarder: SlackWebhookForwarder | undefined;
-  let tracker!: ReturnType<typeof createWaitUntilTracker>;
+  let harness: EmulatorChatHarness;
 
   beforeAll(async () => {
     emulator = await createSlackEmulator();
@@ -53,52 +44,18 @@ describe("Slack emulator: member_joined_channel flow", () => {
       channelId: UNJOINED_CHANNEL_ID,
       name: UNJOINED_CHANNEL_NAME,
     });
-
-    adapter = createSlackAdapter({
-      apiUrl: emulator.apiUrl,
-      botToken: EMULATOR_BOT_TOKEN,
-      signingSecret: emulator.signingSecret,
-      userName: EMULATOR_BOT_NAME,
-      logger: silentLogger,
-    });
-    chat = new Chat({
-      userName: EMULATOR_BOT_NAME,
-      adapters: { slack: adapter },
-      state: createMemoryState(),
-      logger: silentLogger,
-    });
-    tracker = createWaitUntilTracker();
-    await chat.initialize();
-
-    const activeChat = chat;
-    forwarder = await startSlackWebhookForwarder({
-      signingSecret: emulator.signingSecret,
-      teamId: emulator.teamId,
-      webhooks: emulator.webhooks,
-      onWebhook: (request) =>
-        activeChat.webhooks.slack(request, { waitUntil: tracker.waitUntil }),
+    harness = await createEmulatorChatHarness(emulator, {
+      withForwarder: true,
     });
   });
 
   afterEach(async () => {
-    if (forwarder) {
-      await forwarder.close();
-      forwarder = undefined;
-    }
-    if (chat) {
-      await chat.shutdown();
-      chat = undefined;
-    }
-    emulator.reset();
+    await harness.teardown();
   });
 
   it("delivers member_joined_channel when the bot joins via conversations.join", async () => {
-    if (!chat) {
-      throw new Error("chat not initialized");
-    }
-
     const captured = vi.fn<(event: MemberJoinedChannelEvent) => void>();
-    chat.onMemberJoinedChannel((event) => {
+    harness.chat.onMemberJoinedChannel((event) => {
       captured(event);
     });
 
@@ -108,7 +65,7 @@ describe("Slack emulator: member_joined_channel flow", () => {
       emulator,
       (d) => d.event === "member_joined_channel" && d.success
     );
-    await tracker.waitForAll();
+    await harness.tracker.waitForAll();
 
     expect(captured).toHaveBeenCalledTimes(1);
     expect(captured.mock.calls[0]?.[0]).toMatchObject({

--- a/packages/integration-tests/src/emulator/slack/member-joined-channel.test.ts
+++ b/packages/integration-tests/src/emulator/slack/member-joined-channel.test.ts
@@ -35,10 +35,10 @@ const UNJOINED_CHANNEL_NAME = "unjoined-channel";
 
 describe("Slack emulator: member_joined_channel flow", () => {
   let emulator: SlackEmulatorHandle;
-  let chat: Chat<{ slack: SlackAdapter }>;
-  let adapter: SlackAdapter;
-  let forwarder: SlackWebhookForwarder;
-  let tracker: ReturnType<typeof createWaitUntilTracker>;
+  let chat: Chat<{ slack: SlackAdapter }> | undefined;
+  let adapter!: SlackAdapter;
+  let forwarder: SlackWebhookForwarder | undefined;
+  let tracker!: ReturnType<typeof createWaitUntilTracker>;
 
   beforeAll(async () => {
     emulator = await createSlackEmulator();
@@ -70,26 +70,33 @@ describe("Slack emulator: member_joined_channel flow", () => {
     tracker = createWaitUntilTracker();
     await chat.initialize();
 
+    const activeChat = chat;
     forwarder = await startSlackWebhookForwarder({
       signingSecret: emulator.signingSecret,
       teamId: emulator.teamId,
       webhooks: emulator.webhooks,
       onWebhook: (request) =>
-        chat.webhooks.slack(request, { waitUntil: tracker.waitUntil }),
+        activeChat.webhooks.slack(request, { waitUntil: tracker.waitUntil }),
     });
   });
 
   afterEach(async () => {
     if (forwarder) {
       await forwarder.close();
+      forwarder = undefined;
     }
     if (chat) {
       await chat.shutdown();
+      chat = undefined;
     }
     emulator.reset();
   });
 
   it("delivers member_joined_channel when the bot joins via conversations.join", async () => {
+    if (!chat) {
+      throw new Error("chat not initialized");
+    }
+
     const captured = vi.fn<(event: MemberJoinedChannelEvent) => void>();
     chat.onMemberJoinedChannel((event) => {
       captured(event);

--- a/packages/integration-tests/src/emulator/slack/member-joined-channel.test.ts
+++ b/packages/integration-tests/src/emulator/slack/member-joined-channel.test.ts
@@ -1,0 +1,118 @@
+/**
+ * member_joined_channel event via conversations.join against a channel
+ * the bot has not yet joined.
+ */
+
+import { createSlackAdapter, type SlackAdapter } from "@chat-adapter/slack";
+import { createMemoryState } from "@chat-adapter/state-memory";
+import { Chat, type MemberJoinedChannelEvent } from "chat";
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vitest";
+import { createWaitUntilTracker } from "../../test-scenarios";
+import {
+  createSlackEmulator,
+  EMULATOR_BOT_NAME,
+  EMULATOR_BOT_TOKEN,
+  joinChannelAsBot,
+  type SlackEmulatorHandle,
+  type SlackWebhookForwarder,
+  seedChannelWithoutBot,
+  silentLogger,
+  startSlackWebhookForwarder,
+  waitForDelivery,
+} from "./utils";
+
+const UNJOINED_CHANNEL_ID = "C_UNJOINED";
+const UNJOINED_CHANNEL_NAME = "unjoined-channel";
+
+describe("Slack emulator: member_joined_channel flow", () => {
+  let emulator: SlackEmulatorHandle;
+  let chat: Chat<{ slack: SlackAdapter }>;
+  let adapter: SlackAdapter;
+  let forwarder: SlackWebhookForwarder;
+  let tracker: ReturnType<typeof createWaitUntilTracker>;
+
+  beforeAll(async () => {
+    emulator = await createSlackEmulator();
+  });
+
+  afterAll(async () => {
+    await emulator.close();
+  });
+
+  beforeEach(async () => {
+    seedChannelWithoutBot(emulator, {
+      channelId: UNJOINED_CHANNEL_ID,
+      name: UNJOINED_CHANNEL_NAME,
+    });
+
+    adapter = createSlackAdapter({
+      apiUrl: emulator.apiUrl,
+      botToken: EMULATOR_BOT_TOKEN,
+      signingSecret: emulator.signingSecret,
+      userName: EMULATOR_BOT_NAME,
+      logger: silentLogger,
+    });
+    chat = new Chat({
+      userName: EMULATOR_BOT_NAME,
+      adapters: { slack: adapter },
+      state: createMemoryState(),
+      logger: silentLogger,
+    });
+    tracker = createWaitUntilTracker();
+    await chat.initialize();
+
+    forwarder = await startSlackWebhookForwarder({
+      signingSecret: emulator.signingSecret,
+      teamId: emulator.teamId,
+      webhooks: emulator.webhooks,
+      onWebhook: (request) =>
+        chat.webhooks.slack(request, { waitUntil: tracker.waitUntil }),
+    });
+  });
+
+  afterEach(async () => {
+    if (forwarder) {
+      await forwarder.close();
+    }
+    if (chat) {
+      await chat.shutdown();
+    }
+    emulator.reset();
+  });
+
+  it("delivers member_joined_channel when the bot joins via conversations.join", async () => {
+    const captured = vi.fn<(event: MemberJoinedChannelEvent) => void>();
+    chat.onMemberJoinedChannel((event) => {
+      captured(event);
+    });
+
+    await joinChannelAsBot(emulator, UNJOINED_CHANNEL_ID);
+
+    await waitForDelivery(
+      emulator,
+      (d) => d.event === "member_joined_channel" && d.success
+    );
+    await tracker.waitForAll();
+
+    expect(captured).toHaveBeenCalledTimes(1);
+    expect(captured.mock.calls[0]?.[0]).toMatchObject({
+      userId: emulator.botUserId,
+      channelId: `slack:${UNJOINED_CHANNEL_ID}:`,
+    });
+
+    const channel = emulator.slackStore.channels.findOneBy(
+      "channel_id",
+      UNJOINED_CHANNEL_ID
+    );
+    expect(channel?.members).toContain(emulator.botUserId);
+  });
+});

--- a/packages/integration-tests/src/emulator/slack/oauth.test.ts
+++ b/packages/integration-tests/src/emulator/slack/oauth.test.ts
@@ -23,6 +23,7 @@ import {
 } from "./utils";
 
 const BOT_TOKEN_PATTERN = /^xoxb-/;
+const BOT_USER_ID_PATTERN = /^U[A-Z0-9]+$/;
 const INVALID_CODE_PATTERN = /invalid_code/;
 const INVALID_CLIENT_ID_PATTERN = /invalid_client_id/;
 
@@ -114,7 +115,12 @@ describe("Slack emulator: OAuth v2 install flow", () => {
 
     expect(result.teamId).toBe(emulator.teamId);
     expect(result.installation.botToken).toMatch(BOT_TOKEN_PATTERN);
-    expect(result.installation.botUserId).toBe(emulator.humanUserId);
+    expect(result.installation.botUserId).toMatch(BOT_USER_ID_PATTERN);
+    const botUser = emulator.slackStore.users.findOneBy(
+      "user_id",
+      result.installation.botUserId
+    );
+    expect(botUser?.is_bot).toBe(true);
     expect(result.installation.teamName).toBe(emulator.teamName);
 
     // The installation is observable via the adapter's getInstallation helper,

--- a/packages/integration-tests/src/emulator/slack/oauth.test.ts
+++ b/packages/integration-tests/src/emulator/slack/oauth.test.ts
@@ -115,11 +115,15 @@ describe("Slack emulator: OAuth v2 install flow", () => {
 
     expect(result.teamId).toBe(emulator.teamId);
     expect(result.installation.botToken).toMatch(BOT_TOKEN_PATTERN);
+    // The install mints a dedicated bot user id (Slack-style `U` + hex), which
+    // must be a real bot in the store and must not be the installing human.
     expect(result.installation.botUserId).toMatch(BOT_USER_ID_PATTERN);
+    expect(result.installation.botUserId).not.toBe(emulator.humanUserId);
     const botUser = emulator.slackStore.users.findOneBy(
       "user_id",
       result.installation.botUserId
     );
+    expect(botUser).toBeDefined();
     expect(botUser?.is_bot).toBe(true);
     expect(result.installation.teamName).toBe(emulator.teamName);
 

--- a/packages/integration-tests/src/emulator/slack/post-message.test.ts
+++ b/packages/integration-tests/src/emulator/slack/post-message.test.ts
@@ -10,26 +10,28 @@
  * server.
  */
 
-import { createSlackAdapter, type SlackAdapter } from "@chat-adapter/slack";
-import { createMemoryState } from "@chat-adapter/state-memory";
-import { Chat } from "chat";
-import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
-import { createSlackEvent, createSlackWebhookRequest } from "../../slack-utils";
-import { createWaitUntilTracker } from "../../test-scenarios";
 import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+} from "vitest";
+import {
+  createEmulatorChatHarness,
   createSlackEmulator,
-  EMULATOR_BOT_NAME,
+  deliverMention,
   EMULATOR_BOT_TOKEN,
   EMULATOR_BOT_USER_ID,
+  type EmulatorChatHarness,
   type SlackEmulatorHandle,
-  silentLogger,
 } from "./utils";
 
 describe("Slack emulator: chat.postMessage round-trip", () => {
   let emulator: SlackEmulatorHandle;
-  let chat: Chat<{ slack: SlackAdapter }>;
-  let adapter: SlackAdapter;
-  let tracker: ReturnType<typeof createWaitUntilTracker>;
+  let harness: EmulatorChatHarness;
 
   beforeAll(async () => {
     emulator = await createSlackEmulator();
@@ -39,60 +41,21 @@ describe("Slack emulator: chat.postMessage round-trip", () => {
     await emulator.close();
   });
 
-  afterEach(async () => {
-    if (chat) {
-      await chat.shutdown();
-    }
-    emulator.reset();
+  beforeEach(async () => {
+    harness = await createEmulatorChatHarness(emulator);
   });
 
-  async function setupChat() {
-    adapter = createSlackAdapter({
-      apiUrl: emulator.apiUrl,
-      botToken: EMULATOR_BOT_TOKEN,
-      signingSecret: emulator.signingSecret,
-      userName: EMULATOR_BOT_NAME,
-      logger: silentLogger,
-    });
-    chat = new Chat({
-      userName: EMULATOR_BOT_NAME,
-      adapters: { slack: adapter },
-      state: createMemoryState(),
-      logger: silentLogger,
-    });
-    tracker = createWaitUntilTracker();
-    await chat.initialize();
-  }
-
-  async function deliverMention(threadTs: string) {
-    const event = createSlackEvent({
-      type: "app_mention",
-      text: `<@${EMULATOR_BOT_USER_ID}> ping`,
-      userId: "U_USER_TEST",
-      messageTs: threadTs,
-      threadTs,
-      channel: emulator.channelId,
-      teamId: emulator.teamId,
-    });
-    const req = createSlackWebhookRequest(event, emulator.signingSecret);
-    const res = await chat.webhooks.slack(req, {
-      waitUntil: tracker.waitUntil,
-    });
-    if (res.status !== 200) {
-      throw new Error(`webhook handler returned ${res.status}`);
-    }
-    await tracker.waitForAll();
-  }
+  afterEach(async () => {
+    await harness.teardown();
+  });
 
   it("posts a plain text reply that lands in the emulator's message store", async () => {
-    await setupChat();
-
-    chat.onNewMention(async (thread) => {
+    harness.chat.onNewMention(async (thread) => {
       await thread.post("Hello from the bot!");
     });
 
     const threadTs = "1700000000.000001";
-    await deliverMention(threadTs);
+    await deliverMention(emulator, harness, threadTs);
 
     const messages = emulator.slackStore.messages
       .all()
@@ -104,15 +67,13 @@ describe("Slack emulator: chat.postMessage round-trip", () => {
   });
 
   it("threads the reply under thread_ts so conversations.replies sees it", async () => {
-    await setupChat();
-
-    chat.onNewMention(async (thread) => {
+    harness.chat.onNewMention(async (thread) => {
       await thread.post("first reply");
       await thread.post("second reply");
     });
 
     const threadTs = "1700000000.000002";
-    await deliverMention(threadTs);
+    await deliverMention(emulator, harness, threadTs);
 
     // Hit conversations.replies via HTTP to prove the messages are
     // discoverable through Slack's threading API, not just via the raw store.
@@ -139,15 +100,13 @@ describe("Slack emulator: chat.postMessage round-trip", () => {
   });
 
   it("editMessage updates the stored text via chat.update", async () => {
-    await setupChat();
-
-    chat.onNewMention(async (thread) => {
+    harness.chat.onNewMention(async (thread) => {
       const msg = await thread.post("draft");
       await msg.edit("final");
     });
 
     const threadTs = "1700000000.000003";
-    await deliverMention(threadTs);
+    await deliverMention(emulator, harness, threadTs);
 
     const reply = emulator.slackStore.messages
       .all()
@@ -159,15 +118,13 @@ describe("Slack emulator: chat.postMessage round-trip", () => {
   });
 
   it("deleteMessage removes the message via chat.delete", async () => {
-    await setupChat();
-
-    chat.onNewMention(async (thread) => {
+    harness.chat.onNewMention(async (thread) => {
       const msg = await thread.post("transient");
       await msg.delete();
     });
 
     const threadTs = "1700000000.000004";
-    await deliverMention(threadTs);
+    await deliverMention(emulator, harness, threadTs);
 
     const replies = emulator.slackStore.messages
       .all()
@@ -179,16 +136,14 @@ describe("Slack emulator: chat.postMessage round-trip", () => {
   });
 
   it("sends an ephemeral message via chat.postEphemeral", async () => {
-    await setupChat();
-
-    chat.onNewMention(async (thread) => {
+    harness.chat.onNewMention(async (thread) => {
       await thread.postEphemeral(emulator.humanUserId, "only you see this", {
         fallbackToDM: false,
       });
     });
 
     const threadTs = "1700000000.000005";
-    await deliverMention(threadTs);
+    await deliverMention(emulator, harness, threadTs);
 
     const ephemeral = emulator.slackStore.ephemeralMessages
       .all()

--- a/packages/integration-tests/src/emulator/slack/post-message.test.ts
+++ b/packages/integration-tests/src/emulator/slack/post-message.test.ts
@@ -178,25 +178,25 @@ describe("Slack emulator: chat.postMessage round-trip", () => {
     expect(replies).toHaveLength(0);
   });
 
-  it("sends markdown via the markdown_text channel", async () => {
+  it("sends an ephemeral message via chat.postEphemeral", async () => {
     await setupChat();
 
     chat.onNewMention(async (thread) => {
-      await thread.post({ markdown: "**bold** and _italic_" });
+      await thread.postEphemeral(emulator.humanUserId, "only you see this", {
+        fallbackToDM: false,
+      });
     });
 
     const threadTs = "1700000000.000005";
     await deliverMention(threadTs);
 
-    // The emulator only stores `text`, but Slack allows posts that have a
-    // markdown_text body and an empty plain text. Verify the post landed at
-    // all (any new message in the channel) so the round-trip succeeded.
-    const replies = emulator.slackStore.messages
+    const ephemeral = emulator.slackStore.ephemeralMessages
       .all()
       .filter(
         (m) =>
-          m.channel_id === emulator.channelId && m.user === EMULATOR_BOT_USER_ID
+          m.channel_id === emulator.channelId &&
+          m.target_user === emulator.humanUserId
       );
-    expect(replies.length).toBeGreaterThan(0);
+    expect(ephemeral.map((m) => m.text)).toEqual(["only you see this"]);
   });
 });

--- a/packages/integration-tests/src/emulator/slack/reactions-events.test.ts
+++ b/packages/integration-tests/src/emulator/slack/reactions-events.test.ts
@@ -1,0 +1,156 @@
+/**
+ * Inbound `reaction_added` flow: a human reacts to a bot message in the
+ * emulator, the event is forwarded to `chat.webhooks.slack(...)`, and
+ * `onReaction` handlers run with a live Thread.
+ */
+
+import { createSlackAdapter, type SlackAdapter } from "@chat-adapter/slack";
+import { createMemoryState } from "@chat-adapter/state-memory";
+import { Chat, type ReactionEvent } from "chat";
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vitest";
+import { createSlackEvent, createSlackWebhookRequest } from "../../slack-utils";
+import { createWaitUntilTracker } from "../../test-scenarios";
+import {
+  addReactionAsHuman,
+  createSlackEmulator,
+  EMULATOR_BOT_NAME,
+  EMULATOR_BOT_TOKEN,
+  EMULATOR_BOT_USER_ID,
+  type SlackEmulatorHandle,
+  type SlackWebhookForwarder,
+  silentLogger,
+  startSlackWebhookForwarder,
+  waitForDelivery,
+} from "./utils";
+
+describe("Slack emulator: inbound reaction_added flow", () => {
+  let emulator: SlackEmulatorHandle;
+  let chat: Chat<{ slack: SlackAdapter }>;
+  let adapter: SlackAdapter;
+  let forwarder: SlackWebhookForwarder;
+  let tracker: ReturnType<typeof createWaitUntilTracker>;
+
+  beforeAll(async () => {
+    emulator = await createSlackEmulator();
+  });
+
+  afterAll(async () => {
+    await emulator.close();
+  });
+
+  beforeEach(async () => {
+    adapter = createSlackAdapter({
+      apiUrl: emulator.apiUrl,
+      botToken: EMULATOR_BOT_TOKEN,
+      signingSecret: emulator.signingSecret,
+      userName: EMULATOR_BOT_NAME,
+      logger: silentLogger,
+    });
+    chat = new Chat({
+      userName: EMULATOR_BOT_NAME,
+      adapters: { slack: adapter },
+      state: createMemoryState(),
+      logger: silentLogger,
+    });
+    tracker = createWaitUntilTracker();
+    await chat.initialize();
+
+    forwarder = await startSlackWebhookForwarder({
+      signingSecret: emulator.signingSecret,
+      teamId: emulator.teamId,
+      webhooks: emulator.webhooks,
+      onWebhook: (request) =>
+        chat.webhooks.slack(request, { waitUntil: tracker.waitUntil }),
+    });
+  });
+
+  afterEach(async () => {
+    await forwarder.close();
+    await chat.shutdown();
+    emulator.reset();
+  });
+
+  async function deliverMention(threadTs: string) {
+    const event = createSlackEvent({
+      type: "app_mention",
+      text: `<@${EMULATOR_BOT_USER_ID}> ping`,
+      userId: emulator.humanUserId,
+      messageTs: threadTs,
+      threadTs,
+      channel: emulator.channelId,
+      teamId: emulator.teamId,
+    });
+    const req = createSlackWebhookRequest(event, emulator.signingSecret);
+    const res = await chat.webhooks.slack(req, {
+      waitUntil: tracker.waitUntil,
+    });
+    if (res.status !== 200) {
+      throw new Error(`webhook handler returned ${res.status}`);
+    }
+    await tracker.waitForAll();
+  }
+
+  it("delivers reaction_added to onReaction and allows a threaded reply", async () => {
+    const captured = vi.fn<(event: ReactionEvent) => void>();
+    chat.onReaction(async (event) => {
+      captured(event);
+      await event.thread?.post(`Thanks for the ${event.emoji}!`);
+    });
+
+    chat.onNewMention(async (thread) => {
+      await thread.post("react to me");
+    });
+
+    const threadTs = "1700000000.200001";
+    await deliverMention(threadTs);
+
+    const botMessage = emulator.slackStore.messages
+      .all()
+      .find(
+        (m) =>
+          m.channel_id === emulator.channelId && m.user === EMULATOR_BOT_USER_ID
+      );
+    expect(botMessage?.ts).toBeDefined();
+    if (!botMessage?.ts) {
+      return;
+    }
+
+    await addReactionAsHuman(emulator, {
+      channel: emulator.channelId,
+      name: "tada",
+      timestamp: botMessage.ts,
+    });
+
+    await waitForDelivery(
+      emulator,
+      (d) => d.event === "reaction_added" && d.success
+    );
+    await tracker.waitForAll();
+
+    expect(captured).toHaveBeenCalledTimes(1);
+    expect(captured.mock.calls[0]?.[0]).toMatchObject({
+      adapter,
+      rawEmoji: "tada",
+      user: expect.objectContaining({ userId: emulator.humanUserId }),
+    });
+
+    const replies = emulator.slackStore.messages
+      .all()
+      .filter(
+        (m) =>
+          m.channel_id === emulator.channelId &&
+          m.user === EMULATOR_BOT_USER_ID &&
+          m.text.includes("Thanks for the :tada:")
+      );
+    expect(replies).toHaveLength(1);
+  });
+});

--- a/packages/integration-tests/src/emulator/slack/reactions-events.test.ts
+++ b/packages/integration-tests/src/emulator/slack/reactions-events.test.ts
@@ -34,10 +34,10 @@ import {
 
 describe("Slack emulator: inbound reaction_added flow", () => {
   let emulator: SlackEmulatorHandle;
-  let chat: Chat<{ slack: SlackAdapter }>;
-  let adapter: SlackAdapter;
-  let forwarder: SlackWebhookForwarder;
-  let tracker: ReturnType<typeof createWaitUntilTracker>;
+  let chat: Chat<{ slack: SlackAdapter }> | undefined;
+  let adapter!: SlackAdapter;
+  let forwarder: SlackWebhookForwarder | undefined;
+  let tracker!: ReturnType<typeof createWaitUntilTracker>;
 
   beforeAll(async () => {
     emulator = await createSlackEmulator();
@@ -64,22 +64,33 @@ describe("Slack emulator: inbound reaction_added flow", () => {
     tracker = createWaitUntilTracker();
     await chat.initialize();
 
+    const activeChat = chat;
     forwarder = await startSlackWebhookForwarder({
       signingSecret: emulator.signingSecret,
       teamId: emulator.teamId,
       webhooks: emulator.webhooks,
       onWebhook: (request) =>
-        chat.webhooks.slack(request, { waitUntil: tracker.waitUntil }),
+        activeChat.webhooks.slack(request, { waitUntil: tracker.waitUntil }),
     });
   });
 
   afterEach(async () => {
-    await forwarder.close();
-    await chat.shutdown();
+    if (forwarder) {
+      await forwarder.close();
+      forwarder = undefined;
+    }
+    if (chat) {
+      await chat.shutdown();
+      chat = undefined;
+    }
     emulator.reset();
   });
 
   async function deliverMention(threadTs: string) {
+    if (!chat) {
+      throw new Error("chat not initialized");
+    }
+
     const event = createSlackEvent({
       type: "app_mention",
       text: `<@${EMULATOR_BOT_USER_ID}> ping`,
@@ -100,6 +111,10 @@ describe("Slack emulator: inbound reaction_added flow", () => {
   }
 
   it("delivers reaction_added to onReaction and allows a threaded reply", async () => {
+    if (!chat) {
+      throw new Error("chat not initialized");
+    }
+
     const captured = vi.fn<(event: ReactionEvent) => void>();
     chat.onReaction(async (event) => {
       captured(event);

--- a/packages/integration-tests/src/emulator/slack/reactions-events.test.ts
+++ b/packages/integration-tests/src/emulator/slack/reactions-events.test.ts
@@ -4,9 +4,7 @@
  * `onReaction` handlers run with a live Thread.
  */
 
-import { createSlackAdapter, type SlackAdapter } from "@chat-adapter/slack";
-import { createMemoryState } from "@chat-adapter/state-memory";
-import { Chat, type ReactionEvent } from "chat";
+import type { ReactionEvent } from "chat";
 import {
   afterAll,
   afterEach,
@@ -17,27 +15,20 @@ import {
   it,
   vi,
 } from "vitest";
-import { createSlackEvent, createSlackWebhookRequest } from "../../slack-utils";
-import { createWaitUntilTracker } from "../../test-scenarios";
 import {
   addReactionAsHuman,
+  createEmulatorChatHarness,
   createSlackEmulator,
-  EMULATOR_BOT_NAME,
-  EMULATOR_BOT_TOKEN,
+  deliverMention,
   EMULATOR_BOT_USER_ID,
+  type EmulatorChatHarness,
   type SlackEmulatorHandle,
-  type SlackWebhookForwarder,
-  silentLogger,
-  startSlackWebhookForwarder,
   waitForDelivery,
 } from "./utils";
 
 describe("Slack emulator: inbound reaction_added flow", () => {
   let emulator: SlackEmulatorHandle;
-  let chat: Chat<{ slack: SlackAdapter }> | undefined;
-  let adapter!: SlackAdapter;
-  let forwarder: SlackWebhookForwarder | undefined;
-  let tracker!: ReturnType<typeof createWaitUntilTracker>;
+  let harness: EmulatorChatHarness;
 
   beforeAll(async () => {
     emulator = await createSlackEmulator();
@@ -48,85 +39,28 @@ describe("Slack emulator: inbound reaction_added flow", () => {
   });
 
   beforeEach(async () => {
-    adapter = createSlackAdapter({
-      apiUrl: emulator.apiUrl,
-      botToken: EMULATOR_BOT_TOKEN,
-      signingSecret: emulator.signingSecret,
-      userName: EMULATOR_BOT_NAME,
-      logger: silentLogger,
-    });
-    chat = new Chat({
-      userName: EMULATOR_BOT_NAME,
-      adapters: { slack: adapter },
-      state: createMemoryState(),
-      logger: silentLogger,
-    });
-    tracker = createWaitUntilTracker();
-    await chat.initialize();
-
-    const activeChat = chat;
-    forwarder = await startSlackWebhookForwarder({
-      signingSecret: emulator.signingSecret,
-      teamId: emulator.teamId,
-      webhooks: emulator.webhooks,
-      onWebhook: (request) =>
-        activeChat.webhooks.slack(request, { waitUntil: tracker.waitUntil }),
+    harness = await createEmulatorChatHarness(emulator, {
+      withForwarder: true,
     });
   });
 
   afterEach(async () => {
-    if (forwarder) {
-      await forwarder.close();
-      forwarder = undefined;
-    }
-    if (chat) {
-      await chat.shutdown();
-      chat = undefined;
-    }
-    emulator.reset();
+    await harness.teardown();
   });
 
-  async function deliverMention(threadTs: string) {
-    if (!chat) {
-      throw new Error("chat not initialized");
-    }
-
-    const event = createSlackEvent({
-      type: "app_mention",
-      text: `<@${EMULATOR_BOT_USER_ID}> ping`,
-      userId: emulator.humanUserId,
-      messageTs: threadTs,
-      threadTs,
-      channel: emulator.channelId,
-      teamId: emulator.teamId,
-    });
-    const req = createSlackWebhookRequest(event, emulator.signingSecret);
-    const res = await chat.webhooks.slack(req, {
-      waitUntil: tracker.waitUntil,
-    });
-    if (res.status !== 200) {
-      throw new Error(`webhook handler returned ${res.status}`);
-    }
-    await tracker.waitForAll();
-  }
-
   it("delivers reaction_added to onReaction and allows a threaded reply", async () => {
-    if (!chat) {
-      throw new Error("chat not initialized");
-    }
-
     const captured = vi.fn<(event: ReactionEvent) => void>();
-    chat.onReaction(async (event) => {
+    harness.chat.onReaction(async (event) => {
       captured(event);
       await event.thread?.post(`Thanks for the ${event.emoji}!`);
     });
 
-    chat.onNewMention(async (thread) => {
+    harness.chat.onNewMention(async (thread) => {
       await thread.post("react to me");
     });
 
     const threadTs = "1700000000.200001";
-    await deliverMention(threadTs);
+    await deliverMention(emulator, harness, threadTs);
 
     const botMessage = emulator.slackStore.messages
       .all()
@@ -149,11 +83,11 @@ describe("Slack emulator: inbound reaction_added flow", () => {
       emulator,
       (d) => d.event === "reaction_added" && d.success
     );
-    await tracker.waitForAll();
+    await harness.tracker.waitForAll();
 
     expect(captured).toHaveBeenCalledTimes(1);
     expect(captured.mock.calls[0]?.[0]).toMatchObject({
-      adapter,
+      adapter: harness.adapter,
       rawEmoji: "tada",
       user: expect.objectContaining({ userId: emulator.humanUserId }),
     });

--- a/packages/integration-tests/src/emulator/slack/scheduled-messages.test.ts
+++ b/packages/integration-tests/src/emulator/slack/scheduled-messages.test.ts
@@ -21,9 +21,9 @@ const ONE_HOUR_MS = 60 * 60 * 1000;
 
 describe("Slack emulator: scheduled messages", () => {
   let emulator: SlackEmulatorHandle;
-  let chat: Chat<{ slack: SlackAdapter }>;
-  let adapter: SlackAdapter;
-  let tracker: ReturnType<typeof createWaitUntilTracker>;
+  let chat: Chat<{ slack: SlackAdapter }> | undefined;
+  let adapter!: SlackAdapter;
+  let tracker!: ReturnType<typeof createWaitUntilTracker>;
 
   beforeAll(async () => {
     emulator = await createSlackEmulator();
@@ -36,11 +36,12 @@ describe("Slack emulator: scheduled messages", () => {
   afterEach(async () => {
     if (chat) {
       await chat.shutdown();
+      chat = undefined;
     }
     emulator.reset();
   });
 
-  async function setupChat() {
+  async function setupChat(): Promise<Chat<{ slack: SlackAdapter }>> {
     adapter = createSlackAdapter({
       apiUrl: emulator.apiUrl,
       botToken: EMULATOR_BOT_TOKEN,
@@ -48,20 +49,22 @@ describe("Slack emulator: scheduled messages", () => {
       userName: EMULATOR_BOT_NAME,
       logger: silentLogger,
     });
-    chat = new Chat({
+    const instance = new Chat({
       userName: EMULATOR_BOT_NAME,
       adapters: { slack: adapter },
       state: createMemoryState(),
       logger: silentLogger,
     });
+    chat = instance;
     tracker = createWaitUntilTracker();
-    await chat.initialize();
+    await instance.initialize();
+    return instance;
   }
 
   it("schedules a message in the emulator store and can cancel it", async () => {
-    await setupChat();
+    const activeChat = await setupChat();
 
-    chat.onNewMention(async (thread) => {
+    activeChat.onNewMention(async (thread) => {
       const postAt = new Date(Date.now() + ONE_HOUR_MS);
       const scheduled = await thread.schedule("scheduled hello", { postAt });
       expect(scheduled.scheduledMessageId).toBeTruthy();
@@ -91,7 +94,7 @@ describe("Slack emulator: scheduled messages", () => {
       teamId: emulator.teamId,
     });
     const req = createSlackWebhookRequest(event, emulator.signingSecret);
-    await chat.webhooks.slack(req, { waitUntil: tracker.waitUntil });
+    await activeChat.webhooks.slack(req, { waitUntil: tracker.waitUntil });
     await tracker.waitForAll();
   });
 });

--- a/packages/integration-tests/src/emulator/slack/scheduled-messages.test.ts
+++ b/packages/integration-tests/src/emulator/slack/scheduled-messages.test.ts
@@ -1,0 +1,97 @@
+/**
+ * Scheduled message round-trip via chat.scheduleMessage and cancel().
+ */
+
+import { createSlackAdapter, type SlackAdapter } from "@chat-adapter/slack";
+import { createMemoryState } from "@chat-adapter/state-memory";
+import { Chat } from "chat";
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
+import { createSlackEvent, createSlackWebhookRequest } from "../../slack-utils";
+import { createWaitUntilTracker } from "../../test-scenarios";
+import {
+  createSlackEmulator,
+  EMULATOR_BOT_NAME,
+  EMULATOR_BOT_TOKEN,
+  EMULATOR_BOT_USER_ID,
+  type SlackEmulatorHandle,
+  silentLogger,
+} from "./utils";
+
+const ONE_HOUR_MS = 60 * 60 * 1000;
+
+describe("Slack emulator: scheduled messages", () => {
+  let emulator: SlackEmulatorHandle;
+  let chat: Chat<{ slack: SlackAdapter }>;
+  let adapter: SlackAdapter;
+  let tracker: ReturnType<typeof createWaitUntilTracker>;
+
+  beforeAll(async () => {
+    emulator = await createSlackEmulator();
+  });
+
+  afterAll(async () => {
+    await emulator.close();
+  });
+
+  afterEach(async () => {
+    if (chat) {
+      await chat.shutdown();
+    }
+    emulator.reset();
+  });
+
+  async function setupChat() {
+    adapter = createSlackAdapter({
+      apiUrl: emulator.apiUrl,
+      botToken: EMULATOR_BOT_TOKEN,
+      signingSecret: emulator.signingSecret,
+      userName: EMULATOR_BOT_NAME,
+      logger: silentLogger,
+    });
+    chat = new Chat({
+      userName: EMULATOR_BOT_NAME,
+      adapters: { slack: adapter },
+      state: createMemoryState(),
+      logger: silentLogger,
+    });
+    tracker = createWaitUntilTracker();
+    await chat.initialize();
+  }
+
+  it("schedules a message in the emulator store and can cancel it", async () => {
+    await setupChat();
+
+    chat.onNewMention(async (thread) => {
+      const postAt = new Date(Date.now() + ONE_HOUR_MS);
+      const scheduled = await thread.schedule("scheduled hello", { postAt });
+      expect(scheduled.scheduledMessageId).toBeTruthy();
+
+      const stored = emulator.slackStore.scheduledMessages
+        .all()
+        .find((m) => m.scheduled_message_id === scheduled.scheduledMessageId);
+      expect(stored?.text).toBe("scheduled hello");
+      expect(stored?.channel_id).toBe(emulator.channelId);
+
+      await scheduled.cancel();
+
+      const afterCancel = emulator.slackStore.scheduledMessages
+        .all()
+        .find((m) => m.scheduled_message_id === scheduled.scheduledMessageId);
+      expect(afterCancel).toBeUndefined();
+    });
+
+    const threadTs = "1700000000.600001";
+    const event = createSlackEvent({
+      type: "app_mention",
+      text: `<@${EMULATOR_BOT_USER_ID}> schedule please`,
+      userId: emulator.humanUserId,
+      messageTs: threadTs,
+      threadTs,
+      channel: emulator.channelId,
+      teamId: emulator.teamId,
+    });
+    const req = createSlackWebhookRequest(event, emulator.signingSecret);
+    await chat.webhooks.slack(req, { waitUntil: tracker.waitUntil });
+    await tracker.waitForAll();
+  });
+});

--- a/packages/integration-tests/src/emulator/slack/scheduled-messages.test.ts
+++ b/packages/integration-tests/src/emulator/slack/scheduled-messages.test.ts
@@ -2,28 +2,29 @@
  * Scheduled message round-trip via chat.scheduleMessage and cancel().
  */
 
-import { createSlackAdapter, type SlackAdapter } from "@chat-adapter/slack";
-import { createMemoryState } from "@chat-adapter/state-memory";
-import { Chat } from "chat";
-import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
-import { createSlackEvent, createSlackWebhookRequest } from "../../slack-utils";
-import { createWaitUntilTracker } from "../../test-scenarios";
+import type { ScheduledMessage } from "chat";
 import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+} from "vitest";
+import {
+  createEmulatorChatHarness,
   createSlackEmulator,
-  EMULATOR_BOT_NAME,
-  EMULATOR_BOT_TOKEN,
-  EMULATOR_BOT_USER_ID,
+  deliverMention,
+  type EmulatorChatHarness,
   type SlackEmulatorHandle,
-  silentLogger,
 } from "./utils";
 
 const ONE_HOUR_MS = 60 * 60 * 1000;
 
 describe("Slack emulator: scheduled messages", () => {
   let emulator: SlackEmulatorHandle;
-  let chat: Chat<{ slack: SlackAdapter }> | undefined;
-  let adapter!: SlackAdapter;
-  let tracker!: ReturnType<typeof createWaitUntilTracker>;
+  let harness: EmulatorChatHarness;
 
   beforeAll(async () => {
     emulator = await createSlackEmulator();
@@ -33,68 +34,47 @@ describe("Slack emulator: scheduled messages", () => {
     await emulator.close();
   });
 
-  afterEach(async () => {
-    if (chat) {
-      await chat.shutdown();
-      chat = undefined;
-    }
-    emulator.reset();
+  beforeEach(async () => {
+    harness = await createEmulatorChatHarness(emulator);
   });
 
-  async function setupChat(): Promise<Chat<{ slack: SlackAdapter }>> {
-    adapter = createSlackAdapter({
-      apiUrl: emulator.apiUrl,
-      botToken: EMULATOR_BOT_TOKEN,
-      signingSecret: emulator.signingSecret,
-      userName: EMULATOR_BOT_NAME,
-      logger: silentLogger,
-    });
-    const instance = new Chat({
-      userName: EMULATOR_BOT_NAME,
-      adapters: { slack: adapter },
-      state: createMemoryState(),
-      logger: silentLogger,
-    });
-    chat = instance;
-    tracker = createWaitUntilTracker();
-    await instance.initialize();
-    return instance;
-  }
+  afterEach(async () => {
+    await harness.teardown();
+  });
 
   it("schedules a message in the emulator store and can cancel it", async () => {
-    const activeChat = await setupChat();
-
-    activeChat.onNewMention(async (thread) => {
+    // Capture the scheduled handle from the handler, but run the assertions in
+    // the test body. Chat.processMessage swallows handler rejections (they are
+    // only logged via waitUntil), so an `expect` thrown inside onNewMention
+    // would never fail the test — the assertions must live where Vitest sees
+    // them.
+    let scheduled: ScheduledMessage | undefined;
+    harness.chat.onNewMention(async (thread) => {
       const postAt = new Date(Date.now() + ONE_HOUR_MS);
-      const scheduled = await thread.schedule("scheduled hello", { postAt });
-      expect(scheduled.scheduledMessageId).toBeTruthy();
-
-      const stored = emulator.slackStore.scheduledMessages
-        .all()
-        .find((m) => m.scheduled_message_id === scheduled.scheduledMessageId);
-      expect(stored?.text).toBe("scheduled hello");
-      expect(stored?.channel_id).toBe(emulator.channelId);
-
-      await scheduled.cancel();
-
-      const afterCancel = emulator.slackStore.scheduledMessages
-        .all()
-        .find((m) => m.scheduled_message_id === scheduled.scheduledMessageId);
-      expect(afterCancel).toBeUndefined();
+      scheduled = await thread.schedule("scheduled hello", { postAt });
     });
 
     const threadTs = "1700000000.600001";
-    const event = createSlackEvent({
-      type: "app_mention",
-      text: `<@${EMULATOR_BOT_USER_ID}> schedule please`,
-      userId: emulator.humanUserId,
-      messageTs: threadTs,
-      threadTs,
-      channel: emulator.channelId,
-      teamId: emulator.teamId,
-    });
-    const req = createSlackWebhookRequest(event, emulator.signingSecret);
-    await activeChat.webhooks.slack(req, { waitUntil: tracker.waitUntil });
-    await tracker.waitForAll();
+    await deliverMention(emulator, harness, threadTs, "schedule please");
+
+    // Guard against a vacuous pass: if onNewMention never fired, none of the
+    // scheduling behavior was exercised.
+    if (!scheduled) {
+      throw new Error("onNewMention handler did not fire");
+    }
+    expect(scheduled.scheduledMessageId).toBeTruthy();
+
+    const stored = emulator.slackStore.scheduledMessages
+      .all()
+      .find((m) => m.scheduled_message_id === scheduled?.scheduledMessageId);
+    expect(stored?.text).toBe("scheduled hello");
+    expect(stored?.channel_id).toBe(emulator.channelId);
+
+    await scheduled.cancel();
+
+    const afterCancel = emulator.slackStore.scheduledMessages
+      .all()
+      .find((m) => m.scheduled_message_id === scheduled?.scheduledMessageId);
+    expect(afterCancel).toBeUndefined();
   });
 });

--- a/packages/integration-tests/src/emulator/slack/utils.ts
+++ b/packages/integration-tests/src/emulator/slack/utils.ts
@@ -18,11 +18,15 @@
 import { createHmac } from "node:crypto";
 import { createServer as createNodeServer, type Server } from "node:http";
 import type { AddressInfo } from "node:net";
+import { createSlackAdapter, type SlackAdapter } from "@chat-adapter/slack";
+import { createMemoryState } from "@chat-adapter/state-memory";
 import type { Store, TokenMap, WebhookDispatcher } from "@emulators/core";
 import { createServer as createCoreServer } from "@emulators/core";
 import { getSlackStore, type SlackStore, slackPlugin } from "@emulators/slack";
 import { serve } from "@hono/node-server";
-import type { Logger } from "chat";
+import { Chat, type Logger } from "chat";
+import { createSlackEvent, createSlackWebhookRequest } from "../../slack-utils";
+import { createWaitUntilTracker } from "../../test-scenarios";
 
 /**
  * Silent logger shared across emulator-backed tests so we don't spam test
@@ -120,15 +124,22 @@ export interface SlackEmulatorHandle {
 export async function createSlackEmulator(): Promise<SlackEmulatorHandle> {
   const seed = DEFAULT_SEED;
 
+  // Reserve the listening port up front so the emulator can be created with a
+  // `baseUrl` that matches where it actually binds. The emulator bakes this
+  // baseUrl into self-built URLs (file upload URLs, permalinks), so passing the
+  // real origin here means tests can fetch those URLs directly without
+  // rewriting the host.
+  const port = await allocateEphemeralPort();
+  const baseUrl = `http://127.0.0.1:${port}`;
+  const apiUrl = `${baseUrl}/api/`;
+
   const { app, store, webhooks, tokenMap } = createCoreServer(slackPlugin, {
-    port: 0,
+    port,
+    baseUrl,
     tokens: buildTokenSeedEntries(seed),
   });
 
-  const httpServer = await listen(app.fetch);
-  const port = (httpServer.address() as AddressInfo).port;
-  const baseUrl = `http://127.0.0.1:${port}`;
-  const apiUrl = `${baseUrl}/api/`;
+  const httpServer = await listen(app.fetch, port);
 
   // Slack plugin's seed() installs a default team/channel/admin user that we
   // don't use; replace with our own deterministic ids so tests can refer to
@@ -167,11 +178,31 @@ export async function createSlackEmulator(): Promise<SlackEmulatorHandle> {
   };
 }
 
-function listen(fetch: (req: Request) => Response | Promise<Response>) {
+function listen(
+  fetch: (req: Request) => Response | Promise<Response>,
+  port: number
+) {
   return new Promise<Server>((resolve) => {
-    const server = serve({ fetch, port: 0, hostname: "127.0.0.1" }, () => {
+    const server = serve({ fetch, port, hostname: "127.0.0.1" }, () => {
       resolve(server as unknown as Server);
     }) as unknown as Server;
+  });
+}
+
+/**
+ * Bind an ephemeral port (port 0 → OS-assigned), read the assigned port, then
+ * release it so the emulator server can claim it. There is a small window
+ * between release and re-bind, but concurrent `listen(0)` calls receive
+ * distinct ports from the OS so this is safe for in-process tests.
+ */
+function allocateEphemeralPort(): Promise<number> {
+  return new Promise((resolve, reject) => {
+    const probe = createNodeServer();
+    probe.once("error", reject);
+    probe.listen(0, "127.0.0.1", () => {
+      const { port } = probe.address() as AddressInfo;
+      probe.close((err) => (err ? reject(err) : resolve(port)));
+    });
   });
 }
 
@@ -292,7 +323,6 @@ export function addEmulatorWorkspace(
 
 function applySeed(store: Store, seed: EmulatorSeed) {
   const ss = getSlackStore(store);
-  const now = Math.floor(Date.now() / 1000);
 
   ss.teams.insert({
     team_id: seed.team.id,
@@ -351,18 +381,11 @@ function applySeed(store: Store, seed: EmulatorSeed) {
     ...seed.humans.map((h) => h.userId),
   ];
   for (const ch of seed.channels) {
-    ss.channels.insert({
-      channel_id: ch.id,
-      team_id: seed.team.id,
+    insertChannel(ss, {
+      channelId: ch.id,
       name: ch.name,
-      is_channel: true,
-      is_private: false,
-      is_archived: false,
-      topic: { value: "", creator: memberIds[0] ?? "", last_set: now },
-      purpose: { value: "", creator: memberIds[0] ?? "", last_set: now },
       members: memberIds,
-      creator: memberIds[0] ?? "",
-      num_members: memberIds.length,
+      teamId: seed.team.id,
     });
   }
 
@@ -374,6 +397,37 @@ function applySeed(store: Store, seed: EmulatorSeed) {
   });
 
   store.setData("slack.signing_secret", EMULATOR_SIGNING_SECRET);
+}
+
+/**
+ * Insert a public channel into the Slack store. Shared by `applySeed` (initial
+ * boot + reset) and `seedChannelWithoutBot` so the channel record shape lives
+ * in one place. The first member is treated as the creator.
+ */
+function insertChannel(
+  ss: SlackStore,
+  options: {
+    channelId: string;
+    members: string[];
+    name: string;
+    teamId: string;
+  }
+): void {
+  const now = Math.floor(Date.now() / 1000);
+  const creator = options.members[0] ?? "";
+  ss.channels.insert({
+    channel_id: options.channelId,
+    team_id: options.teamId,
+    name: options.name,
+    is_channel: true,
+    is_private: false,
+    is_archived: false,
+    topic: { value: "", creator, last_set: now },
+    purpose: { value: "", creator, last_set: now },
+    members: options.members,
+    creator,
+    num_members: options.members.length,
+  });
 }
 
 /**
@@ -544,6 +598,34 @@ function signSlackBody(
 }
 
 /**
+ * POST to an emulator Slack Web API method with bearer auth, parse the JSON
+ * envelope, and throw if the call was not `ok`. Centralizes the auth header,
+ * content-type, and error-envelope handling shared by every emulator helper.
+ * Defaults to the bot token; pass `token` to act as another user.
+ */
+async function callEmulatorApi<T extends { error?: string; ok: boolean }>(
+  emulator: SlackEmulatorHandle,
+  method: string,
+  body: Record<string, unknown>,
+  options: { token?: string } = {}
+): Promise<T> {
+  const token = options.token ?? emulator.botToken;
+  const response = await fetch(`${emulator.apiUrl}${method}`, {
+    method: "POST",
+    headers: {
+      authorization: `Bearer ${token}`,
+      "content-type": "application/json; charset=utf-8",
+    },
+    body: JSON.stringify(body),
+  });
+  const json = (await response.json()) as T;
+  if (!json.ok) {
+    throw new Error(`emulator ${method} failed: ${JSON.stringify(json)}`);
+  }
+  return json;
+}
+
+/**
  * Convenience: post a message to a channel via the emulator using the human
  * user token, mirroring an end-user posting in Slack. Returns the inserted
  * message's `ts` so tests can correlate replies/threads.
@@ -557,28 +639,16 @@ export async function postAsHuman(
   }
 ): Promise<{ channel: string; ts: string }> {
   const channel = options.channel ?? emulator.channelId;
-  const response = await fetch(`${emulator.apiUrl}chat.postMessage`, {
-    method: "POST",
-    headers: {
-      "content-type": "application/json; charset=utf-8",
-      authorization: `Bearer ${emulator.humanUserToken}`,
-    },
-    body: JSON.stringify({
-      channel,
-      text: options.text,
-      thread_ts: options.threadTs,
-    }),
-  });
-  const json = (await response.json()) as {
+  const json = await callEmulatorApi<{
     channel: string;
     ok: boolean;
     ts: string;
-  };
-  if (!json.ok) {
-    throw new Error(
-      `emulator chat.postMessage failed: ${JSON.stringify(json)}`
-    );
-  }
+  }>(
+    emulator,
+    "chat.postMessage",
+    { channel, text: options.text, thread_ts: options.threadTs },
+    { token: emulator.humanUserToken }
+  );
   return { channel: json.channel, ts: json.ts };
 }
 
@@ -594,57 +664,34 @@ export async function addReactionAsHuman(
     timestamp: string;
   }
 ): Promise<void> {
-  const response = await fetch(`${emulator.apiUrl}reactions.add`, {
-    method: "POST",
-    headers: {
-      authorization: `Bearer ${emulator.humanUserToken}`,
-      "content-type": "application/json; charset=utf-8",
-    },
-    body: JSON.stringify({
+  await callEmulatorApi(
+    emulator,
+    "reactions.add",
+    {
       channel: options.channel,
       name: options.name,
       timestamp: options.timestamp,
-    }),
-  });
-  const json = (await response.json()) as { error?: string; ok: boolean };
-  if (!json.ok) {
-    throw new Error(`emulator reactions.add failed: ${JSON.stringify(json)}`);
-  }
+    },
+    { token: emulator.humanUserToken }
+  );
 }
 
 /**
  * Obtain a single-use trigger id for `views.open` / `views.push`.
  */
 export async function generateViewTriggerId(
-  emulator: SlackEmulatorHandle,
-  options: { userId?: string; viewId?: string } = {}
-): Promise<{ expiresAt: number; triggerId: string }> {
-  const response = await fetch(`${emulator.apiUrl}views.generateTriggerId`, {
-    method: "POST",
-    headers: {
-      authorization: `Bearer ${emulator.botToken}`,
-      "content-type": "application/json; charset=utf-8",
-    },
-    body: JSON.stringify({
-      user_id: options.userId ?? emulator.humanUserId,
-      ...(options.viewId ? { view_id: options.viewId } : {}),
-    }),
-  });
-  const json = (await response.json()) as {
-    error?: string;
-    expires_at?: number;
+  emulator: SlackEmulatorHandle
+): Promise<string> {
+  const json = await callEmulatorApi<{
     ok: boolean;
     trigger_id?: string;
-  };
-  if (!(json.ok && json.trigger_id)) {
+  }>(emulator, "views.generateTriggerId", { user_id: emulator.humanUserId });
+  if (!json.trigger_id) {
     throw new Error(
-      `emulator views.generateTriggerId failed: ${JSON.stringify(json)}`
+      `emulator views.generateTriggerId returned no trigger_id: ${JSON.stringify(json)}`
     );
   }
-  return {
-    triggerId: json.trigger_id,
-    expiresAt: json.expires_at ?? 0,
-  };
+  return json.trigger_id;
 }
 
 /**
@@ -655,20 +702,7 @@ export async function joinChannelAsBot(
   emulator: SlackEmulatorHandle,
   channelId: string
 ): Promise<void> {
-  const response = await fetch(`${emulator.apiUrl}conversations.join`, {
-    method: "POST",
-    headers: {
-      authorization: `Bearer ${emulator.botToken}`,
-      "content-type": "application/json; charset=utf-8",
-    },
-    body: JSON.stringify({ channel: channelId }),
-  });
-  const json = (await response.json()) as { error?: string; ok: boolean };
-  if (!json.ok) {
-    throw new Error(
-      `emulator conversations.join failed: ${JSON.stringify(json)}`
-    );
-  }
+  await callEmulatorApi(emulator, "conversations.join", { channel: channelId });
 }
 
 /**
@@ -678,27 +712,11 @@ export function seedChannelWithoutBot(
   emulator: SlackEmulatorHandle,
   options: { channelId: string; name: string }
 ): void {
-  const now = Math.floor(Date.now() / 1000);
-  emulator.slackStore.channels.insert({
-    channel_id: options.channelId,
-    team_id: emulator.teamId,
+  insertChannel(emulator.slackStore, {
+    channelId: options.channelId,
     name: options.name,
-    is_channel: true,
-    is_private: false,
-    is_archived: false,
-    topic: {
-      value: "",
-      creator: emulator.humanUserId,
-      last_set: now,
-    },
-    purpose: {
-      value: "",
-      creator: emulator.humanUserId,
-      last_set: now,
-    },
     members: [emulator.humanUserId],
-    creator: emulator.humanUserId,
-    num_members: 1,
+    teamId: emulator.teamId,
   });
 }
 
@@ -710,26 +728,19 @@ export async function addBookmarkViaApi(
     title: string;
   }
 ): Promise<{ bookmarkId: string }> {
-  const response = await fetch(`${emulator.apiUrl}bookmarks.add`, {
-    method: "POST",
-    headers: {
-      authorization: `Bearer ${emulator.botToken}`,
-      "content-type": "application/json; charset=utf-8",
-    },
-    body: JSON.stringify({
-      channel_id: options.channelId,
-      type: "link",
-      title: options.title,
-      link: options.link,
-    }),
-  });
-  const json = (await response.json()) as {
+  const json = await callEmulatorApi<{
     bookmark?: { id?: string };
-    error?: string;
     ok: boolean;
-  };
-  if (!(json.ok && json.bookmark?.id)) {
-    throw new Error(`emulator bookmarks.add failed: ${JSON.stringify(json)}`);
+  }>(emulator, "bookmarks.add", {
+    channel_id: options.channelId,
+    type: "link",
+    title: options.title,
+    link: options.link,
+  });
+  if (!json.bookmark?.id) {
+    throw new Error(
+      `emulator bookmarks.add returned no bookmark id: ${JSON.stringify(json)}`
+    );
   }
   return { bookmarkId: json.bookmark.id };
 }
@@ -738,23 +749,100 @@ export async function listBookmarksViaApi(
   emulator: SlackEmulatorHandle,
   channelId: string
 ): Promise<Array<{ id: string; link: string; title: string }>> {
-  const response = await fetch(`${emulator.apiUrl}bookmarks.list`, {
-    method: "POST",
-    headers: {
-      authorization: `Bearer ${emulator.botToken}`,
-      "content-type": "application/json; charset=utf-8",
-    },
-    body: JSON.stringify({ channel_id: channelId }),
-  });
-  const json = (await response.json()) as {
+  const json = await callEmulatorApi<{
     bookmarks?: Array<{ id: string; link: string; title: string }>;
-    error?: string;
     ok: boolean;
-  };
-  if (!json.ok) {
-    throw new Error(`emulator bookmarks.list failed: ${JSON.stringify(json)}`);
-  }
+  }>(emulator, "bookmarks.list", { channel_id: channelId });
   return json.bookmarks ?? [];
+}
+
+export interface EmulatorChatHarness {
+  adapter: SlackAdapter;
+  chat: Chat<{ slack: SlackAdapter }>;
+  /** Present only when `withForwarder` was requested. */
+  forwarder?: SlackWebhookForwarder;
+  /** Close the forwarder (if any), shut down the chat, and reset the emulator. */
+  teardown: () => Promise<void>;
+  tracker: ReturnType<typeof createWaitUntilTracker>;
+}
+
+/**
+ * Boot a `Chat` wired to the emulator with the silent logger, in-memory state,
+ * and a shared waitUntil tracker — the setup every emulator-backed test repeats.
+ * With `withForwarder: true` it also starts the inbound webhook forwarder so
+ * emulator-dispatched events (reactions, joins, DMs) reach
+ * `chat.webhooks.slack(...)`. Call the returned `teardown` from `afterEach`.
+ */
+export async function createEmulatorChatHarness(
+  emulator: SlackEmulatorHandle,
+  options: { withForwarder?: boolean } = {}
+): Promise<EmulatorChatHarness> {
+  const adapter = createSlackAdapter({
+    apiUrl: emulator.apiUrl,
+    botToken: EMULATOR_BOT_TOKEN,
+    signingSecret: emulator.signingSecret,
+    userName: EMULATOR_BOT_NAME,
+    logger: silentLogger,
+  });
+  const chat = new Chat({
+    userName: EMULATOR_BOT_NAME,
+    adapters: { slack: adapter },
+    state: createMemoryState(),
+    logger: silentLogger,
+  });
+  const tracker = createWaitUntilTracker();
+  await chat.initialize();
+
+  let forwarder: SlackWebhookForwarder | undefined;
+  if (options.withForwarder) {
+    forwarder = await startSlackWebhookForwarder({
+      signingSecret: emulator.signingSecret,
+      teamId: emulator.teamId,
+      webhooks: emulator.webhooks,
+      onWebhook: (request) =>
+        chat.webhooks.slack(request, { waitUntil: tracker.waitUntil }),
+    });
+  }
+
+  const teardown = async () => {
+    if (forwarder) {
+      await forwarder.close();
+    }
+    await chat.shutdown();
+    emulator.reset();
+  };
+
+  return { adapter, chat, tracker, forwarder, teardown };
+}
+
+/**
+ * Deliver an `app_mention` of the bot into the seeded channel via a signed
+ * webhook request, assert the handler returned 200, and drain the tracker so
+ * all `waitUntil`-tracked handler work has settled before returning.
+ */
+export async function deliverMention(
+  emulator: SlackEmulatorHandle,
+  harness: Pick<EmulatorChatHarness, "chat" | "tracker">,
+  threadTs: string,
+  text = "ping"
+): Promise<void> {
+  const event = createSlackEvent({
+    type: "app_mention",
+    text: `<@${EMULATOR_BOT_USER_ID}> ${text}`,
+    userId: emulator.humanUserId,
+    messageTs: threadTs,
+    threadTs,
+    channel: emulator.channelId,
+    teamId: emulator.teamId,
+  });
+  const req = createSlackWebhookRequest(event, emulator.signingSecret);
+  const res = await harness.chat.webhooks.slack(req, {
+    waitUntil: harness.tracker.waitUntil,
+  });
+  if (res.status !== 200) {
+    throw new Error(`webhook handler returned ${res.status}`);
+  }
+  await harness.tracker.waitForAll();
 }
 
 /**

--- a/packages/integration-tests/src/emulator/slack/utils.ts
+++ b/packages/integration-tests/src/emulator/slack/utils.ts
@@ -613,10 +613,6 @@ export async function addReactionAsHuman(
 }
 
 /**
- * Wait until at least one webhook delivery has been recorded, with a small
- * polling loop to absorb async dispatch timing.
- */
-/**
  * Obtain a single-use trigger id for `views.open` / `views.push`.
  */
 export async function generateViewTriggerId(
@@ -761,6 +757,10 @@ export async function listBookmarksViaApi(
   return json.bookmarks ?? [];
 }
 
+/**
+ * Wait until at least one webhook delivery has been recorded, with a small
+ * polling loop to absorb async dispatch timing.
+ */
 export async function waitForDelivery(
   emulator: SlackEmulatorHandle,
   predicate: (

--- a/packages/integration-tests/src/emulator/slack/utils.ts
+++ b/packages/integration-tests/src/emulator/slack/utils.ts
@@ -179,6 +179,13 @@ const BOT_TOKEN_SCOPES = [
   "chat:write",
   "channels:read",
   "channels:history",
+  "channels:join",
+  "bookmarks:read",
+  "bookmarks:write",
+  "files:write",
+  "im:read",
+  "im:history",
+  "im:write",
   "users:read",
   "reactions:read",
   "reactions:write",
@@ -576,9 +583,184 @@ export async function postAsHuman(
 }
 
 /**
+ * Add a reaction as the seeded human user. Dispatches `reaction_added` when
+ * the emulator webhook forwarder is registered.
+ */
+export async function addReactionAsHuman(
+  emulator: SlackEmulatorHandle,
+  options: {
+    channel: string;
+    name: string;
+    timestamp: string;
+  }
+): Promise<void> {
+  const response = await fetch(`${emulator.apiUrl}reactions.add`, {
+    method: "POST",
+    headers: {
+      authorization: `Bearer ${emulator.humanUserToken}`,
+      "content-type": "application/json; charset=utf-8",
+    },
+    body: JSON.stringify({
+      channel: options.channel,
+      name: options.name,
+      timestamp: options.timestamp,
+    }),
+  });
+  const json = (await response.json()) as { error?: string; ok: boolean };
+  if (!json.ok) {
+    throw new Error(`emulator reactions.add failed: ${JSON.stringify(json)}`);
+  }
+}
+
+/**
  * Wait until at least one webhook delivery has been recorded, with a small
  * polling loop to absorb async dispatch timing.
  */
+/**
+ * Obtain a single-use trigger id for `views.open` / `views.push`.
+ */
+export async function generateViewTriggerId(
+  emulator: SlackEmulatorHandle,
+  options: { userId?: string; viewId?: string } = {}
+): Promise<{ expiresAt: number; triggerId: string }> {
+  const response = await fetch(`${emulator.apiUrl}views.generateTriggerId`, {
+    method: "POST",
+    headers: {
+      authorization: `Bearer ${emulator.botToken}`,
+      "content-type": "application/json; charset=utf-8",
+    },
+    body: JSON.stringify({
+      user_id: options.userId ?? emulator.humanUserId,
+      ...(options.viewId ? { view_id: options.viewId } : {}),
+    }),
+  });
+  const json = (await response.json()) as {
+    error?: string;
+    expires_at?: number;
+    ok: boolean;
+    trigger_id?: string;
+  };
+  if (!(json.ok && json.trigger_id)) {
+    throw new Error(
+      `emulator views.generateTriggerId failed: ${JSON.stringify(json)}`
+    );
+  }
+  return {
+    triggerId: json.trigger_id,
+    expiresAt: json.expires_at ?? 0,
+  };
+}
+
+/**
+ * Join a channel as the seeded bot user via `conversations.join`.
+ * Dispatches `member_joined_channel` when the webhook forwarder is active.
+ */
+export async function joinChannelAsBot(
+  emulator: SlackEmulatorHandle,
+  channelId: string
+): Promise<void> {
+  const response = await fetch(`${emulator.apiUrl}conversations.join`, {
+    method: "POST",
+    headers: {
+      authorization: `Bearer ${emulator.botToken}`,
+      "content-type": "application/json; charset=utf-8",
+    },
+    body: JSON.stringify({ channel: channelId }),
+  });
+  const json = (await response.json()) as { error?: string; ok: boolean };
+  if (!json.ok) {
+    throw new Error(
+      `emulator conversations.join failed: ${JSON.stringify(json)}`
+    );
+  }
+}
+
+/**
+ * Seed a public channel that only contains the human user (bot not yet joined).
+ */
+export function seedChannelWithoutBot(
+  emulator: SlackEmulatorHandle,
+  options: { channelId: string; name: string }
+): void {
+  const now = Math.floor(Date.now() / 1000);
+  emulator.slackStore.channels.insert({
+    channel_id: options.channelId,
+    team_id: emulator.teamId,
+    name: options.name,
+    is_channel: true,
+    is_private: false,
+    is_archived: false,
+    topic: {
+      value: "",
+      creator: emulator.humanUserId,
+      last_set: now,
+    },
+    purpose: {
+      value: "",
+      creator: emulator.humanUserId,
+      last_set: now,
+    },
+    members: [emulator.humanUserId],
+    creator: emulator.humanUserId,
+    num_members: 1,
+  });
+}
+
+export async function addBookmarkViaApi(
+  emulator: SlackEmulatorHandle,
+  options: {
+    channelId: string;
+    link: string;
+    title: string;
+  }
+): Promise<{ bookmarkId: string }> {
+  const response = await fetch(`${emulator.apiUrl}bookmarks.add`, {
+    method: "POST",
+    headers: {
+      authorization: `Bearer ${emulator.botToken}`,
+      "content-type": "application/json; charset=utf-8",
+    },
+    body: JSON.stringify({
+      channel_id: options.channelId,
+      type: "link",
+      title: options.title,
+      link: options.link,
+    }),
+  });
+  const json = (await response.json()) as {
+    bookmark?: { id?: string };
+    error?: string;
+    ok: boolean;
+  };
+  if (!(json.ok && json.bookmark?.id)) {
+    throw new Error(`emulator bookmarks.add failed: ${JSON.stringify(json)}`);
+  }
+  return { bookmarkId: json.bookmark.id };
+}
+
+export async function listBookmarksViaApi(
+  emulator: SlackEmulatorHandle,
+  channelId: string
+): Promise<Array<{ id: string; link: string; title: string }>> {
+  const response = await fetch(`${emulator.apiUrl}bookmarks.list`, {
+    method: "POST",
+    headers: {
+      authorization: `Bearer ${emulator.botToken}`,
+      "content-type": "application/json; charset=utf-8",
+    },
+    body: JSON.stringify({ channel_id: channelId }),
+  });
+  const json = (await response.json()) as {
+    bookmarks?: Array<{ id: string; link: string; title: string }>;
+    error?: string;
+    ok: boolean;
+  };
+  if (!json.ok) {
+    throw new Error(`emulator bookmarks.list failed: ${JSON.stringify(json)}`);
+  }
+  return json.bookmarks ?? [];
+}
+
 export async function waitForDelivery(
   emulator: SlackEmulatorHandle,
   predicate: (

--- a/packages/integration-tests/src/emulator/slack/views.test.ts
+++ b/packages/integration-tests/src/emulator/slack/views.test.ts
@@ -1,0 +1,156 @@
+/**
+ * Modal views round-trip: trigger generation, views.open/update, and
+ * view_submission interactivity against the emulator store.
+ */
+
+import { createSlackAdapter, type SlackAdapter } from "@chat-adapter/slack";
+import { createMemoryState } from "@chat-adapter/state-memory";
+import { Chat, Modal, type ModalSubmitEvent, TextInput } from "chat";
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vitest";
+import { createSlackViewSubmissionRequest } from "../../slack-utils";
+import { createWaitUntilTracker } from "../../test-scenarios";
+import {
+  createSlackEmulator,
+  EMULATOR_BOT_NAME,
+  EMULATOR_BOT_TOKEN,
+  generateViewTriggerId,
+  type SlackEmulatorHandle,
+  silentLogger,
+} from "./utils";
+
+describe("Slack emulator: modal views round-trip", () => {
+  let emulator: SlackEmulatorHandle;
+  let chat: Chat<{ slack: SlackAdapter }>;
+  let adapter: SlackAdapter;
+  let tracker: ReturnType<typeof createWaitUntilTracker>;
+
+  beforeAll(async () => {
+    emulator = await createSlackEmulator();
+  });
+
+  afterAll(async () => {
+    await emulator.close();
+  });
+
+  beforeEach(async () => {
+    adapter = createSlackAdapter({
+      apiUrl: emulator.apiUrl,
+      botToken: EMULATOR_BOT_TOKEN,
+      signingSecret: emulator.signingSecret,
+      userName: EMULATOR_BOT_NAME,
+      logger: silentLogger,
+    });
+    chat = new Chat({
+      userName: EMULATOR_BOT_NAME,
+      adapters: { slack: adapter },
+      state: createMemoryState(),
+      logger: silentLogger,
+    });
+    tracker = createWaitUntilTracker();
+    await chat.initialize();
+  });
+
+  afterEach(async () => {
+    if (chat) {
+      await chat.shutdown();
+    }
+    emulator.reset();
+  });
+
+  it("opens and updates a modal via views.open and views.update", async () => {
+    const { triggerId } = await generateViewTriggerId(emulator);
+    const modal = Modal({
+      title: "Feedback",
+      callbackId: "feedback_form",
+      children: [
+        TextInput({
+          id: "note",
+          label: "Your note",
+          placeholder: "Type here",
+        }),
+      ],
+    });
+
+    const opened = await adapter.openModal(triggerId, modal);
+    const stored = emulator.slackStore.views.findOneBy(
+      "view_id",
+      opened.viewId
+    );
+    expect(stored?.callback_id).toBe("feedback_form");
+    expect(stored?.type).toBe("modal");
+
+    await adapter.updateModal(
+      opened.viewId,
+      Modal({
+        title: "Updated feedback",
+        callbackId: "feedback_form",
+        children: [
+          TextInput({
+            id: "note",
+            label: "Updated label",
+          }),
+        ],
+      })
+    );
+
+    const updated = emulator.slackStore.views.findOneBy(
+      "view_id",
+      opened.viewId
+    );
+    expect(updated?.title?.text).toBe("Updated feedback");
+  });
+
+  it("delivers view_submission to onModalSubmit", async () => {
+    const captured = vi.fn<(event: ModalSubmitEvent) => void>();
+    chat.onModalSubmit("feedback_form", (event) => {
+      captured(event);
+    });
+
+    const { triggerId } = await generateViewTriggerId(emulator);
+    const { viewId } = await adapter.openModal(
+      triggerId,
+      Modal({
+        title: "Feedback",
+        callbackId: "feedback_form",
+        children: [TextInput({ id: "note", label: "Note" })],
+      })
+    );
+
+    const req = createSlackViewSubmissionRequest(
+      {
+        viewId,
+        callbackId: "feedback_form",
+        teamId: emulator.teamId,
+        userId: emulator.humanUserId,
+        stateValues: {
+          note: {
+            note: { type: "plain_text_input", value: "great emulator" },
+          },
+        },
+      },
+      emulator.signingSecret
+    );
+
+    const res = await chat.webhooks.slack(req, {
+      waitUntil: tracker.waitUntil,
+    });
+    await tracker.waitForAll();
+
+    expect(res.status).toBe(200);
+    expect(captured).toHaveBeenCalledTimes(1);
+    expect(captured.mock.calls[0]?.[0]).toMatchObject({
+      callbackId: "feedback_form",
+      viewId,
+      values: { note: "great emulator" },
+    });
+  });
+});

--- a/packages/integration-tests/src/emulator/slack/views.test.ts
+++ b/packages/integration-tests/src/emulator/slack/views.test.ts
@@ -29,9 +29,9 @@ import {
 
 describe("Slack emulator: modal views round-trip", () => {
   let emulator: SlackEmulatorHandle;
-  let chat: Chat<{ slack: SlackAdapter }>;
-  let adapter: SlackAdapter;
-  let tracker: ReturnType<typeof createWaitUntilTracker>;
+  let chat: Chat<{ slack: SlackAdapter }> | undefined;
+  let adapter!: SlackAdapter;
+  let tracker!: ReturnType<typeof createWaitUntilTracker>;
 
   beforeAll(async () => {
     emulator = await createSlackEmulator();
@@ -62,6 +62,7 @@ describe("Slack emulator: modal views round-trip", () => {
   afterEach(async () => {
     if (chat) {
       await chat.shutdown();
+      chat = undefined;
     }
     emulator.reset();
   });
@@ -110,6 +111,10 @@ describe("Slack emulator: modal views round-trip", () => {
   });
 
   it("delivers view_submission to onModalSubmit", async () => {
+    if (!chat) {
+      throw new Error("chat not initialized");
+    }
+
     const captured = vi.fn<(event: ModalSubmitEvent) => void>();
     chat.onModalSubmit("feedback_form", (event) => {
       captured(event);

--- a/packages/integration-tests/src/emulator/slack/views.test.ts
+++ b/packages/integration-tests/src/emulator/slack/views.test.ts
@@ -3,9 +3,7 @@
  * view_submission interactivity against the emulator store.
  */
 
-import { createSlackAdapter, type SlackAdapter } from "@chat-adapter/slack";
-import { createMemoryState } from "@chat-adapter/state-memory";
-import { Chat, Modal, type ModalSubmitEvent, TextInput } from "chat";
+import { Modal, type ModalSubmitEvent, TextInput } from "chat";
 import {
   afterAll,
   afterEach,
@@ -17,21 +15,17 @@ import {
   vi,
 } from "vitest";
 import { createSlackViewSubmissionRequest } from "../../slack-utils";
-import { createWaitUntilTracker } from "../../test-scenarios";
 import {
+  createEmulatorChatHarness,
   createSlackEmulator,
-  EMULATOR_BOT_NAME,
-  EMULATOR_BOT_TOKEN,
+  type EmulatorChatHarness,
   generateViewTriggerId,
   type SlackEmulatorHandle,
-  silentLogger,
 } from "./utils";
 
 describe("Slack emulator: modal views round-trip", () => {
   let emulator: SlackEmulatorHandle;
-  let chat: Chat<{ slack: SlackAdapter }> | undefined;
-  let adapter!: SlackAdapter;
-  let tracker!: ReturnType<typeof createWaitUntilTracker>;
+  let harness: EmulatorChatHarness;
 
   beforeAll(async () => {
     emulator = await createSlackEmulator();
@@ -42,33 +36,15 @@ describe("Slack emulator: modal views round-trip", () => {
   });
 
   beforeEach(async () => {
-    adapter = createSlackAdapter({
-      apiUrl: emulator.apiUrl,
-      botToken: EMULATOR_BOT_TOKEN,
-      signingSecret: emulator.signingSecret,
-      userName: EMULATOR_BOT_NAME,
-      logger: silentLogger,
-    });
-    chat = new Chat({
-      userName: EMULATOR_BOT_NAME,
-      adapters: { slack: adapter },
-      state: createMemoryState(),
-      logger: silentLogger,
-    });
-    tracker = createWaitUntilTracker();
-    await chat.initialize();
+    harness = await createEmulatorChatHarness(emulator);
   });
 
   afterEach(async () => {
-    if (chat) {
-      await chat.shutdown();
-      chat = undefined;
-    }
-    emulator.reset();
+    await harness.teardown();
   });
 
   it("opens and updates a modal via views.open and views.update", async () => {
-    const { triggerId } = await generateViewTriggerId(emulator);
+    const triggerId = await generateViewTriggerId(emulator);
     const modal = Modal({
       title: "Feedback",
       callbackId: "feedback_form",
@@ -81,7 +57,7 @@ describe("Slack emulator: modal views round-trip", () => {
       ],
     });
 
-    const opened = await adapter.openModal(triggerId, modal);
+    const opened = await harness.adapter.openModal(triggerId, modal);
     const stored = emulator.slackStore.views.findOneBy(
       "view_id",
       opened.viewId
@@ -89,7 +65,7 @@ describe("Slack emulator: modal views round-trip", () => {
     expect(stored?.callback_id).toBe("feedback_form");
     expect(stored?.type).toBe("modal");
 
-    await adapter.updateModal(
+    await harness.adapter.updateModal(
       opened.viewId,
       Modal({
         title: "Updated feedback",
@@ -111,17 +87,13 @@ describe("Slack emulator: modal views round-trip", () => {
   });
 
   it("delivers view_submission to onModalSubmit", async () => {
-    if (!chat) {
-      throw new Error("chat not initialized");
-    }
-
     const captured = vi.fn<(event: ModalSubmitEvent) => void>();
-    chat.onModalSubmit("feedback_form", (event) => {
+    harness.chat.onModalSubmit("feedback_form", (event) => {
       captured(event);
     });
 
-    const { triggerId } = await generateViewTriggerId(emulator);
-    const { viewId } = await adapter.openModal(
+    const triggerId = await generateViewTriggerId(emulator);
+    const { viewId } = await harness.adapter.openModal(
       triggerId,
       Modal({
         title: "Feedback",
@@ -145,10 +117,10 @@ describe("Slack emulator: modal views round-trip", () => {
       emulator.signingSecret
     );
 
-    const res = await chat.webhooks.slack(req, {
-      waitUntil: tracker.waitUntil,
+    const res = await harness.chat.webhooks.slack(req, {
+      waitUntil: harness.tracker.waitUntil,
     });
-    await tracker.waitForAll();
+    await harness.tracker.waitForAll();
 
     expect(res.status).toBe(200);
     expect(captured).toHaveBeenCalledTimes(1);

--- a/packages/integration-tests/src/slack-utils.ts
+++ b/packages/integration-tests/src/slack-utils.ts
@@ -377,7 +377,7 @@ function createSlackViewSubmissionPayload(options: SlackViewSubmissionOptions) {
 /**
  * Create a signed Slack interactivity webhook request (form-urlencoded).
  */
-export function createSlackInteractiveRequest(
+function createSlackInteractiveRequest(
   payload: Record<string, unknown>,
   signingSecret = SLACK_SIGNING_SECRET
 ): Request {

--- a/packages/integration-tests/src/slack-utils.ts
+++ b/packages/integration-tests/src/slack-utils.ts
@@ -323,6 +323,7 @@ function createSlackBlockActionsPayload(options: SlackBlockActionsOptions) {
 export interface SlackViewSubmissionOptions {
   apiAppId?: string;
   callbackId: string;
+  /** Defaults to `""` so payloads match Slack's always-present string field. */
   privateMetadata?: string;
   stateValues?: Record<
     string,
@@ -342,7 +343,7 @@ function createSlackViewSubmissionPayload(options: SlackViewSubmissionOptions) {
     userName = "testuser",
     teamId,
     apiAppId = "A_TEST",
-    privateMetadata,
+    privateMetadata = "",
     stateValues = {},
   } = options;
 

--- a/packages/integration-tests/src/slack-utils.ts
+++ b/packages/integration-tests/src/slack-utils.ts
@@ -320,14 +320,66 @@ function createSlackBlockActionsPayload(options: SlackBlockActionsOptions) {
   return payload;
 }
 
+export interface SlackViewSubmissionOptions {
+  apiAppId?: string;
+  callbackId: string;
+  privateMetadata?: string;
+  stateValues?: Record<
+    string,
+    Record<string, { type?: string; value?: string }>
+  >;
+  teamId: string;
+  userId: string;
+  userName?: string;
+  viewId: string;
+}
+
+function createSlackViewSubmissionPayload(options: SlackViewSubmissionOptions) {
+  const {
+    viewId,
+    callbackId,
+    userId,
+    userName = "testuser",
+    teamId,
+    apiAppId = "A_TEST",
+    privateMetadata,
+    stateValues = {},
+  } = options;
+
+  return {
+    type: "view_submission",
+    team: { id: teamId, domain: "test-workspace" },
+    user: {
+      id: userId,
+      username: userName,
+      name: userName,
+      team_id: teamId,
+    },
+    api_app_id: apiAppId,
+    token: "test-interactivity-token",
+    trigger_id: "trigger-for-view-submission",
+    view: {
+      id: viewId,
+      team_id: teamId,
+      type: "modal",
+      callback_id: callbackId,
+      private_metadata: privateMetadata,
+      state: { values: stateValues },
+      blocks: [],
+      title: { type: "plain_text", text: "Modal" },
+      submit: { type: "plain_text", text: "Submit" },
+      close: { type: "plain_text", text: "Cancel" },
+    },
+  };
+}
+
 /**
- * Create a Slack block_actions webhook request (form-urlencoded)
+ * Create a signed Slack interactivity webhook request (form-urlencoded).
  */
-export function createSlackBlockActionsRequest(
-  options: SlackBlockActionsOptions,
+export function createSlackInteractiveRequest(
+  payload: Record<string, unknown>,
   signingSecret = SLACK_SIGNING_SECRET
 ): Request {
-  const payload = createSlackBlockActionsPayload(options);
   const body = `payload=${encodeURIComponent(JSON.stringify(payload))}`;
   const timestamp = Math.floor(Date.now() / 1000).toString();
   const sigBasestring = `v0:${timestamp}:${body}`;
@@ -344,4 +396,30 @@ export function createSlackBlockActionsRequest(
     },
     body,
   });
+}
+
+/**
+ * Create a Slack view_submission webhook request (form-urlencoded).
+ */
+export function createSlackViewSubmissionRequest(
+  options: SlackViewSubmissionOptions,
+  signingSecret = SLACK_SIGNING_SECRET
+): Request {
+  return createSlackInteractiveRequest(
+    createSlackViewSubmissionPayload(options),
+    signingSecret
+  );
+}
+
+/**
+ * Create a Slack block_actions webhook request (form-urlencoded)
+ */
+export function createSlackBlockActionsRequest(
+  options: SlackBlockActionsOptions,
+  signingSecret = SLACK_SIGNING_SECRET
+): Request {
+  return createSlackInteractiveRequest(
+    createSlackBlockActionsPayload(options),
+    signingSecret
+  );
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -710,14 +710,14 @@ importers:
         version: 0.37.120
     devDependencies:
       '@emulators/core':
-        specifier: ^0.5.0
-        version: 0.5.0
+        specifier: ^0.6.0
+        version: 0.6.0
       '@emulators/github':
-        specifier: ^0.5.0
-        version: 0.5.0
+        specifier: ^0.6.0
+        version: 0.6.0
       '@emulators/slack':
-        specifier: ^0.5.0
-        version: 0.5.0
+        specifier: ^0.6.0
+        version: 0.6.0
       '@hono/node-server':
         specifier: ^2.0.2
         version: 2.0.2(hono@4.12.18)
@@ -1233,14 +1233,14 @@ packages:
   '@emnapi/wasi-threads@1.1.0':
     resolution: {integrity: sha512-WI0DdZ8xFSbgMjR1sFsKABJ/C5OnRrjT06JXbZKexJGrDuPTzZdDYfFlsgcCXCyf+suG5QU2e/y1Wo2V/OapLQ==}
 
-  '@emulators/core@0.5.0':
-    resolution: {integrity: sha512-GCWKlCJCso4ZlVtnfLHY+k2M+SOhtE8NyZ+fkb51N2ZBhniH046tw46vJXCRQE9YjYGoaSrrpzAatcpov35wnQ==}
+  '@emulators/core@0.6.0':
+    resolution: {integrity: sha512-HFGyF4yA3NoUCYq/5lg7YNXx5Cfaz8oMUz5gfJ/8X+tFdZbi2oKAmQoAzfXV9kiAUWvXlkiahZ1EZDpxeC36gA==}
 
-  '@emulators/github@0.5.0':
-    resolution: {integrity: sha512-LgaEoFJca2gs1p19y3KbAyjhoWdM082jaV7P8CXOv8oS6SKtBDZlfrDi8Uv1ChkOFaQ0r+fv/JfltQSSjc8gjA==}
+  '@emulators/github@0.6.0':
+    resolution: {integrity: sha512-12mpVv8gUrYcAAfohFDLlPWA4y2OoZVWgPbLCabULL9P6D6dzRi4Ik/JyZ1Kc3ryLwUSWmCm6VqVjY1YvVnOvQ==}
 
-  '@emulators/slack@0.5.0':
-    resolution: {integrity: sha512-PqacsHNQDKfgl1vA5e4waeGIoI0uhOr40+nos8cKX0S6YGEXF8vbrMriINlbC6I3GLwSlfO23P1gt6L3AIfHDg==}
+  '@emulators/slack@0.6.0':
+    resolution: {integrity: sha512-zXrrYFdwFczRO4+BdZmmuWWtwJkI62B7BEy0+E7ddpXOTditaGKzM3Aso8xm/YbRsypkdLfZ/q48RjIfSkxf5Q==}
 
   '@esbuild/aix-ppc64@0.27.2':
     resolution: {integrity: sha512-GZMB+a0mOMZs4MpDbj8RJp4cw+w1WV5NYD6xzgvzUJ5Ek2jerwfO2eADyI6ExDSUED+1X8aMbegahsJi+8mgpw==}
@@ -8865,20 +8865,17 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
-  '@emulators/core@0.5.0':
+  '@emulators/core@0.6.0':
     dependencies:
-      hono: 4.12.18
       jose: 6.2.3
 
-  '@emulators/github@0.5.0':
+  '@emulators/github@0.6.0':
     dependencies:
-      '@emulators/core': 0.5.0
-      hono: 4.12.18
+      '@emulators/core': 0.6.0
 
-  '@emulators/slack@0.5.0':
+  '@emulators/slack@0.6.0':
     dependencies:
-      '@emulators/core': 0.5.0
-      hono: 4.12.18
+      '@emulators/core': 0.6.0
 
   '@esbuild/aix-ppc64@0.27.2':
     optional: true


### PR DESCRIPTION
Upgrade @emulators/* to 0.6.0 and add integration tests for DMs, reactions, fetch history, modals, scheduled messages, file uploads, member joins, and bookmarks against the in-process Slack emulator.