### PR TITLE
fix(telegram): start typing before message processing

### DIFF
--- a/.changeset/telegram-early-typing.md
+++ b/.changeset/telegram-early-typing.md
@@ -1,0 +1,5 @@
+---
+"@chat-adapter/telegram": patch
+---
+
+Send Telegram typing actions immediately when private message updates arrive.

--- a/packages/adapter-telegram/src/index.test.ts
+++ b/packages/adapter-telegram/src/index.test.ts
@@ -345,6 +345,61 @@ describe("TelegramAdapter", () => {
     expect(threadId).toBe("telegram:-100123");
     expect(parsedMessage.text).toBe("hello @mybot");
     expect(parsedMessage.isMention).toBe(true);
+    expect(
+      mockFetch.mock.calls.some(([input]) =>
+        String(input).includes("/sendChatAction")
+      )
+    ).toBe(false);
+  });
+
+  it("starts typing before processing private message updates", async () => {
+    const events: string[] = [];
+    mockFetch
+      .mockResolvedValueOnce(
+        telegramOk({
+          id: 999,
+          is_bot: true,
+          first_name: "Bot",
+          username: "mybot",
+        })
+      )
+      .mockImplementationOnce((input) => {
+        expect(String(input)).toContain("/sendChatAction");
+        events.push("typing");
+        return Promise.resolve(telegramOk(true));
+      });
+
+    const adapter = createTelegramAdapter({
+      botToken: "token",
+      mode: "webhook",
+      logger: mockLogger,
+      userName: "mybot",
+    });
+
+    const chat = createMockChat();
+    const processMessage = chat.processMessage as ReturnType<typeof vi.fn>;
+    processMessage.mockImplementation(() => {
+      events.push("processMessage");
+    });
+
+    await adapter.initialize(chat);
+
+    const waitUntil = vi.fn();
+    const response = await adapter.handleWebhook(
+      new Request("https://example.com/webhook", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          update_id: 1,
+          message: sampleMessage({ text: "hello" }),
+        }),
+      }),
+      { waitUntil }
+    );
+
+    expect(response.status).toBe(200);
+    expect(events).toEqual(["typing", "processMessage"]);
+    expect(waitUntil).toHaveBeenCalledTimes(1);
   });
 
   it("routes bot command messages to slash command handlers", async () => {
@@ -646,6 +701,7 @@ describe("TelegramAdapter", () => {
           },
         ])
       )
+      .mockResolvedValueOnce(telegramOk(true))
       .mockImplementationOnce((_input, init) => {
         return new Promise<Response>((_resolve, reject) => {
           const signal = init?.signal;
@@ -683,15 +739,17 @@ describe("TelegramAdapter", () => {
       () =>
         (chat.processMessage as ReturnType<typeof vi.fn>).mock.calls.length > 0
     );
-    await waitForCondition(() => mockFetch.mock.calls.length >= 4);
+    await waitForCondition(() => mockFetch.mock.calls.length >= 5);
     await adapter.stopPolling();
 
     expect(String(mockFetch.mock.calls[1]?.[0])).toContain("/deleteWebhook");
-    expect(String(mockFetch.mock.calls[2]?.[0])).toContain("/getUpdates");
-    expect(String(mockFetch.mock.calls[3]?.[0])).toContain("/getUpdates");
+    const pollCalls = mockFetch.mock.calls.filter(([input]) =>
+      String(input).includes("/getUpdates")
+    );
+    expect(pollCalls).toHaveLength(2);
 
     const firstPollBody = JSON.parse(
-      String((mockFetch.mock.calls[2]?.[1] as RequestInit).body)
+      String((pollCalls[0]?.[1] as RequestInit).body)
     ) as {
       allowed_updates?: string[];
       limit?: number;
@@ -699,7 +757,7 @@ describe("TelegramAdapter", () => {
       timeout?: number;
     };
     const secondPollBody = JSON.parse(
-      String((mockFetch.mock.calls[3]?.[1] as RequestInit).body)
+      String((pollCalls[1]?.[1] as RequestInit).body)
     ) as {
       offset?: number;
     };
@@ -796,6 +854,7 @@ describe("TelegramAdapter", () => {
           },
         ])
       )
+      .mockResolvedValueOnce(telegramOk(true))
       .mockImplementationOnce((_input, init) => {
         return new Promise<Response>((_resolve, reject) => {
           const signal = init?.signal;
@@ -832,12 +891,14 @@ describe("TelegramAdapter", () => {
       () =>
         (chat.processMessage as ReturnType<typeof vi.fn>).mock.calls.length > 0
     );
-    await waitForCondition(() => mockFetch.mock.calls.length >= 4);
+    await waitForCondition(() => mockFetch.mock.calls.length >= 5);
     await adapter.stopPolling();
 
     expect(String(mockFetch.mock.calls[1]?.[0])).toContain("/getWebhookInfo");
-    expect(String(mockFetch.mock.calls[2]?.[0])).toContain("/getUpdates");
-    expect(String(mockFetch.mock.calls[3]?.[0])).toContain("/getUpdates");
+    const pollCalls = mockFetch.mock.calls.filter(([input]) =>
+      String(input).includes("/getUpdates")
+    );
+    expect(pollCalls).toHaveLength(2);
     expect(adapter.isPolling).toBe(false);
   });
 

--- a/packages/adapter-telegram/src/index.test.ts
+++ b/packages/adapter-telegram/src/index.test.ts
@@ -458,6 +458,61 @@ describe("TelegramAdapter", () => {
     expect(event.user).toMatchObject({ fullName: "User", userId: "456" });
   });
 
+  it("starts typing before processing private slash command updates", async () => {
+    const events: string[] = [];
+    mockFetch
+      .mockResolvedValueOnce(
+        telegramOk({
+          id: 999,
+          is_bot: true,
+          first_name: "Bot",
+          username: "mybot",
+        })
+      )
+      .mockImplementationOnce((input) => {
+        expect(String(input)).toContain("/sendChatAction");
+        events.push("typing");
+        return Promise.resolve(telegramOk(true));
+      });
+
+    const adapter = createTelegramAdapter({
+      botToken: "token",
+      mode: "webhook",
+      logger: mockLogger,
+      userName: "mybot",
+    });
+
+    const chat = createMockChat();
+    const processSlashCommand = chat.processSlashCommand as ReturnType<
+      typeof vi.fn
+    >;
+    processSlashCommand.mockImplementation(() => {
+      events.push("processSlashCommand");
+    });
+
+    await adapter.initialize(chat);
+
+    const waitUntil = vi.fn();
+    const response = await adapter.handleWebhook(
+      new Request("https://example.com/webhook", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          update_id: 2,
+          message: sampleMessage({
+            text: "/ping@mybot hello world",
+            entities: [{ type: "bot_command", offset: 0, length: 11 }],
+          }),
+        }),
+      }),
+      { waitUntil }
+    );
+
+    expect(response.status).toBe(200);
+    expect(events).toEqual(["typing", "processSlashCommand"]);
+    expect(waitUntil).toHaveBeenCalledTimes(1);
+  });
+
   it("routes bot command captions to slash command handlers", async () => {
     mockFetch.mockResolvedValueOnce(
       telegramOk({

--- a/packages/adapter-telegram/src/index.ts
+++ b/packages/adapter-telegram/src/index.ts
@@ -589,19 +589,7 @@ export class TelegramAdapter
       messageThreadId: telegramMessage.message_thread_id,
     });
 
-    if (
-      telegramMessage.chat.type === "private" &&
-      !telegramMessage.from?.is_bot
-    ) {
-      const typingTask = this.startTyping(threadId).catch((error) => {
-        this.logger.warn("Failed to send Telegram typing action", {
-          error: String(error),
-          threadId,
-        });
-      });
-
-      options?.waitUntil?.(typingTask);
-    }
+    this.startTypingForPrivateMessage(telegramMessage, threadId, options);
 
     const parsedMessage = this.parseTelegramMessage(telegramMessage, threadId);
     this.cacheMessage(parsedMessage);
@@ -627,6 +615,8 @@ export class TelegramAdapter
       messageThreadId: telegramMessage.message_thread_id,
     });
 
+    this.startTypingForPrivateMessage(telegramMessage, threadId, options);
+
     const parsedMessage = this.parseTelegramMessage(telegramMessage, threadId);
     this.cacheMessage(parsedMessage);
 
@@ -643,6 +633,28 @@ export class TelegramAdapter
     );
 
     return true;
+  }
+
+  protected startTypingForPrivateMessage(
+    telegramMessage: TelegramMessage,
+    threadId: string,
+    options?: WebhookOptions
+  ): void {
+    if (
+      telegramMessage.chat.type !== "private" ||
+      telegramMessage.from?.is_bot
+    ) {
+      return;
+    }
+
+    const typingTask = this.startTyping(threadId).catch((error) => {
+      this.logger.warn("Failed to send Telegram typing action", {
+        error: String(error),
+        threadId,
+      });
+    });
+
+    options?.waitUntil?.(typingTask);
   }
 
   protected parseSlashCommand(

--- a/packages/adapter-telegram/src/index.ts
+++ b/packages/adapter-telegram/src/index.ts
@@ -589,6 +589,20 @@ export class TelegramAdapter
       messageThreadId: telegramMessage.message_thread_id,
     });
 
+    if (
+      telegramMessage.chat.type === "private" &&
+      !telegramMessage.from?.is_bot
+    ) {
+      const typingTask = this.startTyping(threadId).catch((error) => {
+        this.logger.warn("Failed to send Telegram typing action", {
+          error: String(error),
+          threadId,
+        });
+      });
+
+      options?.waitUntil?.(typingTask);
+    }
+
     const parsedMessage = this.parseTelegramMessage(telegramMessage, threadId);
     this.cacheMessage(parsedMessage);
 


### PR DESCRIPTION
## Summary

Send Telegram typing actions immediately for private incoming message and slash command updates before handing the message to Chat SDK processing. This lets Telegram clients show the native `...` indicator during early processing instead of waiting for downstream handler code to call `thread.startTyping()`.

The change is scoped to private, non-bot Telegram messages and adds regression coverage for normal messages and slash commands plus a patch changeset.

Closes #611

## Test plan

- [x] `pnpm validate`
- [x] `pnpm --filter @chat-adapter/telegram test`
- [x] `pnpm --filter @chat-adapter/telegram typecheck`
- [x] `pnpm --filter @chat-adapter/telegram build`

## Checklist

- [x] All commits are signed and verified
- [x] `pnpm validate` passes
- [x] Changeset added (or N/A — see [CONTRIBUTING.md](./CONTRIBUTING.md))
- [x] Documentation updated (or N/A)
