### PR TITLE
fix(docs): restore Open Graph images

### DIFF
--- a/apps/docs/app/[lang]/(home)/page.tsx
+++ b/apps/docs/app/[lang]/(home)/page.tsx
@@ -37,6 +37,7 @@ export const metadata: Metadata = {
   description: heroDescription,
   openGraph: {
     title: { absolute: metadataTitle },
+    images: "/opengraph-image.png",
   },
   twitter: {
     card: "summary_large_image",

--- a/apps/docs/app/[lang]/(home)/resources/page.tsx
+++ b/apps/docs/app/[lang]/(home)/resources/page.tsx
@@ -19,6 +19,7 @@ export const metadata: Metadata = {
   ],
   openGraph: {
     title: "Resources",
+    images: "/opengraph-image.png",
   },
   twitter: {
     card: "summary_large_image",

--- a/apps/docs/app/[lang]/adapters/(listing)/page.tsx
+++ b/apps/docs/app/[lang]/adapters/(listing)/page.tsx
@@ -11,6 +11,7 @@ export const metadata: Metadata = {
   description: ADAPTERS_LISTING_DESCRIPTION,
   openGraph: {
     title: "Adapters",
+    images: "/opengraph-image.png",
   },
   twitter: {
     card: "summary_large_image",

--- a/apps/docs/app/[lang]/layout.tsx
+++ b/apps/docs/app/[lang]/layout.tsx
@@ -8,6 +8,7 @@ import { mono, sans } from "@/lib/geistdocs/fonts";
 import { cn } from "@/lib/utils";
 
 export const metadata: Metadata = {
+  metadataBase: new URL("https://chat-sdk.dev"),
   title: {
     template: "%s | Chat SDK",
     default: "Chat SDK",
@@ -17,6 +18,7 @@ export const metadata: Metadata = {
       template: "%s | Chat SDK",
       default: "Chat SDK",
     },
+    images: "/opengraph-image.png",
   },
 };
 


### PR DESCRIPTION
## summary

restores Open Graph and Twitter preview images across the homepage, adapters, and resources pages

adds the canonical metadata base so social image URLs resolve against chat-sdk.dev instead of localhost