### PR TITLE
[slack] skip mention resolution inside code blocks

### DIFF
--- a/.changeset/slack-skip-mentions-in-code.md
+++ b/.changeset/slack-skip-mentions-in-code.md
@@ -1,0 +1,5 @@
+---
+"@chat-adapter/slack": patch
+---
+
+Fix `@mention` rewriting so handles inside inline code spans (`` `@vercel/postgres` ``) and fenced code blocks (```` ``` ````) are no longer turned into `<@USER_ID>` Slack mentions. Agents printing npm package names or shell snippets previously had those handles corrupted into bot user IDs. Mention linking now skips whole code spans and code blocks; handles outside code (including the same name mentioned elsewhere in the message) still resolve normally.

--- a/packages/adapter-slack/src/index.test.ts
+++ b/packages/adapter-slack/src/index.test.ts
@@ -6675,6 +6675,70 @@ describe("reverse user lookup", () => {
 
       expect(result).toBe("Hey @dominik");
     });
+
+    it("skips mentions inside inline code (backticks)", async () => {
+      const { adapter, state } = createAdapterWithState();
+
+      await state.appendToList("slack:user-by-name:vercel", "U_VER_123");
+
+      const result = await (
+        adapter as unknown as MentionAdapter
+      ).resolveOutgoingMentions(
+        "Use `@vercel/postgres` for the database",
+        "slack:C123:1234567890.123456"
+      );
+
+      expect(result).toBe("Use `@vercel/postgres` for the database");
+    });
+
+    it("skips mentions inside code blocks (triple backticks)", async () => {
+      const { adapter, state } = createAdapterWithState();
+
+      await state.appendToList("slack:user-by-name:vercel", "U_VER_123");
+
+      const result = await (
+        adapter as unknown as MentionAdapter
+      ).resolveOutgoingMentions(
+        "Install:\n```\nnpm install @vercel/postgres\n```",
+        "slack:C123:1234567890.123456"
+      );
+
+      expect(result).toBe("Install:\n```\nnpm install @vercel/postgres\n```");
+    });
+
+    it("resolves mentions outside code but skips those inside", async () => {
+      const { adapter, state } = createAdapterWithState();
+
+      await state.appendToList("slack:user-by-name:dominik", "U_DOM_123");
+      await state.appendToList("slack:user-by-name:vercel", "U_VER_123");
+
+      const result = await (
+        adapter as unknown as MentionAdapter
+      ).resolveOutgoingMentions(
+        "Hey @dominik, use `@vercel/postgres` for this",
+        "slack:C123:1234567890.123456"
+      );
+
+      expect(result).toBe("Hey <@U_DOM_123>, use `@vercel/postgres` for this");
+    });
+
+    it("handles multiple inline code spans with mentions", async () => {
+      const { adapter, state } = createAdapterWithState();
+
+      await state.appendToList("slack:user-by-name:neondatabase", "U_NEON_123");
+      await state.appendToList("slack:user-by-name:vercel", "U_VER_123");
+
+      const result = await (
+        adapter as unknown as MentionAdapter
+      ).resolveOutgoingMentions(
+        "Use `@neondatabase/serverless` or `@vercel/postgres`",
+        "slack:C123:1234567890.123456"
+      );
+
+      expect(result).toBe(
+        "Use `@neondatabase/serverless` or `@vercel/postgres`"
+      );
+    });
   });
 
   describe("resolveMessageMentions", () => {

--- a/packages/adapter-slack/src/index.test.ts
+++ b/packages/adapter-slack/src/index.test.ts
@@ -6739,6 +6739,102 @@ describe("reverse user lookup", () => {
         "Use `@neondatabase/serverless` or `@vercel/postgres`"
       );
     });
+
+    it("resolves the same name outside code while skipping it inside code", async () => {
+      const { adapter, state } = createAdapterWithState();
+
+      await state.appendToList("slack:user-by-name:vercel", "U_VER_123");
+
+      const result = await (
+        adapter as unknown as MentionAdapter
+      ).resolveOutgoingMentions(
+        "Ping @vercel, but don't link `@vercel/postgres`",
+        "slack:C123:1234567890.123456"
+      );
+
+      expect(result).toBe(
+        "Ping <@U_VER_123>, but don't link `@vercel/postgres`"
+      );
+    });
+
+    it("resolves a mention immediately following an inline code span", async () => {
+      const { adapter, state } = createAdapterWithState();
+
+      await state.appendToList("slack:user-by-name:dominik", "U_DOM_123");
+
+      const result = await (
+        adapter as unknown as MentionAdapter
+      ).resolveOutgoingMentions(
+        "Run `npm i` then ping @dominik",
+        "slack:C123:1234567890.123456"
+      );
+
+      expect(result).toBe("Run `npm i` then ping <@U_DOM_123>");
+    });
+
+    it("resolves a mention immediately preceding an inline code span", async () => {
+      const { adapter, state } = createAdapterWithState();
+
+      await state.appendToList("slack:user-by-name:dominik", "U_DOM_123");
+
+      const result = await (
+        adapter as unknown as MentionAdapter
+      ).resolveOutgoingMentions(
+        "@dominik try `npm i`",
+        "slack:C123:1234567890.123456"
+      );
+
+      expect(result).toBe("<@U_DOM_123> try `npm i`");
+    });
+
+    it("resolves mentions surrounding a multiline fenced code block", async () => {
+      const { adapter, state } = createAdapterWithState();
+
+      await state.appendToList("slack:user-by-name:dominik", "U_DOM_123");
+      await state.appendToList("slack:user-by-name:george", "U_GEO_123");
+      await state.appendToList("slack:user-by-name:vercel", "U_VER_123");
+
+      const result = await (
+        adapter as unknown as MentionAdapter
+      ).resolveOutgoingMentions(
+        "Hey @dominik:\n```bash\nnpm install @vercel/postgres\n```\ncc @george",
+        "slack:C123:1234567890.123456"
+      );
+
+      expect(result).toBe(
+        "Hey <@U_DOM_123>:\n```bash\nnpm install @vercel/postgres\n```\ncc <@U_GEO_123>"
+      );
+    });
+
+    it("does not skip a mention after an unbalanced single backtick", async () => {
+      const { adapter, state } = createAdapterWithState();
+
+      await state.appendToList("slack:user-by-name:dominik", "U_DOM_123");
+
+      const result = await (
+        adapter as unknown as MentionAdapter
+      ).resolveOutgoingMentions(
+        "Cost is `5 and @dominik should know",
+        "slack:C123:1234567890.123456"
+      );
+
+      expect(result).toBe("Cost is `5 and <@U_DOM_123> should know");
+    });
+
+    it("skips a mention inside inline code at the start of the text", async () => {
+      const { adapter, state } = createAdapterWithState();
+
+      await state.appendToList("slack:user-by-name:vercel", "U_VER_123");
+
+      const result = await (
+        adapter as unknown as MentionAdapter
+      ).resolveOutgoingMentions(
+        "`@vercel/postgres` is the package",
+        "slack:C123:1234567890.123456"
+      );
+
+      expect(result).toBe("`@vercel/postgres` is the package");
+    });
   });
 
   describe("resolveMessageMentions", () => {

--- a/packages/adapter-slack/src/index.ts
+++ b/packages/adapter-slack/src/index.ts
@@ -120,6 +120,38 @@ const TRAILING_SLASH_PATTERN = /\/$/;
 const UNFURL_WAIT_MS = 2000;
 const UNFURL_POLL_MS = 150;
 
+interface CodeRange {
+  end: number;
+  start: number;
+}
+
+function findCodeRanges(text: string): CodeRange[] {
+  const ranges: CodeRange[] = [];
+
+  // Match code blocks first (triple backticks), then inline code (single backticks)
+  // Code blocks: ```...``` (may span multiple lines)
+  // Inline code: `...` (single line, no nested backticks)
+  const codeBlockPattern = /```[\s\S]*?```/g;
+  const inlineCodePattern = /`[^`\n]+`/g;
+
+  for (const match of text.matchAll(codeBlockPattern)) {
+    ranges.push({ start: match.index, end: match.index + match[0].length });
+  }
+  for (const match of text.matchAll(inlineCodePattern)) {
+    const start = match.index;
+    const end = start + match[0].length;
+    // Skip if this inline code is inside a code block
+    if (!ranges.some((r) => start >= r.start && end <= r.end)) {
+      ranges.push({ start, end });
+    }
+  }
+  return ranges;
+}
+
+function isInsideCodeRange(index: number, ranges: CodeRange[]): boolean {
+  return ranges.some((r) => index >= r.start && index < r.end);
+}
+
 interface SlackUnfurl {
   description?: string;
   imageUrl?: string;
@@ -3009,6 +3041,9 @@ export class SlackAdapter implements Adapter<SlackThreadId, unknown> {
     }
     const state = this.chat.getState();
 
+    // Build ranges for code spans and code blocks to skip mentions inside them
+    const codeRanges = findCodeRanges(text);
+
     // Find all @word patterns that aren't already wrapped in <@...>
     const mentionPattern = /@(\w+)/g;
     const mentions = new Map<string, string[]>();
@@ -3022,6 +3057,10 @@ export class SlackAdapter implements Adapter<SlackThreadId, unknown> {
       // Check the character before @ to skip <@...> patterns
       const idx = match.index;
       if (idx > 0 && text[idx - 1] === "<") {
+        continue;
+      }
+      // Skip if inside a code span or code block
+      if (isInsideCodeRange(idx, codeRanges)) {
         continue;
       }
       if (!mentions.has(name.toLowerCase())) {
@@ -3061,6 +3100,10 @@ export class SlackAdapter implements Adapter<SlackThreadId, unknown> {
           return match;
         }
         if (SLACK_USER_ID_EXACT_PATTERN.test(name)) {
+          return match;
+        }
+        // Skip if inside a code span or code block
+        if (isInsideCodeRange(offset, codeRanges)) {
           return match;
         }
 


### PR DESCRIPTION
Mention resolution happening inside code blocks – results in agents attempting to write NPM package names printing a Slack Bot user ID instead. 

<img width="837" height="627" alt="image" src="https://github.com/user-attachments/assets/6690af58-61e6-469a-910d-f71c36bcdd61" />
