### PR TITLE
feat(docs): add eve to product switcher

### DIFF
--- a/apps/docs/components/geistcn-fallbacks/geistcn-assets/logos/index.tsx
+++ b/apps/docs/components/geistcn-fallbacks/geistcn-assets/logos/index.tsx
@@ -6,6 +6,7 @@
 export { LogoAiElements } from "./logo-ai-elements";
 export { LogoAiSdk } from "./logo-ai-sdk";
 export { LogoChatSdk } from "./logo-chat-sdk";
+export { LogoEve } from "./logo-eve";
 export { LogoFlagsSdk } from "./logo-flags-sdk";
 export { LogoIconVercel } from "./logo-icon-vercel";
 export { LogoStreamdown } from "./logo-streamdown";

--- a/apps/docs/components/geistcn-fallbacks/geistcn-assets/logos/logo-eve.tsx
+++ b/apps/docs/components/geistcn-fallbacks/geistcn-assets/logos/logo-eve.tsx
@@ -1,0 +1,24 @@
+import { cn } from "@/lib/utils";
+
+/**
+ * eve wordmark + Beta badge. eve ships a text-based brand mark rather than an
+ * SVG wordmark, so this mirrors its docs logo. `height` is accepted for parity
+ * with the other product logos but does not drive sizing for this text mark.
+ */
+export function LogoEve({
+  className,
+}: {
+  height?: number;
+  className?: string;
+}) {
+  return (
+    <span className={cn("flex items-center gap-2", className)}>
+      <span className="font-semibold text-gray-1000 text-lg leading-none">
+        eve
+      </span>
+      <span className="rounded-full border border-blue-300 px-2 py-0.5 font-medium text-blue-700 text-xs leading-none">
+        Beta
+      </span>
+    </span>
+  );
+}

--- a/apps/docs/components/geistdocs/navbar-logo.tsx
+++ b/apps/docs/components/geistdocs/navbar-logo.tsx
@@ -5,6 +5,7 @@ import type { ComponentType, ReactNode } from "react";
 import { IconSlashForward } from "@/components/geistcn-fallbacks/geistcn-assets/icons/icon-slash-forward";
 import { LogoAiElements } from "@/components/geistcn-fallbacks/geistcn-assets/logos/logo-ai-elements";
 import { LogoAiSdk } from "@/components/geistcn-fallbacks/geistcn-assets/logos/logo-ai-sdk";
+import { LogoEve } from "@/components/geistcn-fallbacks/geistcn-assets/logos/logo-eve";
 import { LogoFlagsSdk } from "@/components/geistcn-fallbacks/geistcn-assets/logos/logo-flags-sdk";
 import { LogoIconVercel } from "@/components/geistcn-fallbacks/geistcn-assets/logos/logo-icon-vercel";
 import { LogoStreamdown } from "@/components/geistcn-fallbacks/geistcn-assets/logos/logo-streamdown";
@@ -25,6 +26,7 @@ const OSS_PRODUCT_LINKS: {
   logo: ComponentType<{ height: number }>;
   height: number;
 }[] = [
+  { href: "https://eve.dev/docs", logo: LogoEve, height: 18 },
   { href: "https://ai-sdk.dev/", logo: LogoAiSdk, height: 12 },
   { href: "https://flags-sdk.dev/", logo: LogoFlagsSdk, height: 20 },
   { href: "https://elements.ai-sdk.dev/", logo: LogoAiElements, height: 12 },


### PR DESCRIPTION
Add an eve entry (text wordmark + Beta badge, linking to eve.dev/docs) to the top of the OSS product switcher in the docs navbar.

<img width="352" height="328" alt="CleanShot 2026-06-20 at 01 09 35" src="https://github.com/user-attachments/assets/cd2f03b0-8b40-477b-a8a2-ac4a9911f44d" />
