### PR TITLE
docs(adapters): add Linq as vendor-official adapter

### DIFF
--- a/.changeset/linq-vendor-adapter.md
+++ b/.changeset/linq-vendor-adapter.md
@@ -1,0 +1,6 @@
+---
+"chat": patch
+"create-chat-sdk": patch
+---
+
+docs(adapters): add Linq as a vendor-official adapter (`@linqapp/chat-sdk-adapter`) to the catalog, docs listing, and CLI scaffold spec

--- a/apps/docs/adapters.json
+++ b/apps/docs/adapters.json
@@ -338,5 +338,16 @@
     "author": "Novu",
     "readme": "https://github.com/novuhq/novu/blob/24d8855c294bcf27450c91d2e2a0f9db9ffb8f73/packages/chat-adapter",
     "vendorOfficial": true
+  },
+  {
+    "name": "Linq",
+    "slug": "linq",
+    "type": "platform",
+    "community": true,
+    "description": "iMessage and SMS adapter for Chat SDK, built and maintained by Linq.",
+    "packageName": "@linqapp/chat-sdk-adapter",
+    "author": "Linq",
+    "readme": "https://github.com/linq-team/linq-chat-sdk/tree/main/packages/adapter-linq",
+    "vendorOfficial": true
   }
 ]

--- a/apps/docs/content/adapters/vendor-official/linq.mdx
+++ b/apps/docs/content/adapters/vendor-official/linq.mdx
@@ -192,3 +192,7 @@ Inbound media (images, audio, files) arrives as Chat SDK attachments with downlo
 
 - [Adapter source and README](https://github.com/linq-team/linq-chat-sdk/tree/main/packages/adapter-linq)
 - [Example app](https://github.com/linq-team/linq-chat-sdk/tree/main/apps/api) — one AI bot running across Linq, Telegram, and WhatsApp from a single set of handlers.
+
+## Feature support
+
+<FeatureSupport />

--- a/apps/docs/content/adapters/vendor-official/linq.mdx
+++ b/apps/docs/content/adapters/vendor-official/linq.mdx
@@ -94,12 +94,12 @@ The adapter maps a Linq chat to a Chat SDK thread, a text to a message, and an i
   type={{
     apiKey: {
       type: "string",
-      description: "Linq API key for outbound API calls. Falls back to `LINQ_API_KEY`.",
+      description: "Linq API key for outbound API calls.",
     },
     signingSecret: {
       type: "string",
       description:
-        "Webhook signing secret. Inbound requests are verified with HMAC-SHA256 over `{timestamp}.{body}` with replay protection. Falls back to `LINQ_WEBHOOK_SECRET`.",
+        "Webhook signing secret. Inbound requests are verified with HMAC-SHA256 over `{timestamp}.{body}` with replay protection.",
     },
     baseURL: {
       type: "string",

--- a/apps/docs/content/adapters/vendor-official/linq.mdx
+++ b/apps/docs/content/adapters/vendor-official/linq.mdx
@@ -1,0 +1,194 @@
+---
+title: Linq
+description: iMessage and SMS adapter for Chat SDK, built and maintained by Linq. Send and receive texts, media, and tapback reactions over Apple Messages and SMS, with HMAC-verified webhooks and stable threading.
+packageName: "@linqapp/chat-sdk-adapter"
+slug: linq
+type: platform
+tagline: Bots that text over iMessage and SMS through Linq — DMs and group chats, media both ways, and native tapback reactions, mapping Linq chats to the Chat SDK thread/message/reaction model.
+community: true
+vendorOfficial: true
+author: Linq
+mdxBody: true
+features:
+  postMessage: yes
+  editMessage:
+    status: yes
+    label: Text, first part
+  deleteMessage: no
+  fileUploads:
+    status: yes
+    label: Images, audio, files
+  streaming:
+    status: partial
+    label: Buffered
+  scheduledMessages: no
+  cardFormat: no
+  buttons: no
+  linkButtons: no
+  selectMenus: no
+  tables: no
+  fields: no
+  imagesInCards: no
+  modals: no
+  slashCommands: no
+  mentions: no
+  addReactions:
+    status: yes
+    label: Tapbacks
+  removeReactions:
+    status: yes
+    label: Tapbacks
+  typingIndicator:
+    status: partial
+    label: DMs only
+  directMessages: yes
+  ephemeralMessages: no
+  userLookup: no
+  customApiEndpoint: no
+  fetchMessages: yes
+  fetchSingleMessage: yes
+  fetchThreadInfo: yes
+  fetchChannelMessages: no
+  listThreads: no
+  fetchChannelInfo: no
+  postChannelMessage: no
+---
+
+## Install
+
+<PackageInstall package="@linqapp/chat-sdk-adapter" />
+
+## Quick start
+
+```typescript title="lib/bot.ts" lineNumbers
+import { Chat } from "chat";
+import { createMemoryState } from "@chat-adapter/state-memory";
+import { createLinqAdapter } from "@linqapp/chat-sdk-adapter";
+
+export const bot = new Chat({
+  userName: "Linq Bot",
+  adapters: {
+    linq: createLinqAdapter({
+      apiKey: process.env.LINQ_API_KEY,
+      signingSecret: process.env.LINQ_WEBHOOK_SECRET,
+    }),
+  },
+  state: createMemoryState(),
+});
+
+bot.onDirectMessage(async (thread, message) => {
+  await thread.subscribe();
+  await thread.post(`You said: ${message.text}`);
+});
+
+bot.onReaction(["thumbs_up"], async (event) => {
+  await event.thread.post("Appreciate the tapback 🫡");
+});
+```
+
+The adapter maps a Linq chat to a Chat SDK thread, a text to a message, and an iMessage tapback to a reaction, so the rest of the Chat SDK API (subscriptions, handlers, posts, reactions) works exactly the same as with any other adapter.
+
+## Configuration
+
+<TypeTable
+  type={{
+    apiKey: {
+      type: "string",
+      description: "Linq API key for outbound API calls. Falls back to `LINQ_API_KEY`.",
+    },
+    signingSecret: {
+      type: "string",
+      description:
+        "Webhook signing secret. Inbound requests are verified with HMAC-SHA256 over `{timestamp}.{body}` with replay protection. Falls back to `LINQ_WEBHOOK_SECRET`.",
+    },
+    baseURL: {
+      type: "string",
+      description: "Override the Linq API base URL (e.g. a sandbox host).",
+    },
+  }}
+/>
+
+## Platform setup
+
+1. Create a Linq account and copy your **API key**. For testing, the [Linq CLI](https://www.npmjs.com/package/@linqapp/cli) provisions a sandbox number: `linq signup --phone <your cell>`.
+2. Create a **webhook subscription** pointing at the route that forwards to `bot.webhooks.linq`, and subscribe to:
+   - `message.received`
+   - `reaction.added`
+   - `reaction.removed`
+3. Copy the **signing secret** returned by the subscription into `signingSecret`.
+
+Other event types are acknowledged with a `200` and ignored.
+
+## Webhook events
+
+| Event | Role |
+| --- | --- |
+| `message.received` | Drives Chat SDK message processing |
+| `reaction.added` | Drives reaction handlers |
+| `reaction.removed` | Drives reaction handlers |
+
+```typescript title="app/api/webhooks/linq/route.ts" lineNumbers
+import { after } from "next/server";
+import { bot } from "@/lib/bot";
+
+export const runtime = "nodejs"; // raw body + crypto; not edge
+
+export async function POST(request: Request) {
+  return bot.webhooks.linq(request, {
+    waitUntil: (task) => after(() => task),
+  });
+}
+```
+
+Requests are verified with HMAC-SHA256 and a replay-window check before dispatch; an invalid or stale signature returns **401**. Passing `waitUntil` lets work continue after the response is sent in serverless environments like Vercel.
+
+## Thread IDs
+
+Thread IDs are stable and always take the form `linq:{chatId}`, so a conversation maps to the same Chat SDK thread whether it first arrives via webhook or API.
+
+### `encodeThreadId`
+
+```typescript
+adapter.encodeThreadId(data: { chatId: string; isGroup?: boolean }): string;
+```
+
+```typescript
+const encoded = adapter.encodeThreadId({ chatId: "3caaf1a0-ef9f-46e0-8c22-31e82c8514dc" });
+// "linq:3caaf1a0-ef9f-46e0-8c22-31e82c8514dc"
+```
+
+### `decodeThreadId`
+
+```typescript
+adapter.decodeThreadId(threadId: string): { chatId: string; isGroup?: boolean };
+```
+
+Group vs. DM identity is tracked internally from webhook payloads; legacy `linq:{chatId}:group` / `linq:{chatId}:dm` IDs still decode.
+
+## Message format
+
+Outbound markdown is rendered to plain text — Linq delivers message text as-is (iMessage has no markdown). Inbound text is parsed to the Chat SDK AST, with URLs surfaced as link previews.
+
+## Reactions
+
+Standard iMessage tapbacks map to normalized Chat SDK emoji in both directions:
+
+| Linq tapback | Chat SDK emoji |
+| ------------ | -------------- |
+| `like`       | `thumbs_up`    |
+| `dislike`    | `thumbs_down`  |
+| `love`       | `heart`        |
+| `laugh`      | `laugh`        |
+| `emphasize`  | `exclamation`  |
+| `question`   | `question`     |
+
+Custom emoji reactions pass through the default emoji resolver (e.g. `👍` → `thumbs_up`), falling back to the raw emoji for anything unmapped. Sticker reactions have no Chat SDK equivalent and are skipped.
+
+## Attachments
+
+Inbound media (images, audio, files) arrives as Chat SDK attachments with downloadable data. Outbound `attachments` and `files` are sent as Linq media parts: a public HTTPS URL under 10 MB is sent by reference, while raw bytes, non-HTTPS URLs, and files up to 100 MB are pre-uploaded. Messages can be media-only.
+
+## Examples
+
+- [Adapter source and README](https://github.com/linq-team/linq-chat-sdk/tree/main/packages/adapter-linq)
+- [Example app](https://github.com/linq-team/linq-chat-sdk/tree/main/apps/api) — one AI bot running across Linq, Telegram, and WhatsApp from a single set of handlers.

--- a/apps/docs/content/adapters/vendor-official/meta.json
+++ b/apps/docs/content/adapters/vendor-official/meta.json
@@ -10,6 +10,7 @@
     "agentphone",
     "lark",
     "velt",
-    "kapso"
+    "kapso",
+    "linq"
   ]
 }

--- a/packages/chat/src/adapters/index.ts
+++ b/packages/chat/src/adapters/index.ts
@@ -446,6 +446,27 @@ export const ADAPTERS = {
     slug: "linear",
     type: "platform",
   },
+  linq: {
+    description:
+      "iMessage and SMS adapter for Chat SDK, built and maintained by Linq.",
+    env: {
+      config: ["baseURL"],
+      required: [
+        secretEnv("LINQ_API_KEY", "Linq API key for outbound API calls."),
+        secretEnv(
+          "LINQ_WEBHOOK_SECRET",
+          "Webhook signing secret used to verify inbound HMAC-SHA256 signatures."
+        ),
+      ],
+    },
+    factoryExport: "createLinqAdapter",
+    group: "vendor-official",
+    name: "Linq",
+    packageName: "@linqapp/chat-sdk-adapter",
+    peerDeps: [],
+    slug: "linq",
+    type: "platform",
+  },
   liveblocks: {
     description:
       "Liveblocks Comments adapter for building conversational bots on top of Liveblocks rooms, threads, and comments.",

--- a/packages/create-chat-sdk/src/catalog/scaffold-spec.ts
+++ b/packages/create-chat-sdk/src/catalog/scaffold-spec.ts
@@ -130,6 +130,15 @@ export const CLI_SCAFFOLD_SPEC = {
   linear: {
     invocation: { kind: "zero-arg" },
   },
+  linq: {
+    invocation: {
+      kind: "object",
+      properties: [
+        { key: "apiKey", value: env("LINQ_API_KEY") },
+        { key: "signingSecret", value: env("LINQ_WEBHOOK_SECRET") },
+      ],
+    },
+  },
   liveblocks: {
     invocation: {
       kind: "object",

--- a/packages/integration-tests/src/docs-adapters.test.ts
+++ b/packages/integration-tests/src/docs-adapters.test.ts
@@ -141,6 +141,7 @@ describe("Vendor-Official adapter MDX", () => {
         "agentphone",
         "kapso",
         "lark",
+        "linq",
         "liveblocks",
         "matrix",
         "novu",

--- a/packages/integration-tests/src/documentation-test-utils.ts
+++ b/packages/integration-tests/src/documentation-test-utils.ts
@@ -207,6 +207,7 @@ export const VALID_DOC_PACKAGES = [
   "@agentphone/chat-sdk-adapter",
   "@kapso/chat-adapter",
   "@novu/chat-sdk-adapter",
+  "@linqapp/chat-sdk-adapter",
   "chat-adapter-baileys",
   "baileys",
   "chat-adapter-blooio",


### PR DESCRIPTION
Adds Linq as a vendor-official adapter — iMessage and SMS for Chat SDK.

- `vendor-official/linq.mdx` adapter page (following the Velt / AgentPhone format)
- catalog entry in `adapters.json`
- `linq` added to the vendor-official `meta.json`

Repo: https://github.com/linq-team/linq-chat-sdk · npm: `@linqapp/chat-sdk-adapter` (Apache-2.0)

The adapter is built and tested end-to-end against the live Linq API and the Chat SDK runtime (real iMessage round-trip, webhooks, reactions, media). Confirmed with Benji that a repo link works and Apache-2.0 is fine. Happy to adjust the page to match any conventions I missed.