### PR TITLE
docs: homepage nits

### DIFF
--- a/apps/docs/app/[lang]/(home)/components/code-section.tsx
+++ b/apps/docs/app/[lang]/(home)/components/code-section.tsx
@@ -51,7 +51,7 @@ export const CodeSection = () => (
             <span className="font-mono text-muted-foreground text-sm">
               +{" "}
               <DynamicLink
-                className="whitespace-nowrap text-foreground hover:underline hover:underline-offset-4"
+                className="whitespace-nowrap text-muted-foreground hover:underline hover:underline-offset-4"
                 href="/[lang]/adapters"
               >
                 more adapters

--- a/apps/docs/app/[lang]/(home)/components/code-window.tsx
+++ b/apps/docs/app/[lang]/(home)/components/code-window.tsx
@@ -32,9 +32,7 @@ export const CodeWindow = ({
       ) : null}
     </div>
     <div className="relative min-w-0 flex-1 overflow-hidden rounded-b-lg border border-gray-200 bg-background-100">
-      <div className="[&_pre]:!overflow-x-hidden h-56 overflow-y-auto">
-        {children}
-      </div>
+      <div className="h-56 overflow-auto">{children}</div>
       <div className="pointer-events-none absolute inset-x-0 bottom-0 h-12 rounded-b-lg bg-gradient-to-t from-background-100 to-transparent" />
     </div>
   </div>

--- a/apps/docs/app/[lang]/(home)/components/highlighted-code.tsx
+++ b/apps/docs/app/[lang]/(home)/components/highlighted-code.tsx
@@ -11,7 +11,7 @@ export const HighlightedCode = ({
 }) => (
   <pre
     className={cn(
-      "overflow-x-auto bg-transparent py-5 font-mono text-[13px] leading-5 [font-feature-settings:'ss09']",
+      "bg-transparent py-5 font-mono text-[13px] leading-5 [font-feature-settings:'ss09']",
       className
     )}
   >

--- a/apps/docs/app/[lang]/(home)/components/oss-stats-section.tsx
+++ b/apps/docs/app/[lang]/(home)/components/oss-stats-section.tsx
@@ -92,7 +92,9 @@ export const OssStatsSection = async () => {
       {stats.map((stat) => (
         <div className="home-grid-cell text-left" key={stat.label}>
           <dt className="text-gray-1000 text-heading-32">{stat.value}</dt>
-          <dd className="font-mono text-gray-900 text-sm">{stat.label}</dd>
+          <dd className="whitespace-nowrap font-mono text-gray-900 text-sm">
+            {stat.label}
+          </dd>
         </div>
       ))}
     </dl>

--- a/apps/docs/app/[lang]/(home)/components/supported-platforms.tsx
+++ b/apps/docs/app/[lang]/(home)/components/supported-platforms.tsx
@@ -74,10 +74,10 @@ export const SupportedPlatforms = () => (
     <div className="home-grid home-grid-features" data-home-grid>
       {features.map((feature) => (
         <div className="home-grid-cell" key={feature.title}>
-          <span className="block text-heading-16 sm:text-heading-20">
+          <span className="block text-heading-14 sm:text-heading-20">
             {feature.title}
           </span>
-          <span className="block font-medium! text-gray-900 text-heading-16 sm:text-heading-20">
+          <span className="block font-medium! text-gray-900 text-heading-14 sm:text-heading-20">
             {feature.description}
           </span>
         </div>

--- a/apps/docs/app/[lang]/(home)/page.tsx
+++ b/apps/docs/app/[lang]/(home)/page.tsx
@@ -25,7 +25,7 @@ const metadataTitle = "Chat SDK";
 const heroTitleDisplay = (
   <>
     Universal chat layer for
-    <br />
+    <br className="hidden sm:block" />{" "}
     building bots and agents
   </>
 );

--- a/apps/docs/app/[lang]/(home)/page.tsx
+++ b/apps/docs/app/[lang]/(home)/page.tsx
@@ -25,8 +25,7 @@ const metadataTitle = "Chat SDK";
 const heroTitleDisplay = (
   <>
     Universal chat layer for
-    <br className="hidden sm:block" />{" "}
-    building bots and agents
+    <br className="hidden sm:block" /> building bots and agents
   </>
 );
 const heroDescription =

--- a/apps/docs/app/styles/geistdocs.css
+++ b/apps/docs/app/styles/geistdocs.css
@@ -508,6 +508,14 @@ html {
   line-height: 24px;
 }
 
+@utility text-heading-14 {
+  font-family: var(--font-family-geist);
+  font-size: 14px;
+  font-weight: 600;
+  letter-spacing: -0.28px;
+  line-height: 20px;
+}
+
 @utility text-heading-40 {
   font-family: var(--font-family-geist);
   font-size: 40px;

--- a/apps/docs/app/styles/home-grid.css
+++ b/apps/docs/app/styles/home-grid.css
@@ -175,8 +175,7 @@
 
 .home-grid-features .home-grid-cell:nth-child(3) {
   grid-row: 2;
-  grid-column: 1;
-  border-right: var(--home-guide-width) solid var(--home-guide-color);
+  grid-column: 1 / -1;
 }
 
 @media screen and (min-width: 961px) {


### PR DESCRIPTION
- Break hero title cleanly on desktop only so "for" doesn't strand on mobile
- Keep OSS stat labels (e.g. "Weekly downloads") on one line
- Shrink feature box headings on mobile, full size from sm
- Span the third feature box full-width on mobile
- Enable horizontal scroll for long code lines in the code showcase
- Match "more adapters" link color to the "Supports" label