### PR TITLE
fix(telegram): prevent truncation of valid URLs with entity-marker characters in MarkdownV2 links

### DIFF
--- a/.changeset/loud-falcons-wave.md
+++ b/.changeset/loud-falcons-wave.md
@@ -1,0 +1,5 @@
+---
+"@chat-adapter/telegram": patch
+---
+
+fix(telegram): stop `trimToMarkdownV2SafeBoundary` from truncating valid messages at entity-marker characters (`_`, `*`, `~`) inside link URLs. Per the MarkdownV2 spec, only `)` and `\` are special inside the `(...)` part of an inline link, so URLs with raw underscores in query parameters (e.g. `?a_b=1&c_d=2&e_f=3`) are now left intact instead of being sliced mid-URL and degraded to plain text. Hard truncation that cuts inside a link URL now trims back to before the link's `[`.

--- a/packages/adapter-telegram/src/markdown.test.ts
+++ b/packages/adapter-telegram/src/markdown.test.ts
@@ -535,6 +535,58 @@ describe("truncateForTelegram", () => {
     const result = truncateForTelegram(input, 4096, "MarkdownV2");
     expect(result).toBe(input);
   });
+
+  describe("link URLs with raw entity-marker characters", () => {
+    it("preserves a link whose URL contains one underscore", () => {
+      const input = "[x](https://e.co/?a_b=1)";
+      expect(truncateForTelegram(input, 4096, "MarkdownV2")).toBe(input);
+    });
+
+    it("preserves a link whose URL contains an odd number of underscores", () => {
+      const input = "[x](https://e.co/?a_b=1&c_d=2&e_f=3)";
+      expect(truncateForTelegram(input, 4096, "MarkdownV2")).toBe(input);
+    });
+
+    it("preserves surrounding entities alongside an underscore-bearing URL", () => {
+      const input = "text *bold* [x](https://e.co/?a_b=1)";
+      expect(truncateForTelegram(input, 4096, "MarkdownV2")).toBe(input);
+    });
+
+    it("preserves a link whose URL contains * and ~", () => {
+      const input = "[x](https://e.co/?glob=*.ts&home=~user)";
+      expect(truncateForTelegram(input, 4096, "MarkdownV2")).toBe(input);
+    });
+
+    it("preserves a message ending with a link whose URL has odd underscores (regression)", () => {
+      const converter = new TelegramFormatConverter();
+      const rendered = converter.renderPostable({
+        markdown:
+          "body text\n\n[Read more](https://example.com/page?first_param=a&second_param=b&third_param=c)",
+      });
+      const result = truncateForTelegram(rendered, 4096, "MarkdownV2");
+      expect(result).toBe(rendered);
+      expect(result).toContain("&third_param=c)");
+    });
+
+    it("still strips an unpaired underscore outside any link URL", () => {
+      const input = "_oops [x](https://e.co/?a_b=1)";
+      const result = truncateForTelegram(input, 4096, "MarkdownV2");
+      expect(result).toBe("");
+    });
+  });
+
+  it("trims back to before the [ when hard-truncated inside a link URL", () => {
+    const prefix = "a".repeat(80);
+    const input = `${prefix}[link](https://example.com/${"x".repeat(100)})`;
+    const result = truncateForTelegram(input, 100, "MarkdownV2");
+    expect(result).toBe(`${prefix}\\.\\.\\.`);
+  });
+
+  it("trims at the orphan * when hard-truncated inside bold", () => {
+    const input = `${"a".repeat(80)}*${"b".repeat(100)}`;
+    const result = truncateForTelegram(input, 100, "MarkdownV2");
+    expect(result).toBe(`${"a".repeat(80)}\\.\\.\\.`);
+  });
 });
 
 describe("findUnescapedPositions", () => {

--- a/packages/adapter-telegram/src/markdown.ts
+++ b/packages/adapter-telegram/src/markdown.ts
@@ -99,8 +99,8 @@ export function findUnescapedPositions(text: string, marker: string): number[] {
 
 /**
  * Like `findUnescapedPositions` but skips occurrences inside fenced code
- * blocks (``` ```) or inline code spans (`` ` ``). Inside those regions
- * Telegram treats `*`, `_`, `~`, `[`, `]` as literal text.
+ * blocks (``` ```), inline code spans (`` ` ``), or the `(...)` URL part
+ * of an inline link, where Telegram treats entity markers as literal text.
  */
 function findUnescapedPositionsOutsideCode(
   text: string,
@@ -110,6 +110,8 @@ function findUnescapedPositionsOutsideCode(
   let inFence = false;
   let inInline = false;
   let backslashes = 0;
+  // Index of the `]` that opened the current `](...)` link URL, or -1.
+  let linkCloseBracket = -1;
 
   for (let i = 0; i < text.length; i++) {
     const ch = text[i];
@@ -122,6 +124,18 @@ function findUnescapedPositionsOutsideCode(
     const escaped = backslashes % 2 === 1;
     backslashes = 0;
 
+    if (linkCloseBracket >= 0) {
+      if (ch === ")" && !escaped) {
+        // A link's `]` only counts toward bracket pairing once its URL
+        // closes, so a slice mid-URL leaves the `[` unmatched.
+        if (marker === "]") {
+          positions.push(linkCloseBracket);
+        }
+        linkCloseBracket = -1;
+      }
+      continue;
+    }
+
     if (ch === "`" && !escaped) {
       const isTriple = text[i + 1] === "`" && text[i + 2] === "`";
       if (isTriple && !inInline) {
@@ -132,6 +146,18 @@ function findUnescapedPositionsOutsideCode(
       if (!inFence) {
         inInline = !inInline;
       }
+      continue;
+    }
+
+    if (
+      ch === "]" &&
+      !escaped &&
+      !inFence &&
+      !inInline &&
+      text[i + 1] === "("
+    ) {
+      linkCloseBracket = i;
+      i += 1;
       continue;
     }
 
@@ -158,7 +184,8 @@ export function endsWithOrphanBackslash(text: string): boolean {
  *  - orphan trailing `\` (would escape the appended ellipsis or nothing)
  *  - unclosed entity delimiter (`*`, `_`, `~`, `` ` ``) left open because
  *    the slice cut between the opener and its closer
- *  - unmatched `[` from a link whose closer was cut off
+ *  - unmatched `[` from a link whose closer was cut off, or whose `(...)`
+ *    URL part was left unterminated by the slice
  *
  * Best-effort: may drop more than strictly necessary in edge cases, but
  * guarantees the output is parseable MarkdownV2 (when the input was).


### PR DESCRIPTION

## Summary

Fixes `@chat-adapter/telegram` silently truncating valid MarkdownV2 messages whose link URLs contain an odd number of entity-marker characters (`_`, `*`, `~`).

`trimToMarkdownV2SafeBoundary` counted unescaped markers anywhere outside code spans and treated an odd total as an unterminated entity. But per the [MarkdownV2 spec](https://core.telegram.org/bots/api#markdownv2-style), only `)` and `\` are special inside the `(...)` URL part of an inline link — so a message ending with e.g. `[Read more](https://example.com/page?utm_campaign=a&utm_source=b&utm_channel=c)` (3 raw underscores in the URL) was sliced mid-URL, rejected by Telegram with `can't parse entities: Can't find end of a URL`, and degraded to plain text by the markdown fallback — links and formatting silently stripped.

Changes in `findUnescapedPositionsOutsideCode`:

- Tracks a link-URL state alongside the existing `inFence`/`inInline` tracking: it opens when an unescaped `](` is consumed outside code and closes at the first unescaped `)`. Markers inside that span are never recorded.
- A link's `]` only counts toward bracket pairing once its URL closes, so hard truncation (4096-char limit) that slices mid-URL now leaves the `[` unmatched and trims back to before the link — previously the cut left an unterminated `(` that Telegram rejected.

The defensive under-limit safety pass from #446 (streaming chunks) is intentionally kept; it's now link-aware.

## Test plan

- Added unit tests in `packages/adapter-telegram/src/markdown.test.ts`:
  - URLs with 1 and 3 (odd) underscores pass through unchanged
  - URL with raw underscores alongside surrounding `*bold*` entities — unchanged
  - URL with `*` and `~` in the query string — unchanged
  - Full-pipeline regression: `renderPostable` + `truncateForTelegram` on a message ending with a multi-query-param link
  - Hard truncation inside a link URL trims back to before the `[`
  - Hard truncation inside `*bold*` still trims at the orphan `*` (existing behavior)
  - Unpaired `_` outside a link URL is still stripped (under-limit pass from #446 preserved)
- All 216 `@chat-adapter/telegram` tests pass
- `pnpm validate` passes (knip, lint, typecheck, test, build)

## Checklist

- [x] All commits are signed and verified
- [x] `pnpm validate` passes
- [x] Changeset added (or N/A — see [CONTRIBUTING.md](./CONTRIBUTING.md)) — `.changeset/loud-falcons-wave.md`, patch for `@chat-adapter/telegram`
- [x] Documentation updated (or N/A) — N/A, internal truncation behavior, no user-facing API or docs change
