### PR TITLE
fix(adapter-slack): don't rewrite @handles inside URL paths as mentions

### DIFF
--- a/.changeset/slack-mention-regex-url-paths.md
+++ b/.changeset/slack-mention-regex-url-paths.md
@@ -2,4 +2,4 @@
 "@chat-adapter/slack": patch
 ---
 
-Fix `@mention` rewrite regex so an `@handle` inside a URL path (e.g. `https://hackmd.io/@jkyang/abc`, `https://mastodon.social/@user`) is no longer rewritten into a `<@handle>` Slack mention, which corrupted the link. The lookbehind now also excludes a `/` immediately before `@`. Whitespace- and punctuation-led mentions (e.g. `(cc @george)`), emails, and `<mailto:…>` links are unaffected.
+Fix `@mention` rewriting so an `@handle` inside a URL is no longer turned into a `<@handle>` Slack mention, which corrupted the link. Mention linking now skips whole `http(s)://…` spans, so handles in paths (`https://hackmd.io/@jkyang/abc`), query strings (`?user=@george`), and fragments (`#@george`) are preserved; the lookbehind also excludes a `/` immediately before `@` to cover schemeless URLs (`mastodon.social/@user`). Whitespace- and punctuation-led mentions (e.g. `(cc @george)`), emails, and `<mailto:…>` links are unaffected.

--- a/.changeset/slack-mention-regex-url-paths.md
+++ b/.changeset/slack-mention-regex-url-paths.md
@@ -1,0 +1,5 @@
+---
+"@chat-adapter/slack": patch
+---
+
+Fix `@mention` rewrite regex so an `@handle` inside a URL path (e.g. `https://hackmd.io/@jkyang/abc`, `https://mastodon.social/@user`) is no longer rewritten into a `<@handle>` Slack mention, which corrupted the link. The lookbehind now also excludes a `/` immediately before `@`. Whitespace- and punctuation-led mentions (e.g. `(cc @george)`), emails, and `<mailto:…>` links are unaffected.

--- a/packages/adapter-slack/src/markdown.test.ts
+++ b/packages/adapter-slack/src/markdown.test.ts
@@ -186,6 +186,22 @@ describe("SlackFormatConverter", () => {
         text: "(cc <@george>, <@anne>)",
       });
     });
+
+    it("does not mangle @handles inside URL paths in plain strings", () => {
+      expect(
+        converter.toSlackPayload("See https://hackmd.io/@jkyang/B1W69XA-fe")
+      ).toEqual({ text: "See https://hackmd.io/@jkyang/B1W69XA-fe" });
+    });
+
+    it("does not mangle @handles inside URL paths in markdown", () => {
+      expect(
+        converter.toSlackPayload({
+          markdown: "See https://mastodon.social/@user for updates",
+        })
+      ).toEqual({
+        markdown_text: "See https://mastodon.social/@user for updates",
+      });
+    });
   });
 
   describe("toPlainText", () => {

--- a/packages/adapter-slack/src/markdown.test.ts
+++ b/packages/adapter-slack/src/markdown.test.ts
@@ -202,6 +202,32 @@ describe("SlackFormatConverter", () => {
         markdown_text: "See https://mastodon.social/@user for updates",
       });
     });
+
+    it("does not mangle @handles inside URL query strings", () => {
+      expect(
+        converter.toSlackPayload("Profile https://example.com/p?user=@george")
+      ).toEqual({ text: "Profile https://example.com/p?user=@george" });
+    });
+
+    it("does not mangle @handles inside URL fragments", () => {
+      expect(
+        converter.toSlackPayload("Jump https://example.com/docs#@george")
+      ).toEqual({ text: "Jump https://example.com/docs#@george" });
+    });
+
+    it("does not mangle @handles inside schemeless host paths", () => {
+      expect(converter.toSlackPayload("See hackmd.io/@jkyang/abc")).toEqual({
+        text: "See hackmd.io/@jkyang/abc",
+      });
+    });
+
+    it("still rewrites a real mention that follows a URL", () => {
+      expect(
+        converter.toSlackPayload("See https://hackmd.io/@jkyang/abc cc @george")
+      ).toEqual({
+        text: "See https://hackmd.io/@jkyang/abc cc <@george>",
+      });
+    });
   });
 
   describe("toPlainText", () => {

--- a/packages/adapter-slack/src/markdown.ts
+++ b/packages/adapter-slack/src/markdown.ts
@@ -34,7 +34,11 @@ import {
 } from "chat";
 import { linkBareSlackMentions, slackMrkdwnToMarkdown } from "./format";
 
-const BARE_MENTION_PATTERN = /(?<![<\w])@(\w+)/g;
+// The leading `/` in the negative lookbehind keeps an `@handle` inside a URL
+// path (e.g. https://hackmd.io/@jkyang/abc, mastodon.social/@user) from being
+// rewritten into a `<@handle>` mention, which corrupts the link. Whitespace- and
+// punctuation-led mentions (e.g. "(cc @george)") still match.
+const BARE_MENTION_PATTERN = /(?<![<\w/])@(\w+)/g;
 
 export type SlackTextPayload = { text: string } | { markdown_text: string };
 

--- a/packages/adapter-slack/src/markdown.ts
+++ b/packages/adapter-slack/src/markdown.ts
@@ -34,11 +34,20 @@ import {
 } from "chat";
 import { linkBareSlackMentions, slackMrkdwnToMarkdown } from "./format";
 
-// The leading `/` in the negative lookbehind keeps an `@handle` inside a URL
-// path (e.g. https://hackmd.io/@jkyang/abc, mastodon.social/@user) from being
-// rewritten into a `<@handle>` mention, which corrupts the link. Whitespace- and
-// punctuation-led mentions (e.g. "(cc @george)") still match.
+// `@handle`s inside URLs (paths, query strings, fragments) must not be rewritten
+// into `<@handle>` Slack mentions, which corrupts the link. Two layers guard
+// against this:
+//   1. `finalize` skips whole `http(s)://…` spans before linking mentions, so an
+//      `@handle` anywhere in a URL (e.g. `?user=@george`, `#@george`) is left
+//      intact.
+//   2. The leading `/` in this negative lookbehind covers the schemeless case
+//      (e.g. `mastodon.social/@user`) that the URL matcher in (1) doesn't catch.
+// Whitespace- and punctuation-led mentions (e.g. "(cc @george)") still match.
 const BARE_MENTION_PATTERN = /(?<![<\w/])@(\w+)/g;
+
+// Matches an `http(s)` URL up to the first whitespace or angle bracket so the
+// span can be excluded from mention linking.
+const URL_PATTERN = /\bhttps?:\/\/[^\s<>]+/g;
 
 export type SlackTextPayload = { text: string } | { markdown_text: string };
 
@@ -112,10 +121,7 @@ export class SlackFormatConverter extends BaseFormatConverter {
   }
 
   private finalize(text: string): string {
-    return convertEmojiPlaceholders(
-      linkBareMentionNames(linkBareSlackMentions(text)),
-      "slack"
-    );
+    return convertEmojiPlaceholders(linkBareMentionsOutsideUrls(text), "slack");
   }
 
   private astToMrkdwn(ast: Root): string {
@@ -199,4 +205,21 @@ export class SlackFormatConverter extends BaseFormatConverter {
 
 function linkBareMentionNames(text: string): string {
   return text.replace(BARE_MENTION_PATTERN, "<@$1>");
+}
+
+// Apply mention linking only to the text outside `http(s)` URL spans, so a bare
+// `@handle` anywhere inside a URL (path, query, or fragment) is preserved.
+function linkBareMentionsOutsideUrls(text: string): string {
+  let result = "";
+  let lastIndex = 0;
+  for (const match of text.matchAll(URL_PATTERN)) {
+    const start = match.index ?? lastIndex;
+    result += linkBareMentionNames(
+      linkBareSlackMentions(text.slice(lastIndex, start))
+    );
+    result += match[0];
+    lastIndex = start + match[0].length;
+  }
+  result += linkBareMentionNames(linkBareSlackMentions(text.slice(lastIndex)));
+  return result;
 }


### PR DESCRIPTION
## Problem

`linkBareMentionNames` (in `markdown.ts`) rewrites any bare `@word` into a `<@word>` Slack mention. Its lookbehind `(?<![<\w])@(\w+)` excludes `<` and word characters, but **not `/`** — so an `@handle` inside a URL path gets rewritten, corrupting the link:

```
See https://hackmd.io/@jkyang/B1W69XA-fe
  → See https://hackmd.io/<@jkyang>/B1W69XA-fe   ❌ (Slack renders a broken mention; link dead)
```

This affects common `@handle` URLs (HackMD `/@user`, Mastodon `/@user`, Medium `/@user`, …). It reproduces on `main` via `toSlackPayload` for both the plain `text` and the native `markdown_text` paths, because `finalize()` runs the regex over the whole string. (The `renderPostable({ markdown })` AST path is unaffected — bare URLs become link nodes there — which is likely why it's gone unnoticed.)

This is the same class of bug as the email fix in #394, which tuned this same regex; URL paths are the sibling case it didn't cover.

## Fix

Add `/` to the negative lookbehind so a handle preceded by a path separator is left intact:

```diff
-const BARE_MENTION_PATTERN = /(?<![<\w])@(\w+)/g;
+const BARE_MENTION_PATTERN = /(?<![<\w/])@(\w+)/g;
```

Whitespace-/punctuation-led mentions (`(cc @george)`), emails (`user@example.com`), and `<mailto:…>` links are unaffected.

## Tests

Two cases added to the `mentions` suite (plain string + markdown). Verified against current `main`:

- **Without the fix:** both new tests fail (e.g. `…/@user` → `…/<@user>`).
- **With the fix:** full `markdown.test.ts` suite passes (28/28).

Changeset included (`patch`).