### PR TITLE
[chat] adding stable id to link button action handlers

### DIFF
--- a/.changeset/link-button-action-ids.md
+++ b/.changeset/link-button-action-ids.md
@@ -1,6 +1,0 @@
----
-"chat": minor
-"@chat-adapter/slack": minor
----
-
-Add optional LinkButton ids so Slack link buttons can emit stable action ids.

--- a/.changeset/link-button-action-ids.md
+++ b/.changeset/link-button-action-ids.md
@@ -1,0 +1,6 @@
+---
+"chat": minor
+"@chat-adapter/slack": minor
+---
+
+Add optional LinkButton ids so Slack link buttons can emit stable action ids.

--- a/.changeset/some-books-jog.md
+++ b/.changeset/some-books-jog.md
@@ -1,0 +1,7 @@
+---
+"@chat-adapter/slack": minor
+"chat": minor
+"docs": minor
+---
+
+Adding support for stable IDs to link button action handlers

--- a/.changeset/some-books-jog.md
+++ b/.changeset/some-books-jog.md
@@ -1,7 +1,6 @@
 ---
 "@chat-adapter/slack": minor
 "chat": minor
-"docs": minor
 ---
 
 Adding support for stable IDs to link button action handlers

--- a/apps/docs/content/docs/api/cards.mdx
+++ b/apps/docs/content/docs/api/cards.mdx
@@ -130,14 +130,21 @@ CardLink({ url: "https://example.com", label: "Visit Site" })
 
 ## LinkButton
 
-Button that opens a URL. No `onAction` handler needed.
+Button that opens a URL. No `onAction` handler needed for navigation. On
+platforms that emit link-button click events, such as Slack, pass `id` when you
+need a stable action identifier for routing or analytics.
 
 ```typescript
 LinkButton({ url: "https://example.com", label: "View Docs" })
+LinkButton({ id: "view_docs", url: "https://example.com", label: "View Docs" })
 ```
 
 <TypeTable
   type={{
+    id: {
+      description: 'Optional action identifier emitted by platforms that report link clicks.',
+      type: 'string',
+    },
     url: {
       description: 'URL to open when clicked.',
       type: 'string',

--- a/apps/docs/content/docs/cards.mdx
+++ b/apps/docs/content/docs/cards.mdx
@@ -141,10 +141,18 @@ Or with children as the label:
 
 ### LinkButton
 
-Opens an external URL. No `onAction` handler needed.
+Opens an external URL. No `onAction` handler needed for navigation. On platforms
+that emit link-button click events, such as Slack, pass `id` when you need a
+stable action identifier for routing or analytics.
 
 ```tsx title="lib/bot.tsx"
 <LinkButton url="https://example.com/order/1234">View Order</LinkButton>
+```
+
+```tsx title="lib/bot.tsx"
+<LinkButton id="view_order" url="https://example.com/order/1234">
+  View Order
+</LinkButton>
 ```
 
 ### Actions

--- a/packages/adapter-slack/src/blocks/index.test.ts
+++ b/packages/adapter-slack/src/blocks/index.test.ts
@@ -121,6 +121,7 @@ describe("Slack Block Kit primitives", () => {
               type: "button",
             },
             {
+              id: "agent_slack_auth_signin",
               label: "Docs",
               style: "default",
               type: "link-button",
@@ -159,6 +160,7 @@ describe("Slack Block Kit primitives", () => {
           type: "button",
         },
         {
+          action_id: "agent_slack_auth_signin",
           text: { emoji: true, text: "Docs", type: "plain_text" },
           type: "button",
           url: "https://example.com/docs",

--- a/packages/adapter-slack/src/blocks/index.ts
+++ b/packages/adapter-slack/src/blocks/index.ts
@@ -255,7 +255,7 @@ function linkButtonToElement(
   convertEmoji: (text: string) => string
 ): Record<string, unknown> {
   return compact({
-    action_id: truncateText(`link-${button.url}`, LIMITS.actionId),
+    action_id: truncateText(button.id ?? `link-${button.url}`, LIMITS.actionId),
     style: mapButtonStyle(button.style),
     text: plainText(button.label, convertEmoji, LIMITS.buttonText),
     type: "button",

--- a/packages/adapter-slack/src/blocks/types.ts
+++ b/packages/adapter-slack/src/blocks/types.ts
@@ -57,6 +57,7 @@ export interface SlackButtonElement {
 }
 
 export interface SlackLinkButtonElement {
+  id?: string;
   label: string;
   style?: SlackButtonStyle;
   type: "link-button";

--- a/packages/adapter-slack/src/cards.test.ts
+++ b/packages/adapter-slack/src/cards.test.ts
@@ -208,6 +208,24 @@ describe("cardToBlockKit", () => {
     expect(elements[0].style).toBe("primary");
   });
 
+  it("uses custom link button action ids", () => {
+    const card = Card({
+      children: [
+        Actions([
+          LinkButton({
+            id: "agent_slack_auth_signin",
+            url: "https://vercel.com/oauth/authorize",
+            label: "Sign in",
+          }),
+        ]),
+      ],
+    });
+    const blocks = cardToBlockKit(card);
+
+    const elements = blocks[0].elements as Array<{ action_id: string }>;
+    expect(elements[0].action_id).toBe("agent_slack_auth_signin");
+  });
+
   it("converts fields", () => {
     const card = Card({
       children: [

--- a/packages/adapter-slack/src/cards.ts
+++ b/packages/adapter-slack/src/cards.ts
@@ -274,7 +274,7 @@ function convertLinkButtonToElement(
       text: convertEmoji(button.label),
       emoji: true,
     },
-    action_id: `link-${button.url.slice(0, 200)}`,
+    action_id: button.id ?? `link-${button.url.slice(0, 200)}`,
     url: button.url,
   };
 

--- a/packages/chat/src/cards.ts
+++ b/packages/chat/src/cards.ts
@@ -78,6 +78,8 @@ export interface ButtonElement {
 
 /** Link button element that opens a URL */
 export interface LinkButtonElement {
+  /** Optional action identifier emitted by platforms that report link clicks */
+  id?: string;
   /** Button label text */
   label: string;
   /** Visual style */
@@ -394,6 +396,8 @@ export function Button(options: ButtonOptions): ButtonElement {
 
 /** Options for LinkButton */
 export interface LinkButtonOptions {
+  /** Optional action identifier emitted by platforms that report link clicks */
+  id?: string;
   /** Button label text */
   label: string;
   /** Visual style */
@@ -414,6 +418,7 @@ export interface LinkButtonOptions {
 export function LinkButton(options: LinkButtonOptions): LinkButtonElement {
   return {
     type: "link-button",
+    id: options.id,
     url: options.url,
     label: options.label,
     style: options.style,

--- a/packages/chat/src/jsx-runtime.ts
+++ b/packages/chat/src/jsx-runtime.ts
@@ -121,6 +121,7 @@ export interface ButtonProps {
 /** Props for LinkButton component in JSX */
 export interface LinkButtonProps {
   children?: string | number | (string | number | undefined)[];
+  id?: string;
   label?: string;
   style?: ButtonStyle;
   url: string;
@@ -647,6 +648,7 @@ function resolveJSXElement(element: JSXElement): AnyCardElement {
         ? processedChildren.map(String).join("")
         : (props.label ?? "");
     return LinkButton({
+      id: props.id,
       url: props.url,
       label,
       style: props.style,


### PR DESCRIPTION
Enabling overriding the `link:<url>` action ID for `LinkButton` events.  