### PR TITLE
feat(telegram): support native rich messages

### DIFF
--- a/.changeset/brown-tires-push.md
+++ b/.changeset/brown-tires-push.md
@@ -1,0 +1,5 @@
+---
+"@chat-adapter/telegram": minor
+---
+
+add native rich message formatting and streaming for Telegram Bot API 10.1

--- a/apps/docs/content/adapters/official/telegram.mdx
+++ b/apps/docs/content/adapters/official/telegram.mdx
@@ -190,7 +190,7 @@ Use `bot.onSlashCommand` to handle Telegram bot commands such as `/status` and `
 
 ### Markdown formatting
 
-On Telegram Bot API 10.1 and newer, explicit `{ markdown }` and `{ ast }` messages use rich messages. Standard markdown gains native headings, lists, tables, task lists, formulas, details, and inline media where supported by Telegram. Private chat streams use rich draft previews and persist the completed response as a rich message.
+On Telegram Bot API 10.1 and newer, explicit `{ markdown }` and `{ ast }` messages use rich messages. Standard markdown gains native headings, lists, tables, task lists, formulas, details, and separate media blocks where supported by Telegram. Private chat streams use rich draft previews and persist the completed response as a rich message.
 
 Plain strings, raw messages, cards, and media captions retain their existing lightweight message paths. Cards and captions use Telegram's `MarkdownV2` parse mode with context-aware escaping. Older or custom Bot API servers automatically fall back to this existing path when rich message methods are unavailable.
 

--- a/apps/docs/content/adapters/official/telegram.mdx
+++ b/apps/docs/content/adapters/official/telegram.mdx
@@ -16,7 +16,7 @@ features:
     label: Single file
   streaming:
     status: partial
-    label: Private chat drafts / Post+Edit
+    label: Rich drafts / Post+Edit
   scheduledMessages: no
   cardFormat:
     status: partial
@@ -30,7 +30,7 @@ features:
   selectMenus: no
   tables:
     status: partial
-    label: ASCII
+    label: Native messages / ASCII cards
   fields: yes
   imagesInCards: no
   modals: no
@@ -190,7 +190,9 @@ Use `bot.onSlashCommand` to handle Telegram bot commands such as `/status` and `
 
 ### Markdown formatting
 
-Outbound messages are sent with Telegram's `MarkdownV2` parse mode. The adapter walks the markdown AST and emits MarkdownV2 with context-aware escaping (text vs. code blocks vs. link URLs), so you author standard markdown and the adapter handles every reserved character.
+On Telegram Bot API 10.1 and newer, explicit `{ markdown }` and `{ ast }` messages use rich messages. Standard markdown gains native headings, lists, tables, task lists, formulas, details, and inline media where supported by Telegram. Private chat streams use rich draft previews and persist the completed response as a rich message.
+
+Plain strings, raw messages, cards, and media captions retain their existing lightweight message paths. Cards and captions use Telegram's `MarkdownV2` parse mode with context-aware escaping. Older or custom Bot API servers automatically fall back to this existing path when rich message methods are unavailable.
 
 Pass `{ raw: "..." }` only if you need to ship a fully pre-escaped MarkdownV2 string.
 

--- a/apps/docs/content/docs/index.mdx
+++ b/apps/docs/content/docs/index.mdx
@@ -55,7 +55,7 @@ Each adapter factory auto-detects credentials from environment variables (`SLACK
 | Microsoft Teams | `@chat-adapter/teams` | Yes | Read-only | Yes | Yes | Native (DMs) / Buffered | Yes |
 | Google Chat | `@chat-adapter/gchat` | Yes | Yes | Yes | No | Post+Edit | Yes |
 | Discord | `@chat-adapter/discord` | Yes | Yes | Yes | No | Post+Edit | Yes |
-| Telegram | `@chat-adapter/telegram` | Yes | Yes | Partial | No | Private chat drafts / Post+Edit | Yes |
+| Telegram | `@chat-adapter/telegram` | Yes | Yes | Partial | No | Rich drafts / Post+Edit | Yes |
 | GitHub | `@chat-adapter/github` | Yes | Yes | No | No | Buffered | No |
 | Linear | `@chat-adapter/linear` | Yes | Yes | No | No | Agent sessions / Post+Edit | No |
 | WhatsApp | `@chat-adapter/whatsapp` | N/A | Yes | Partial | No | Buffered | Yes |

--- a/apps/docs/content/docs/platform-adapters.mdx
+++ b/apps/docs/content/docs/platform-adapters.mdx
@@ -25,7 +25,7 @@ Ready to build your own? Follow the [building](/docs/contributing/building) guid
 | Edit message | <Check /> | <Check /> | <Check /> | <Check /> | <Check /> | <Check /> | <Warn /> Partial | <Cross /> | <Cross /> |
 | Delete message | <Check /> | <Check /> | <Check /> | <Check /> | <Check /> | <Check /> | <Warn /> Partial | <Cross /> | <Cross /> |
 | File uploads | <Check /> | <Check /> | <Cross /> | <Check /> | <Warn /> Single file/media | <Cross /> | <Cross /> | <Check /> Images, audio, docs | <Cross /> |
-| Streaming | <Check /> Native | <Warn /> Native (DMs) / Buffered | <Warn /> Post+Edit | <Warn /> Post+Edit | <Warn /> Private chat drafts / Post+Edit | <Warn /> Buffered | <Warn /> Agent sessions / Post+Edit | <Warn /> Buffered | <Warn /> Buffered |
+| Streaming | <Check /> Native | <Warn /> Native (DMs) / Buffered | <Warn /> Post+Edit | <Warn /> Post+Edit | <Warn /> Rich drafts / Post+Edit | <Warn /> Buffered | <Warn /> Agent sessions / Post+Edit | <Warn /> Buffered | <Warn /> Buffered |
 | Scheduled messages | <Check /> Native | <Cross /> | <Cross /> | <Cross /> | <Cross /> | <Cross /> | <Cross /> | <Cross /> | <Cross /> |
 
 ### Rich content
@@ -36,7 +36,7 @@ Ready to build your own? Follow the [building](/docs/contributing/building) guid
 | Buttons | <Check /> | <Check /> | <Check /> | <Check /> | <Warn /> Inline keyboard callbacks | <Cross /> | <Cross /> | <Check /> Interactive replies | <Warn /> Max 3, postback |
 | Link buttons | <Check /> | <Check /> | <Check /> | <Check /> | <Warn /> Inline keyboard URLs | <Cross /> | <Cross /> | <Cross /> | <Check /> |
 | Select menus | <Check /> | <Cross /> | <Check /> | <Cross /> | <Cross /> | <Cross /> | <Cross /> | <Cross /> | <Cross /> |
-| Tables | <Check /> Block Kit | <Check /> GFM | <Warn /> ASCII | <Check /> GFM | <Warn /> ASCII | <Check /> GFM | <Check /> GFM | <Cross /> | <Warn /> ASCII |
+| Tables | <Check /> Block Kit | <Check /> GFM | <Warn /> ASCII | <Check /> GFM | <Warn /> Native messages / ASCII cards | <Check /> GFM | <Check /> GFM | <Cross /> | <Warn /> ASCII |
 | Fields | <Check /> | <Check /> | <Check /> | <Check /> | <Check /> | <Check /> | <Check /> | <Warn /> Template variables | <Warn /> ASCII |
 | Images in cards | <Check /> | <Check /> | <Check /> | <Check /> | <Cross /> | <Check /> | <Cross /> | <Check /> | <Check /> |
 | Modals | <Check /> | <Check /> | <Cross /> | <Cross /> | <Cross /> | <Cross /> | <Cross /> | <Cross /> | <Cross /> |

--- a/apps/docs/content/docs/streaming.mdx
+++ b/apps/docs/content/docs/streaming.mdx
@@ -59,7 +59,7 @@ await thread.post(stream);
 | Platform | Method | Description |
 |----------|--------|-------------|
 | Slack | Native streaming API | Uses Slack's `chatStream` for smooth, real-time updates |
-| Telegram | Private chat draft previews | Uses Telegram's `sendMessageDraft` in private chats and falls back to post + edit elsewhere |
+| Telegram | Private chat rich draft previews | Uses Telegram's `sendRichMessageDraft` in private chats, persists the final response with `sendRichMessage`, and falls back to post + edit elsewhere |
 | Teams | Native (DMs) / Buffered (group chats) | Uses the Teams SDK's native `stream.emit()` for direct messages; accumulates chunks and posts one final message when no native streamer is active |
 | Google Chat | Post + Edit | Posts a message then edits it as chunks arrive |
 | Discord | Post + Edit | Posts a message then edits it as chunks arrive |

--- a/packages/adapter-telegram/README.md
+++ b/packages/adapter-telegram/README.md
@@ -191,7 +191,7 @@ TELEGRAM_API_BASE_URL=https://api.telegram.org
 
 ## Markdown formatting
 
-On Telegram Bot API 10.1 and newer, explicit `{ markdown }` and `{ ast }` messages use rich messages, including native headings, lists, tables, task lists, formulas, details, and inline media supported by the Bot API. Private chat streams use rich draft previews and persist the completed response as a rich message.
+On Telegram Bot API 10.1 and newer, explicit `{ markdown }` and `{ ast }` messages use rich messages, including native headings, lists, tables, task lists, formulas, details, and separate media blocks supported by the Bot API. Private chat streams use rich draft previews and persist the completed response as a rich message.
 
 Plain strings, raw messages, cards, and media captions retain their existing lightweight message paths. Cards and captions use Telegram's `MarkdownV2` parse mode with context-aware escaping. If an older or custom Bot API server does not support rich message methods, the adapter automatically falls back to the existing MarkdownV2 path.
 

--- a/packages/adapter-telegram/README.md
+++ b/packages/adapter-telegram/README.md
@@ -150,7 +150,7 @@ TELEGRAM_API_BASE_URL=https://api.telegram.org
 | Delete message | Yes |
 | File uploads | Single file (`sendDocument`) |
 | Attachment uploads | Single image/audio/video/file (`sendPhoto`, `sendAudio`, `sendVideo`, `sendDocument`) |
-| Streaming | Private chat draft previews + post/edit fallback |
+| Streaming | Private chat rich draft previews + post/edit fallback |
 
 ### Rich content
 
@@ -160,7 +160,7 @@ TELEGRAM_API_BASE_URL=https://api.telegram.org
 | Buttons | Inline keyboard callbacks |
 | Link buttons | Inline keyboard URLs |
 | Select menus | No |
-| Tables | ASCII |
+| Tables | Native for markdown and AST messages, ASCII in cards |
 | Fields | Yes |
 | Images in cards | No |
 | Modals | No |
@@ -191,9 +191,11 @@ TELEGRAM_API_BASE_URL=https://api.telegram.org
 
 ## Markdown formatting
 
-Outbound messages are sent with Telegram's `MarkdownV2` parse mode. The adapter walks the markdown AST and emits MarkdownV2 with context-aware escaping (normal text vs. code blocks vs. link URLs), so you author standard markdown (`**bold**`, `*italic*`, `` `code` ``, `[label](url)`) and the adapter handles every reserved character.
+On Telegram Bot API 10.1 and newer, explicit `{ markdown }` and `{ ast }` messages use rich messages, including native headings, lists, tables, task lists, formulas, details, and inline media supported by the Bot API. Private chat streams use rich draft previews and persist the completed response as a rich message.
 
-Behavior change in 4.27.0: previous versions used Telegram's legacy `Markdown` parse mode, which used different syntax (`*bold*` instead of `**bold**`) and silently rejected any text containing unescaped `.`, `!`, `(`, `)`, `-`, `_`. If you were emitting raw legacy-Markdown strings or hand-escaping characters yourself, drop the manual escaping — the renderer does it for you. Pass `{ raw: "..." }` only if you need to ship a fully pre-escaped MarkdownV2 string.
+Plain strings, raw messages, cards, and media captions retain their existing lightweight message paths. Cards and captions use Telegram's `MarkdownV2` parse mode with context-aware escaping. If an older or custom Bot API server does not support rich message methods, the adapter automatically falls back to the existing MarkdownV2 path.
+
+Behavior change in 4.27.0: previous versions used Telegram's legacy `Markdown` parse mode, which used different syntax (`*bold*` instead of `**bold**`) and silently rejected any text containing unescaped `.`, `!`, `(`, `)`, `-`, `_`. If you were emitting raw legacy-Markdown strings or hand-escaping characters yourself, drop the manual escaping. The renderer does it for you. Pass `{ raw: "..." }` only if you need to ship a fully pre-escaped MarkdownV2 string.
 
 ## Notes
 

--- a/packages/adapter-telegram/src/index.test.ts
+++ b/packages/adapter-telegram/src/index.test.ts
@@ -1383,7 +1383,7 @@ describe("TelegramAdapter", () => {
     expect(mockFetch).toHaveBeenCalledTimes(1);
   });
 
-  it("falls back to a final message when draft streaming updates fail", async () => {
+  it("renders MarkdownV2 when rich draft streaming is unavailable", async () => {
     mockFetch
       .mockResolvedValueOnce(
         telegramOk({
@@ -1396,7 +1396,6 @@ describe("TelegramAdapter", () => {
       .mockResolvedValueOnce(
         telegramError(404, 404, "Not Found: method not found")
       )
-      .mockResolvedValueOnce(telegramOk(true))
       .mockResolvedValueOnce(telegramOk(true))
       .mockResolvedValueOnce(
         telegramOk(
@@ -1416,8 +1415,7 @@ describe("TelegramAdapter", () => {
     await adapter.initialize(createMockChat());
 
     async function* textStream(): AsyncIterable<string> {
-      yield "hello";
-      yield " world";
+      yield "**hello**";
     }
 
     const result = await adapter.stream("telegram:123", textStream(), {
@@ -1432,7 +1430,17 @@ describe("TelegramAdapter", () => {
       })
     );
 
-    const finalSendUrl = String(mockFetch.mock.calls[4]?.[0]);
+    const fallbackDraft = JSON.parse(
+      String((mockFetch.mock.calls[2]?.[1] as RequestInit).body)
+    ) as { parse_mode?: string; text: string };
+    const finalSendUrl = String(mockFetch.mock.calls[3]?.[0]);
+
+    expect(fallbackDraft).toEqual({
+      chat_id: "123",
+      draft_id: expect.any(Number),
+      parse_mode: "MarkdownV2",
+      text: "*hello*",
+    });
     expect(finalSendUrl).toContain("/sendMessage");
   });
 
@@ -3860,6 +3868,91 @@ describe("applyTelegramEntities", () => {
     expect(parsed.formatted.children.map((node) => node.type)).toEqual(
       expect.arrayContaining(["heading", "table"])
     );
+  });
+
+  it("normalizes nested rich media as attachments", async () => {
+    mockFetch.mockResolvedValueOnce(
+      telegramOk({
+        id: 999,
+        is_bot: true,
+        first_name: "Bot",
+        username: "mybot",
+      })
+    );
+
+    const adapter = createTelegramAdapter({
+      botToken: "token",
+      mode: "webhook",
+      logger: mockLogger,
+      userName: "mybot",
+    });
+
+    await adapter.initialize(createMockChat());
+
+    const parsed = adapter.parseMessage(
+      sampleMessage({
+        text: undefined,
+        rich_message: {
+          blocks: [
+            {
+              type: "collage",
+              blocks: [
+                {
+                  type: "photo",
+                  photo: [
+                    {
+                      file_id: "small",
+                      file_unique_id: "small-unique",
+                      height: 100,
+                      width: 100,
+                    },
+                    {
+                      file_id: "large",
+                      file_unique_id: "large-unique",
+                      file_size: 2048,
+                      height: 800,
+                      width: 1200,
+                    },
+                  ],
+                },
+                {
+                  type: "video",
+                  video: {
+                    file_id: "video",
+                    file_unique_id: "video-unique",
+                    duration: 10,
+                    file_name: "clip.mp4",
+                    file_size: 4096,
+                    height: 720,
+                    mime_type: "video/mp4",
+                    width: 1280,
+                  },
+                },
+              ],
+            },
+          ],
+        },
+      })
+    );
+
+    expect(parsed.attachments).toMatchObject([
+      {
+        fetchMetadata: { fileId: "large" },
+        height: 800,
+        size: 2048,
+        type: "image",
+        width: 1200,
+      },
+      {
+        fetchMetadata: { fileId: "video" },
+        height: 720,
+        mimeType: "video/mp4",
+        name: "clip.mp4",
+        size: 4096,
+        type: "video",
+        width: 1280,
+      },
+    ]);
   });
 });
 

--- a/packages/adapter-telegram/src/index.test.ts
+++ b/packages/adapter-telegram/src/index.test.ts
@@ -2151,6 +2151,36 @@ describe("TelegramAdapter", () => {
     ).rejects.toThrow("Bad Request: chat not found");
   });
 
+  it("does not treat unrelated unsupported errors as rich message failures", async () => {
+    mockFetch
+      .mockResolvedValueOnce(
+        telegramOk({
+          id: 999,
+          is_bot: true,
+          first_name: "Bot",
+          username: "mybot",
+        })
+      )
+      .mockResolvedValueOnce(
+        telegramError(400, 400, "Bad Request: message thread is unsupported")
+      );
+
+    const adapter = createTelegramAdapter({
+      botToken: "token",
+      mode: "webhook",
+      logger: mockLogger,
+      userName: "mybot",
+    });
+
+    await adapter.initialize(createMockChat());
+
+    await expect(
+      adapter.postMessage("telegram:123", {
+        markdown: "**hello**",
+      })
+    ).rejects.toThrow("Bad Request: message thread is unsupported");
+  });
+
   it("falls back from rich edits to plain text when Telegram can't parse markdown", async () => {
     mockFetch
       .mockResolvedValueOnce(

--- a/packages/adapter-telegram/src/index.test.ts
+++ b/packages/adapter-telegram/src/index.test.ts
@@ -1093,17 +1093,17 @@ describe("TelegramAdapter", () => {
     const deleteMessageUrl = String(mockFetch.mock.calls[3]?.[0]);
     const typingUrl = String(mockFetch.mock.calls[4]?.[0]);
 
-    expect(sendMessageUrl).toContain("/sendMessage");
+    expect(sendMessageUrl).toContain("/sendRichMessage");
     expect(editMessageUrl).toContain("/editMessageText");
     expect(deleteMessageUrl).toContain("/deleteMessage");
     expect(typingUrl).toContain("/sendChatAction");
 
     const sendMessageBody = JSON.parse(
       String((mockFetch.mock.calls[1]?.[1] as RequestInit).body)
-    ) as { chat_id: string; text: string };
+    ) as { chat_id: string; rich_message: { markdown: string } };
 
     expect(sendMessageBody.chat_id).toBe("123");
-    expect(sendMessageBody.text).toBe("hello");
+    expect(sendMessageBody.rich_message.markdown).toBe("hello");
   });
 
   it("streams draft updates for private chats and sends a final message", async () => {
@@ -1118,11 +1118,13 @@ describe("TelegramAdapter", () => {
       )
       .mockResolvedValueOnce(telegramOk(true))
       .mockResolvedValueOnce(telegramOk(true))
-      .mockResolvedValueOnce(telegramOk(true))
       .mockResolvedValueOnce(
         telegramOk(
           sampleMessage({
-            text: "hello world",
+            text: undefined,
+            rich_message: {
+              blocks: [{ type: "paragraph", text: "hello world" }],
+            },
           })
         )
       );
@@ -1149,67 +1151,100 @@ describe("TelegramAdapter", () => {
     expect(result?.id).toBe("123:11");
     expect(result?.threadId).toBe("telegram:123");
 
-    const initialDraftUrl = String(mockFetch.mock.calls[1]?.[0]);
-    const firstDraftUrl = String(mockFetch.mock.calls[2]?.[0]);
-    const secondDraftUrl = String(mockFetch.mock.calls[3]?.[0]);
-    const finalSendUrl = String(mockFetch.mock.calls[4]?.[0]);
+    const firstDraftUrl = String(mockFetch.mock.calls[1]?.[0]);
+    const secondDraftUrl = String(mockFetch.mock.calls[2]?.[0]);
+    const finalSendUrl = String(mockFetch.mock.calls[3]?.[0]);
 
-    expect(initialDraftUrl).toContain("/sendMessageDraft");
-    expect(firstDraftUrl).toContain("/sendMessageDraft");
-    expect(secondDraftUrl).toContain("/sendMessageDraft");
-    expect(finalSendUrl).toContain("/sendMessage");
-
-    const initialDraftBody = JSON.parse(
+    const firstDraftBody = JSON.parse(
       String((mockFetch.mock.calls[1]?.[1] as RequestInit).body)
     ) as {
       chat_id: string;
       draft_id: number;
-      parse_mode?: string;
-      text: string;
+      rich_message: { markdown: string };
     };
 
-    const firstDraftBody = JSON.parse(
+    const secondDraftBody = JSON.parse(
       String((mockFetch.mock.calls[2]?.[1] as RequestInit).body)
     ) as {
       chat_id: string;
       draft_id: number;
-      parse_mode?: string;
-      text: string;
-    };
-
-    const secondDraftBody = JSON.parse(
-      String((mockFetch.mock.calls[3]?.[1] as RequestInit).body)
-    ) as {
-      chat_id: string;
-      draft_id: number;
-      parse_mode?: string;
-      text: string;
+      rich_message: { markdown: string };
     };
 
     const finalSendBody = JSON.parse(
-      String((mockFetch.mock.calls[4]?.[1] as RequestInit).body)
-    ) as { chat_id: string; parse_mode?: string; text: string };
+      String((mockFetch.mock.calls[3]?.[1] as RequestInit).body)
+    ) as { chat_id: string; rich_message: { markdown: string } };
 
-    expect(initialDraftBody.chat_id).toBe("123");
-    expect(initialDraftBody.text).toBe("");
-    expect(initialDraftBody.parse_mode).toBeUndefined();
+    expect(firstDraftUrl).toContain("/sendRichMessageDraft");
+    expect(secondDraftUrl).toContain("/sendRichMessageDraft");
+    expect(finalSendUrl).toContain("/sendRichMessage");
     expect(firstDraftBody.chat_id).toBe("123");
-    expect(firstDraftBody.draft_id).toBe(initialDraftBody.draft_id);
-    expect(firstDraftBody.text).toBe("hello");
-    expect(firstDraftBody.parse_mode).toBe("MarkdownV2");
+    expect(firstDraftBody.rich_message.markdown).toBe("hello");
     expect(secondDraftBody.draft_id).toBe(firstDraftBody.draft_id);
-    expect(secondDraftBody.text).toBe("hello world");
+    expect(secondDraftBody.rich_message.markdown).toBe("hello world");
     expect(finalSendBody.chat_id).toBe("123");
-    expect(finalSendBody.text).toBe("hello world");
-    expect(finalSendBody.parse_mode).toBe("MarkdownV2");
+    expect(finalSendBody.rich_message.markdown).toBe("hello world");
   });
 
-  it("keeps markdown parse mode for an exact-limit draft and final message", async () => {
+  it("flushes trailing table-like lines before completing a rich stream", async () => {
+    mockFetch
+      .mockResolvedValueOnce(
+        telegramOk({
+          id: 999,
+          is_bot: true,
+          first_name: "Bot",
+          username: "mybot",
+        })
+      )
+      .mockResolvedValueOnce(telegramOk(true))
+      .mockResolvedValueOnce(
+        telegramOk(
+          sampleMessage({
+            text: undefined,
+            rich_message: {
+              blocks: [{ type: "paragraph", text: "| tail |" }],
+            },
+          })
+        )
+      );
+
+    const adapter = createTelegramAdapter({
+      botToken: "token",
+      mode: "webhook",
+      logger: mockLogger,
+      userName: "mybot",
+    });
+
+    await adapter.initialize(createMockChat());
+
+    async function* textStream(): AsyncIterable<string> {
+      yield "| tail |";
+    }
+
+    await adapter.stream("telegram:123", textStream(), {
+      updateIntervalMs: Number.MAX_SAFE_INTEGER,
+    });
+
+    const draftBody = JSON.parse(
+      String((mockFetch.mock.calls[1]?.[1] as RequestInit).body)
+    ) as { rich_message: { markdown: string } };
+    const finalSendBody = JSON.parse(
+      String((mockFetch.mock.calls[2]?.[1] as RequestInit).body)
+    ) as { rich_message: { markdown: string } };
+
+    expect(draftBody.rich_message.markdown).toBe("| tail |");
+    expect(finalSendBody.rich_message.markdown).toBe("| tail |");
+  });
+
+  it("keeps rich markdown for a draft and final message", async () => {
     const longMarkdown = `${"a".repeat(3494)}**ok**`;
-    const renderedMarkdown = `${"a".repeat(3494)}*ok*`;
     const requestBodies: Array<{
       method: string;
-      body: { parse_mode?: string; text?: string };
+      body: {
+        parse_mode?: string;
+        rich_message?: { markdown: string };
+        text?: string;
+      };
     }> = [];
     let nextMessageId = 41;
 
@@ -1219,7 +1254,11 @@ describe("TelegramAdapter", () => {
       const rawBody = (init as RequestInit | undefined)?.body;
       const body =
         typeof rawBody === "string"
-          ? (JSON.parse(rawBody) as { parse_mode?: string; text?: string })
+          ? (JSON.parse(rawBody) as {
+              parse_mode?: string;
+              rich_message?: { markdown: string };
+              text?: string;
+            })
           : {};
 
       requestBodies.push({ method, body });
@@ -1233,15 +1272,18 @@ describe("TelegramAdapter", () => {
         });
       }
 
-      if (method === "sendMessageDraft") {
+      if (method === "sendRichMessageDraft") {
         return telegramOk(true);
       }
 
-      if (method === "sendMessage") {
+      if (method === "sendRichMessage") {
         return telegramOk(
           sampleMessage({
             message_id: nextMessageId++,
-            text: `${"a".repeat(3494)}ok`,
+            text: undefined,
+            rich_message: {
+              blocks: [{ type: "paragraph", text: "ok" }],
+            },
           })
         );
       }
@@ -1270,8 +1312,12 @@ describe("TelegramAdapter", () => {
     expect(
       requestBodies.map((request) => ({
         method: request.method,
-        len: request.body.text?.length,
-        tail: request.body.text?.slice(-10),
+        len:
+          request.body.rich_message?.markdown.length ??
+          request.body.text?.length,
+        tail:
+          request.body.rich_message?.markdown.slice(-10) ??
+          request.body.text?.slice(-10),
         parse_mode: request.body.parse_mode,
       }))
     ).toEqual([
@@ -1282,38 +1328,28 @@ describe("TelegramAdapter", () => {
         parse_mode: undefined,
       },
       {
-        method: "sendMessageDraft",
-        len: 0,
-        tail: "",
+        method: "sendRichMessageDraft",
+        len: longMarkdown.length,
+        tail: longMarkdown.slice(-10),
         parse_mode: undefined,
       },
       {
-        method: "sendMessageDraft",
-        len: renderedMarkdown.length,
-        tail: renderedMarkdown.slice(-10),
-        parse_mode: "MarkdownV2",
-      },
-      {
-        method: "sendMessage",
-        len: renderedMarkdown.length,
-        tail: renderedMarkdown.slice(-10),
-        parse_mode: "MarkdownV2",
+        method: "sendRichMessage",
+        len: longMarkdown.length,
+        tail: longMarkdown.slice(-10),
+        parse_mode: undefined,
       },
     ]);
 
-    const draftBody = requestBodies[2]?.body as {
-      parse_mode?: string;
-      text: string;
+    const draftBody = requestBodies[1]?.body as {
+      rich_message: { markdown: string };
     };
-    const finalSendBody = requestBodies[3]?.body as {
-      parse_mode?: string;
-      text: string;
+    const finalSendBody = requestBodies[2]?.body as {
+      rich_message: { markdown: string };
     };
 
-    expect(draftBody.parse_mode).toBe("MarkdownV2");
-    expect(draftBody.text).toBe(renderedMarkdown);
-    expect(finalSendBody.parse_mode).toBe("MarkdownV2");
-    expect(finalSendBody.text).toBe(renderedMarkdown);
+    expect(draftBody.rich_message.markdown).toBe(longMarkdown);
+    expect(finalSendBody.rich_message.markdown).toBe(longMarkdown);
   });
 
   it("returns null for non-DM streaming so Chat SDK can use fallback streaming", async () => {
@@ -1358,8 +1394,10 @@ describe("TelegramAdapter", () => {
         })
       )
       .mockResolvedValueOnce(
-        telegramError(400, 400, "Bad Request: chat not found")
+        telegramError(404, 404, "Not Found: method not found")
       )
+      .mockResolvedValueOnce(telegramOk(true))
+      .mockResolvedValueOnce(telegramOk(true))
       .mockResolvedValueOnce(
         telegramOk(
           sampleMessage({
@@ -1388,13 +1426,13 @@ describe("TelegramAdapter", () => {
 
     expect(result?.id).toBe("123:11");
     expect(mockLogger.warn).toHaveBeenCalledWith(
-      "Telegram draft streaming update failed",
+      "Telegram rich draft failed; retrying with a regular draft",
       expect.objectContaining({
         threadId: "telegram:123",
       })
     );
 
-    const finalSendUrl = String(mockFetch.mock.calls[2]?.[0]);
+    const finalSendUrl = String(mockFetch.mock.calls[4]?.[0]);
     expect(finalSendUrl).toContain("/sendMessage");
   });
 
@@ -1408,7 +1446,9 @@ describe("TelegramAdapter", () => {
           username: "mybot",
         })
       )
-      .mockResolvedValueOnce(telegramOk(true))
+      .mockResolvedValueOnce(
+        telegramError(404, 404, "Not Found: method not found")
+      )
       .mockResolvedValueOnce(
         telegramError(
           400,
@@ -1489,10 +1529,10 @@ describe("TelegramAdapter", () => {
 
     const sendMessageBody = JSON.parse(
       String((mockFetch.mock.calls[1]?.[1] as RequestInit).body)
-    ) as { chat_id: string; text: string };
+    ) as { chat_id: string; rich_message: { markdown: string } };
 
     expect(sendMessageBody.chat_id).toBe("123");
-    expect(sendMessageBody.text).toBe("channel message");
+    expect(sendMessageBody.rich_message.markdown).toBe("channel message");
   });
 
   it("postChannelMessage works with raw channel ID", async () => {
@@ -1524,10 +1564,10 @@ describe("TelegramAdapter", () => {
 
     const sendMessageBody = JSON.parse(
       String((mockFetch.mock.calls[1]?.[1] as RequestInit).body)
-    ) as { chat_id: string; text: string };
+    ) as { chat_id: string; rich_message: { markdown: string } };
 
     expect(sendMessageBody.chat_id).toBe("123");
-    expect(sendMessageBody.text).toBe("raw id message");
+    expect(sendMessageBody.rich_message.markdown).toBe("raw id message");
   });
 
   it.each([
@@ -1796,7 +1836,7 @@ describe("TelegramAdapter", () => {
     expect(mockFetch.mock.calls).toHaveLength(1);
   });
 
-  it("sets parse_mode for markdown messages", async () => {
+  it("uses rich messages for markdown messages", async () => {
     mockFetch
       .mockResolvedValueOnce(
         telegramOk({
@@ -1821,14 +1861,16 @@ describe("TelegramAdapter", () => {
       markdown: "**bold** and _italic_",
     });
 
+    const sendMessageUrl = String(mockFetch.mock.calls[1]?.[0]);
     const sendMessageBody = JSON.parse(
       String((mockFetch.mock.calls[1]?.[1] as RequestInit).body)
-    ) as { parse_mode?: string };
+    ) as { rich_message: { markdown: string } };
 
-    expect(sendMessageBody.parse_mode).toBe("MarkdownV2");
+    expect(sendMessageUrl).toContain("/sendRichMessage");
+    expect(sendMessageBody.rich_message.markdown).toBe("**bold** and _italic_");
   });
 
-  it("sets parse_mode for AST messages", async () => {
+  it("uses rich messages for AST messages", async () => {
     mockFetch
       .mockResolvedValueOnce(
         telegramOk({
@@ -1852,15 +1894,13 @@ describe("TelegramAdapter", () => {
     const ast = new TelegramFormatConverter().toAst("**hello** world!");
     await adapter.postMessage("telegram:123", { ast });
 
+    const sendMessageUrl = String(mockFetch.mock.calls[1]?.[0]);
     const sendMessageBody = JSON.parse(
       String((mockFetch.mock.calls[1]?.[1] as RequestInit).body)
-    ) as { parse_mode?: string; text: string };
+    ) as { rich_message: { markdown: string } };
 
-    // AST messages were shipping without parse_mode, so Telegram rendered
-    // MarkdownV2 asterisks literally. Guard against regression.
-    expect(sendMessageBody.parse_mode).toBe("MarkdownV2");
-    expect(sendMessageBody.text).toContain("*hello*");
-    expect(sendMessageBody.text).toContain("world\\!");
+    expect(sendMessageUrl).toContain("/sendRichMessage");
+    expect(sendMessageBody.rich_message.markdown).toBe("**hello** world!\n");
   });
 
   it("omits parse_mode for plain string messages", async () => {
@@ -1924,7 +1964,7 @@ describe("TelegramAdapter", () => {
     expect(sendMessageBody.text).toBe("raw.unparsed!(text)");
   });
 
-  it("retries markdown messages without parse_mode when Telegram can't parse entities", async () => {
+  it("falls back from rich messages to plain text when Telegram can't parse markdown", async () => {
     mockFetch
       .mockResolvedValueOnce(
         telegramOk({
@@ -1933,6 +1973,9 @@ describe("TelegramAdapter", () => {
           first_name: "Bot",
           username: "mybot",
         })
+      )
+      .mockResolvedValueOnce(
+        telegramError(400, 400, "Bad Request: can't parse rich message")
       )
       .mockResolvedValueOnce(
         telegramError(
@@ -1964,16 +2007,27 @@ describe("TelegramAdapter", () => {
 
     expect(result.id).toBe("123:11");
 
-    const firstSendBody = JSON.parse(
+    const richSendBody = JSON.parse(
       String((mockFetch.mock.calls[1]?.[1] as RequestInit).body)
-    ) as { parse_mode?: string; text: string };
-    const secondSendBody = JSON.parse(
+    ) as { rich_message: { markdown: string } };
+    const markdownSendBody = JSON.parse(
       String((mockFetch.mock.calls[2]?.[1] as RequestInit).body)
     ) as { parse_mode?: string; text: string };
+    const plainSendBody = JSON.parse(
+      String((mockFetch.mock.calls[3]?.[1] as RequestInit).body)
+    ) as { parse_mode?: string; text: string };
 
-    expect(firstSendBody.parse_mode).toBe("MarkdownV2");
-    expect(secondSendBody.parse_mode).toBeUndefined();
-    expect(secondSendBody.text).toBe("**broken");
+    expect(richSendBody.rich_message.markdown).toBe("**broken");
+    expect(markdownSendBody.parse_mode).toBe("MarkdownV2");
+    expect(plainSendBody.parse_mode).toBeUndefined();
+    expect(plainSendBody.text).toBe("**broken");
+    expect(mockLogger.warn).toHaveBeenCalledWith(
+      "Telegram rich message failed; retrying with a regular message",
+      expect.objectContaining({
+        method: "sendRichMessage",
+        threadId: "telegram:123",
+      })
+    );
     expect(mockLogger.warn).toHaveBeenCalledWith(
       "Telegram markdown parse failed; retrying without parse mode",
       expect.objectContaining({
@@ -1983,7 +2037,7 @@ describe("TelegramAdapter", () => {
     );
   });
 
-  it("retries markdown messages with original text when plain-text fallback would be empty", async () => {
+  it("reuses original markdown when rich and plain-text parsing fail", async () => {
     mockFetch
       .mockResolvedValueOnce(
         telegramOk({
@@ -1992,6 +2046,9 @@ describe("TelegramAdapter", () => {
           first_name: "Bot",
           username: "mybot",
         })
+      )
+      .mockResolvedValueOnce(
+        telegramError(404, 404, "Not Found: method not found")
       )
       .mockResolvedValueOnce(
         telegramError(
@@ -2023,12 +2080,45 @@ describe("TelegramAdapter", () => {
 
     expect(result.id).toBe("123:11");
 
-    const secondSendBody = JSON.parse(
-      String((mockFetch.mock.calls[2]?.[1] as RequestInit).body)
+    const plainSendBody = JSON.parse(
+      String((mockFetch.mock.calls[3]?.[1] as RequestInit).body)
     ) as { parse_mode?: string; text: string };
 
-    expect(secondSendBody.parse_mode).toBeUndefined();
-    expect(secondSendBody.text).toBe("**");
+    expect(plainSendBody.parse_mode).toBeUndefined();
+    expect(plainSendBody.text).toBe("**");
+  });
+
+  it("caches unavailable rich message endpoints", async () => {
+    mockFetch
+      .mockResolvedValueOnce(
+        telegramOk({
+          id: 999,
+          is_bot: true,
+          first_name: "Bot",
+          username: "mybot",
+        })
+      )
+      .mockResolvedValueOnce(
+        telegramError(404, 404, "Not Found: method not found")
+      )
+      .mockResolvedValueOnce(telegramOk(sampleMessage()))
+      .mockResolvedValueOnce(telegramOk(sampleMessage({ message_id: 12 })));
+
+    const adapter = createTelegramAdapter({
+      botToken: "token",
+      mode: "webhook",
+      logger: mockLogger,
+      userName: "mybot",
+    });
+
+    await adapter.initialize(createMockChat());
+
+    await adapter.postMessage("telegram:123", { markdown: "first" });
+    await adapter.postMessage("telegram:123", { markdown: "second" });
+
+    expect(String(mockFetch.mock.calls[1]?.[0])).toContain("/sendRichMessage");
+    expect(String(mockFetch.mock.calls[2]?.[0])).toContain("/sendMessage");
+    expect(String(mockFetch.mock.calls[3]?.[0])).toContain("/sendMessage");
   });
 
   it("does not swallow non-parse validation errors during markdown send", async () => {
@@ -2061,7 +2151,7 @@ describe("TelegramAdapter", () => {
     ).rejects.toThrow("Bad Request: chat not found");
   });
 
-  it("retries markdown edits without parse_mode when Telegram can't parse entities", async () => {
+  it("falls back from rich edits to plain text when Telegram can't parse markdown", async () => {
     mockFetch
       .mockResolvedValueOnce(
         telegramOk({
@@ -2072,6 +2162,9 @@ describe("TelegramAdapter", () => {
         })
       )
       .mockResolvedValueOnce(telegramOk(sampleMessage()))
+      .mockResolvedValueOnce(
+        telegramError(400, 400, "Bad Request: rich message is unsupported")
+      )
       .mockResolvedValueOnce(
         telegramError(
           400,
@@ -2103,16 +2196,20 @@ describe("TelegramAdapter", () => {
 
     expect(result.id).toBe("123:11");
 
-    const firstEditBody = JSON.parse(
+    const richEditBody = JSON.parse(
       String((mockFetch.mock.calls[2]?.[1] as RequestInit).body)
-    ) as { parse_mode?: string; text: string };
-    const secondEditBody = JSON.parse(
+    ) as { rich_message: { markdown: string } };
+    const markdownEditBody = JSON.parse(
       String((mockFetch.mock.calls[3]?.[1] as RequestInit).body)
     ) as { parse_mode?: string; text: string };
+    const plainEditBody = JSON.parse(
+      String((mockFetch.mock.calls[4]?.[1] as RequestInit).body)
+    ) as { parse_mode?: string; text: string };
 
-    expect(firstEditBody.parse_mode).toBe("MarkdownV2");
-    expect(secondEditBody.parse_mode).toBeUndefined();
-    expect(secondEditBody.text).toBe("**broken");
+    expect(richEditBody.rich_message.markdown).toBe("**broken");
+    expect(markdownEditBody.parse_mode).toBe("MarkdownV2");
+    expect(plainEditBody.parse_mode).toBeUndefined();
+    expect(plainEditBody.text).toBe("**broken");
     expect(mockLogger.warn).toHaveBeenCalledWith(
       "Telegram markdown parse failed; retrying without parse mode",
       expect.objectContaining({
@@ -2123,7 +2220,7 @@ describe("TelegramAdapter", () => {
     );
   });
 
-  it("retries markdown edits with original text when plain-text fallback would be empty", async () => {
+  it("reuses original markdown when rich edit fallback text is empty", async () => {
     mockFetch
       .mockResolvedValueOnce(
         telegramOk({
@@ -2134,6 +2231,9 @@ describe("TelegramAdapter", () => {
         })
       )
       .mockResolvedValueOnce(telegramOk(sampleMessage()))
+      .mockResolvedValueOnce(
+        telegramError(400, 400, "Bad Request: rich message is unsupported")
+      )
       .mockResolvedValueOnce(
         telegramError(
           400,
@@ -2165,12 +2265,12 @@ describe("TelegramAdapter", () => {
 
     expect(result.id).toBe("123:11");
 
-    const secondEditBody = JSON.parse(
-      String((mockFetch.mock.calls[3]?.[1] as RequestInit).body)
+    const plainEditBody = JSON.parse(
+      String((mockFetch.mock.calls[4]?.[1] as RequestInit).body)
     ) as { parse_mode?: string; text: string };
 
-    expect(secondEditBody.parse_mode).toBeUndefined();
-    expect(secondEditBody.text).toBe("**");
+    expect(plainEditBody.parse_mode).toBeUndefined();
+    expect(plainEditBody.text).toBe("**");
   });
 
   it("falls back to plain-text draft and final send when Telegram can't parse streamed markdown", async () => {
@@ -2183,7 +2283,9 @@ describe("TelegramAdapter", () => {
           username: "mybot",
         })
       )
-      .mockResolvedValueOnce(telegramOk(true))
+      .mockResolvedValueOnce(
+        telegramError(404, 404, "Not Found: method not found")
+      )
       .mockResolvedValueOnce(
         telegramError(
           400,
@@ -2219,6 +2321,12 @@ describe("TelegramAdapter", () => {
 
     expect(result?.id).toBe("123:11");
 
+    const richDraftBody = JSON.parse(
+      String((mockFetch.mock.calls[1]?.[1] as RequestInit).body)
+    ) as { rich_message: { markdown: string } };
+    const markdownDraftBody = JSON.parse(
+      String((mockFetch.mock.calls[2]?.[1] as RequestInit).body)
+    ) as { parse_mode?: string; text: string };
     const retryDraftBody = JSON.parse(
       String((mockFetch.mock.calls[3]?.[1] as RequestInit).body)
     ) as { parse_mode?: string; text: string };
@@ -2226,6 +2334,8 @@ describe("TelegramAdapter", () => {
       String((mockFetch.mock.calls[4]?.[1] as RequestInit).body)
     ) as { parse_mode?: string; text: string };
 
+    expect(richDraftBody.rich_message.markdown).toBe("**broken**");
+    expect(markdownDraftBody.parse_mode).toBe("MarkdownV2");
     expect(retryDraftBody.parse_mode).toBeUndefined();
     expect(retryDraftBody.text).toBe("**broken");
     expect(finalSendBody.parse_mode).toBeUndefined();
@@ -2242,7 +2352,9 @@ describe("TelegramAdapter", () => {
           username: "mybot",
         })
       )
-      .mockResolvedValueOnce(telegramOk(true))
+      .mockResolvedValueOnce(
+        telegramError(404, 404, "Not Found: method not found")
+      )
       .mockResolvedValueOnce(
         telegramError(
           400,
@@ -2278,6 +2390,12 @@ describe("TelegramAdapter", () => {
 
     expect(result?.id).toBe("123:11");
 
+    const richDraftBody = JSON.parse(
+      String((mockFetch.mock.calls[1]?.[1] as RequestInit).body)
+    ) as { rich_message: { markdown: string } };
+    const markdownDraftBody = JSON.parse(
+      String((mockFetch.mock.calls[2]?.[1] as RequestInit).body)
+    ) as { parse_mode?: string; text: string };
     const retryDraftBody = JSON.parse(
       String((mockFetch.mock.calls[3]?.[1] as RequestInit).body)
     ) as { parse_mode?: string; text: string };
@@ -2285,6 +2403,8 @@ describe("TelegramAdapter", () => {
       String((mockFetch.mock.calls[4]?.[1] as RequestInit).body)
     ) as { parse_mode?: string; text: string };
 
+    expect(richDraftBody.rich_message.markdown).toBe("**");
+    expect(markdownDraftBody.parse_mode).toBe("MarkdownV2");
     expect(retryDraftBody.parse_mode).toBeUndefined();
     expect(retryDraftBody.text).toBe("**");
     expect(finalSendBody.parse_mode).toBeUndefined();
@@ -3230,11 +3350,15 @@ describe("TelegramAdapter", () => {
 
     const sendMessageBody = JSON.parse(
       String((mockFetch.mock.calls[1]?.[1] as RequestInit).body)
-    ) as { chat_id: string; message_thread_id?: number; text: string };
+    ) as {
+      chat_id: string;
+      message_thread_id?: number;
+      rich_message: { markdown: string };
+    };
 
     expect(sendMessageBody.chat_id).toBe("-1001234");
     expect(sendMessageBody.message_thread_id).toBe(42);
-    expect(sendMessageBody.text).toBe("forum topic message");
+    expect(sendMessageBody.rich_message.markdown).toBe("forum topic message");
   });
 });
 
@@ -3261,12 +3385,25 @@ describe("message length limits", () => {
   }
 
   function readSentBody(callIndex: number): {
-    text?: string;
     parse_mode?: string;
+    rich_message?: { markdown: string };
+    text?: string;
   } {
     return JSON.parse(
       String((mockFetch.mock.calls[callIndex]?.[1] as RequestInit).body)
-    ) as { text?: string; parse_mode?: string };
+    ) as {
+      parse_mode?: string;
+      rich_message?: { markdown: string };
+      text?: string;
+    };
+  }
+
+  function useLegacyMessage(): void {
+    mockFetch
+      .mockResolvedValueOnce(
+        telegramError(404, 404, "Not Found: method not found")
+      )
+      .mockResolvedValueOnce(telegramOk(sampleMessage()));
   }
 
   /**
@@ -3329,25 +3466,34 @@ describe("message length limits", () => {
     expect(body.text).toBe(exact);
   });
 
-  it("MarkdownV2 message over 4096 chars escapes the trailing ellipsis as '\\.\\.\\.'", async () => {
+  it("rich markdown messages can exceed the regular message limit", async () => {
     const adapter = await createInitializedAdapter();
     mockFetch.mockResolvedValueOnce(telegramOk(sampleMessage()));
 
-    // 5000 'a' chars through the markdown path renders to 5000 'a' (nothing to escape).
-    // Must end with escaped ellipsis, NOT literal dots.
-    await adapter.postMessage("telegram:123", {
-      markdown: "a".repeat(5000),
-    });
+    const markdown = "a".repeat(5000);
+    await adapter.postMessage("telegram:123", { markdown });
 
     const body = readSentBody(1);
-    expect(body.parse_mode).toBe("MarkdownV2");
-    expect(body.text?.length).toBeLessThanOrEqual(TELEGRAM_MESSAGE_LIMIT);
-    expect(body.text?.endsWith("\\.\\.\\.")).toBe(true);
+    expect(body.parse_mode).toBeUndefined();
+    expect(body.rich_message?.markdown).toBe(markdown);
+  });
+
+  it("rich markdown messages truncate at the rich message limit", async () => {
+    const adapter = await createInitializedAdapter();
+    mockFetch.mockResolvedValueOnce(telegramOk(sampleMessage()));
+
+    await adapter.postMessage("telegram:123", {
+      markdown: "a".repeat(40_000),
+    });
+
+    const markdown = readSentBody(1).rich_message?.markdown ?? "";
+    expect(Array.from(markdown).length).toBeLessThanOrEqual(32_768);
+    expect(markdown.endsWith("...")).toBe(true);
   });
 
   it("MarkdownV2 truncation does not leave an orphan trailing backslash before the ellipsis", async () => {
     const adapter = await createInitializedAdapter();
-    mockFetch.mockResolvedValueOnce(telegramOk(sampleMessage()));
+    useLegacyMessage();
 
     // Construct input so the rendered text has an escape sequence (`\.`)
     // straddling the 4096 - ellipsisLen boundary. 4092 'a's + 50 '.' → renders
@@ -3355,7 +3501,7 @@ describe("message length limits", () => {
     const longWithDots = "a".repeat(4092) + ".".repeat(50);
     await adapter.postMessage("telegram:123", { markdown: longWithDots });
 
-    const body = readSentBody(1);
+    const body = readSentBody(2);
     const text = body.text ?? "";
     // Strip the trailing ellipsis (escaped or not) before checking the body
     const ellipsis = text.endsWith("\\.\\.\\.") ? "\\.\\.\\." : "...";
@@ -3365,7 +3511,7 @@ describe("message length limits", () => {
 
   it("MarkdownV2 truncation leaves all entity delimiters balanced (no unclosed **bold**)", async () => {
     const adapter = await createInitializedAdapter();
-    mockFetch.mockResolvedValueOnce(telegramOk(sampleMessage()));
+    useLegacyMessage();
 
     // Long bold span crossing the limit: 4000 'a' + `**` + 1000 'b' + `**`
     // Rendered MarkdownV2: 4000 'a' + `*` + 1000 'b' + `*` → 5002 chars.
@@ -3373,7 +3519,7 @@ describe("message length limits", () => {
     const bolded = `${"a".repeat(4000)}**${"b".repeat(1000)}**`;
     await adapter.postMessage("telegram:123", { markdown: bolded });
 
-    const body = readSentBody(1);
+    const body = readSentBody(2);
     const text = body.text ?? "";
     const ellipsis = text.endsWith("\\.\\.\\.") ? "\\.\\.\\." : "...";
     const beforeEllipsis = text.slice(0, -ellipsis.length);
@@ -3389,13 +3535,13 @@ describe("message length limits", () => {
 
   it("MarkdownV2 truncation closes or drops an unmatched inline code span", async () => {
     const adapter = await createInitializedAdapter();
-    mockFetch.mockResolvedValueOnce(telegramOk(sampleMessage()));
+    useLegacyMessage();
 
     // Long inline code span crossing the limit
     const coded = `${"a".repeat(4000)}\`${"b".repeat(1000)}\``;
     await adapter.postMessage("telegram:123", { markdown: coded });
 
-    const body = readSentBody(1);
+    const body = readSentBody(2);
     const text = body.text ?? "";
     const ellipsis = text.endsWith("\\.\\.\\.") ? "\\.\\.\\." : "...";
     const beforeEllipsis = text.slice(0, -ellipsis.length);
@@ -3610,6 +3756,79 @@ describe("applyTelegramEntities", () => {
     const parsed = adapter.parseMessage(messageWithLink);
     expect(parsed.text).toBe(
       "Visit our [website](https://example.com) for details"
+    );
+  });
+
+  it("normalizes inbound rich messages", async () => {
+    mockFetch.mockResolvedValueOnce(
+      telegramOk({
+        id: 999,
+        is_bot: true,
+        first_name: "Bot",
+        username: "mybot",
+      })
+    );
+
+    const adapter = createTelegramAdapter({
+      botToken: "token",
+      mode: "webhook",
+      logger: mockLogger,
+      userName: "mybot",
+    });
+
+    await adapter.initialize(createMockChat());
+
+    const parsed = adapter.parseMessage(
+      sampleMessage({
+        text: undefined,
+        rich_message: {
+          blocks: [
+            {
+              type: "heading",
+              size: 2,
+              text: "Release",
+            },
+            {
+              type: "table",
+              cells: [
+                [
+                  {
+                    align: "left",
+                    is_header: true,
+                    text: "Package",
+                    valign: "top",
+                  },
+                  {
+                    align: "left",
+                    is_header: true,
+                    text: "Status",
+                    valign: "top",
+                  },
+                ],
+                [
+                  {
+                    align: "left",
+                    text: "chat",
+                    valign: "top",
+                  },
+                  {
+                    align: "left",
+                    text: "ready",
+                    valign: "top",
+                  },
+                ],
+              ],
+            },
+          ],
+        },
+      })
+    );
+
+    expect(parsed.text).toContain("Release");
+    expect(parsed.text).toContain("chat");
+    expect(parsed.text).toContain("ready");
+    expect(parsed.formatted.children.map((node) => node.type)).toEqual(
+      expect.arrayContaining(["heading", "table"])
     );
   });
 });

--- a/packages/adapter-telegram/src/index.ts
+++ b/packages/adapter-telegram/src/index.ts
@@ -2779,6 +2779,7 @@ export type {
   TelegramUpdate,
   TelegramUser,
   TelegramVideo,
+  TelegramVideoQuality,
   TelegramVoice,
   TelegramWebhookInfo,
 } from "./types";

--- a/packages/adapter-telegram/src/index.ts
+++ b/packages/adapter-telegram/src/index.ts
@@ -38,6 +38,7 @@ import {
   markdownToPlainText,
   NotImplementedError,
   StreamingMarkdownRenderer,
+  stringifyMarkdown,
   toPlainText,
 } from "chat";
 import {
@@ -53,6 +54,11 @@ import {
   toBotApiParseMode,
   truncateForTelegram,
 } from "./markdown";
+import {
+  richMessageToMarkdown,
+  richMessageToText,
+  truncateRichMarkdown,
+} from "./rich";
 import type {
   TelegramAdapterConfig,
   TelegramAdapterMode,
@@ -102,6 +108,9 @@ const TELEGRAM_DEFAULT_POLLING_RETRY_DELAY_MS = 1000;
 const TELEGRAM_DEFAULT_STREAM_UPDATE_INTERVAL_MS = 250;
 const TELEGRAM_MARKDOWN_PARSE_ERROR_PATTERN =
   /can't parse (?:caption )?entities/i;
+const TELEGRAM_RICH_FALLBACK_PATTERN =
+  /can't parse|method.*not found|rich message|unsupported/i;
+const TELEGRAM_RICH_UNAVAILABLE_PATTERN = /method.*not found|unsupported/i;
 const TELEGRAM_MAX_POLLING_LIMIT = 100;
 const TELEGRAM_MIN_POLLING_LIMIT = 1;
 const TELEGRAM_MIN_POLLING_TIMEOUT_SECONDS = 0;
@@ -242,6 +251,7 @@ export class TelegramAdapter
   private pollingTask: Promise<void> | null = null;
   private pollingActive = false;
   private nextDraftId = Math.max(1, Date.now() % 2_147_483_647);
+  private richMessagesAvailable = true;
 
   get botUserId(): string | undefined {
     return this._botUserId;
@@ -848,6 +858,12 @@ export class TelegramAdapter
       );
     }
 
+    const rich = this.resolveRichMessage(
+      message,
+      card,
+      files.length,
+      attachments.length
+    );
     let rawMessage: TelegramMessage;
 
     if (files.length === 1) {
@@ -884,23 +900,34 @@ export class TelegramAdapter
         throw new ValidationError("telegram", "Message text cannot be empty");
       }
 
-      rawMessage = await this.withTelegramMarkdownFallback(
-        parseMode,
-        (resolvedParseMode, resolvedText) =>
-          this.telegramFetch<TelegramMessage>("sendMessage", {
-            chat_id: parsedThread.chatId,
-            message_thread_id: parsedThread.messageThreadId,
-            text: resolvedText,
-            reply_markup: replyMarkup,
-            parse_mode: toBotApiParseMode(resolvedParseMode),
-          }),
-        {
-          initialText: text,
-          fallbackText: plainText,
-          method: "sendMessage",
-          threadId,
-        }
-      );
+      const sendRegular = () =>
+        this.sendRegularMessage(
+          parsedThread,
+          text,
+          plainText,
+          parseMode,
+          replyMarkup,
+          threadId
+        );
+
+      rawMessage = rich
+        ? await this.withTelegramRichFallback(
+            () =>
+              this.telegramFetch<TelegramMessage>("sendRichMessage", {
+                chat_id: parsedThread.chatId,
+                message_thread_id: parsedThread.messageThreadId,
+                rich_message: {
+                  markdown: rich.markdown,
+                },
+                reply_markup: replyMarkup,
+              }),
+            sendRegular,
+            {
+              method: "sendRichMessage",
+              threadId,
+            }
+          )
+        : await sendRegular();
     }
 
     const resultingThreadId = this.encodeThreadId({
@@ -911,7 +938,13 @@ export class TelegramAdapter
 
     const parsedMessage = this.parseTelegramMessage(
       rawMessage,
-      resultingThreadId
+      resultingThreadId,
+      rich
+        ? {
+            formatted: rich.formatted,
+            text: rich.text,
+          }
+        : undefined
     );
     this.cacheMessage(parsedMessage);
 
@@ -964,29 +997,51 @@ export class TelegramAdapter
       TELEGRAM_MESSAGE_LIMIT,
       parseMode
     );
+    const rich = this.resolveRichMessage(message, card, 0, 0);
 
     if (!text.trim()) {
       throw new ValidationError("telegram", "Message text cannot be empty");
     }
 
-    const result = await this.withTelegramMarkdownFallback(
-      parseMode,
-      (resolvedParseMode, resolvedText) =>
-        this.telegramFetch<TelegramMessage | true>("editMessageText", {
-          chat_id: chatId,
-          message_id: telegramMessageId,
-          text: resolvedText,
-          reply_markup: replyMarkup ?? emptyTelegramInlineKeyboard(),
-          parse_mode: toBotApiParseMode(resolvedParseMode),
-        }),
-      {
-        initialText: text,
-        fallbackText: plainText,
-        messageId,
-        method: "editMessageText",
-        threadId,
-      }
-    );
+    const editRegular = () =>
+      this.withTelegramMarkdownFallback(
+        parseMode,
+        (resolvedParseMode, resolvedText) =>
+          this.telegramFetch<TelegramMessage | true>("editMessageText", {
+            chat_id: chatId,
+            message_id: telegramMessageId,
+            text: resolvedText,
+            reply_markup: replyMarkup ?? emptyTelegramInlineKeyboard(),
+            parse_mode: toBotApiParseMode(resolvedParseMode),
+          }),
+        {
+          initialText: text,
+          fallbackText: plainText,
+          messageId,
+          method: "editMessageText",
+          threadId,
+        }
+      );
+
+    const result = rich
+      ? await this.withTelegramRichFallback(
+          () =>
+            this.telegramFetch<TelegramMessage | true>("editMessageText", {
+              chat_id: chatId,
+              message_id: telegramMessageId,
+              rich_message: {
+                markdown: rich.markdown,
+              },
+              reply_markup: replyMarkup ?? emptyTelegramInlineKeyboard(),
+            }),
+          editRegular,
+          {
+            messageId,
+            method: "editMessageText",
+            threadId,
+          }
+        )
+      : await editRegular();
 
     if (result === true) {
       const existing = this.findCachedMessage(compositeId);
@@ -999,8 +1054,8 @@ export class TelegramAdapter
 
       const updated = new Message<TelegramRawMessage>({
         ...existing,
-        text,
-        formatted: this.formatConverter.toAst(text),
+        text: rich?.text ?? text,
+        formatted: rich?.formatted ?? this.formatConverter.toAst(text),
         metadata: {
           ...existing.metadata,
           edited: true,
@@ -1022,7 +1077,16 @@ export class TelegramAdapter
       messageThreadId: result.message_thread_id ?? parsedThread.messageThreadId,
     });
 
-    const parsedMessage = this.parseTelegramMessage(result, resultingThreadId);
+    const parsedMessage = this.parseTelegramMessage(
+      result,
+      resultingThreadId,
+      rich
+        ? {
+            formatted: rich.formatted,
+            text: rich.text,
+          }
+        : undefined
+    );
     this.cacheMessage(parsedMessage);
 
     return {
@@ -1113,6 +1177,7 @@ export class TelegramAdapter
     let lastFlushAt = 0;
     let draftStreamingEnabled = true;
     let streamUsesMarkdown = true;
+    let streamUsesRich = this.richMessagesAvailable;
 
     const renderMarkdownForTelegram = (text: string): string =>
       convertEmojiPlaceholders(
@@ -1140,6 +1205,41 @@ export class TelegramAdapter
     ): Promise<void> => {
       if (!draftStreamingEnabled || text === lastDraftText) {
         return;
+      }
+
+      if (streamUsesRich) {
+        try {
+          await this.telegramFetch<boolean>("sendRichMessageDraft", {
+            chat_id: parsedThread.chatId,
+            message_thread_id: parsedThread.messageThreadId,
+            draft_id: draftId,
+            rich_message: {
+              markdown: text,
+            },
+          });
+          lastDraftText = text;
+          lastFlushAt = Date.now();
+          return;
+        } catch (error) {
+          if (!this.canFallbackFromRichMessage(error, "sendRichMessageDraft")) {
+            draftStreamingEnabled = false;
+            this.logger.warn("Telegram rich draft streaming update failed", {
+              error: String(error),
+              threadId,
+            });
+            return;
+          }
+
+          this.rememberRichMessageFailure(error, "sendRichMessageDraft");
+          this.logger.warn(
+            "Telegram rich draft failed; retrying with a regular draft",
+            {
+              error: String(error),
+              threadId,
+            }
+          );
+          streamUsesRich = false;
+        }
       }
 
       try {
@@ -1199,13 +1299,14 @@ export class TelegramAdapter
         return;
       }
 
-      const draftText = streamUsesMarkdown
-        ? renderMarkdownText(renderer.render())
-        : renderPlainText(accumulated);
+      let draftText = renderPlainText(accumulated);
+      if (streamUsesRich) {
+        draftText = truncateRichMarkdown(renderer.render());
+      } else if (streamUsesMarkdown) {
+        draftText = renderMarkdownText(renderer.render());
+      }
       await sendDraft(draftText, streamUsesMarkdown);
     };
-
-    await sendDraft("", false);
 
     for await (const chunk of textStream) {
       let text: string | null = null;
@@ -1227,8 +1328,6 @@ export class TelegramAdapter
       }
     }
 
-    await flushDraft();
-
     if (!accumulated.trim()) {
       throw new ValidationError(
         "telegram",
@@ -1236,14 +1335,69 @@ export class TelegramAdapter
       );
     }
 
-    const finalPostable: AdapterPostableMessage = streamUsesMarkdown
-      ? { markdown: accumulated }
-      : this.resolveTelegramFallbackText(
-          accumulated,
-          markdownToPlainText(accumulated)
-        );
+    const finalMarkdown = renderer.finish();
+    await flushDraft();
 
-    return this.postMessage(threadId, finalPostable);
+    if (streamUsesRich) {
+      const markdown = truncateRichMarkdown(finalMarkdown);
+      try {
+        const raw = await this.telegramFetch<TelegramMessage>(
+          "sendRichMessage",
+          {
+            chat_id: parsedThread.chatId,
+            message_thread_id: parsedThread.messageThreadId,
+            rich_message: {
+              markdown,
+            },
+          }
+        );
+        const resultingThreadId = this.encodeThreadId({
+          chatId: String(raw.chat.id),
+          messageThreadId:
+            raw.message_thread_id ?? parsedThread.messageThreadId,
+        });
+        const formatted = this.formatConverter.toAst(accumulated);
+        const message = this.parseTelegramMessage(raw, resultingThreadId, {
+          formatted,
+          text: toPlainText(formatted),
+        });
+        this.cacheMessage(message);
+        return {
+          id: message.id,
+          threadId: message.threadId,
+          raw,
+        };
+      } catch (error) {
+        if (!this.canFallbackFromRichMessage(error, "sendRichMessage")) {
+          throw error;
+        }
+        this.rememberRichMessageFailure(error, "sendRichMessage");
+      }
+    }
+
+    const regularText = streamUsesMarkdown
+      ? renderMarkdownText(finalMarkdown)
+      : renderPlainText(accumulated);
+    const plainText = renderPlainText(accumulated);
+    const raw = await this.sendRegularMessage(
+      parsedThread,
+      regularText,
+      plainText,
+      streamUsesMarkdown ? "MarkdownV2" : "plain",
+      undefined,
+      threadId
+    );
+    const resultingThreadId = this.encodeThreadId({
+      chatId: String(raw.chat.id),
+      messageThreadId: raw.message_thread_id ?? parsedThread.messageThreadId,
+    });
+    const message = this.parseTelegramMessage(raw, resultingThreadId);
+    this.cacheMessage(message);
+    return {
+      id: message.id,
+      threadId: message.threadId,
+      raw,
+    };
   }
 
   async fetchMessages(
@@ -1412,11 +1566,24 @@ export class TelegramAdapter
 
   protected parseTelegramMessage(
     raw: TelegramMessage,
-    threadId: string
+    threadId: string,
+    content?: {
+      formatted: FormattedContent;
+      text: string;
+    }
   ): Message<TelegramRawMessage> {
-    const plainText = raw.text ?? raw.caption ?? "";
+    const richMarkdown = raw.rich_message
+      ? richMessageToMarkdown(raw.rich_message)
+      : "";
+    const plainText =
+      content?.text ??
+      raw.text ??
+      raw.caption ??
+      (raw.rich_message ? richMessageToText(raw.rich_message) : "");
     const entities = raw.entities ?? raw.caption_entities ?? [];
-    const text = applyTelegramEntities(plainText, entities);
+    const text = content?.text
+      ? content.text
+      : applyTelegramEntities(plainText, entities);
     let author: TelegramMessageAuthor;
 
     if (raw.from) {
@@ -1439,7 +1606,8 @@ export class TelegramAdapter
       id: this.encodeMessageId(String(raw.chat.id), raw.message_id),
       threadId,
       text,
-      formatted: this.formatConverter.toAst(text),
+      formatted:
+        content?.formatted ?? this.formatConverter.toAst(richMarkdown || text),
       raw,
       author,
       metadata: {
@@ -2073,6 +2241,51 @@ export class TelegramAdapter
     return "MarkdownV2";
   }
 
+  protected resolveRichMessage(
+    message: AdapterPostableMessage,
+    card: ReturnType<typeof extractCard>,
+    fileCount: number,
+    attachmentCount: number
+  ): {
+    formatted: FormattedContent;
+    markdown: string;
+    text: string;
+  } | null {
+    if (
+      !this.richMessagesAvailable ||
+      card ||
+      fileCount > 0 ||
+      attachmentCount > 0 ||
+      typeof message === "string" ||
+      "raw" in message
+    ) {
+      return null;
+    }
+
+    if ("markdown" in message) {
+      const formatted = this.formatConverter.toAst(message.markdown);
+      return {
+        formatted,
+        markdown: truncateRichMarkdown(
+          convertEmojiPlaceholders(message.markdown, "gchat")
+        ),
+        text: toPlainText(formatted),
+      };
+    }
+
+    if ("ast" in message) {
+      return {
+        formatted: message.ast,
+        markdown: truncateRichMarkdown(
+          convertEmojiPlaceholders(stringifyMarkdown(message.ast), "gchat")
+        ),
+        text: toPlainText(message.ast),
+      };
+    }
+
+    return null;
+  }
+
   protected renderPlainTextMessage(
     message: AdapterPostableMessage,
     card: ReturnType<typeof extractCard>
@@ -2103,6 +2316,56 @@ export class TelegramAdapter
     fallbackText: string
   ): string {
     return fallbackText.trim() ? fallbackText : originalText;
+  }
+
+  protected async sendRegularMessage(
+    thread: TelegramThreadId,
+    text: string,
+    plainText: string,
+    parseMode: TelegramParseMode,
+    replyMarkup: TelegramInlineKeyboardMarkup | undefined,
+    threadId: string
+  ): Promise<TelegramMessage> {
+    return this.withTelegramMarkdownFallback(
+      parseMode,
+      (resolvedParseMode, resolvedText) =>
+        this.telegramFetch<TelegramMessage>("sendMessage", {
+          chat_id: thread.chatId,
+          message_thread_id: thread.messageThreadId,
+          text: resolvedText,
+          reply_markup: replyMarkup,
+          parse_mode: toBotApiParseMode(resolvedParseMode),
+        }),
+      {
+        initialText: text,
+        fallbackText: plainText,
+        method: "sendMessage",
+        threadId,
+      }
+    );
+  }
+
+  protected canFallbackFromRichMessage(
+    error: unknown,
+    method: string
+  ): boolean {
+    return (
+      (method.startsWith("sendRichMessage") &&
+        error instanceof ResourceNotFoundError) ||
+      (error instanceof ValidationError &&
+        TELEGRAM_RICH_FALLBACK_PATTERN.test(error.message))
+    );
+  }
+
+  protected rememberRichMessageFailure(error: unknown, method: string): void {
+    if (
+      (method.startsWith("sendRichMessage") &&
+        error instanceof ResourceNotFoundError) ||
+      (error instanceof ValidationError &&
+        TELEGRAM_RICH_UNAVAILABLE_PATTERN.test(error.message))
+    ) {
+      this.richMessagesAvailable = false;
+    }
   }
 
   protected toTelegramReaction(
@@ -2427,6 +2690,34 @@ export class TelegramAdapter
       TELEGRAM_MARKDOWN_PARSE_ERROR_PATTERN.test(error.message)
     );
   }
+
+  protected async withTelegramRichFallback<TResult>(
+    operation: () => Promise<TResult>,
+    fallback: () => Promise<TResult>,
+    context: {
+      method: string;
+      messageId?: string;
+      threadId?: string;
+    }
+  ): Promise<TResult> {
+    try {
+      return await operation();
+    } catch (error) {
+      if (!this.canFallbackFromRichMessage(error, context.method)) {
+        throw error;
+      }
+
+      this.rememberRichMessageFailure(error, context.method);
+      this.logger.warn(
+        "Telegram rich message failed; retrying with a regular message",
+        {
+          error: String(error),
+          ...context,
+        }
+      );
+      return fallback();
+    }
+  }
 }
 
 export function createTelegramAdapter(
@@ -2446,6 +2737,12 @@ export type {
   TelegramMessageReactionUpdated,
   TelegramRawMessage,
   TelegramReactionType,
+  TelegramRichBlock,
+  TelegramRichCaption,
+  TelegramRichCell,
+  TelegramRichItem,
+  TelegramRichMessage,
+  TelegramRichText,
   TelegramThreadId,
   TelegramUpdate,
   TelegramUser,

--- a/packages/adapter-telegram/src/index.ts
+++ b/packages/adapter-telegram/src/index.ts
@@ -55,6 +55,7 @@ import {
   truncateForTelegram,
 } from "./markdown";
 import {
+  richMessageMedia,
   richMessageToMarkdown,
   richMessageToText,
   truncateRichMarkdown,
@@ -1204,6 +1205,7 @@ export class TelegramAdapter
         return;
       }
 
+      let draftText = text;
       if (streamUsesRich) {
         try {
           await this.telegramFetch<boolean>("sendRichMessageDraft", {
@@ -1236,6 +1238,9 @@ export class TelegramAdapter
             }
           );
           streamUsesRich = false;
+          draftText = useMarkdown
+            ? renderMarkdownText(renderer.render())
+            : renderPlainText(accumulated);
         }
       }
 
@@ -1245,7 +1250,7 @@ export class TelegramAdapter
             chat_id: parsedThread.chatId,
             message_thread_id: parsedThread.messageThreadId,
             draft_id: draftId,
-            text,
+            text: draftText,
             parse_mode: toBotApiParseMode("MarkdownV2"),
           });
         } else {
@@ -1253,10 +1258,10 @@ export class TelegramAdapter
             chat_id: parsedThread.chatId,
             message_thread_id: parsedThread.messageThreadId,
             draft_id: draftId,
-            text,
+            text: draftText,
           });
         }
-        lastDraftText = text;
+        lastDraftText = draftText;
         lastFlushAt = Date.now();
       } catch (error) {
         if (useMarkdown && this.isTelegramMarkdownParseError(error)) {
@@ -1685,6 +1690,20 @@ export class TelegramAdapter
           height: raw.video_note.length,
         })
       );
+    }
+
+    if (raw.rich_message) {
+      for (const media of richMessageMedia(raw.rich_message)) {
+        attachments.push(
+          this.createAttachment(media.type, media.file.file_id, {
+            size: media.file.file_size,
+            width: media.width,
+            height: media.height,
+            name: media.name,
+            mimeType: media.mimeType,
+          })
+        );
+      }
     }
 
     return attachments;
@@ -2740,8 +2759,11 @@ export { escapeMarkdownV2, TelegramFormatConverter } from "./markdown";
 export type {
   TelegramAdapterConfig,
   TelegramAdapterMode,
+  TelegramAnimation,
+  TelegramAudio,
   TelegramCallbackQuery,
   TelegramChat,
+  TelegramLocation,
   TelegramLongPollingConfig,
   TelegramMessage,
   TelegramMessageReactionUpdated,
@@ -2756,5 +2778,7 @@ export type {
   TelegramThreadId,
   TelegramUpdate,
   TelegramUser,
+  TelegramVideo,
+  TelegramVoice,
   TelegramWebhookInfo,
 } from "./types";

--- a/packages/adapter-telegram/src/index.ts
+++ b/packages/adapter-telegram/src/index.ts
@@ -108,9 +108,6 @@ const TELEGRAM_DEFAULT_POLLING_RETRY_DELAY_MS = 1000;
 const TELEGRAM_DEFAULT_STREAM_UPDATE_INTERVAL_MS = 250;
 const TELEGRAM_MARKDOWN_PARSE_ERROR_PATTERN =
   /can't parse (?:caption )?entities/i;
-const TELEGRAM_RICH_FALLBACK_PATTERN =
-  /can't parse|method.*not found|rich message|unsupported/i;
-const TELEGRAM_RICH_UNAVAILABLE_PATTERN = /method.*not found|unsupported/i;
 const TELEGRAM_MAX_POLLING_LIMIT = 100;
 const TELEGRAM_MIN_POLLING_LIMIT = 1;
 const TELEGRAM_MIN_POLLING_TIMEOUT_SECONDS = 0;
@@ -2349,20 +2346,33 @@ export class TelegramAdapter
     error: unknown,
     method: string
   ): boolean {
+    const message =
+      error instanceof ValidationError ? error.message.toLowerCase() : "";
+    const missingMethod =
+      message.includes("method") && message.includes("not found");
+    const unsupportedRich =
+      message.includes("rich message") && message.includes("unsupported");
+
     return (
       (method.startsWith("sendRichMessage") &&
         error instanceof ResourceNotFoundError) ||
       (error instanceof ValidationError &&
-        TELEGRAM_RICH_FALLBACK_PATTERN.test(error.message))
+        (message.includes("can't parse") || missingMethod || unsupportedRich))
     );
   }
 
   protected rememberRichMessageFailure(error: unknown, method: string): void {
+    const message =
+      error instanceof ValidationError ? error.message.toLowerCase() : "";
+    const missingMethod =
+      message.includes("method") && message.includes("not found");
+    const unsupportedRich =
+      message.includes("rich message") && message.includes("unsupported");
+
     if (
       (method.startsWith("sendRichMessage") &&
         error instanceof ResourceNotFoundError) ||
-      (error instanceof ValidationError &&
-        TELEGRAM_RICH_UNAVAILABLE_PATTERN.test(error.message))
+      (error instanceof ValidationError && (missingMethod || unsupportedRich))
     ) {
       this.richMessagesAvailable = false;
     }

--- a/packages/adapter-telegram/src/rich.test.ts
+++ b/packages/adapter-telegram/src/rich.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, it } from "vitest";
+import {
+  richMessageToMarkdown,
+  richMessageToText,
+  TELEGRAM_RICH_MESSAGE_LIMIT,
+  truncateRichMarkdown,
+} from "./rich";
+import type { TelegramRichMessage } from "./types";
+
+describe("Telegram rich messages", () => {
+  it("normalizes structured rich blocks to markdown", () => {
+    const message: TelegramRichMessage = {
+      blocks: [
+        {
+          type: "heading",
+          size: 2,
+          text: "Summary",
+        },
+        {
+          type: "paragraph",
+          text: [
+            "Read ",
+            {
+              type: "url",
+              text: "the guide",
+              url: "https://example.com",
+            },
+            " and ",
+            {
+              type: "bold",
+              text: "continue",
+            },
+          ],
+        },
+        {
+          type: "table",
+          cells: [
+            [
+              {
+                align: "left",
+                is_header: true,
+                text: "Name",
+                valign: "top",
+              },
+              {
+                align: "right",
+                is_header: true,
+                text: "Status",
+                valign: "top",
+              },
+            ],
+            [
+              {
+                align: "left",
+                text: "Build",
+                valign: "top",
+              },
+              {
+                align: "right",
+                text: "Ready",
+                valign: "top",
+              },
+            ],
+          ],
+        },
+      ],
+    };
+
+    expect(richMessageToMarkdown(message)).toBe(
+      [
+        "## Summary",
+        "Read [the guide](https://example.com) and **continue**",
+        "| Name | Status |\n| --- | --- |\n| Build | Ready |",
+      ].join("\n\n")
+    );
+    expect(richMessageToText(message)).toContain("Read the guide and continue");
+  });
+
+  it("preserves displayed text for detected entities", () => {
+    const message: TelegramRichMessage = {
+      blocks: [
+        {
+          type: "paragraph",
+          text: [
+            {
+              type: "mention",
+              text: "@chat_sdk",
+              username: "chat_sdk",
+            },
+            " ",
+            {
+              type: "hashtag",
+              hashtag: "release",
+              text: "#release",
+            },
+          ],
+        },
+      ],
+    };
+
+    expect(richMessageToMarkdown(message)).toBe("@chat_sdk #release");
+  });
+
+  it("truncates markdown at the rich message limit", () => {
+    const markdown = truncateRichMarkdown(
+      "a".repeat(TELEGRAM_RICH_MESSAGE_LIMIT + 100)
+    );
+
+    expect(Array.from(markdown).length).toBeLessThanOrEqual(
+      TELEGRAM_RICH_MESSAGE_LIMIT
+    );
+    expect(markdown.endsWith("...")).toBe(true);
+  });
+
+  it("preserves a table-like trailing line when truncating", () => {
+    const prefix = `${"a".repeat(TELEGRAM_RICH_MESSAGE_LIMIT - 12)}\n| tail |`;
+    const markdown = `${prefix}${"b".repeat(100)}`;
+
+    expect(truncateRichMarkdown(markdown)).toContain("| tail |");
+  });
+});

--- a/packages/adapter-telegram/src/rich.test.ts
+++ b/packages/adapter-telegram/src/rich.test.ts
@@ -101,6 +101,65 @@ describe("Telegram rich messages", () => {
     expect(richMessageToMarkdown(message)).toBe("@chat_sdk #release");
   });
 
+  it("normalizes rich formatting to plain text", () => {
+    const message: TelegramRichMessage = {
+      blocks: [
+        {
+          type: "paragraph",
+          text: [
+            {
+              type: "underline",
+              text: "underlined",
+            },
+            " ",
+            {
+              type: "subscript",
+              text: "subscript",
+            },
+            " ",
+            {
+              type: "marked",
+              text: "marked",
+            },
+          ],
+        },
+        {
+          type: "table",
+          cells: [
+            [
+              {
+                align: "left",
+                text: "Name",
+                valign: "top",
+              },
+              {
+                align: "left",
+                text: "Status",
+                valign: "top",
+              },
+            ],
+            [
+              {
+                align: "left",
+                text: "Build",
+                valign: "top",
+              },
+              {
+                align: "left",
+                text: "Ready",
+                valign: "top",
+              },
+            ],
+          ],
+        },
+      ],
+    };
+
+    expect(richMessageToText(message)).toBe(
+      "underlined subscript marked\n\nName\tStatus\nBuild\tReady"
+    );
+  });
+
   it("truncates markdown at the rich message limit", () => {
     const markdown = truncateRichMarkdown(
       "a".repeat(TELEGRAM_RICH_MESSAGE_LIMIT + 100)

--- a/packages/adapter-telegram/src/rich.test.ts
+++ b/packages/adapter-telegram/src/rich.test.ts
@@ -1,3 +1,4 @@
+import { parseMarkdown, toPlainText } from "chat";
 import { describe, expect, it } from "vitest";
 import {
   richMessageToMarkdown,
@@ -5,7 +6,7 @@ import {
   TELEGRAM_RICH_MESSAGE_LIMIT,
   truncateRichMarkdown,
 } from "./rich";
-import type { TelegramRichMessage } from "./types";
+import type { TelegramMessage, TelegramRichMessage } from "./types";
 
 describe("Telegram rich messages", () => {
   it("normalizes structured rich blocks to markdown", () => {
@@ -69,7 +70,7 @@ describe("Telegram rich messages", () => {
     expect(richMessageToMarkdown(message)).toBe(
       [
         "## Summary",
-        "Read [the guide](https://example.com) and **continue**",
+        "Read [the guide](<https://example.com>) and **continue**",
         "| Name | Status |\n| --- | --- |\n| Build | Ready |",
       ].join("\n\n")
     );
@@ -98,7 +99,103 @@ describe("Telegram rich messages", () => {
       ],
     };
 
-    expect(richMessageToMarkdown(message)).toBe("@chat_sdk #release");
+    expect(richMessageToText(message)).toBe("@chat_sdk #release");
+    expect(toPlainText(parseMarkdown(richMessageToMarkdown(message)))).toBe(
+      "@chat_sdk #release"
+    );
+  });
+
+  it("escapes literal rich text without changing displayed content", () => {
+    const message: TelegramRichMessage = {
+      blocks: [
+        {
+          type: "paragraph",
+          text: [
+            {
+              type: "code",
+              text: " a ` b ",
+            },
+            {
+              type: "code",
+              text: "",
+            },
+            " ",
+            {
+              type: "url",
+              text: "label ] x",
+              url: "https://example.com/a_(b)",
+            },
+            "\n# literal\n- item\n~~plain~~",
+          ],
+        },
+        {
+          type: "pre",
+          language: "type`script",
+          text: "const fence = ```;",
+        },
+      ],
+    };
+
+    const markdown = richMessageToMarkdown(message);
+    const formatted = parseMarkdown(markdown);
+
+    expect(formatted.children[0]).toMatchObject({
+      children: expect.arrayContaining([
+        expect.objectContaining({
+          type: "inlineCode",
+          value: " a ` b ",
+        }),
+        expect.objectContaining({
+          children: expect.arrayContaining([
+            expect.objectContaining({
+              type: "text",
+              value: "label ] x",
+            }),
+          ]),
+          type: "link",
+          url: "https://example.com/a_(b)",
+        }),
+        expect.objectContaining({
+          type: "text",
+          value: "\n# literal\n- item\n~~plain~~",
+        }),
+      ]),
+      type: "paragraph",
+    });
+    expect(formatted.children[1]).toMatchObject({
+      lang: "typescript",
+      type: "code",
+      value: "const fence = ```;",
+    });
+  });
+
+  it("includes current Telegram video quality fields", () => {
+    const message: TelegramMessage = {
+      chat: {
+        id: 1,
+        type: "private",
+      },
+      date: 1,
+      message_id: 1,
+      video: {
+        duration: 10,
+        file_id: "video",
+        file_unique_id: "video-unique",
+        height: 720,
+        qualities: [
+          {
+            codec: "h264",
+            file_id: "video-h264",
+            file_unique_id: "video-h264-unique",
+            height: 720,
+            width: 1280,
+          },
+        ],
+        width: 1280,
+      },
+    };
+
+    expect(message.video?.qualities?.[0]?.codec).toBe("h264");
   });
 
   it("normalizes rich formatting to plain text", () => {

--- a/packages/adapter-telegram/src/rich.ts
+++ b/packages/adapter-telegram/src/rich.ts
@@ -1,0 +1,187 @@
+import { markdownToPlainText, StreamingMarkdownRenderer } from "chat";
+import type {
+  TelegramRichBlock,
+  TelegramRichCaption,
+  TelegramRichCell,
+  TelegramRichItem,
+  TelegramRichMessage,
+  TelegramRichText,
+} from "./types";
+
+export const TELEGRAM_RICH_MESSAGE_LIMIT = 32_768;
+
+export function truncateRichMarkdown(markdown: string): string {
+  const characters = Array.from(markdown);
+  if (characters.length <= TELEGRAM_RICH_MESSAGE_LIMIT) {
+    return markdown;
+  }
+
+  let end = TELEGRAM_RICH_MESSAGE_LIMIT - 3;
+  while (end > 0) {
+    const renderer = new StreamingMarkdownRenderer();
+    renderer.push(characters.slice(0, end).join(""));
+    const rendered = `${renderer.finish()}...`;
+    if (Array.from(rendered).length <= TELEGRAM_RICH_MESSAGE_LIMIT) {
+      return rendered;
+    }
+    end -= Array.from(rendered).length - TELEGRAM_RICH_MESSAGE_LIMIT;
+  }
+
+  return "...";
+}
+
+function text(markdown: TelegramRichText): string {
+  if (typeof markdown === "string") {
+    return markdown;
+  }
+  if (Array.isArray(markdown)) {
+    return markdown.map(text).join("");
+  }
+
+  switch (markdown.type) {
+    case "bold":
+      return `**${text(markdown.text)}**`;
+    case "italic":
+      return `_${text(markdown.text)}_`;
+    case "underline":
+      return `<u>${text(markdown.text)}</u>`;
+    case "strikethrough":
+      return `~~${text(markdown.text)}~~`;
+    case "spoiler":
+      return `||${text(markdown.text)}||`;
+    case "subscript":
+      return `<sub>${text(markdown.text)}</sub>`;
+    case "superscript":
+      return `<sup>${text(markdown.text)}</sup>`;
+    case "marked":
+      return `==${text(markdown.text)}==`;
+    case "code":
+      return `\`${text(markdown.text)}\``;
+    case "date_time":
+    case "text_mention":
+      return text(markdown.text);
+    case "bank_card_number":
+    case "bot_command":
+    case "cashtag":
+    case "hashtag":
+    case "mention":
+      return text(markdown.text);
+    case "custom_emoji":
+      return markdown.alternative_text;
+    case "mathematical_expression":
+      return `$${markdown.expression}$`;
+    case "url":
+      return `[${text(markdown.text)}](${markdown.url})`;
+    case "email_address":
+      return `[${text(markdown.text)}](mailto:${markdown.email_address})`;
+    case "phone_number":
+      return `[${text(markdown.text)}](tel:${markdown.phone_number})`;
+    case "anchor":
+      return "";
+    case "anchor_link":
+    case "reference":
+    case "reference_link":
+      return text(markdown.text);
+    default:
+      return "";
+  }
+}
+
+function caption(value?: TelegramRichCaption): string {
+  if (!value) {
+    return "";
+  }
+  const credit = value.credit ? `\n${text(value.credit)}` : "";
+  return `${text(value.text)}${credit}`;
+}
+
+function cell(value: TelegramRichCell): string {
+  return value.text ? text(value.text).replaceAll("|", "\\|") : "";
+}
+
+function item(value: TelegramRichItem): string {
+  let checked = "";
+  if (value.has_checkbox) {
+    checked = value.is_checked ? "[x] " : "[ ] ";
+  }
+  const content = value.blocks.map(block).join("\n\n").replaceAll("\n", "\n  ");
+  return `${value.label} ${checked}${content}`.trimEnd();
+}
+
+function table(value: Extract<TelegramRichBlock, { type: "table" }>): string {
+  const rows = value.cells.map((row) => `| ${row.map(cell).join(" | ")} |`);
+  if (rows.length === 0) {
+    return value.caption ? text(value.caption) : "";
+  }
+
+  const columns = Math.max(...value.cells.map((row) => row.length));
+  const separator = `| ${Array.from({ length: columns }, () => "---").join(" | ")} |`;
+  const content = [rows[0], separator, ...rows.slice(1)].join("\n");
+  return value.caption ? `${text(value.caption)}\n\n${content}` : content;
+}
+
+function quote(value: string): string {
+  return value
+    .split("\n")
+    .map((line) => `> ${line}`)
+    .join("\n");
+}
+
+function block(value: TelegramRichBlock): string {
+  switch (value.type) {
+    case "paragraph":
+    case "footer":
+    case "thinking":
+      return text(value.text);
+    case "heading":
+      return `${"#".repeat(Math.min(6, Math.max(1, value.size)))} ${text(value.text)}`;
+    case "pre":
+      return `\`\`\`${value.language ?? ""}\n${text(value.text)}\n\`\`\``;
+    case "divider":
+      return "---";
+    case "mathematical_expression":
+      return `$$${value.expression}$$`;
+    case "anchor":
+      return "";
+    case "list":
+      return value.items.map(item).join("\n");
+    case "blockquote": {
+      const content = value.blocks.map(block).join("\n\n");
+      const credit = value.credit ? `\n\n${text(value.credit)}` : "";
+      return quote(`${content}${credit}`);
+    }
+    case "pullquote": {
+      const credit = value.credit ? `\n\n${text(value.credit)}` : "";
+      return quote(`${text(value.text)}${credit}`);
+    }
+    case "collage":
+    case "slideshow": {
+      const content = value.blocks.map(block).filter(Boolean).join("\n\n");
+      const description = caption(value.caption);
+      return [content, description].filter(Boolean).join("\n\n");
+    }
+    case "table":
+      return table(value);
+    case "details":
+      return `${text(value.summary)}\n\n${value.blocks.map(block).join("\n\n")}`;
+    case "map":
+      return caption(value.caption);
+    case "animation":
+    case "audio":
+    case "photo":
+    case "video":
+    case "voice_note":
+      return caption(value.caption);
+    default:
+      return "";
+  }
+}
+
+export function richMessageToMarkdown(message: TelegramRichMessage): string {
+  return message.blocks.map(block).filter(Boolean).join("\n\n").trim();
+}
+
+export function richMessageToText(message: TelegramRichMessage): string {
+  const markdown = richMessageToMarkdown(message);
+  return markdownToPlainText(markdown).trim() || markdown;
+}

--- a/packages/adapter-telegram/src/rich.ts
+++ b/packages/adapter-telegram/src/rich.ts
@@ -11,6 +11,9 @@ import type {
 } from "./types";
 
 export const TELEGRAM_RICH_MESSAGE_LIMIT = 32_768;
+const MARKDOWN_PUNCTUATION = /[!-/:-@[-`{-~]/g;
+const LINE_BREAKS = /[\r\n]/g;
+const BACKTICKS = /`+/g;
 
 export function truncateRichMarkdown(markdown: string): string {
   const characters = Array.from(markdown);
@@ -32,9 +35,44 @@ export function truncateRichMarkdown(markdown: string): string {
   return "...";
 }
 
+function escapeText(value: string): string {
+  return value.replace(MARKDOWN_PUNCTUATION, "\\$&");
+}
+
+function inlineCode(value: string): string {
+  if (!value) {
+    return "";
+  }
+  const runs = value.match(BACKTICKS) ?? [];
+  const size = Math.max(1, ...runs.map((run) => run.length + 1));
+  const marker = "`".repeat(size);
+  const hasBoundarySpace =
+    value.startsWith(" ") && value.endsWith(" ") && value.trim().length > 0;
+  const padding =
+    value.startsWith("`") || value.endsWith("`") || hasBoundarySpace ? " " : "";
+  return `${marker}${padding}${value}${padding}${marker}`;
+}
+
+function codeBlock(value: string, language?: string): string {
+  const runs = value.match(BACKTICKS) ?? [];
+  const size = Math.max(3, ...runs.map((run) => run.length + 1));
+  const marker = "`".repeat(size);
+  const info = language?.replace(LINE_BREAKS, " ").replaceAll("`", "") ?? "";
+  return `${marker}${info}\n${value}\n${marker}`;
+}
+
+function linkDestination(value: string): string {
+  return `<${value
+    .replaceAll("\\", "%5C")
+    .replaceAll("<", "%3C")
+    .replaceAll(">", "%3E")
+    .replaceAll("\r", "%0D")
+    .replaceAll("\n", "%0A")}>`;
+}
+
 function text(markdown: TelegramRichText): string {
   if (typeof markdown === "string") {
-    return markdown;
+    return escapeText(markdown);
   }
   if (Array.isArray(markdown)) {
     return markdown.map(text).join("");
@@ -58,7 +96,7 @@ function text(markdown: TelegramRichText): string {
     case "marked":
       return `==${text(markdown.text)}==`;
     case "code":
-      return `\`${text(markdown.text)}\``;
+      return inlineCode(plain(markdown.text));
     case "date_time":
     case "text_mention":
       return text(markdown.text);
@@ -73,11 +111,15 @@ function text(markdown: TelegramRichText): string {
     case "mathematical_expression":
       return `$${markdown.expression}$`;
     case "url":
-      return `[${text(markdown.text)}](${markdown.url})`;
+      return `[${text(markdown.text)}](${linkDestination(markdown.url)})`;
     case "email_address":
-      return `[${text(markdown.text)}](mailto:${markdown.email_address})`;
+      return `[${text(markdown.text)}](${linkDestination(
+        `mailto:${markdown.email_address}`
+      )})`;
     case "phone_number":
-      return `[${text(markdown.text)}](tel:${markdown.phone_number})`;
+      return `[${text(markdown.text)}](${linkDestination(
+        `tel:${markdown.phone_number}`
+      )})`;
     case "anchor":
       return "";
     case "anchor_link":
@@ -149,7 +191,7 @@ function plainCaption(value?: TelegramRichCaption): string {
 }
 
 function cell(value: TelegramRichCell): string {
-  return value.text ? text(value.text).replaceAll("|", "\\|") : "";
+  return value.text ? text(value.text) : "";
 }
 
 function item(value: TelegramRichItem): string {
@@ -202,7 +244,7 @@ function block(value: TelegramRichBlock): string {
     case "heading":
       return `${"#".repeat(Math.min(6, Math.max(1, value.size)))} ${text(value.text)}`;
     case "pre":
-      return `\`\`\`${value.language ?? ""}\n${text(value.text)}\n\`\`\``;
+      return codeBlock(plain(value.text), value.language);
     case "divider":
       return "---";
     case "mathematical_expression":

--- a/packages/adapter-telegram/src/rich.ts
+++ b/packages/adapter-telegram/src/rich.ts
@@ -1,5 +1,7 @@
-import { markdownToPlainText, StreamingMarkdownRenderer } from "chat";
+import type { Attachment } from "chat";
+import { StreamingMarkdownRenderer } from "chat";
 import type {
+  TelegramFile,
   TelegramRichBlock,
   TelegramRichCaption,
   TelegramRichCell,
@@ -87,12 +89,63 @@ function text(markdown: TelegramRichText): string {
   }
 }
 
+function plain(markdown: TelegramRichText): string {
+  if (typeof markdown === "string") {
+    return markdown;
+  }
+  if (Array.isArray(markdown)) {
+    return markdown.map(plain).join("");
+  }
+
+  switch (markdown.type) {
+    case "bold":
+    case "italic":
+    case "underline":
+    case "strikethrough":
+    case "spoiler":
+    case "subscript":
+    case "superscript":
+    case "marked":
+    case "code":
+    case "date_time":
+    case "text_mention":
+    case "url":
+    case "email_address":
+    case "phone_number":
+    case "bank_card_number":
+    case "mention":
+    case "hashtag":
+    case "cashtag":
+    case "bot_command":
+    case "anchor_link":
+    case "reference":
+    case "reference_link":
+      return plain(markdown.text);
+    case "custom_emoji":
+      return markdown.alternative_text;
+    case "mathematical_expression":
+      return markdown.expression;
+    case "anchor":
+      return "";
+    default:
+      return "";
+  }
+}
+
 function caption(value?: TelegramRichCaption): string {
   if (!value) {
     return "";
   }
   const credit = value.credit ? `\n${text(value.credit)}` : "";
   return `${text(value.text)}${credit}`;
+}
+
+function plainCaption(value?: TelegramRichCaption): string {
+  if (!value) {
+    return "";
+  }
+  const credit = value.credit ? `\n${plain(value.credit)}` : "";
+  return `${plain(value.text)}${credit}`;
 }
 
 function cell(value: TelegramRichCell): string {
@@ -105,6 +158,19 @@ function item(value: TelegramRichItem): string {
     checked = value.is_checked ? "[x] " : "[ ] ";
   }
   const content = value.blocks.map(block).join("\n\n").replaceAll("\n", "\n  ");
+  return `${value.label} ${checked}${content}`.trimEnd();
+}
+
+function plainItem(value: TelegramRichItem): string {
+  let checked = "";
+  if (value.has_checkbox) {
+    checked = value.is_checked ? "[x] " : "[ ] ";
+  }
+  const content = value.blocks
+    .map(plainBlock)
+    .filter(Boolean)
+    .join("\n")
+    .replaceAll("\n", "\n  ");
   return `${value.label} ${checked}${content}`.trimEnd();
 }
 
@@ -177,11 +243,149 @@ function block(value: TelegramRichBlock): string {
   }
 }
 
+function plainBlock(value: TelegramRichBlock): string {
+  switch (value.type) {
+    case "paragraph":
+    case "footer":
+    case "thinking":
+    case "heading":
+    case "pre":
+      return plain(value.text);
+    case "divider":
+    case "anchor":
+      return "";
+    case "mathematical_expression":
+      return value.expression;
+    case "list":
+      return value.items.map(plainItem).join("\n");
+    case "blockquote": {
+      const content = value.blocks.map(plainBlock).filter(Boolean).join("\n\n");
+      const credit = value.credit ? `\n\n${plain(value.credit)}` : "";
+      return `${content}${credit}`;
+    }
+    case "pullquote": {
+      const credit = value.credit ? `\n\n${plain(value.credit)}` : "";
+      return `${plain(value.text)}${credit}`;
+    }
+    case "collage":
+    case "slideshow": {
+      const content = value.blocks.map(plainBlock).filter(Boolean).join("\n\n");
+      const description = plainCaption(value.caption);
+      return [content, description].filter(Boolean).join("\n\n");
+    }
+    case "table": {
+      const rows = value.cells.map((row) =>
+        row.map((entry) => (entry.text ? plain(entry.text) : "")).join("\t")
+      );
+      const content = rows.join("\n");
+      return value.caption ? `${plain(value.caption)}\n\n${content}` : content;
+    }
+    case "details":
+      return `${plain(value.summary)}\n\n${value.blocks
+        .map(plainBlock)
+        .filter(Boolean)
+        .join("\n\n")}`;
+    case "map":
+      return plainCaption(value.caption);
+    case "animation":
+    case "audio":
+    case "photo":
+    case "video":
+    case "voice_note":
+      return plainCaption(value.caption);
+    default:
+      return "";
+  }
+}
+
+interface RichMedia {
+  file: TelegramFile;
+  height?: number;
+  mimeType?: string;
+  name?: string;
+  type: Attachment["type"];
+  width?: number;
+}
+
+function media(blocks: TelegramRichBlock[], result: RichMedia[]): void {
+  for (const value of blocks) {
+    switch (value.type) {
+      case "list":
+        for (const entry of value.items) {
+          media(entry.blocks, result);
+        }
+        break;
+      case "blockquote":
+      case "collage":
+      case "slideshow":
+      case "details":
+        media(value.blocks, result);
+        break;
+      case "animation":
+        result.push({
+          file: value.animation,
+          height: value.animation.height,
+          mimeType: value.animation.mime_type,
+          name: value.animation.file_name,
+          type: value.animation.mime_type?.startsWith("image/")
+            ? "image"
+            : "video",
+          width: value.animation.width,
+        });
+        break;
+      case "audio":
+        result.push({
+          file: value.audio,
+          mimeType: value.audio.mime_type,
+          name: value.audio.file_name,
+          type: "audio",
+        });
+        break;
+      case "photo": {
+        const photo = value.photo.at(-1);
+        if (photo) {
+          result.push({
+            file: photo,
+            height: photo.height,
+            type: "image",
+            width: photo.width,
+          });
+        }
+        break;
+      }
+      case "video":
+        result.push({
+          file: value.video,
+          height: value.video.height,
+          mimeType: value.video.mime_type,
+          name: value.video.file_name,
+          type: "video",
+          width: value.video.width,
+        });
+        break;
+      case "voice_note":
+        result.push({
+          file: value.voice_note,
+          mimeType: value.voice_note.mime_type,
+          type: "audio",
+        });
+        break;
+      default:
+        break;
+    }
+  }
+}
+
 export function richMessageToMarkdown(message: TelegramRichMessage): string {
   return message.blocks.map(block).filter(Boolean).join("\n\n").trim();
 }
 
 export function richMessageToText(message: TelegramRichMessage): string {
-  const markdown = richMessageToMarkdown(message);
-  return markdownToPlainText(markdown).trim() || markdown;
+  return message.blocks.map(plainBlock).filter(Boolean).join("\n\n").trim();
+}
+
+export function richMessageMedia(message: TelegramRichMessage): RichMedia[] {
+  const result: RichMedia[] = [];
+  media(message.blocks, result);
+  return result;
 }

--- a/packages/adapter-telegram/src/types.ts
+++ b/packages/adapter-telegram/src/types.ts
@@ -128,6 +128,249 @@ export interface TelegramPhotoSize extends TelegramFile {
 }
 
 /**
+ * Rich formatted text received from Telegram.
+ * @see https://core.telegram.org/bots/api#richtext
+ */
+export type TelegramRichText =
+  | string
+  | TelegramRichText[]
+  | {
+      type:
+        | "bold"
+        | "italic"
+        | "underline"
+        | "strikethrough"
+        | "spoiler"
+        | "subscript"
+        | "superscript"
+        | "marked"
+        | "code";
+      text: TelegramRichText;
+    }
+  | {
+      type: "date_time";
+      text: TelegramRichText;
+      unix_time: number;
+      date_time_format: string;
+    }
+  | {
+      type: "text_mention";
+      text: TelegramRichText;
+      user: TelegramUser;
+    }
+  | {
+      type: "custom_emoji";
+      alternative_text: string;
+      custom_emoji_id: string;
+    }
+  | {
+      type: "mathematical_expression";
+      expression: string;
+    }
+  | {
+      type: "url";
+      text: TelegramRichText;
+      url: string;
+    }
+  | {
+      type: "email_address";
+      email_address: string;
+      text: TelegramRichText;
+    }
+  | {
+      type: "phone_number";
+      phone_number: string;
+      text: TelegramRichText;
+    }
+  | {
+      type: "bank_card_number";
+      bank_card_number: string;
+      text: TelegramRichText;
+    }
+  | {
+      type: "mention";
+      text: TelegramRichText;
+      username: string;
+    }
+  | {
+      type: "hashtag";
+      hashtag: string;
+      text: TelegramRichText;
+    }
+  | {
+      type: "cashtag";
+      cashtag: string;
+      text: TelegramRichText;
+    }
+  | {
+      type: "bot_command";
+      bot_command: string;
+      text: TelegramRichText;
+    }
+  | {
+      type: "anchor";
+      name: string;
+    }
+  | {
+      type: "anchor_link";
+      anchor_name: string;
+      text: TelegramRichText;
+    }
+  | {
+      type: "reference";
+      name: string;
+      text: TelegramRichText;
+    }
+  | {
+      type: "reference_link";
+      reference_name: string;
+      text: TelegramRichText;
+    };
+
+/**
+ * Caption attached to a rich message block.
+ * @see https://core.telegram.org/bots/api#richblockcaption
+ */
+export interface TelegramRichCaption {
+  credit?: TelegramRichText;
+  text: TelegramRichText;
+}
+
+/**
+ * Cell in a rich message table.
+ * @see https://core.telegram.org/bots/api#richblocktablecell
+ */
+export interface TelegramRichCell {
+  align: "left" | "center" | "right";
+  colspan?: number;
+  is_header?: true;
+  rowspan?: number;
+  text?: TelegramRichText;
+  valign: "top" | "middle" | "bottom";
+}
+
+/**
+ * Item in a rich message list.
+ * @see https://core.telegram.org/bots/api#richblocklistitem
+ */
+export interface TelegramRichItem {
+  blocks: TelegramRichBlock[];
+  has_checkbox?: true;
+  is_checked?: true;
+  label: string;
+  type?: "a" | "A" | "i" | "I" | "1";
+  value?: number;
+}
+
+/**
+ * Structured block in a rich message received from Telegram.
+ * @see https://core.telegram.org/bots/api#richblock
+ */
+export type TelegramRichBlock =
+  | {
+      type: "paragraph" | "footer" | "thinking";
+      text: TelegramRichText;
+    }
+  | {
+      type: "heading";
+      size: number;
+      text: TelegramRichText;
+    }
+  | {
+      type: "pre";
+      language?: string;
+      text: TelegramRichText;
+    }
+  | {
+      type: "divider";
+    }
+  | {
+      type: "mathematical_expression";
+      expression: string;
+    }
+  | {
+      type: "anchor";
+      name: string;
+    }
+  | {
+      type: "list";
+      items: TelegramRichItem[];
+    }
+  | {
+      type: "blockquote";
+      blocks: TelegramRichBlock[];
+      credit?: TelegramRichText;
+    }
+  | {
+      type: "pullquote";
+      credit?: TelegramRichText;
+      text: TelegramRichText;
+    }
+  | {
+      type: "collage" | "slideshow";
+      blocks: TelegramRichBlock[];
+      caption?: TelegramRichCaption;
+    }
+  | {
+      type: "table";
+      caption?: TelegramRichText;
+      cells: TelegramRichCell[][];
+      is_bordered?: true;
+      is_striped?: true;
+    }
+  | {
+      type: "details";
+      blocks: TelegramRichBlock[];
+      is_open?: true;
+      summary: TelegramRichText;
+    }
+  | {
+      type: "map";
+      caption?: TelegramRichCaption;
+      height: number;
+      location: { latitude: number; longitude: number };
+      width: number;
+      zoom: number;
+    }
+  | {
+      type: "animation";
+      animation: TelegramFile;
+      caption?: TelegramRichCaption;
+      has_spoiler?: true;
+    }
+  | {
+      type: "audio";
+      audio: TelegramFile;
+      caption?: TelegramRichCaption;
+    }
+  | {
+      type: "photo";
+      caption?: TelegramRichCaption;
+      has_spoiler?: true;
+      photo: TelegramPhotoSize[];
+    }
+  | {
+      type: "video";
+      caption?: TelegramRichCaption;
+      has_spoiler?: true;
+      video: TelegramFile;
+    }
+  | {
+      type: "voice_note";
+      caption?: TelegramRichCaption;
+      voice_note: TelegramFile;
+    };
+
+/**
+ * Rich formatted message received from Telegram.
+ * @see https://core.telegram.org/bots/api#richmessage
+ */
+export interface TelegramRichMessage {
+  blocks: TelegramRichBlock[];
+  is_rtl?: boolean;
+}
+
+/**
  * Telegram message.
  * @see https://core.telegram.org/bots/api#message
  */
@@ -150,6 +393,7 @@ export interface TelegramMessage {
   message_id: number;
   message_thread_id?: number;
   photo?: TelegramPhotoSize[];
+  rich_message?: TelegramRichMessage;
   sender_chat?: TelegramChat;
   sticker?: TelegramFile & { emoji?: string };
   text?: string;

--- a/packages/adapter-telegram/src/types.ts
+++ b/packages/adapter-telegram/src/types.ts
@@ -154,12 +154,19 @@ export interface TelegramLocation {
   proximity_alert_radius?: number;
 }
 
+export interface TelegramVideoQuality extends TelegramFile {
+  codec: string;
+  height: number;
+  width: number;
+}
+
 export interface TelegramVideo extends TelegramFile {
   cover?: TelegramPhotoSize[];
   duration: number;
   file_name?: string;
   height: number;
   mime_type?: string;
+  qualities?: TelegramVideoQuality[];
   start_timestamp?: number;
   thumbnail?: TelegramPhotoSize;
   width: number;
@@ -440,12 +447,7 @@ export interface TelegramMessage {
   sender_chat?: TelegramChat;
   sticker?: TelegramFile & { emoji?: string };
   text?: string;
-  video?: TelegramFile & {
-    width?: number;
-    height?: number;
-    mime_type?: string;
-    file_name?: string;
-  };
+  video?: TelegramVideo;
   video_note?: TelegramFile & { length?: number; duration?: number };
   voice?: TelegramFile & { duration?: number; mime_type?: string };
 }

--- a/packages/adapter-telegram/src/types.ts
+++ b/packages/adapter-telegram/src/types.ts
@@ -127,6 +127,49 @@ export interface TelegramPhotoSize extends TelegramFile {
   width: number;
 }
 
+export interface TelegramAnimation extends TelegramFile {
+  duration: number;
+  file_name?: string;
+  height: number;
+  mime_type?: string;
+  thumbnail?: TelegramPhotoSize;
+  width: number;
+}
+
+export interface TelegramAudio extends TelegramFile {
+  duration: number;
+  file_name?: string;
+  mime_type?: string;
+  performer?: string;
+  thumbnail?: TelegramPhotoSize;
+  title?: string;
+}
+
+export interface TelegramLocation {
+  heading?: number;
+  horizontal_accuracy?: number;
+  latitude: number;
+  live_period?: number;
+  longitude: number;
+  proximity_alert_radius?: number;
+}
+
+export interface TelegramVideo extends TelegramFile {
+  cover?: TelegramPhotoSize[];
+  duration: number;
+  file_name?: string;
+  height: number;
+  mime_type?: string;
+  start_timestamp?: number;
+  thumbnail?: TelegramPhotoSize;
+  width: number;
+}
+
+export interface TelegramVoice extends TelegramFile {
+  duration: number;
+  mime_type?: string;
+}
+
 /**
  * Rich formatted text received from Telegram.
  * @see https://core.telegram.org/bots/api#richtext
@@ -328,19 +371,19 @@ export type TelegramRichBlock =
       type: "map";
       caption?: TelegramRichCaption;
       height: number;
-      location: { latitude: number; longitude: number };
+      location: TelegramLocation;
       width: number;
       zoom: number;
     }
   | {
       type: "animation";
-      animation: TelegramFile;
+      animation: TelegramAnimation;
       caption?: TelegramRichCaption;
       has_spoiler?: true;
     }
   | {
       type: "audio";
-      audio: TelegramFile;
+      audio: TelegramAudio;
       caption?: TelegramRichCaption;
     }
   | {
@@ -353,12 +396,12 @@ export type TelegramRichBlock =
       type: "video";
       caption?: TelegramRichCaption;
       has_spoiler?: true;
-      video: TelegramFile;
+      video: TelegramVideo;
     }
   | {
       type: "voice_note";
       caption?: TelegramRichCaption;
-      voice_note: TelegramFile;
+      voice_note: TelegramVoice;
     };
 
 /**


### PR DESCRIPTION
## summary

adds native rich message support for Telegram Bot API 10.1

explicit markdown and AST messages now use `sendRichMessage`, edits use rich message payloads, and private chat streams use `sendRichMessageDraft` before persisting the completed response

preserves existing behavior for plain strings, raw messages, cards, media captions, and older or custom Bot API servers through automatic fallback

adds typed inbound rich message parsing, rich message limits, regression coverage, and updated adapter documentation