### PR TITLE
fix username regexp

### DIFF
--- a/.changeset/eager-eggs-grow.md
+++ b/.changeset/eager-eggs-grow.md
@@ -1,5 +1,6 @@
 ---
 "chat": patch
+"@chat-adapter/telegram": patch
 ---
 
-Fix `detectMention` falsely matching `@bot` when `@bot-dev` is mentioned. `\b` (word boundary) matches between a word character and a hyphen, so `/@bot\b/` incorrectly matches `@bot-dev`. Replaced with `(?![\w-])` to exclude hyphens.
+Fix `detectMention` (and the Telegram adapter's `isBotMentioned`) falsely matching `@bot` when `@bot-dev` is mentioned. `\b` (word boundary) matches between a word character and a hyphen, so `/@bot\b/` incorrectly matches `@bot-dev`. Replaced with `(?![\w-])` to exclude hyphens.

--- a/.changeset/eager-eggs-grow.md
+++ b/.changeset/eager-eggs-grow.md
@@ -1,0 +1,5 @@
+---
+"chat": major
+---
+
+Fix `detectMention` falsely matching `@bot` when `@bot-dev` is mentioned. `\b` (word boundary) matches between a word character and a hyphen, so `/@bot\b/` incorrectly matches `@bot-dev`. Replaced with `(?![\w-])` to exclude hyphens.

--- a/.changeset/eager-eggs-grow.md
+++ b/.changeset/eager-eggs-grow.md
@@ -1,5 +1,5 @@
 ---
-"chat": major
+"chat": patch
 ---
 
 Fix `detectMention` falsely matching `@bot` when `@bot-dev` is mentioned. `\b` (word boundary) matches between a word character and a hyphen, so `/@bot\b/` incorrectly matches `@bot-dev`. Replaced with `(?![\w-])` to exclude hyphens.

--- a/packages/adapter-telegram/src/index.test.ts
+++ b/packages/adapter-telegram/src/index.test.ts
@@ -347,6 +347,57 @@ describe("TelegramAdapter", () => {
     expect(parsedMessage.isMention).toBe(true);
   });
 
+  it("does not mark a mention when a hyphen-suffixed name is mentioned", async () => {
+    mockFetch.mockResolvedValueOnce(
+      telegramOk({
+        id: 999,
+        is_bot: true,
+        first_name: "Bot",
+        username: "mybot",
+      })
+    );
+
+    const adapter = createTelegramAdapter({
+      botToken: "token",
+      mode: "webhook",
+      logger: mockLogger,
+      userName: "mybot",
+    });
+
+    const chat = createMockChat();
+    await adapter.initialize(chat);
+
+    const request = new Request("https://example.com/webhook", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        update_id: 1,
+        message: sampleMessage({
+          chat: {
+            id: -100123,
+            type: "supergroup",
+            title: "General",
+          },
+          text: "see @mybot-dev for details",
+        }),
+      }),
+    });
+
+    const response = await adapter.handleWebhook(request);
+    expect(response.status).toBe(200);
+
+    const processMessage = chat.processMessage as ReturnType<typeof vi.fn>;
+    expect(processMessage).toHaveBeenCalledTimes(1);
+
+    const [, , parsedMessage] = processMessage.mock.calls[0] as [
+      unknown,
+      string,
+      { isMention?: boolean; text: string },
+    ];
+
+    expect(parsedMessage.isMention).toBe(false);
+  });
+
   it("routes bot command messages to slash command handlers", async () => {
     mockFetch.mockResolvedValueOnce(
       telegramOk({

--- a/packages/adapter-telegram/src/index.ts
+++ b/packages/adapter-telegram/src/index.ts
@@ -2216,7 +2216,10 @@ export class TelegramAdapter
       }
     }
 
-    const mentionRegex = new RegExp(`@${this.escapeRegex(username)}\\b`, "i");
+    const mentionRegex = new RegExp(
+      `@${this.escapeRegex(username)}(?![\\w-])`,
+      "i"
+    );
     return mentionRegex.test(text);
   }
 

--- a/packages/chat/src/adapters/index.ts
+++ b/packages/chat/src/adapters/index.ts
@@ -794,7 +794,7 @@ export const ADAPTERS = {
   },
   velt: {
     description:
-      "Velt Comments adapter for bots that read, reply, mention, and start threads in anchored comments across documents, rich-text editors, canvases, PDFs, and video. Includes per-comment document context and an AI streaming-reply sample app.",
+      "Velt Comments adapter for building bots that read and respond in Velt comment threads on documents, text editors, and canvases.",
     env: {
       config: [
         "botUserId",

--- a/packages/chat/src/adapters/index.ts
+++ b/packages/chat/src/adapters/index.ts
@@ -794,7 +794,7 @@ export const ADAPTERS = {
   },
   velt: {
     description:
-      "Velt Comments adapter for building bots that read and respond in Velt comment threads on documents, text editors, and canvases.",
+      "Velt Comments adapter for bots that read, reply, mention, and start threads in anchored comments across documents, rich-text editors, canvases, PDFs, and video. Includes per-comment document context and an AI streaming-reply sample app.",
     env: {
       config: [
         "botUserId",

--- a/packages/chat/src/chat.test.ts
+++ b/packages/chat/src/chat.test.ts
@@ -449,6 +449,22 @@ describe("Chat", () => {
       expect(mentionHandler).not.toHaveBeenCalled();
       expect(patternHandler).toHaveBeenCalledTimes(1);
     });
+
+    it("should not trigger onNewMention when a bot with a hyphen-suffixed name is mentioned", async () => {
+      // @slack-bot should not react when @slack-bot-dev is mentioned
+      const mentionHandler = vi.fn().mockResolvedValue(undefined);
+      chat.onNewMention(mentionHandler);
+
+      const message = createTestMessage("msg-1", "Hey @slack-bot-dev help me");
+
+      await chat.handleIncomingMessage(
+        mockAdapter,
+        "slack:C123:1234.5678",
+        message
+      );
+
+      expect(mentionHandler).not.toHaveBeenCalled();
+    });
   });
 
   it("should match message patterns", async () => {

--- a/packages/chat/src/chat.test.ts
+++ b/packages/chat/src/chat.test.ts
@@ -465,6 +465,26 @@ describe("Chat", () => {
 
       expect(mentionHandler).not.toHaveBeenCalled();
     });
+
+    it("should not trigger onNewMention when a hyphen-suffixed user ID is mentioned", async () => {
+      // Bot with ID UBOT123 should not react when @UBOT123-canary is mentioned
+      const adapterWithId = {
+        ...createMockAdapter("slack"),
+        botUserId: "UBOT123",
+      };
+      const mentionHandler = vi.fn().mockResolvedValue(undefined);
+      chat.onNewMention(mentionHandler);
+
+      const message = createTestMessage("msg-1", "deploy @UBOT123-canary now");
+
+      await chat.handleIncomingMessage(
+        adapterWithId,
+        "slack:C123:1234.5678",
+        message
+      );
+
+      expect(mentionHandler).not.toHaveBeenCalled();
+    });
   });
 
   it("should match message patterns", async () => {

--- a/packages/chat/src/chat.ts
+++ b/packages/chat/src/chat.ts
@@ -2600,7 +2600,7 @@ export class Chat<
     // Fallback: check for user ID mention if available (e.g., @U_BOT_123)
     if (botUserId) {
       const userIdPattern = new RegExp(
-        `@${this.escapeRegex(botUserId)}\\b`,
+        `@${this.escapeRegex(botUserId)}(?![\\w-])`,
         "i"
       );
       if (userIdPattern.test(message.text)) {

--- a/packages/chat/src/chat.ts
+++ b/packages/chat/src/chat.ts
@@ -2590,7 +2590,7 @@ export class Chat<
 
     // Primary check: @username format (normalized by all adapters)
     const usernamePattern = new RegExp(
-      `@${this.escapeRegex(botUserName)}\\b`,
+      `@${this.escapeRegex(botUserName)}(?![\\w-])`,
       "i"
     );
     if (usernamePattern.test(message.text)) {


### PR DESCRIPTION
## Summary

<!-- What does this PR do? -->

Fix `detectMention` falsely matching `@bot` when `@bot-dev` is mentioned. `\b` (word boundary) matches between a word character and a hyphen, so `/@bot\b/` incorrectly matches `@bot-dev`. Replaced with `(?![\w-])` to exclude hyphens.

## Test plan

<!-- How did you verify the changes? -->

## Checklist

- [x] All commits are signed and verified
- [x] `pnpm validate` passes
- [x] Changeset added (or N/A — see [CONTRIBUTING.md](./CONTRIBUTING.md))
- [x] Documentation updated (or N/A)
