### PR TITLE
chore(changesets): ignore all example-* packages and enforce the convention

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -10,9 +10,5 @@
   "___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH": {
     "onlyUpdatePeerDependentsWhenOutOfRange": true
   },
-  "ignore": [
-    "example-nextjs-chat",
-    "example-telegram-chat",
-    "@chat-adapter/integration-tests"
-  ]
+  "ignore": ["example-*", "@chat-adapter/integration-tests"]
 }

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -31,6 +31,13 @@ The repo uses [konsistent](https://www.npmjs.com/package/konsistent) (configured
 
 `${Name}` is the kebab-case package suffix in PascalCase — most cases are mechanical (`discord` → `Discord`), but a few overrides live in `kebabToPascalMap` in the config (e.g. `gchat` → `GoogleChat`, `whatsapp` → `WhatsApp`).
 
+**Example apps (`examples/*`)** must:
+
+- Be marked `"private": true` (they are never published)
+- Name their `package.json` `name` field `example-*` (e.g. `example-nextjs-chat`)
+
+The `example-*` name lets the `ignore` glob in `.changeset/config.json` exclude every example from versioning and publishing automatically, so adding a new example needs no changeset and no edit to the changesets config. A test in `packages/integration-tests` asserts every `examples/*` package follows this convention and is in the resolved changesets `ignore` list.
+
 ## Signed Commits
 
 All commits to this repository must be **signed and verified**. Pull requests with unsigned commits will not be merged.
@@ -99,7 +106,7 @@ This creates a markdown file in `.changeset/` describing your change. Commit thi
 ### When to Add a Changeset
 
 - **Do add** for: bug fixes, new features, breaking changes, dependency updates affecting behavior
-- **Don't add** for: documentation changes, internal refactors, test changes, CI updates
+- **Don't add** for: documentation changes, internal refactors, test changes, CI updates, or changes to example apps (`examples/*` are private and ignored by changesets)
 
 ### Changeset Types
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,7 +42,7 @@ pnpm monorepo, Turborepo orchestrated. All packages are ESM (`"type": "module"`)
 - `packages/state-{memory,redis,ioredis,pg}` — state adapters
 - `packages/integration-tests` — integration tests against real platform APIs
 - `apps/docs` — fumadocs-based docs site (chat-sdk.dev)
-- `examples/nextjs-chat` — example Next.js app
+- `examples/*` — standalone example apps (e.g. `examples/nextjs-chat`). Each example's `package.json` `name` must follow the `example-*` convention so changesets ignores it automatically (see Releases). This is enforced by a test in `packages/integration-tests`.
 
 ### Core concepts
 
@@ -93,6 +93,8 @@ User-facing docs live in `apps/docs/content/docs/` (rendered at chat-sdk.dev/doc
 ## Releases
 
 Uses Changesets with fixed versioning (every package shares one version). Every PR that changes a package's behavior must include a changeset (`pnpm changeset`). Full rules in `.github/CONTRIBUTING.md`.
+
+Example apps (`examples/*`) are private and never published. The `ignore` list in `.changeset/config.json` uses an `example-*` glob, so any example named `example-*` is excluded from versioning and publishing automatically — no changeset and no config edit needed when adding one.
 
 ## Environment variables
 

--- a/packages/integration-tests/package.json
+++ b/packages/integration-tests/package.json
@@ -10,10 +10,12 @@
     "typecheck": "tsc --noEmit"
   },
   "devDependencies": {
+    "@changesets/config": "^3.1.2",
     "@emulators/core": "^0.6.0",
     "@emulators/github": "^0.6.0",
     "@emulators/slack": "^0.6.0",
     "@hono/node-server": "^2.0.2",
+    "@manypkg/get-packages": "^1.1.3",
     "@types/node": "^25.3.2",
     "typescript": "^5.7.2",
     "vitest": "^4.0.18"

--- a/packages/integration-tests/src/changeset-config.test.ts
+++ b/packages/integration-tests/src/changeset-config.test.ts
@@ -1,0 +1,48 @@
+import { relative, sep } from "node:path";
+import { read } from "@changesets/config";
+import { getPackages } from "@manypkg/get-packages";
+import { describe, expect, it } from "vitest";
+import { REPO_ROOT } from "./documentation-test-utils";
+
+// Example apps must follow this naming convention so the `example-*` glob in
+// .changeset/config.json picks them up automatically — see the assertions below.
+const EXAMPLE_NAME_CONVENTION = /^example-/;
+
+const toPosix = (path: string): string => path.split(sep).join("/");
+
+describe("changesets config", () => {
+  it("ignores every examples/* workspace package", async () => {
+    const packages = await getPackages(REPO_ROOT);
+    // `read` resolves the `ignore` globs against real package names (and throws
+    // if any glob matches nothing), so `config.ignore` is the exact set of
+    // package names changesets will skip at release time.
+    const config = await read(REPO_ROOT, packages);
+
+    const examplePackages = packages.packages.filter((pkg) =>
+      toPosix(relative(REPO_ROOT, pkg.dir)).startsWith("examples/")
+    );
+
+    // Guard against the test silently passing if examples move or disappear.
+    expect(examplePackages.length).toBeGreaterThan(0);
+
+    for (const pkg of examplePackages) {
+      const { name } = pkg.packageJson;
+      const dir = toPosix(relative(REPO_ROOT, pkg.dir));
+
+      // Enforce the naming convention the `example-*` glob relies on. An app
+      // named e.g. `sample-foo` would not be matched and would silently leak
+      // into releases.
+      expect(
+        name,
+        `Example app at ${dir} must be named "example-*" so the changesets "example-*" ignore glob covers it`
+      ).toMatch(EXAMPLE_NAME_CONVENTION);
+
+      // The real guarantee: every example app is ignored, so releases never
+      // version or publish them.
+      expect(
+        config.ignore,
+        `Example app "${name}" (${dir}) must be ignored by changesets`
+      ).toContain(name);
+    }
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -743,6 +743,9 @@ importers:
         specifier: ^0.37.119
         version: 0.37.120
     devDependencies:
+      '@changesets/config':
+        specifier: ^3.1.2
+        version: 3.1.2
       '@emulators/core':
         specifier: ^0.6.0
         version: 0.6.0
@@ -755,6 +758,9 @@ importers:
       '@hono/node-server':
         specifier: ^2.0.2
         version: 2.0.2(hono@4.12.18)
+      '@manypkg/get-packages':
+        specifier: ^1.1.3
+        version: 1.1.3
       '@types/node':
         specifier: ^25.3.2
         version: 25.3.2
@@ -10940,11 +10946,11 @@ snapshots:
 
   '@slack/logger@4.0.0':
     dependencies:
-      '@types/node': 25.3.2
+      '@types/node': 25.9.2
 
   '@slack/logger@4.0.1':
     dependencies:
-      '@types/node': 25.3.2
+      '@types/node': 25.9.2
 
   '@slack/socket-mode@2.0.6':
     dependencies:
@@ -10986,7 +10992,7 @@ snapshots:
     dependencies:
       '@slack/logger': 4.0.1
       '@slack/types': 2.20.1
-      '@types/node': 25.3.2
+      '@types/node': 25.9.2
       '@types/retry': 0.12.0
       axios: 1.16.1
       eventemitter3: 5.0.1
@@ -11660,7 +11666,7 @@ snapshots:
   '@types/jsonwebtoken@9.0.10':
     dependencies:
       '@types/ms': 2.1.0
-      '@types/node': 25.3.2
+      '@types/node': 25.9.2
 
   '@types/mdast@4.0.4':
     dependencies:
@@ -11708,7 +11714,7 @@ snapshots:
 
   '@types/ws@8.18.1':
     dependencies:
-      '@types/node': 25.3.2
+      '@types/node': 25.9.2
 
   '@ungap/structured-clone@1.3.0': {}
 


### PR DESCRIPTION
Replace the explicit per-example entries in the changesets `ignore` list
with an `example-*` name glob (matched by micromatch). All example apps are
private and never published, so listing them individually only adds version
and changelog churn to release PRs, and each new example required editing
this CODEOWNERS-gated file.

Add an integration test that resolves the changesets config against the
workspace and asserts every examples/* package is in the resolved ignore
list and follows the `example-*` naming convention, so an off-convention
example app fails CI instead of silently leaking into releases.