### PR TITLE
feat(slack): expose webClientOptions to configure the underlying WebClient

### DIFF
--- a/.changeset/slack-web-client-options.md
+++ b/.changeset/slack-web-client-options.md
@@ -1,0 +1,5 @@
+---
+"@chat-adapter/slack": minor
+---
+
+Add `webClientOptions` to `SlackAdapterConfig`, forwarded to both the default and per-token `@slack/web-api` `WebClient`s. This exposes Web API tuning the adapter didn't previously surface — most importantly `retryConfig` and `timeout`. By default the WebClient retries rate-limited (429) requests with `tenRetriesInAboutThirtyMinutes`, so a single `chat.update`/`chat.postMessage` can block for ~30 minutes under sustained rate limiting; callers that stream frequent edits can now pass a bounded `retryConfig` and/or a per-request `timeout`. `apiUrl` continues to take precedence over `webClientOptions.slackApiUrl`.

--- a/.changeset/slack-web-client-options.md
+++ b/.changeset/slack-web-client-options.md
@@ -2,4 +2,4 @@
 "@chat-adapter/slack": minor
 ---
 
-Add `webClientOptions` to `SlackAdapterConfig`, forwarded to both the default and per-token `@slack/web-api` `WebClient`s. This exposes Web API tuning the adapter didn't previously surface — most importantly `retryConfig` and `timeout`. By default the WebClient retries rate-limited (429) requests with `tenRetriesInAboutThirtyMinutes`, so a single `chat.update`/`chat.postMessage` can block for ~30 minutes under sustained rate limiting; callers that stream frequent edits can now pass a bounded `retryConfig` and/or a per-request `timeout`. `apiUrl` continues to take precedence over `webClientOptions.slackApiUrl`.
+Add `webClientOptions` to `SlackAdapterConfig`, forwarded to both the default and per-token `@slack/web-api` `WebClient` instances. This exposes Web API settings such as `retryConfig`, per-request `timeout`, and `rejectRateLimitedCalls`. Use the existing `apiUrl` option to override the Slack Web API base URL.

--- a/apps/docs/content/adapters/official/slack.mdx
+++ b/apps/docs/content/adapters/official/slack.mdx
@@ -136,6 +136,11 @@ bot.onNewMention(async (thread, message) => {
       description:
         "Override the Slack Web API base URL (e.g. for GovSlack or a self-hosted gateway).",
     },
+    webClientOptions: {
+      type: 'Omit<WebClientOptions, "slackApiUrl">',
+      description:
+        "Options forwarded to Slack WebClient instances. Supports settings such as retryConfig, per-request timeout, and rejectRateLimitedCalls.",
+    },
   }}
 />
 

--- a/packages/adapter-slack/README.md
+++ b/packages/adapter-slack/README.md
@@ -333,6 +333,7 @@ All options are auto-detected from environment variables when not provided. You 
 | `installationKeyPrefix` | No | Prefix for the state key used to store workspace installations. Defaults to `slack:installation`. The full key is `{prefix}:{teamId}` (or `{prefix}:{enterpriseId}` for Enterprise Grid org-wide installs) |
 | `installationProvider` | No | External installation lookup `{ getInstallation(installationId, isEnterpriseInstall) => Promise<SlackInstallation \| null> }`. When set, bypasses the internal state adapter for token resolution on incoming webhooks. Read-only — manage your own writes externally |
 | `apiUrl` | No | Override the Slack Web API base URL (e.g. for GovSlack or a self-hosted gateway). Auto-detected from `SLACK_API_URL` |
+| `webClientOptions` | No | Options forwarded to Slack `WebClient` instances, excluding `slackApiUrl`. Supports settings such as `retryConfig`, per-request `timeout`, and `rejectRateLimitedCalls` |
 | `logger` | No | Logger instance (defaults to `ConsoleLogger("info")`) |
 
 *`signingSecret` is required for webhook mode — either via config, `SLACK_SIGNING_SECRET` env var, or a `webhookVerifier`.

--- a/packages/adapter-slack/src/index.test.ts
+++ b/packages/adapter-slack/src/index.test.ts
@@ -2845,39 +2845,39 @@ describe("direct WebClient access via adapter.client", () => {
     ).toBe("https://slack-gov.com/api/");
   });
 
-  it("forwards webClientOptions from createSlackAdapter to the bound WebClient", () => {
+  it("forwards webClientOptions to the internal WebClient", () => {
     const adapter = createSlackAdapter({
       botToken: "xoxb-static-token",
       signingSecret: secret,
-      webClientOptions: { slackApiUrl: "https://from-options.example/api/" },
+      webClientOptions: { timeout: 15_000 },
       logger: mockLogger,
     });
 
     expect(
       (
-        adapter.client as unknown as {
-          axios: { defaults: { baseURL: string } };
+        adapter as unknown as {
+          _client: { axios: { defaults: { timeout: number } } };
         }
-      ).axios.defaults.baseURL
-    ).toBe("https://from-options.example/api/");
+      )._client.axios.defaults.timeout
+    ).toBe(15_000);
   });
 
-  it("lets apiUrl take precedence over webClientOptions.slackApiUrl", () => {
+  it("forwards webClientOptions to token-bound WebClients", async () => {
     const adapter = createSlackAdapter({
-      botToken: "xoxb-static-token",
       signingSecret: secret,
-      apiUrl: "https://slack-gov.com/api/",
-      webClientOptions: { slackApiUrl: "https://override.example/api/" },
+      webClientOptions: { timeout: 15_000 },
       logger: mockLogger,
     });
 
-    expect(
-      (
-        adapter.client as unknown as {
-          axios: { defaults: { baseURL: string } };
-        }
-      ).axios.defaults.baseURL
-    ).toBe("https://slack-gov.com/api/");
+    await adapter.withBotToken("xoxb-context-token", () => {
+      expect(
+        (
+          adapter.webClient as unknown as {
+            axios: { defaults: { timeout: number } };
+          }
+        ).axios.defaults.timeout
+      ).toBe(15_000);
+    });
   });
 
   it("throws when no token is available (multi-workspace, outside context)", () => {

--- a/packages/adapter-slack/src/index.test.ts
+++ b/packages/adapter-slack/src/index.test.ts
@@ -2845,6 +2845,41 @@ describe("direct WebClient access via adapter.client", () => {
     ).toBe("https://slack-gov.com/api/");
   });
 
+  it("forwards webClientOptions from createSlackAdapter to the bound WebClient", () => {
+    const adapter = createSlackAdapter({
+      botToken: "xoxb-static-token",
+      signingSecret: secret,
+      webClientOptions: { slackApiUrl: "https://from-options.example/api/" },
+      logger: mockLogger,
+    });
+
+    expect(
+      (
+        adapter.client as unknown as {
+          axios: { defaults: { baseURL: string } };
+        }
+      ).axios.defaults.baseURL
+    ).toBe("https://from-options.example/api/");
+  });
+
+  it("lets apiUrl take precedence over webClientOptions.slackApiUrl", () => {
+    const adapter = createSlackAdapter({
+      botToken: "xoxb-static-token",
+      signingSecret: secret,
+      apiUrl: "https://slack-gov.com/api/",
+      webClientOptions: { slackApiUrl: "https://override.example/api/" },
+      logger: mockLogger,
+    });
+
+    expect(
+      (
+        adapter.client as unknown as {
+          axios: { defaults: { baseURL: string } };
+        }
+      ).axios.defaults.baseURL
+    ).toBe("https://slack-gov.com/api/");
+  });
+
   it("throws when no token is available (multi-workspace, outside context)", () => {
     const adapter = createSlackAdapter({
       clientId: "test-client-id",

--- a/packages/adapter-slack/src/index.test.ts
+++ b/packages/adapter-slack/src/index.test.ts
@@ -2880,6 +2880,31 @@ describe("direct WebClient access via adapter.client", () => {
     });
   });
 
+  it("isolates custom headers between token-bound WebClients", async () => {
+    const headers = { "X-Test": "value" };
+    const adapter = createSlackAdapter({
+      signingSecret: secret,
+      webClientOptions: { headers },
+      logger: mockLogger,
+    });
+
+    const authorizations: Array<string | undefined> = [];
+    for (const token of ["xoxb-first", "xoxb-second"]) {
+      await adapter.withBotToken(token, () => {
+        authorizations.push(
+          (
+            adapter.webClient as unknown as {
+              axios: { defaults: { headers: { Authorization?: string } } };
+            }
+          ).axios.defaults.headers.Authorization
+        );
+      });
+    }
+
+    expect(authorizations).toEqual(["Bearer xoxb-first", "Bearer xoxb-second"]);
+    expect(headers).toEqual({ "X-Test": "value" });
+  });
+
   it("throws when no token is available (multi-workspace, outside context)", () => {
     const adapter = createSlackAdapter({
       clientId: "test-client-id",

--- a/packages/adapter-slack/src/index.ts
+++ b/packages/adapter-slack/src/index.ts
@@ -10,11 +10,7 @@ import {
   ValidationError,
 } from "@chat-adapter/shared";
 import { SocketModeClient } from "@slack/socket-mode";
-import {
-  type ChatStopStreamArguments,
-  WebClient,
-  type WebClientOptions,
-} from "@slack/web-api";
+import { type ChatStopStreamArguments, WebClient } from "@slack/web-api";
 import type {
   ActionEvent,
   Adapter,
@@ -459,7 +455,7 @@ export class SlackAdapter implements Adapter<SlackThreadId, unknown> {
   protected readonly _client: WebClient;
   protected readonly tokenClientCache = new Map<string, WebClient>();
   protected readonly slackApiUrl: string | undefined;
-  protected readonly webClientOptions: WebClientOptions | undefined;
+  protected readonly webClientOptions: SlackAdapterConfig["webClientOptions"];
   protected readonly signingSecret: string | undefined;
   protected readonly webhookVerifier:
     | ((request: Request, body: string) => unknown | Promise<unknown>)

--- a/packages/adapter-slack/src/index.ts
+++ b/packages/adapter-slack/src/index.ts
@@ -10,7 +10,11 @@ import {
   ValidationError,
 } from "@chat-adapter/shared";
 import { SocketModeClient } from "@slack/socket-mode";
-import { type ChatStopStreamArguments, WebClient } from "@slack/web-api";
+import {
+  type ChatStopStreamArguments,
+  WebClient,
+  type WebClientOptions,
+} from "@slack/web-api";
 import type {
   ActionEvent,
   Adapter,
@@ -455,6 +459,7 @@ export class SlackAdapter implements Adapter<SlackThreadId, unknown> {
   protected readonly _client: WebClient;
   protected readonly tokenClientCache = new Map<string, WebClient>();
   protected readonly slackApiUrl: string | undefined;
+  protected readonly webClientOptions: WebClientOptions | undefined;
   protected readonly signingSecret: string | undefined;
   protected readonly webhookVerifier:
     | ((request: Request, body: string) => unknown | Promise<unknown>)
@@ -574,6 +579,7 @@ export class SlackAdapter implements Adapter<SlackThreadId, unknown> {
     let client = this.tokenClientCache.get(token);
     if (!client) {
       client = new WebClient(token, {
+        ...this.webClientOptions,
         ...(this.slackApiUrl ? { slackApiUrl: this.slackApiUrl } : {}),
       });
       this.tokenClientCache.set(token, client);
@@ -615,9 +621,11 @@ export class SlackAdapter implements Adapter<SlackThreadId, unknown> {
     const botTokenProvider = normalizeBotTokenProvider(botTokenConfig);
 
     this.slackApiUrl = config.apiUrl ?? process.env.SLACK_API_URL;
+    this.webClientOptions = config.webClientOptions;
     // WebClient token argument is only a fallback; every API call below routes
     // through withToken() which resolves the current provider per-call.
     this._client = new WebClient(undefined, {
+      ...this.webClientOptions,
       ...(this.slackApiUrl ? { slackApiUrl: this.slackApiUrl } : {}),
     });
     // webhookVerifier takes precedence; signingSecret is only used when no
@@ -5015,6 +5023,7 @@ export function createSlackAdapter(config?: SlackAdapterConfig): SlackAdapter {
       process.env.SLACK_SOCKET_FORWARDING_SECRET,
     userName: config?.userName,
     botUserId: config?.botUserId,
+    webClientOptions: config?.webClientOptions,
     webhookVerifier,
   };
   return new SlackAdapter(resolved);

--- a/packages/adapter-slack/src/index.ts
+++ b/packages/adapter-slack/src/index.ts
@@ -576,6 +576,9 @@ export class SlackAdapter implements Adapter<SlackThreadId, unknown> {
     if (!client) {
       client = new WebClient(token, {
         ...this.webClientOptions,
+        ...(this.webClientOptions?.headers
+          ? { headers: { ...this.webClientOptions.headers } }
+          : {}),
         ...(this.slackApiUrl ? { slackApiUrl: this.slackApiUrl } : {}),
       });
       this.tokenClientCache.set(token, client);
@@ -622,6 +625,9 @@ export class SlackAdapter implements Adapter<SlackThreadId, unknown> {
     // through withToken() which resolves the current provider per-call.
     this._client = new WebClient(undefined, {
       ...this.webClientOptions,
+      ...(this.webClientOptions?.headers
+        ? { headers: { ...this.webClientOptions.headers } }
+        : {}),
       ...(this.slackApiUrl ? { slackApiUrl: this.slackApiUrl } : {}),
     });
     // webhookVerifier takes precedence; signingSecret is only used when no

--- a/packages/adapter-slack/src/types.ts
+++ b/packages/adapter-slack/src/types.ts
@@ -74,7 +74,7 @@ export interface SlackAdapterConfig {
   /** Override bot username (optional) */
   userName?: string;
   /**
-   * Options forwarded to the underlying `@slack/web-api` `WebClient`(s) — both the
+   * Options forwarded to the underlying `@slack/web-api` `WebClient` instances, both the
    * default client and the per-token clients used for multi-workspace requests.
    *
    * Use this to tune Web API behavior the adapter does not otherwise expose, most
@@ -82,7 +82,9 @@ export interface SlackAdapterConfig {
    * (429) requests with `retryPolicies.tenRetriesInAboutThirtyMinutes`, so a single
    * `chat.update`/`chat.postMessage` can block for ~30 minutes under sustained rate
    * limiting. Callers that stream frequent edits (where a hung call can stall a whole
-   * turn) will typically want a bounded policy and/or a per-request timeout:
+   * turn) will typically want a bounded policy and/or a timeout. `timeout` applies to
+   * each HTTP request attempt, not the total retry period. Set
+   * `rejectRateLimitedCalls` to reject 429 responses without waiting for `Retry-After`.
    *
    * ```ts
    * import { retryPolicies } from "@slack/web-api";
@@ -92,9 +94,9 @@ export interface SlackAdapterConfig {
    * });
    * ```
    *
-   * `apiUrl` (above) takes precedence over `webClientOptions.slackApiUrl` when both are set.
+   * Use `apiUrl` to override the Slack Web API base URL.
    */
-  webClientOptions?: WebClientOptions;
+  webClientOptions?: Omit<WebClientOptions, "slackApiUrl">;
   /**
    * Custom webhook verifier. Used in place of `signingSecret`.
    * Receives the incoming `Request` and the raw body text already

--- a/packages/adapter-slack/src/types.ts
+++ b/packages/adapter-slack/src/types.ts
@@ -2,6 +2,7 @@
  * Slack adapter types.
  */
 
+import type { WebClientOptions } from "@slack/web-api";
 import type { Logger } from "chat";
 import type { SlackWebhookVerifier } from "./webhook/index";
 
@@ -72,6 +73,28 @@ export interface SlackAdapterConfig {
   socketForwardingSecret?: string;
   /** Override bot username (optional) */
   userName?: string;
+  /**
+   * Options forwarded to the underlying `@slack/web-api` `WebClient`(s) — both the
+   * default client and the per-token clients used for multi-workspace requests.
+   *
+   * Use this to tune Web API behavior the adapter does not otherwise expose, most
+   * notably `retryConfig` and `timeout`. By default the WebClient retries rate-limited
+   * (429) requests with `retryPolicies.tenRetriesInAboutThirtyMinutes`, so a single
+   * `chat.update`/`chat.postMessage` can block for ~30 minutes under sustained rate
+   * limiting. Callers that stream frequent edits (where a hung call can stall a whole
+   * turn) will typically want a bounded policy and/or a per-request timeout:
+   *
+   * ```ts
+   * import { retryPolicies } from "@slack/web-api";
+   * createSlackAdapter({
+   *   signingSecret,
+   *   webClientOptions: { retryConfig: retryPolicies.fiveRetriesInFiveMinutes, timeout: 15_000 },
+   * });
+   * ```
+   *
+   * `apiUrl` (above) takes precedence over `webClientOptions.slackApiUrl` when both are set.
+   */
+  webClientOptions?: WebClientOptions;
   /**
    * Custom webhook verifier. Used in place of `signingSecret`.
    * Receives the incoming `Request` and the raw body text already


### PR DESCRIPTION
## summary

adds `webClientOptions` to `SlackAdapterConfig` so users can configure the underlying Slack `WebClient` instances

the options apply to both the default client and per-token clients used for multi-workspace requests, including settings such as `retryConfig`, per-request `timeout`, custom headers, and `rejectRateLimitedCalls`

`slackApiUrl` is intentionally excluded from `webClientOptions` because the existing `apiUrl` option remains the single configuration path for overriding the Slack Web API base URL

custom headers are cloned for each client because the Slack SDK adds authorization to the provided headers object, preventing credentials from leaking between token-bound clients

## test plan

- verified options reach the default Slack client
- verified options reach clients created through `withBotToken()`
- verified custom headers remain isolated between token-bound clients
- verified the original headers object is not mutated
- verified `apiUrl` continues to configure the Slack Web API base URL
- ran the Slack adapter tests, workspace typecheck, formatting checks, and full build
