### PR TITLE
fix(chat): stop crashing thread().post(asyncIterable) on lightweight handles

### DIFF
--- a/.changeset/lightweight-thread-stream-crash.md
+++ b/.changeset/lightweight-thread-stream-crash.md
@@ -1,0 +1,5 @@
+---
+"chat": patch
+---
+
+Fix `TypeError: Cannot read properties of undefined (reading 'userId')` when calling `chat.thread(threadId).post(asyncIterable)` or posting a stream to a thread returned by `chat.openDM(user)`. Both lightweight-handle paths previously threaded `{} as Message` into the `ThreadImpl` constructor; the truthy empty object satisfied the `if (this._currentMessage)` branch in the streaming code path and crashed when it tried to read `this._currentMessage.author.userId`. Pass `undefined` instead so the no-current-message branch is taken — non-streaming `thread.post(stringOrPostable)` and webhook-driven paths are unaffected.

--- a/packages/chat/src/chat.test.ts
+++ b/packages/chat/src/chat.test.ts
@@ -1828,6 +1828,23 @@ describe("Chat", () => {
         'Adapter "unknown" not found'
       );
     });
+
+    // Regression for #631: a lightweight thread handle has no current
+    // message context, so streaming via `thread.post(asyncIterable)` used to
+    // crash on `this._currentMessage.author.userId` after the constructor
+    // cast `{} as Message` and the truthy empty object satisfied the
+    // `if (this._currentMessage)` branch in `handleStream`. Passing
+    // `undefined` instead of the cast keeps that branch unentered.
+    it("should not crash on stream() from a lightweight thread handle", async () => {
+      const thread = chat.thread("slack:C123:1234.5678");
+      await expect(
+        thread.post({
+          async *[Symbol.asyncIterator]() {
+            yield "Hi";
+          },
+        })
+      ).resolves.not.toThrow();
+    });
   });
 
   describe("getUser", () => {

--- a/packages/chat/src/chat.test.ts
+++ b/packages/chat/src/chat.test.ts
@@ -1652,6 +1652,17 @@ describe("Chat", () => {
         "Hello via DM!"
       );
     });
+
+    it("should not crash on stream() from a lightweight DM thread handle", async () => {
+      const thread = await chat.openDM("U123456");
+      await expect(
+        thread.post({
+          async *[Symbol.asyncIterator]() {
+            yield "Hi";
+          },
+        })
+      ).resolves.not.toThrow();
+    });
   });
 
   describe("Options Load", () => {

--- a/packages/chat/src/chat.ts
+++ b/packages/chat/src/chat.ts
@@ -1747,7 +1747,7 @@ export class Chat<
     }
 
     const threadId = await adapter.openDM(userId);
-    return this.createThread(adapter, threadId, {} as Message, false);
+    return this.createThread(adapter, threadId, undefined, false);
   }
 
   /**
@@ -1860,7 +1860,7 @@ export class Chat<
       );
     }
 
-    return this.createThread(adapter, threadId, {} as Message, false);
+    return this.createThread(adapter, threadId, undefined, false);
   }
 
   /**
@@ -2547,7 +2547,7 @@ export class Chat<
   private createThread(
     adapter: Adapter,
     threadId: string,
-    initialMessage: Message,
+    initialMessage: Message | undefined,
     isSubscribedContext = false
   ): Thread<TState> {
     // Parse thread ID to get channel ID with adapter


### PR DESCRIPTION
Closes #631.

`Chat#thread(threadId)` and `Chat#openDM(user)` returned a lightweight `Thread` handle by threading `{} as Message` into `ThreadImpl` as the `currentMessage`. The empty object is truthy, so the `if (this._currentMessage)` branch inside `handleStream` ran on every streaming `thread.post(asyncIterable)` and immediately dereferenced `this._currentMessage.author.userId`, throwing:

```
TypeError: Cannot read properties of undefined (reading 'userId')
```

`ThreadImpl`'s `currentMessage` field is already typed `Message | undefined` and `handleStream` already handles the absent case correctly — the constructor just lied about the type. Widen `createThread`'s `initialMessage` parameter to `Message | undefined` and pass `undefined` at the two lightweight-handle call sites (`Chat#openDM` line 1750, `Chat#thread` line 1863). Non-streaming `thread.post(stringOrPostable)` and webhook-driven paths used a real `Message` already and stay unchanged.

A regression test in `packages/chat/src/chat.test.ts` asserts `thread.post(asyncIterable)` no longer throws on a handle returned by `chat.thread(...)` — `await expect(...).resolves.not.toThrow()`.

### Validation

- `pnpm --filter chat test`: 1025 passed (24 files), including the new regression case.
- `pnpm --filter chat typecheck`: clean.
- `pnpm check` (ultracite / biome across the repo): 607 files, no diff.
- A changeset (`chat: patch`) is included.

### Signing note

The commit is signed with an SSH key I haven't yet registered as a signing key on github.com, so the "Verified" badge will be missing. Happy to register the key (or rotate to one that's already on file) once I have the `admin:ssh_signing_key` scope on this token — let me know if there's a preferred workflow.