### PR TITLE
fix: avoid dummy message context for lightweight threads

### DIFF
--- a/.changeset/lightweight-thread-streaming.md
+++ b/.changeset/lightweight-thread-streaming.md
@@ -1,0 +1,5 @@
+---
+"chat": patch
+---
+
+Fix lightweight thread handles so streaming posts without an incoming message context no longer crash.

--- a/packages/adapter-slack/src/index.test.ts
+++ b/packages/adapter-slack/src/index.test.ts
@@ -7890,23 +7890,68 @@ describe("routeSocketEvent with options", () => {
 // ============================================================================
 
 describe("stream with empty threadTs", () => {
-  it("throws ValidationError when threadTs is empty", async () => {
+  it("delegates to fallback before consuming the stream", async () => {
     const adapter = createSlackAdapter({
       botToken: "xoxb-test-token",
       signingSecret: "test-signing-secret",
       logger: mockLogger,
     });
 
-    async function* emptyStream() {
-      yield "hello";
-    }
+    const next = vi.fn();
+    const stream = {
+      [Symbol.asyncIterator]: () => ({ next }),
+    };
 
     await expect(
-      adapter.stream("slack:C123:", emptyStream(), {
+      adapter.stream("slack:C123:", stream, {
         recipientUserId: "U123",
         recipientTeamId: "T123",
       })
-    ).rejects.toThrow(ValidationError);
+    ).resolves.toBeNull();
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it("delegates channel streams without recipient context to fallback", async () => {
+    const adapter = createSlackAdapter({
+      botToken: "xoxb-test-token",
+      signingSecret: "test-signing-secret",
+      logger: mockLogger,
+    });
+    const next = vi.fn();
+    const stream = {
+      [Symbol.asyncIterator]: () => ({ next }),
+    };
+
+    await expect(
+      adapter.stream("slack:C123:1234567890.000000", stream)
+    ).resolves.toBeNull();
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it("allows DM streams without recipient context", async () => {
+    const adapter = createSlackAdapter({
+      botToken: "xoxb-test-token",
+      signingSecret: "test-signing-secret",
+      logger: mockLogger,
+    });
+    const append = vi.fn().mockResolvedValue(null);
+    const stop = vi.fn().mockResolvedValue({
+      ok: true,
+      ts: "1234567890.111111",
+    });
+    const chatStream = vi.fn().mockReturnValue({ append, stop });
+    mockClientMethod(adapter, "chatStream", chatStream);
+
+    async function* stream() {
+      yield "hello";
+    }
+
+    await adapter.stream("slack:D123:1234567890.000000", stream());
+
+    expect(chatStream).toHaveBeenCalledWith({
+      channel: "D123",
+      thread_ts: "1234567890.000000",
+    });
   });
 
   it("passes token on stream stop", async () => {

--- a/packages/adapter-slack/src/index.ts
+++ b/packages/adapter-slack/src/index.ts
@@ -4008,28 +4008,27 @@ export class SlackAdapter implements Adapter<SlackThreadId, unknown> {
    * streaming API as chunk payloads, enabling native task progress cards
    * and plan displays in the Slack AI Assistant UI.
    *
-   * Requires `recipientUserId` and `recipientTeamId` in options.
+   * Falls back to post-and-edit when the thread lacks native stream context.
    */
   async stream(
     threadId: string,
     textStream: AsyncIterable<string | StreamChunk>,
     options?: StreamOptions
-  ): Promise<RawMessage<unknown>> {
-    if (!(options?.recipientUserId && options?.recipientTeamId)) {
-      throw new ValidationError(
-        "slack",
-        "Slack streaming requires recipientUserId and recipientTeamId in options"
-      );
-    }
+  ): Promise<RawMessage<unknown> | null> {
     const { channel, threadTs: rawThreadTs } = this.decodeThreadId(threadId);
-    // Normalize empty threadTs to undefined to avoid Slack API "invalid_thread_ts" errors
     const threadTs = rawThreadTs || undefined;
     if (!threadTs) {
-      this.logger.debug("Slack: stream skipped - no thread context");
-      throw new ValidationError(
-        "slack",
-        "Slack streaming requires a valid thread context (non-empty threadTs)"
-      );
+      this.logger.debug("Slack: using fallback stream - no thread context");
+      return null;
+    }
+    if (
+      !(
+        channel.startsWith("D") ||
+        (options?.recipientUserId && options?.recipientTeamId)
+      )
+    ) {
+      this.logger.debug("Slack: using fallback stream - no recipient context");
+      return null;
     }
     this.logger.debug("Slack: starting stream", { channel, threadTs });
 
@@ -4037,9 +4036,13 @@ export class SlackAdapter implements Adapter<SlackThreadId, unknown> {
     const streamer = this._client.chatStream({
       channel,
       thread_ts: threadTs,
-      recipient_user_id: options.recipientUserId,
-      recipient_team_id: options.recipientTeamId,
-      ...(options.taskDisplayMode && {
+      ...(options?.recipientUserId && {
+        recipient_user_id: options.recipientUserId,
+      }),
+      ...(options?.recipientTeamId && {
+        recipient_team_id: options.recipientTeamId,
+      }),
+      ...(options?.taskDisplayMode && {
         task_display_mode: options.taskDisplayMode,
       }),
     });

--- a/packages/chat/src/chat.test.ts
+++ b/packages/chat/src/chat.test.ts
@@ -3,6 +3,10 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 const HELP_REGEX = /help/i;
 const HELLO_REGEX = /hello/i;
 
+async function* chunks(): AsyncGenerator<string> {
+  yield "Hello";
+}
+
 import { Chat } from "./chat";
 import { getEmoji } from "./emoji";
 import { LockError } from "./errors";
@@ -997,6 +1001,34 @@ describe("Chat", () => {
         "Thanks for the reaction!"
       );
     });
+
+    it("should allow streaming from a reaction without message context", async () => {
+      chat.onReaction(async (event) => {
+        await event.thread.post(chunks());
+      });
+
+      const event: Omit<ReactionEvent, "thread"> = {
+        emoji: getEmoji("thumbs_up"),
+        rawEmoji: "+1",
+        added: true,
+        user: {
+          userId: "U123",
+          userName: "user",
+          fullName: "Test User",
+          isBot: false,
+          isMe: false,
+        },
+        messageId: "msg-1",
+        threadId: "slack:C123:1234.5678",
+        adapter: mockAdapter,
+        raw: {},
+      };
+
+      chat.processReaction(event);
+      await new Promise((resolve) => setTimeout(resolve, 20));
+
+      expect(mockAdapter.editMessage).toHaveBeenCalled();
+    });
   });
 
   describe("Actions", () => {
@@ -1028,6 +1060,32 @@ describe("Chat", () => {
       expect(receivedEvent.actionId).toBe("approve");
       expect(receivedEvent.value).toBe("order-123");
       expect(receivedEvent.thread).toBeDefined();
+    });
+
+    it("should allow streaming from an action without message context", async () => {
+      chat.onAction(async (event) => {
+        await event.thread?.post(chunks());
+      });
+
+      const event: Omit<ActionEvent, "thread" | "openModal"> = {
+        actionId: "approve",
+        value: "order-123",
+        user: {
+          userId: "U123",
+          userName: "user",
+          fullName: "Test User",
+          isBot: false,
+          isMe: false,
+        },
+        messageId: "",
+        threadId: "slack:C123:1234.5678",
+        adapter: mockAdapter,
+        raw: {},
+      };
+
+      await chat.processAction(event, undefined);
+
+      expect(mockAdapter.editMessage).toHaveBeenCalled();
     });
 
     it("should call onAction handler for specific action IDs", async () => {
@@ -1652,6 +1710,14 @@ describe("Chat", () => {
         "Hello via DM!"
       );
     });
+
+    it("should allow streaming to a DM thread", async () => {
+      const thread = await chat.openDM("U123456");
+
+      await thread.post(chunks());
+
+      expect(mockAdapter.editMessage).toHaveBeenCalled();
+    });
   });
 
   describe("Options Load", () => {
@@ -1817,6 +1883,14 @@ describe("Chat", () => {
         "slack:C123:1234.5678",
         "Hello from outside a webhook!"
       );
+    });
+
+    it("should allow streaming to a thread handle", async () => {
+      const thread = chat.thread("slack:C123:1234.5678");
+
+      await thread.post(chunks());
+
+      expect(mockAdapter.editMessage).toHaveBeenCalled();
     });
 
     it("should throw for an invalid thread ID", () => {

--- a/packages/chat/src/chat.ts
+++ b/packages/chat/src/chat.ts
@@ -1485,7 +1485,7 @@ export class Chat<
           metadata: { dateSent: new Date(), edited: false },
           attachments: [],
         })
-      : ({} as Message);
+      : undefined;
 
     // Create thread for the action event (skip for view-based actions with no threadId)
     const thread = event.threadId
@@ -1638,7 +1638,7 @@ export class Chat<
     const thread = await this.createThread(
       event.adapter,
       event.threadId,
-      event.message ?? ({} as Message),
+      event.message,
       isSubscribed
     );
 
@@ -1747,7 +1747,7 @@ export class Chat<
     }
 
     const threadId = await adapter.openDM(userId);
-    return this.createThread(adapter, threadId, {} as Message, false);
+    return this.createThread(adapter, threadId, undefined, false);
   }
 
   /**
@@ -1860,7 +1860,7 @@ export class Chat<
       );
     }
 
-    return this.createThread(adapter, threadId, {} as Message, false);
+    return this.createThread(adapter, threadId, undefined, false);
   }
 
   /**
@@ -2547,7 +2547,7 @@ export class Chat<
   private createThread(
     adapter: Adapter,
     threadId: string,
-    initialMessage: Message,
+    initialMessage: Message | undefined,
     isSubscribedContext = false
   ): Thread<TState> {
     // Parse thread ID to get channel ID with adapter


### PR DESCRIPTION
## summary

fixes #631

removes dummy `Message` casts from lightweight thread, action, and reaction paths when no incoming message context exists

this keeps the existing `currentMessage` guard meaningful and prevents streaming through `chat.thread(threadId)`, `chat.openDM(...)`, action threads, and reaction threads from reading fields from an empty object

when Slack lacks the thread or recipient context required by `chat.startStream`, the adapter now returns `null` before consuming the stream so Chat SDK can transparently use its post-and-edit fallback

native Slack streaming remains available for webhook-created threads and DM threads with valid native stream context

## test plan

- built `chat` and `@chat-adapter/slack`
- ran the `chat` and `@chat-adapter/slack` test suites
- ran focused formatting and lint checks on the changed files
- verified `chat.thread(threadId).post(asyncIterable)` against a real Slack Socket Mode bot

## checklist

- [x] all commits are signed and verified
- [x] targeted builds and tests pass
- [x] changeset added or not applicable
- [x] documentation updated or not applicable