### PR TITLE
fix: let Plan tasks run in parallel without implicit auto-completion

### DIFF
--- a/.changeset/plan-add-task-auto-complete-previous.md
+++ b/.changeset/plan-add-task-auto-complete-previous.md
@@ -1,0 +1,5 @@
+---
+"chat": minor
+---
+
+Add `autoCompletePrevious` option to `Plan.addTask()`. Defaults to `true` so sequential workflows keep auto-completing existing in-progress tasks; pass `false` to keep multiple tasks in progress for parallel execution.

--- a/apps/docs/content/docs/streaming.mdx
+++ b/apps/docs/content/docs/streaming.mdx
@@ -217,11 +217,14 @@ await plan.addTask({ title: "Summarize findings" });
 await plan.complete({ completeMessage: "Done!" });
 ```
 
-By default `updateTask()` mutates the most recent `in_progress` task. Pass `{ id }` to target a specific task — useful when work runs in parallel or out of order:
+By default `updateTask()` mutates the most recent `in_progress` task. For parallel work, pass `autoCompletePrevious: false` to `addTask()` so earlier tasks stay in progress; then pass `{ id }` to `updateTask()` to target a specific task when updates run out of order:
 
 ```typescript
 const fetchTask = await plan.addTask({ title: "Fetch data" });
-const transformTask = await plan.addTask({ title: "Transform" });
+const transformTask = await plan.addTask({
+  title: "Transform",
+  autoCompletePrevious: false,
+});
 
 // Update a specific task by id, even if it isn't the most recent in_progress one.
 await plan.updateTask({ id: fetchTask.id, output: "Got 42 rows" });
@@ -232,7 +235,7 @@ Adapters that don't support PostableObject editing (e.g. WhatsApp) render the pl
 
 | Method | Description |
 |--------|-------------|
-| `addTask({ title, children? })` | Append a new task. The previous in-progress task is auto-completed |
+| `addTask({ title, children?, autoCompletePrevious? })` | Append a new task. When `autoCompletePrevious` is true (default), existing in-progress tasks are marked complete first; pass `false` for parallel workflows |
 | `updateTask(input)` | Mutate the current (or `{ id }`-targeted) task's `output`, `status`, or `title` |
 | `complete({ completeMessage })` | Mark all in-progress tasks complete and update the plan title |
 | `reset({ initialMessage })` | Discard all tasks and start fresh with a new initial message — useful when re-using a plan handle for a new run |

--- a/packages/chat/src/plan.ts
+++ b/packages/chat/src/plan.ts
@@ -45,6 +45,8 @@ export interface StartPlanOptions {
 }
 
 export interface AddTaskOptions {
+  /** When true (default), mark existing in_progress tasks complete before adding. */
+  autoCompletePrevious?: boolean;
   /** Task details/substeps. */
   children?: PlanContent;
   title: PlanContent;
@@ -106,6 +108,7 @@ interface BoundState {
  *
  * Create a plan with `new Plan({ initialMessage: "..." })` and post it with `thread.post(plan)`.
  * After posting, use methods like `addTask()`, `updateTask()`, and `complete()` to update it.
+ * For parallel steps, pass `autoCompletePrevious: false` to `addTask()` and use `updateTask({ id })` to update individual tasks.
  *
  * @example
  * ```typescript
@@ -203,9 +206,12 @@ export class Plan implements PostableObject<PlanModel> {
       return null;
     }
     const title = contentToPlainText(options.title) || "Task";
-    for (const task of this._model.tasks) {
-      if (task.status === "in_progress") {
-        task.status = "complete";
+    const autoCompletePrevious = options.autoCompletePrevious ?? true;
+    if (autoCompletePrevious) {
+      for (const task of this._model.tasks) {
+        if (task.status === "in_progress") {
+          task.status = "complete";
+        }
       }
     }
     const nextTask: PlanModelTask = {

--- a/packages/chat/src/thread.test.ts
+++ b/packages/chat/src/thread.test.ts
@@ -1752,8 +1752,15 @@ describe("ThreadImpl", () => {
 
       const plan = new Plan({ initialMessage: "Start" });
       await thread.post(plan);
+      const initialTask = plan.currentTask;
       const task1 = await plan.addTask({ title: "Step 1" });
+      expect(plan.tasks.find((t) => t.id === initialTask?.id)?.status).toBe(
+        "complete"
+      );
       const task2 = await plan.addTask({ title: "Step 2" });
+      expect(plan.tasks.find((t) => t.id === task1?.id)?.status).toBe(
+        "complete"
+      );
 
       const updated = await plan.updateTask({
         id: task1?.id,
@@ -1767,6 +1774,113 @@ describe("ThreadImpl", () => {
 
       const step2 = plan.tasks.find((t) => t.id === task2?.id);
       expect(step2?.status).toBe("in_progress");
+    });
+
+    it("should not auto-complete in_progress tasks when autoCompletePrevious is false", async () => {
+      const mockPostObject = vi.fn().mockResolvedValue({
+        id: "plan-msg-1",
+        threadId: "slack:C123:1234.5678",
+      });
+      const mockEditObject = vi.fn().mockResolvedValue(undefined);
+      mockAdapter.postObject = mockPostObject;
+      mockAdapter.editObject = mockEditObject;
+
+      const plan = new Plan({ initialMessage: "Step 1" });
+      await thread.post(plan);
+
+      const step1 = plan.currentTask;
+      const step2 = await plan.addTask({
+        title: "Step 2",
+        autoCompletePrevious: false,
+      });
+      const step3 = await plan.addTask({
+        title: "Step 3",
+        autoCompletePrevious: false,
+      });
+
+      expect(plan.tasks.find((t) => t.id === step1?.id)?.status).toBe(
+        "in_progress"
+      );
+      expect(plan.tasks.find((t) => t.id === step2?.id)?.status).toBe(
+        "in_progress"
+      );
+      expect(plan.tasks.find((t) => t.id === step3?.id)?.status).toBe(
+        "in_progress"
+      );
+    });
+
+    it("should auto-complete all in_progress tasks when switching back to default addTask", async () => {
+      const mockPostObject = vi.fn().mockResolvedValue({
+        id: "plan-msg-1",
+        threadId: "slack:C123:1234.5678",
+      });
+      const mockEditObject = vi.fn().mockResolvedValue(undefined);
+      mockAdapter.postObject = mockPostObject;
+      mockAdapter.editObject = mockEditObject;
+
+      const plan = new Plan({ initialMessage: "Step 1" });
+      await thread.post(plan);
+
+      const step1 = plan.currentTask;
+      const step2 = await plan.addTask({
+        title: "Step 2",
+        autoCompletePrevious: false,
+      });
+      const step3 = await plan.addTask({
+        title: "Step 3",
+        autoCompletePrevious: false,
+      });
+
+      const sequentialTask = await plan.addTask({ title: "Sequential step" });
+
+      expect(plan.tasks.find((t) => t.id === step1?.id)?.status).toBe(
+        "complete"
+      );
+      expect(plan.tasks.find((t) => t.id === step2?.id)?.status).toBe(
+        "complete"
+      );
+      expect(plan.tasks.find((t) => t.id === step3?.id)?.status).toBe(
+        "complete"
+      );
+      expect(sequentialTask?.status).toBe("in_progress");
+      expect(plan.currentTask?.id).toBe(sequentialTask?.id);
+      expect(plan.tasks).toHaveLength(4);
+    });
+
+    it("should target the most recent in_progress task when updating without id", async () => {
+      const mockPostObject = vi.fn().mockResolvedValue({
+        id: "plan-msg-1",
+        threadId: "slack:C123:1234.5678",
+      });
+      const mockEditObject = vi.fn().mockResolvedValue(undefined);
+      mockAdapter.postObject = mockPostObject;
+      mockAdapter.editObject = mockEditObject;
+
+      const plan = new Plan({ initialMessage: "Start" });
+      await thread.post(plan);
+
+      const fetchTask = await plan.addTask({ title: "Fetch data" });
+      const transformTask = await plan.addTask({
+        title: "Transform",
+        autoCompletePrevious: false,
+      });
+
+      expect(plan.currentTask?.id).toBe(transformTask?.id);
+      expect(plan.tasks.find((t) => t.id === fetchTask?.id)?.status).toBe(
+        "in_progress"
+      );
+
+      const updated = await plan.updateTask("parallel output");
+      expect(updated?.id).toBe(transformTask?.id);
+
+      const fetchUpdated = await plan.updateTask({
+        id: fetchTask?.id,
+        output: "fetch output",
+      });
+      expect(fetchUpdated?.id).toBe(fetchTask?.id);
+      expect(plan.tasks.find((t) => t.id === transformTask?.id)?.status).toBe(
+        "in_progress"
+      );
     });
 
     it("should return null when updating by non-existent ID", async () => {


### PR DESCRIPTION
## Summary

Plan’s task list API always marked existing in-progress steps as complete whenever a new step was added. That made sense for simple sequential bots, but it blocked parallel work — even though the docs already showed a parallel pattern and per-task updates by ID were added earlier.

This PR adds an optional flag on task creation so callers can keep multiple steps in progress at once, while leaving the old sequential behavior as the default.


**Opt-out flag, default on**. We considered removing auto-completion entirely. That would’ve been cleaner for parallel use but would’ve broken existing sequential bots that rely on implicit “move to next step” behavior. Defaulting to the current behavior keeps upgrades safe; parallel callers pass the flag off.

**No broader API redesign**. Task completion stays explicit via status updates and the existing “complete plan” flow. The change is scoped to when a new task is appended.

## Test plan

Unit tests

## Checklist

- [x] All commits are signed and verified
- [x] `pnpm validate` passes
- [x] Changeset added (or N/A — see [CONTRIBUTING.md](./CONTRIBUTING.md))
- [x] Documentation updated (or N/A)


closes #630 
