### PR TITLE
docs: sync KB resources and harden sync-resources script

### DIFF
--- a/.changeset/sync-kb-resources.md
+++ b/.changeset/sync-kb-resources.md
@@ -1,0 +1,5 @@
+---
+"chat": patch
+---
+
+Sync bundled KB resources from Edge Config: add four new guides (Vercel Connect, the Slack Vercel Connect bot, AI Gateway + AI SDK, and the daily digest bot), refresh existing guide bodies, and regenerate `resources/templates.json`. The `sync-resources` script now fetches and validates all guides before writing (so a failed fetch leaves the tree untouched), validates the source config shape, rejects duplicate slugs, retries transient fetches, and mirrors `SKILL.md` to all four committed copies.

--- a/apps/docs/public/.well-known/agent-skills/chat-sdk/SKILL.md
+++ b/apps/docs/public/.well-known/agent-skills/chat-sdk/SKILL.md
@@ -101,6 +101,10 @@ Use it for:
 - `node_modules/chat/resources/guides/how-to-build-a-slack-bot-with-next-js-and-redis.md` — This guide walks through building a Slack bot with Next.js, covering project setup, Slack app configuration, event handling, interactive features, and deployment.
 - `node_modules/chat/resources/guides/create-a-discord-support-bot-with-nuxt-and-redis.md` — This guide walks through building a Discord support bot with Nuxt, covering project setup, Discord app configuration, Gateway forwarding, AI-powered responses, and deployment.
 - `node_modules/chat/resources/guides/ship-a-github-code-review-bot-with-hono-and-redis.md` — This guide walks through building a GitHub bot that reviews pull requests on demand. When a user @mentions the bot on a PR, Chat SDK picks up the mention, spins up a Vercel Sandbox with the repo cloned, and uses AI SDK to analyze the diff.
+- `node_modules/chat/resources/guides/build-a-slack-bot-with-vercel-connect.md` — Learn how to build your very own Slackbot with Chat SDK and AI SDK. Vercel Connect supplies runtime Slack tokens and forwards triggers, so you never store a long-lived bot token.
+- `node_modules/chat/resources/guides/vercel-connect.md` — Use Vercel Connect to call provider APIs like Slack, GitHub, and Snowflake from your agents and services with short-lived, user-authorized tokens instead of long-lived secrets.
+- `node_modules/chat/resources/guides/ai-gateway-and-ai-sdk.md` — Build AI agents on Vercel with AI Gateway and AI SDK, then make them reliable, capable, and durable with Sandbox, Chat SDK, Vercel Connect, and Workflow.
+- `node_modules/chat/resources/guides/daily-digest-bot-with-chat-sdk-and-workflow-sdk.md` — Create your own daily digest bot that posts a daily digest of GitHub stats to Slack. Learn how to use Vercel Connect to set up Slack and GitHub app securely in your project.
 
 ### Templates
 
@@ -110,6 +114,7 @@ Listed in `node_modules/chat/resources/templates.json`:
 - **Durable iMessage Agent** — Durable iMessage agent powered by the Sendblue adapter. (https://vercel.com/templates/nitro/durable-imessage-ai-agent)
 - **Knowledge Agent** — Open source file-system and knowledge based agent template. Build AI agents that stay up to date with your knowledge base. (https://vercel.com/templates/nuxt/chat-sdk-knowledge-agent)
 - **Community Agent** — Open source AI-powered Slack community management bot with a built-in Next.js admin panel. Uses Chat SDK, AI SDK, and Vercel Workflow. (https://vercel.com/templates/next.js/chat-sdk-community-agent)
+- **Caltext** — iMessage calorie tracking assistant powered by AI. (https://vercel.com/templates/hono/caltext)
 
 <!-- RESOURCES:END -->
 

--- a/apps/docs/public/AGENTS.md
+++ b/apps/docs/public/AGENTS.md
@@ -101,6 +101,10 @@ Use it for:
 - `node_modules/chat/resources/guides/how-to-build-a-slack-bot-with-next-js-and-redis.md` — This guide walks through building a Slack bot with Next.js, covering project setup, Slack app configuration, event handling, interactive features, and deployment.
 - `node_modules/chat/resources/guides/create-a-discord-support-bot-with-nuxt-and-redis.md` — This guide walks through building a Discord support bot with Nuxt, covering project setup, Discord app configuration, Gateway forwarding, AI-powered responses, and deployment.
 - `node_modules/chat/resources/guides/ship-a-github-code-review-bot-with-hono-and-redis.md` — This guide walks through building a GitHub bot that reviews pull requests on demand. When a user @mentions the bot on a PR, Chat SDK picks up the mention, spins up a Vercel Sandbox with the repo cloned, and uses AI SDK to analyze the diff.
+- `node_modules/chat/resources/guides/build-a-slack-bot-with-vercel-connect.md` — Learn how to build your very own Slackbot with Chat SDK and AI SDK. Vercel Connect supplies runtime Slack tokens and forwards triggers, so you never store a long-lived bot token.
+- `node_modules/chat/resources/guides/vercel-connect.md` — Use Vercel Connect to call provider APIs like Slack, GitHub, and Snowflake from your agents and services with short-lived, user-authorized tokens instead of long-lived secrets.
+- `node_modules/chat/resources/guides/ai-gateway-and-ai-sdk.md` — Build AI agents on Vercel with AI Gateway and AI SDK, then make them reliable, capable, and durable with Sandbox, Chat SDK, Vercel Connect, and Workflow.
+- `node_modules/chat/resources/guides/daily-digest-bot-with-chat-sdk-and-workflow-sdk.md` — Create your own daily digest bot that posts a daily digest of GitHub stats to Slack. Learn how to use Vercel Connect to set up Slack and GitHub app securely in your project.
 
 ### Templates
 
@@ -110,6 +114,7 @@ Listed in `node_modules/chat/resources/templates.json`:
 - **Durable iMessage Agent** — Durable iMessage agent powered by the Sendblue adapter. (https://vercel.com/templates/nitro/durable-imessage-ai-agent)
 - **Knowledge Agent** — Open source file-system and knowledge based agent template. Build AI agents that stay up to date with your knowledge base. (https://vercel.com/templates/nuxt/chat-sdk-knowledge-agent)
 - **Community Agent** — Open source AI-powered Slack community management bot with a built-in Next.js admin panel. Uses Chat SDK, AI SDK, and Vercel Workflow. (https://vercel.com/templates/next.js/chat-sdk-community-agent)
+- **Caltext** — iMessage calorie tracking assistant powered by AI. (https://vercel.com/templates/hono/caltext)
 
 <!-- RESOURCES:END -->
 

--- a/apps/docs/resources-edge-config.json
+++ b/apps/docs/resources-edge-config.json
@@ -55,6 +55,30 @@
       "type": "guide"
     },
     {
+      "title": "Build your own Slackbot with Vercel Connect",
+      "description": "Learn how to build your very own Slackbot with Chat SDK and AI SDK. Vercel Connect supplies runtime Slack tokens and forwards triggers, so you never store a long-lived bot token.",
+      "href": "https://vercel.com/kb/guide/build-a-slack-bot-with-vercel-connect",
+      "type": "guide"
+    },
+    {
+      "title": "Give your agents secure access to third-party APIs",
+      "description": "Use Vercel Connect to call provider APIs like Slack, GitHub, and Snowflake from your agents and services with short-lived, user-authorized tokens instead of long-lived secrets.",
+      "href": "https://vercel.com/kb/guide/vercel-connect",
+      "type": "guide"
+    },
+    {
+      "title": "Build AI agents with AI Gateway and AI SDK",
+      "description": "Build AI agents on Vercel with AI Gateway and AI SDK, then make them reliable, capable, and durable with Sandbox, Chat SDK, Vercel Connect, and Workflow.",
+      "href": "https://vercel.com/kb/guide/ai-gateway-and-ai-sdk",
+      "type": "guide"
+    },
+    {
+      "title": "Build a daily digest bot with Chat SDK and Workflow SDK",
+      "description": "Create your own daily digest bot that posts a daily digest of GitHub stats to Slack. Learn how to use Vercel Connect to set up Slack and GitHub app securely in your project.",
+      "href": "https://vercel.com/kb/guide/daily-digest-bot-with-chat-sdk-and-workflow-sdk",
+      "type": "guide"
+    },
+    {
       "title": "Chat SDK Liveblocks Bot",
       "description": "Build a bot that you can engage with inside Liveblocks.",
       "href": "https://vercel.com/templates/next.js/chat-sdk-liveblocks-bot",
@@ -76,6 +100,12 @@
       "title": "Community Agent",
       "description": "Open source AI-powered Slack community management bot with a built-in Next.js admin panel. Uses Chat SDK, AI SDK, and Vercel Workflow.",
       "href": "https://vercel.com/templates/next.js/chat-sdk-community-agent",
+      "type": "template"
+    },
+    {
+      "title": "Caltext",
+      "description": "iMessage calorie tracking assistant powered by AI.",
+      "href": "https://vercel.com/templates/hono/caltext",
       "type": "template"
     }
   ]

--- a/packages/chat/resources/guides/ai-gateway-and-ai-sdk.md
+++ b/packages/chat/resources/guides/ai-gateway-and-ai-sdk.md
@@ -1,0 +1,224 @@
+# Build AI agents with AI Gateway and AI SDK
+
+**Author:** Ben Sabic
+
+---
+
+An AI agent is a model that runs in a loop, using tools to gather information or take action until it completes a task. The AI SDK gives you the TypeScript primitives to build that loop, and AI Gateway gives it one endpoint and one set of credentials for hundreds of models, so you can switch providers by changing a single string instead of managing separate accounts, keys, and rate limits.
+
+This guide takes you from your first model request to a working agent, then makes that agent reliable with model fallbacks, reachable in chat platforms with Chat SDK, and durable with the Workflow SDK.
+
+## Overview
+
+In this guide, you'll learn how to:
+
+*   Set up a [Next.js](https://nextjs.org/) project and authenticate to AI Gateway with OIDC tokens
+    
+*   Generate text, stream responses, and produce structured outputs
+    
+*   Give your agent tools so they can act, not just respond
+    
+*   Keep your agent available with model fallbacks
+    
+*   Run AI-generated code safely in isolated [Vercel Sandbox](https://vercel.com/sandbox) microVMs
+    
+*   Bring your agent to Slack, Teams, and other chat platforms with [Chat SDK](https://chat-sdk.dev/)
+    
+*   Give your agent secure, short-lived access to third-party APIs with [Vercel Connect](https://vercel.com/connect)
+    
+*   Make your agent durable and resumable with the [Workflow SDK](https://workflow-sdk.dev)
+    
+
+## Prerequisites
+
+Before you begin, make sure you have:
+
+*   A [Vercel account](https://vercel.com/signup)
+    
+*   Node.js 20 or later
+    
+*   [Vercel CLI](https://vercel.com/docs/cli) installed (`npm i -g vercel`)
+    
+
+## How it works
+
+AI Gateway is a single endpoint that sits in front of every supported provider. You send it a model string in the form `creator/model-name`, and the Gateway resolves the provider, authenticates, routes the request, and tracks usage. Because the AI SDK communicates with this endpoint natively, your application code remains the same whether you call Claude Opus 4.8, GPT-5.5, or Gemini 3.1 Pro. Tokens cost the same as they would from the provider directly, with no markup.
+
+The AI SDK provides the function-level API you'll build the agent from (`generateText`, `streamText`, `generateObject`, and the tool loop), and AI Gateway provides the infrastructure underneath: authentication, usage tracking, failover, and billing. The two are built with high cohesion but loose coupling, so you can adopt the SDK on its own and add Gateway features via provider options when needed.
+
+## Steps
+
+### 1\. Create a Next.js app
+
+Use `create-next-app` to bootstrap a new project:
+
+`pnpm create next-app@latest ai-gateway-demo --yes cd ai-gateway-demo`
+
+The `--yes` flag uses the recommended defaults: TypeScript, Tailwind CSS, ESLint, App Router, and Turbopack, with the `@/*` import alias. Omit the flag if you want to customize these options interactively.
+
+### 2\. Install the AI SDK
+
+Add the `ai` package to your project:
+
+`pnpm add ai`
+
+AI Gateway works with both AI SDK v5 and v6. Check your installed version with `pnpm list ai`.
+
+### 3\. Authenticate with OIDC
+
+AI Gateway authenticates requests using [Vercel OIDC tokens](https://vercel.com/docs/oidc), which Vercel generates and links to your project automatically. You don't need to create or store an API key.
+
+First, link your local project to a Vercel project:
+
+`vercel link`
+
+Then pull the environment variables, which include the OIDC token:
+
+`vercel env pull`
+
+This writes the token to your local environment file. OIDC tokens are valid for 12 hours, so during local development, you'll need to run `vercel env pull` again to refresh the token when it expires.
+
+When you deploy to Vercel, OIDC tokens are provisioned automatically, so no further setup is required in production.
+
+### 4\. Generate text
+
+Start with the simplest request: generate a single block of text. Create an API route at `app/api/chat/route.ts`. Pass a plain string model ID to `generateText` and the AI Gateway resolves the provider and routes the request. With OIDC authentication, you don't reference a key anywhere in your code:
+
+`import { generateText } from 'ai'; export async function GET() { const { text } = await generateText({ model: 'anthropic/claude-opus-4.8', prompt: 'Explain quantum computing in one paragraph.', }); return Response.json({ text }); }`
+
+Start the dev server and visit the route to see the response:
+
+`pnpm dev`
+
+### 5\. Stream responses
+
+For real-time output, use `streamText` and return a streamed response. This is the pattern you'll use for chat interfaces and any response long enough that waiting for the full result would hurt the experience:
+
+`import { streamText } from 'ai'; export async function POST(request: Request) { const { prompt } = await request.json(); const result = streamText({ model: 'openai/gpt-5.5', prompt, }); return result.toUIMessageStreamResponse(); }`
+
+To switch models, change the model string. No other code changes are required.
+
+### 6\. Generate structured outputs
+
+Use `generateObject` with a [Zod](https://zod.dev/) schema to get type-safe structured data instead of free text:
+
+`import { generateObject } from 'ai'; import { z } from 'zod'; export async function GET() { const { object } = await generateObject({ model: 'anthropic/claude-opus-4.8', schema: z.object({ name: z.string(), age: z.number(), city: z.string(), }), prompt: 'Extract: John is 30 years old and lives in NYC.', }); return Response.json(object); // { name: 'John', age: 30, city: 'NYC' } }`
+
+### 7\. Give your agent tools
+
+So far, the model has produced text and data, but it hasn't done anything. Tools change that: you define functions the model can invoke to fetch data, call an API, or act on the outside world, and the AI SDK runs the model in a loop, calling tools and feeding results back until the task is done. A model plus tools in a loop is an agent, and the AI SDK handles that loop for you.
+
+Define a tool with a description, an input schema, and an `execute` function:
+
+`import { generateText, tool } from 'ai'; import { z } from 'zod'; export async function GET() { const { text } = await generateText({ model: 'anthropic/claude-opus-4.8', tools: { getWeather: tool({ description: 'Get the current weather for a location', parameters: z.object({ location: z.string().describe('City name, e.g. San Francisco'), }), execute: async ({ location }) => ({ location, temperature: 72, condition: 'sunny', }), }), }, prompt: "What's the weather in Tokyo?", }); return Response.json({ text }); }`
+
+You now have a working agent. Everything that follows makes it more capable and more reliable: fallbacks keep it available, Sandbox lets it run code safely, Chat SDK puts it in front of users, and the Workflow SDK makes it durable.
+
+### 8\. Keep your agent available with fallbacks
+
+An agent makes many model calls over the course of a task, so it has many chances to hit a provider outage or error. That makes failover matter more for agents, not less. Pass a `models` array in `providerOptions.gateway` to list backup models, which the Gateway tries in order when the primary model fails:
+
+`import { streamText } from 'ai'; export async function POST(request: Request) { const { prompt } = await request.json(); const result = streamText({ model: 'openai/gpt-5.5', // Primary model prompt, providerOptions: { gateway: { models: ['anthropic/claude-opus-4.8', 'google/gemini-3.1-pro-preview'], // Fallbacks }, }, }); return result.toUIMessageStreamResponse(); }`
+
+In this example, the Gateway first attempts the primary model. If that fails, it tries `anthropic/claude-opus-4.7`, then `google/gemini-3.1-pro-preview`. The response comes from the first model that succeeds, and failover happens automatically without changes to your application logic.
+
+## Let your agent run code safely
+
+A capable agent often needs to do more than call predefined tools: it may generate code and run it, whether to compute a result, transform data, or test its own output. Executing model-generated code on your own infrastructure is risky because the code might consume excessive resources, read sensitive files, make unwanted network requests, or run destructive commands.
+
+[Vercel Sandbox](https://vercel.com/docs/vercel-sandbox) provides the agent with an isolated environment to run the code. Each sandbox is an ephemeral Linux microVM with resource limits and automatic timeouts, so untrusted code runs without touching your production systems. It's a standalone SDK you can call from any environment, and the same OIDC token you pulled earlier authenticates both Sandbox and AI Gateway.
+
+Add the Sandbox SDK to your project:
+
+`pnpm add @vercel/sandbox ms`
+
+The pattern has two parts: generate code with the model via the AI Gateway, then write it to a fresh sandbox and run it. The sandbox is created, used, and stopped within a single request:
+
+``import ms from 'ms'; import { generateText } from 'ai'; import { Sandbox } from '@vercel/sandbox'; const SYSTEM_PROMPT = `You are a code generator. Write JavaScript that runs in Node.js. Output only the code, with no explanations or markdown.`; async function generateCode(task: string): Promise<string> { const { text } = await generateText({ model: 'anthropic/claude-sonnet-4.6', system: SYSTEM_PROMPT, prompt: `Write JavaScript code to: ${task}`, }); return text .replace(/^\s*```(?:javascript|js)?\s*/i, '') .replace(/\s*```\s*$/i, '') .trim(); } async function executeCode(code: string) { const sandbox = await Sandbox.create({ resources: { vcpus: 2 }, timeout: ms('2m'), runtime: 'node22', }); try { await sandbox.writeFiles([ { path: '/vercel/sandbox/code.mjs', content: Buffer.from(code) }, ]); const result = await sandbox.runCommand({ cmd: 'node', args: ['code.mjs'] }); const stdout = await result.stdout(); const stderr = await result.stderr(); return { output: stdout || stderr || '(no output)', exitCode: result.exitCode }; } finally { await sandbox.stop(); } }``
+
+This gives the agent two layers of safety: the system prompt steers the model away from dangerous operations, and the sandbox enforces isolation regardless of what the model produces. The sandbox captures both `stdout` and `stderr`, so the agent can read failures and retry without those failures affecting your host. For a complete walkthrough, see [How to execute AI-generated code safely with Vercel Sandbox](https://vercel.com/kb/guide/how-to-execute-ai-generated-code-safely).
+
+## Bring your agent to your users
+
+The agent you've built runs over an HTTP route, but your users may already be in Slack, Microsoft Teams, Discord, or Google Chat. [Chat SDK](https://chat-sdk.dev/) is a TypeScript library for building chatbots that work across these platforms from a single codebase, and it integrates directly with AI SDK. That means the same agent you call through AI Gateway can answer inside a thread without rebuilding it for each platform.
+
+Two helpers from the `chat/ai` subpath connect the two SDKs. Importing from `chat/ai` rather than the main `chat` entrypoint keeps the optional `ai` and `zod` peer dependencies out of bundles that don't use them.
+
+### Feed thread history to your agent
+
+`toAiMessages` converts an array of Chat SDK `Message` objects into the `{ role, content }[]` format the AI SDK expects. The output is structurally compatible with the AI SDK's `ModelMessage[]`, so you can pass it straight into a model call. Fetch recent messages from the thread, convert them, and use them as the agent's prompt:
+
+`import { toAiMessages } from 'chat/ai'; bot.onSubscribedMessage(async (thread, message) => { const result = await thread.adapter.fetchMessages(thread.id, { limit: 20 }); const history = await toAiMessages(result.messages); const response = await agent.stream({ prompt: history }); await thread.post(response.fullStream); });`
+
+`toAiMessages` maps messages authored by the bot to the `assistant` role and all others to `user`, sorts them chronologically, and includes image and text attachments as multipart content. For multi-user threads, pass `includeNames: true` so the model can tell speakers apart.
+
+### Let your agent act on the platform
+
+`createChatTools` provides the agent with a set of AI SDK tools for posting messages, adding reactions, and performing other platform actions. Pass it to your Chat instance alongside an AI SDK call:
+
+`import { Chat } from 'chat'; import { createChatTools } from 'chat/ai'; import { createSlackAdapter } from '@chat-adapter/slack'; import { createMemoryState } from '@chat-adapter/state-memory'; import { generateText } from 'ai'; const chat = new Chat({ userName: 'mybot', adapters: { slack: createSlackAdapter() }, state: createMemoryState(), }); const result = await generateText({ model: 'anthropic/claude-opus-4.8', tools: createChatTools({ chat, preset: 'messenger' }), prompt: 'Post a friendly hello in slack:C0123ABC and react to it with a thumbs up.', });`
+
+Each tool resolves the right adapter from the id prefix you give it (`slack:`, `discord:`, `gchat:`), so one agent can drive any platform your Chat instance is wired up to. Because the model string still routes through AI Gateway, you keep the provider failover and unified billing from the earlier steps while reaching users wherever they already work.
+
+## Give your agent secure access to third-party APIs
+
+Once your agent acts on outside services, such as posting to Slack, opening GitHub pull requests, or querying a data warehouse, it needs credentials for those providers. Bundling long-lived API keys into your deployment is risky: the secret sits in your environment indefinitely, applies to every request, and is hard to scope or revoke.
+
+[Vercel Connect](https://vercel.com/docs/connect) solves this by issuing short-lived provider tokens at runtime instead. You register a connector for a provider once, link it to your projects and environments, and your code requests a scoped token only when it needs one. The same OIDC token you've used throughout authenticates the request, so no provider secret lives in your deployment.
+
+Add the Connect SDK to your project:
+
+`pnpm add @vercel/connect`
+
+Request a token with `getToken`, passing the connector, the subject the token acts as, and the scopes you need:
+
+`import { getToken } from '@vercel/connect'; const token = await getToken('slack/acme-slack', { subject: { type: 'app' }, installationId: 'inst_workspace_xyz', scopes: ['chat:write'], });`
+
+The subject controls whose identity the token represents: `{ type: 'app' }` acts as your service, while `{ type: 'user', id: '...' }` acts on behalf of a specific user who authorized access once. The SDK caches tokens in-process and refreshes them automatically, so an agent that makes many provider calls in a single run requests a single token rather than one per call. Connect currently supports Slack, GitHub, and OAuth connectors in Beta. To set up your first connector, see [Access external APIs from your agents with Vercel Connect](https://vercel.com/kb/guide/vercel-connect).
+
+## Build durable agents with the Workflow SDK
+
+The agents you've built so far run in memory. If the process crashes, the function times out, or the user refreshes the page, the agent's progress is lost. That's fine for short, single-tool interactions, but it's costly for production agents that chain several tool calls, such as booking a flight or running a research task across multiple APIs.
+
+`WorkflowAgent` from `@ai-sdk/workflow` runs the same agent loop as the standard in-memory agent, but inside a [Vercel Workflow](https://vercel.com/docs/workflows). Each tool call becomes a durable step, so progress persists across process boundaries, and failed steps are retried from the last checkpoint instead of restarting the whole loop. Tools marked `needsApproval` can suspend the agent for hours or days until a user responds, which makes human-in-the-loop flows possible without a custom state store or polling.
+
+To get durability, the agent runs inside a function marked `'use workflow'`, and each tool's `execute` function is marked `'use step'`:
+
+``import { WorkflowAgent, type ModelCallStreamPart } from '@ai-sdk/workflow'; import { convertToModelMessages, tool, type UIMessage } from 'ai'; import { getWritable } from 'workflow'; import { z } from 'zod'; async function searchFlightsStep(input: { origin: string; destination: string; date: string; }) { 'use step'; const response = await fetch(`https://api.flights.example/search?...`); return response.json(); } export async function chat(messages: UIMessage[]) { 'use workflow'; const modelMessages = await convertToModelMessages(messages); const agent = new WorkflowAgent({ model: 'anthropic/claude-sonnet-4-6', instructions: 'You are a flight booking assistant.', tools: { searchFlights: tool({ description: 'Search for available flights', inputSchema: z.object({ origin: z.string(), destination: z.string(), date: z.string(), }), execute: searchFlightsStep, }), }, }); const result = await agent.stream({ messages: modelMessages, writable: getWritable<ModelCallStreamPart>(), }); return { messages: result.messages }; }``
+
+The model string is the same `creator/model-name` form you've used throughout, so the request still routes through AI Gateway with its failover and unified billing. What changes is the runtime: tool calls now persist, retry, and appear as discrete steps in the workflow dashboard. To add human approval, set `needsApproval: true` on a tool definition, which suspends the durable workflow until the user responds.
+
+Start with the standard in-memory agent, and reach for `WorkflowAgent` when tool calls outlive their request, approvals exceed function timeouts, or each call should be independently retryable and traced. For a full breakdown of what `WorkflowAgent` adds, how `needsApproval` works, and how to keep chat streams resumable across timeouts, see the [What is WorkflowAgent?](https://vercel.com/kb/guide/what-is-workflowagent) guide.
+
+## Best practices
+
+*   **Refresh your OIDC token during local development**: Tokens are valid for 12 hours. If requests start failing locally with an authentication error, run `vercel env pull` to get a fresh token.
+    
+*   **Set fallbacks for production traffic**: A single model and provider is a single point of failure. Listing two or three fallback models in `providerOptions.gateway` keeps requests available when one provider has an outage.
+    
+*   **Keep model IDs in configuration**: Because switching models is a single string change, storing model IDs in environment variables or a config file lets you switch providers without editing application code.
+    
+*   **Confirm your AI SDK version**: All core features are available in both v5 and v6, but v6 adds capabilities such as video generation. Run `pnpm list ai` to check, and see the [AI SDK v6 migration guide](https://ai-sdk.dev/docs/migration-guides/migration-guide-6-0) before upgrading.
+    
+
+## Resources and next steps
+
+*   Learn about [model routing and fallbacks](https://vercel.com/docs/ai-gateway/models-and-providers/provider-options) for finer control over provider preference
+    
+*   Read more about [OIDC authentication](https://vercel.com/docs/ai-gateway/authentication-and-byok/authentication) and how tokens work on Vercel
+    
+*   Explore the [AI SDK documentation](https://ai-sdk.dev/getting-started) for advanced patterns
+    
+*   Run AI-generated code safely with [Vercel Sandbox](https://vercel.com/docs/vercel-sandbox) and the [code execution guide](https://vercel.com/kb/guide/how-to-execute-ai-generated-code-safely)
+    
+*   Build a cross-platform chatbot with [Chat SDK](https://chat-sdk.dev/docs) and its [AI SDK integration](https://chat-sdk.dev/docs/ai/ai-sdk-tools)
+    
+*   Request short-lived provider tokens at runtime with [Vercel Connect](https://vercel.com/docs/connect)
+    
+*   Make your agents durable with [WorkflowAgent](https://vercel.com/kb/guide/what-is-workflowagent) and [Workflow SDK](https://workflow-sdk.dev/)
+    
+*   Browse the [model library](https://vercel.com/ai-gateway/models) to see every supported provider and model
+
+---
+
+[View full KB sitemap](/kb/sitemap.md)

--- a/packages/chat/resources/guides/build-a-slack-bot-with-vercel-connect.md
+++ b/packages/chat/resources/guides/build-a-slack-bot-with-vercel-connect.md
@@ -1,0 +1,239 @@
+# Build your own Slackbot with Vercel Connect
+
+**Author:** Ben Sabic
+
+---
+
+You can build an AI-powered Slack bot that responds to mentions, maintains conversation history, and calls tools autonomously, without storing a long-lived Slack bot token or signing secret in your environment. Chat SDK handles the platform integration (e.g., webhooks and message formatting) and AI SDK's `ToolLoopAgent` runs the reasoning loop that lets your agent call tools and act on results. [Vercel Connect](https://vercel.com/connect) issues a user-authorized Slack token at runtime and forwards Slack events to your project, keeping credentials scoped to the environments that need them.
+
+You'll create a Slack connector using Vercel Connect, link it to your project, and request a scoped runtime token from your agent's code. Along the way, you'll enable streaming responses, tool calling, and more using Redis and the [Vercel AI Gateway](https://vercel.com/ai-gateway).
+
+> **Vercel Connect is in beta and available on all plans.** Features and behavior, including available connectors and trigger forwarding, may change before general availability. Usage is subject to the [Beta Agreement](https://vercel.com/docs/release-phases/public-beta-agreement) and [Vercel Connect terms](https://vercel.com/docs/connect/legal).
+
+## Prerequisites
+
+Before you begin, make sure you have:
+
+*   Node.js 20+ and a package manager (e.g., [pnpm](https://pnpm.io/))
+    
+*   Access to a Vercel team and project with Vercel Connect enabled
+    
+*   Vercel CLI installed (`npm i -g vercel`)
+    
+*   A Slack workspace where you can install an app
+    
+
+## How it works
+
+Chat SDK is a unified TypeScript SDK for building chatbots across Slack, Teams, Discord, and other platforms. You register event handlers (like `onNewMention` and `onSubscribedMessage`), and the SDK routes incoming webhooks to them. The Slack adapter handles message parsing and Slack API interactions. The Redis state adapter tracks which threads your bot has subscribed to and manages distributed locking to handle concurrent messages.
+
+AI SDK's `ToolLoopAgent` wraps a language model with tools and runs an autonomous loop: the model generates text or calls a tool, the SDK executes the tool, feeds the result back, and repeats until the model finishes. When you pass a model string like `"anthropic/claude-opus-4.8"`, and host your application on Vercel, the AI SDK will route the request through the AI Gateway automatically.
+
+Chat SDK accepts any `AsyncIterable<string>` as a message, so you can pass the agent's `fullStream` directly to `thread.post()` for real-time streaming in Slack.
+
+Vercel Connect provides Slack credentials at runtime, so you don't have to manage a static bot token. You register a Slack connector once, link it to your project, then call `getToken` from your code for a short-lived, scoped Slack token. Connect also forwards inbound Slack events to a trigger destination you register on the connector. For this agent, that destination is your project at `/api/webhooks/slack`.
+
+Connect handles authentication in both directions:
+
+*   For outbound calls to the Slack API, `getToken` from `@vercel/connect` gives your agent a short-lived Slack token.
+    
+*   For inbound events, Connect verifies them with Slack and forwards them to your app. Your `webhookVerifier` then confirms each one came from Connect using `verifyVercelOidcToken` from `@vercel/oidc`.
+    
+
+## Steps
+
+### 1\. Scaffold the project, install dependencies, and add the Vercel Plugin
+
+Create a new [Next.js](https://nextjs.org/) app and add your dependencies:
+
+`npx create-next-app@latest my-slack-agent --typescript --app cd my-slack-agent pnpm add chat @chat-adapter/slack @chat-adapter/state-redis ai zod @vercel/connect @vercel/oidc`
+
+Here's what each package does:
+
+*   The `chat` package is the Chat SDK core.
+    
+*   The `@chat-adapter/slack` and `@chat-adapter/state-redis` packages are the [Slack platform adapter](https://chat-sdk.dev/adapters/slack) and [Redis state adapter](https://chat-sdk.dev/adapters/redis), respectively.
+    
+*   The `ai` package is the AI SDK, and includes the [AI Gateway provider](https://ai-sdk.dev/providers/ai-sdk-providers/ai-gateway).
+    
+*   `zod` is used to define tool input schemas.
+    
+*   `@vercel/connect` is the Vercel Connect SDK, which provides `getToken`.
+    
+*   `@vercel/oidc` verifies the Bearer OIDC token on Connect-forwarded webhooks (`verifyVercelOidcToken`).
+    
+
+* * *
+
+The [Vercel Plugin](https://vercel.com/docs/agent-resources/vercel-plugin) turns your AI coding agent (e.g., OpenAI Codex, Claude Code, or Cursor) into a Vercel expert. It adds skills, slash commands, and current knowledge of the tools this template uses, including Vercel Connect, Chat SDK, and AI SDK. The plugin is optional; it isn't required to build your Slackbot or to follow this guide.
+
+`npx plugins add vercel/vercel-plugin`
+
+### 2\. Create a Slack connector with Vercel Connect
+
+Vercel Connect creates and manages the Slack app for you. You don't register an app at [api.slack.com](https://api.slack.com), write a manifest, or copy any credentials. You create a connector in the Vercel dashboard, set its scopes and events there, and install it in your workspace.
+
+Open the [Connect page](https://vercel.com/d?to=%2F%5Bteam%5D%2F~%2Fconnect) on your team's dashboard, then click Create Connector to start the Add Connection flow. Once you've done that:
+
+1.  Choose Slack as the provider.
+    
+2.  Select your Slack workspace and name the app (e.g., `acme-slack`). If you haven't connected a Slack workspace yet, connect and authorize one first, then return to the [Connect page](https://vercel.com/d?to=%2F%5Bteam%5D%2F~%2Fconnect). Keep Triggers enabled so Slack events reach your project.
+    
+3.  Open Advanced and set:
+    
+    *   Bot Scopes the agent needs: `chat:write`, `channels:history`, `channels:read`, `groups:history`, `im:history`, `mpim:history`, `reactions:write`, and `users:read`.
+        
+    *   Trigger Event Types to forward: `app_mention`, plus the message events for the surfaces your agent supports (`message.channels`, `message.groups`, `message.im`, `message.mpim`), so both new mentions and follow-up replies work.
+        
+4.  Click Create Slack Connector, then Install to your Slack Workspace.
+    
+5.  In the connector's settings, link it to your project, select the environments it applies to (e.g., production), and register your project as a trigger destination with the path `/api/webhooks/slack`, the route you'll create in step seven.
+    
+
+Because Connect manages the Slack app, Slack delivers events to Connect's intake URL (shown in the connector settings), not directly to your deployment's `/api/webhooks/slack`. Connect verifies Slack, then forwards each event to the trigger destination you registered.
+
+### 3\. Provision Redis and pull environment variables
+
+Your agent uses Redis for thread subscriptions and distributed locking. Provision [Upstash Redis](https://vercel.com/marketplace/upstash) and connect it to your project with the Vercel CLI:
+
+`vercel link vercel integration add upstash`
+
+`vercel integration add` installs the Upstash integration if it isn't already, provisions a database, connects it to your project, and pulls its connection environment variables into `.env.local`. Follow the prompts to pick the Redis product and a plan.
+
+To use the dashboard instead, open the [Storage](https://vercel.com/d?to=%2F%5Bteam%5D%2F%5Bproject%5D%2Fstores) page for your project, click Create Database, and follow the flow to add Upstash Redis. Then sync the variables locally:
+
+`vercel env pull`
+
+`vercel env pull` also adds a `VERCEL_OIDC_TOKEN`, which AI SDK uses to authenticate requests to the AI Gateway, so there's no API key to generate or store. The OIDC token expires after 12 hours, so re-run `vercel env pull` to refresh it, or start the dev server with `vercel dev` to refresh it automatically. Linking the project also lets Vercel Connect resolve the connector when your code calls `getToken`.
+
+You should see `REDIS_URL` (from Upstash) and `VERCEL_OIDC_TOKEN` (for AI Gateway and `@vercel/connect`). You should not add `SLACK_BOT_TOKEN` or `SLACK_SIGNING_SECRET`.
+
+### 4\. Define your agent's tools
+
+Create `lib/tools.ts` with the tools your agent can call. This example defines a weather tool and a docs tool, but you can add any tools your use case requires:
+
+``import { tool } from "ai"; import { z } from "zod"; export const tools = { getWeather: tool({ description: "Get the current weather for a location", inputSchema: z.object({ location: z.string().describe("City name, e.g. San Francisco"), }), execute: async ({ location }) => { // Replace with a real weather API call const response = await fetch( `https://api.weatherapi.com/v1/current.json?key=${process.env.WEATHER_API_KEY}&q=${encodeURIComponent(location)}` ); const data = await response.json(); return { location, temperature: data.current.temp_f, condition: data.current.condition.text, }; }, }), searchDocs: tool({ description: "Search the company documentation for a topic", inputSchema: z.object({ query: z.string().describe("The search query"), }), execute: async ({ query }) => { // Replace with your actual search implementation return { results: [`Result for: ${query}`] }; }, }), };``
+
+Each tool has a `description` (which tells the model when to use it), an `inputSchema` (a Zod schema that the model fills in), and an `execute` function that runs when the tool is called. If a tool calls another provider that Vercel Connect supports (e.g., GitHub), it can request a scoped token for itself.
+
+### 5\. Create the Connect webhook verifier
+
+Before the bot can trust an incoming event, it needs to verify the OIDC Bearer token that Connect attaches to each forwarded webhook. Create `lib/slack-connect-webhook-verifier.ts`:
+
+`import { verifyVercelOidcToken } from "@vercel/oidc"; const BEARER_TOKEN_PATTERN = /^Bearer\s+(.+)$/i; export async function verifySlackConnectWebhook( request: Request ): Promise<true> { const token = request.headers .get("authorization") ?.match(BEARER_TOKEN_PATTERN)?.[1] ?.trim(); if (!token) { throw new Error("Missing Authorization bearer token"); } await verifyVercelOidcToken(token); return true; }`
+
+`verifyVercelOidcToken` checks the JWT against Vercel's JWKS and, by default, matches `project_id` and `environment` to `VERCEL_PROJECT_ID` and `VERCEL_ENV` on the deployment. Returning `true` tells the adapter the body is trusted; throwing or returning a falsy value yields a `401`. When you use `webhookVerifier`, the adapter doesn't run Slack's 5-minute timestamp check, since Connect is your freshness boundary.
+
+For more details, see the [OIDC API reference](https://vercel.com/docs/oidc/api) and [Connect triggers](https://vercel.com/docs/connect/concepts/triggers).
+
+### 6\. Create the agent and bot
+
+Create `lib/bot.ts` with a `ToolLoopAgent` and a `Chat` instance.
+
+Instead of reading a long-lived `SLACK_BOT_TOKEN`, the Slack adapter fetches a short-lived token with Vercel Connect:
+
+`import { Chat } from "chat"; import { toAiMessages } from "chat/ai"; import { createSlackAdapter } from "@chat-adapter/slack"; import { createRedisState } from "@chat-adapter/state-redis"; import { ToolLoopAgent } from "ai"; import { getToken } from "@vercel/connect"; import { tools } from "./tools"; import { verifySlackConnectWebhook } from "./slack-connect-webhook-verifier"; const agent = new ToolLoopAgent({ model: "anthropic/claude-opus-4.8", instructions: "You are a helpful AI assistant in a Slack workspace. " + "Answer questions clearly and use your tools when you need " + "real-time data. Keep responses concise and well-formatted for chat.", tools, }); export const bot = new Chat({ userName: "ai-agent", adapters: { slack: createSlackAdapter({ // Outbound: short-lived Slack token from Connect botToken: () => getToken("slack/acme-slack", { subject: { type: "app" } }), // Inbound: verify Connect-forwarded OIDC Bearer token webhookVerifier: verifySlackConnectWebhook, }), }, state: createRedisState(), }); // Handle first-time mentions bot.onNewMention(async (thread, message) => { await thread.subscribe(); const result = await agent.stream({ prompt: message.text }); await thread.post(result.fullStream); }); // Handle follow-up messages in subscribed threads bot.onSubscribedMessage(async (thread, message) => { const allMessages = []; for await (const msg of thread.allMessages) { allMessages.push(msg); } const history = await toAiMessages(allMessages); const result = await agent.stream({ messages: history }); await thread.post(result.fullStream); });`
+
+The `botToken` option accepts a function that returns a token, and the adapter calls it on each Slack API request. That makes it a natural fit for Vercel Connect's short-lived tokens, since `getToken` returns a fresh token for the connector's installation each time. Request the token with subject `app` so the agent acts as the application itself; the bot scopes you set on the connector determine what the token can do.
+
+Replace `slack/acme-slack` with your connector UID from the Connect dashboard or `vercel connect list`.
+
+Pass `webhookVerifier` whenever Slack events arrive via Connect triggers. Omit `signingSecret` and don't set `SLACK_SIGNING_SECRET`. If both are present, `webhookVerifier` wins, but leaving `SLACK_SIGNING_SECRET` unset avoids mixing direct-Slack and Connect modes.
+
+When someone tags the bot, `onNewMention` fires. The handler subscribes to the thread (to track future messages in that thread) and streams the agent's response.
+
+For follow-up messages, `onSubscribedMessage` retrieves the full thread history using `thread.allMessages`, converts it to the AI SDK message format with `toAiMessages`, and passes it to the agent so it has complete conversation context.
+
+Using `fullStream` is preferred over `textStream` because it preserves paragraph breaks between tool-calling steps. Chat SDK auto-detects the stream type and handles Slack's native streaming API for real-time updates.
+
+### 7\. Wire up the webhook route
+
+Create the API route at `app/api/webhooks/[platform]/route.ts`:
+
+``import { after } from "next/server"; import { bot } from "@/lib/bot"; type Platform = keyof typeof bot.webhooks; export async function POST( request: Request, context: RouteContext<"/api/webhooks/[platform]"> ) { const { platform } = await context.params; const handler = bot.webhooks[platform as Platform]; if (!handler) { return new Response(`Unknown platform: ${platform}`, { status: 404 }); } return handler(request, { waitUntil: (task) => after(() => task), }); }``
+
+This creates a `POST /api/webhooks/slack` endpoint. The `waitUntil` option ensures your event handlers finish processing after the HTTP response is sent, which is required on serverless platforms where the function would otherwise terminate early.
+
+With trigger forwarding enabled, Connect POSTs verified Slack payloads to this route. Verification happens in `webhookVerifier` before the adapter parses the body. The route itself stays unchanged. Only the adapter config gains `webhookVerifier`.
+
+### 8\. Test the agent
+
+Slack sends events to Connect, which forwards them to a deployed Vercel project rather than to your machine. You test the full round trip against a preview or development deployment, with no local tunnel to spin up. Your app rejects direct Slack POSTs unless you add a separate direct-webhook path with `SLACK_SIGNING_SECRET`.
+
+1.  Deploy a preview build to receive the Slack events:
+    
+
+`vercel`
+
+1.  In the [connector's settings](https://vercel.com/d?to=%2F%5Bteam%5D%2F~%2Fconnect?service=slack), make sure that deployment's environment is linked and registered as the trigger destination at `/api/webhooks/slack`.
+    
+2.  Invite the bot to a channel (`/invite @AI Agent`).
+    
+3.  Tag the bot and ask it, "What's the weather in San Francisco?". You should see a streaming response appear in the thread.
+    
+
+### 9\. Deploy to Production
+
+Once you've tested your agent, deploy it to production:
+
+`vercel --prod`
+
+Your Slack AI agent is now live and will respond to mentions in your workspace.
+
+## Troubleshooting
+
+### Bot doesn't respond to mentions
+
+Check that your Slack connector has trigger forwarding enabled and that your project is registered as a trigger destination with the correct path (`/api/webhooks/slack`). Confirm the connector is installed in your workspace and that its Trigger Event Types include the events your agent needs (`app_mention` and the relevant message events). You can review all of this in the connector's settings. Verify production/preview deployment logs on `/api/webhooks/slack` for 401s before debugging `getToken`.
+
+### Token requests fail or return unauthorized
+
+Make sure the project is linked (`vercel link`) and that the connector is linked to it for the current environment. Confirm the connector is installed in your workspace and that the bot scopes the agent uses are enabled on the connector. You can check the connector's link, environments, and scopes in its settings.
+
+### Webhook returns 401 / Invalid signature
+
+*   Confirm `webhookVerifier` is set and imports `verifyVercelOidcToken`.
+    
+*   Confirm OIDC Federation is enabled on the project.
+    
+*   Remove `SLACK_SIGNING_SECRET` from the project if set (can force the wrong verification path in some setups).
+    
+*   Confirm the request is coming from Connect (trigger destination configured), not from Slack hitting your app directly.
+    
+
+### Missing Authorization bearer token
+
+*   The event reached your app without Connect forwarding (wrong Events URL on the Slack side, or trigger destination not registered).
+    
+*   Fix the trigger path to `/api/webhooks/slack` and link the correct environment.
+    
+
+### Streaming appears choppy or delayed
+
+Chat SDK uses Slack's native streaming API for smooth updates. If you're seeing issues, check that your Redis connection is stable, as the SDK uses distributed locks to manage concurrent messages.
+
+### Tool calls fail silently
+
+If the agent calls a tool but no result appears, check for errors in your tool's `execute` function. AI SDK surfaces tool execution errors back to the model, which may attempt to recover. Add error handling in your tools and check your server logs for details.
+
+### Thread history grows too large
+
+For long-running threads, the conversation history can exceed the model's context window. Consider limiting the number of messages you pass to the agent by slicing the history array or by using a summarization step for older messages.
+
+## Related resources
+
+*   [Vercel Connect overview](https://vercel.com/docs/connect)
+    
+*   [Vercel Connect quickstart guide](https://vercel.com/docs/connect/quickstart)
+    
+*   [Chat SDK streaming](https://chat-sdk.dev/docs/streaming)
+    
+*   [Chat SDK actions](https://chat-sdk.dev/docs/actions) and [cards](https://chat-sdk.dev/docs/cards)
+    
+*   [AI SDK agent documentation](https://ai-sdk.dev/docs/agents/building-agents)
+    
+*   [AI Gateway documentation](https://vercel.com/docs/ai-gateway)
+
+---
+
+[View full KB sitemap](/kb/sitemap.md)

--- a/packages/chat/resources/guides/create-a-discord-support-bot-with-nuxt-and-redis.md
+++ b/packages/chat/resources/guides/create-a-discord-support-bot-with-nuxt-and-redis.md
@@ -56,7 +56,7 @@ The `chat` package is the Chat SDK core. The `@chat-adapter/discord` and `@chat-
 
 Then set up the Interactions endpoint:
 
-1.  In **General Information**, set the **Interactions Endpoint URL** to [`https://your-domain.com/api/webhooks/discord`](https://your-domain.com/api/webhooks/discord)
+1.  In **General Information**, set the **Interactions Endpoint URL** to `https://your-domain.com/api/webhooks/discord`
     
 2.  Discord will send a PING to verify the endpoint. You'll need to deploy first or use a tunnel
     
@@ -128,7 +128,7 @@ The Gateway listener connects to Discord's WebSocket, receives messages, and for
     
 3.  Expose your server with a tunnel (e.g. `ngrok http 3000`)
     
-4.  Update the **Interactions Endpoint URL** in your Discord app settings to your tunnel URL (e.g. [`https://abc123.ngrok.io/api/webhooks/discord`](https://abc123.ngrok.io/api/webhooks/discord))
+4.  Update the **Interactions Endpoint URL** in your Discord app settings to your tunnel URL (e.g. `https://abc123.ngrok.io/api/webhooks/discord`)
     
 5.  @mention the bot in your Discord server. It should respond with a support card
     

--- a/packages/chat/resources/guides/daily-digest-bot-with-chat-sdk-and-workflow-sdk.md
+++ b/packages/chat/resources/guides/daily-digest-bot-with-chat-sdk-and-workflow-sdk.md
@@ -1,0 +1,306 @@
+# Build a daily digest bot with Chat SDK and Workflow SDK
+
+**Author:** Anshuman Bhardwaj
+
+---
+
+Build a daily digest bot that gathers GitHub activity, summarizes it with a model, and posts to Slack on a schedule without running it inline in a cron handler, where a single slow source or a failing channel can take down the whole run. A cron route starts a single durable workflow that fans out a step per channel, so each fetches, summarizes, and posts on its own, and retries independently.
+
+This guide builds the bot with [Chat SDK](https://chat-sdk.dev) and [Workflow SDK](https://workflow-sdk.dev). Every credential is brokered at runtime: Slack and GitHub authenticate through [Vercel Connect](https://vercel.com/connect), and the model authenticates with your project's [OpenID Connect (OIDC) token](https://vercel.com/docs/oidc). There are no API keys or client secrets to set.
+
+Deploy the template now, or read on for a deeper look at how it all works.
+
+## Quick start with an AI coding agent
+
+If you are working with an AI coding agent, hand it the project and this prompt:
+
+### Vercel Plugin
+
+Turn your agent into a Vercel expert with this [plugin](https://vercel.com/docs/agent-resources/vercel-plugin). It gives your coding agent current knowledge of the Vercel products this template uses, including Vercel Connect, Vercel Workflows, Vercel Cron, AI Gateway, and Chat SDK. The plugin is optional; it is not required to use this template or for this guide.
+
+`npx plugins add vercel/vercel-plugin`
+
+## Prerequisites
+
+Before you begin, make sure you have:
+
+*   Node.js 20+
+    
+*   [pnpm](https://pnpm.io/) (or npm/yarn)
+    
+*   A Vercel team and project with Vercel Connect enabled, plus permission to create connectors and link them to projects
+    
+*   The [Vercel CLI](https://vercel.com/docs/cli) is installed
+    
+*   A Slack workspace where you can install apps
+    
+*   A GitHub account where you can install apps
+    
+
+## Create the project
+
+Create a new [Next.js](https://nextjs.org/docs) app with `create-next-app` :
+
+`pnpm create next-app@latest scheduled-digest-bot --yes cd scheduled-digest-bot`
+
+Then install the Chat SDK, Vercel Connect, and Workflow SDK packages:
+
+`pnpm add chat @chat-adapter/slack @chat-adapter/state-redis ai workflow @vercel/connect zod`
+
+Wrap your Next.js config in `withWorkflow`:
+
+`import { withWorkflow } from "workflow/next"; import type { NextConfig } from "next"; const nextConfig: NextConfig = { serverExternalPackages: [ "@chat-adapter/slack", "@chat-adapter/state-redis", "@redis/client", "@slack/socket-mode", "@slack/web-api", "redis", ], }; export default withWorkflow(nextConfig);`
+
+## Configure credentials
+
+Your agent uses Redis for thread subscriptions and distributed locking. Provision [Upstash Redis](https://vercel.com/marketplace/upstash) and connect it to your project with the Vercel CLI:
+
+`vercel link vercel integration add upstash`
+
+`vercel integration add` installs the Upstash integration if it isn’t already, provisions a database, connects it to your project, and pulls its connection environment variables into `.env.local`. Follow the prompts to pick the Redis product and a plan.
+
+Use the [Vercel CLI](https://vercel.com/docs/cli) to link the project and pull [environment variables](https://vercel.com/docs/environment-variables):
+
+`vercel env pull`
+
+AI SDK uses `VERCEL_OIDC_TOKEN` to authenticate with the Vercel AI Gateway with [OIDC authentication](https://vercel.com/docs/ai-gateway/authentication-and-byok/authentication#oidc-token).
+
+`VERCEL_OIDC_TOKEN=...`
+
+### Create and link the Slack connector
+
+Create the Slack connector in Vercel Connect before you wire the bot locally. Vercel Connect creates and manages the Slack app, so you do not need to create a Slack app at [`api.slack.com`](http://api.slack.com) or copy a long-lived Slack bot token.
+
+1.  Open the Connect page in your Vercel team dashboard.
+    
+2.  Choose **Create Connector**.
+    
+3.  Select **Slack** as the provider.
+    
+4.  Select the Slack workspace and name the connector, for example `digest-bot`.
+    
+5.  Keep triggers enabled if this project should receive Slack events.
+    
+6.  Keep the default scopes selected.
+    
+7.  Create the connector and install it in the Slack workspace.
+    
+8.  In the connector settings, link it to the Vercel project and select the environments where it should be available.
+    
+
+Copy the Slack connector id and store it in `.env.local` file as `CONNECTOR_SLACK`, for example:
+
+`CONNECTOR_SLACK=slack/digest-bot`
+
+Also, add the following environment variables:
+
+`CRON_SECRET="replace-with-a-long-random-string" # e.g. "openssl rand --base64 32" DIGEST_CHANNEL_ID="slack:SLACK_CHANNEL_ID"`
+
+### Create and link the GitHub connector
+
+Create the GitHub connector in Vercel Connect and install it on the repositories you want included in the digest.
+
+1.  Open the Connect page in your Vercel team dashboard.
+    
+2.  Choose **Create Connector**.
+    
+3.  Select **GitHub** as the provider.
+    
+4.  Select the GitHub account or organization to connect.
+    
+5.  Install the connector on all repositories the digest should read, or select a smaller repository allowlist.
+    
+6.  Create the connector.
+    
+7.  In the connector settings, link it to the Vercel project and select the environments where it should be available.
+    
+
+Copy the GitHub connector id and store it in `.env.local` file as `CONNECTOR_GITHUB`, for example:
+
+`CONNECTOR_GITHUB=github/digest-github`
+
+The digest requests an app-scoped token from Vercel Connect:
+
+`import { getToken } from "@vercel/connect"; export async function getGitHubToken() { const connector = process.env.CONNECTOR_GITHUB; if (!connector) { throw new Error("CONNECTOR_GITHUB is required."); } return getToken(connector, { subject: { type: "app" } }); }`
+
+The connector installation determines which repositories the token can access. If a repository is missing from the digest, check the connector installation and project/environment link before changing code.
+
+## Create the Chat SDK bot
+
+`lib/bot.ts` centralizes the Chat SDK instance. It requests short-lived Slack tokens from Vercel Connect and configures Redis state so proactive posts and webhook handling share the same bot.
+
+`import { createSlackAdapter } from "@chat-adapter/slack"; import { createRedisState } from "@chat-adapter/state-redis"; import { getToken } from "@vercel/connect"; import { Chat } from "chat"; let bot: Chat | null = null; function getSlackBotToken() { const connector = process.env.CONNECTOR_SLACK; if (!connector) { throw new Error( "CONNECTOR_SLACK is required. Use the Vercel Connect connector id, such as slack/acme-slack.", ); } return getToken(connector, { subject: { type: "app" } }); } function verifyConnectForwardedSlackRequest() { return true; } export function getBot() { if (!bot) { bot = new Chat({ userName: process.env.BOT_USER_NAME ?? "digest-bot", adapters: { slack: createSlackAdapter({ botToken: getSlackBotToken, webhookVerifier: verifyConnectForwardedSlackRequest, }), }, state: createRedisState(), dedupeTtlMs: 600_000, }).registerSingleton(); } return bot; }`
+
+## Define digest schemas and types
+
+`lib/digest/types.ts` keeps the workflow input, source contract, and model output schema in one place. The same schema validates the cron input and constrains the AI SDK response.
+
+`import { z } from "zod"; export const DigestConfigSchema = z.object({ tone: z.enum(["terse", "detailed"]).default("terse"), maxSections: z.number().int().positive().max(8).default(4), include: z .array(z.string()) .default(["github-repositories", "github-issues"]), }); export const DigestInputSchema = z.object({ channelId: z.string().min(1), lookbackHours: z.number().int().positive().max(168).default(24), detailsUrl: z.url().optional(), config: DigestConfigSchema.default({ tone: "terse", maxSections: 4, include: ["github-repositories", "github-issues"], }), }); export const DigestChannelIdSchema = z.string().min(1); export type DigestConfig = z.infer<typeof DigestConfigSchema>; export type DigestInput = z.infer<typeof DigestInputSchema>; export type GatherActivity = (input: DigestInput) => Promise<unknown>; export const DigestSchema = z.object({ headline: z.string().min(1), sections: z .array( z.object({ label: z.string().min(1), body: z.string().min(1), }), ) .min(1), }); export type Digest = z.infer<typeof DigestSchema>;`
+
+## Enroll the digest channel
+
+`lib/digest/enrollment.ts` turns the single `DIGEST_CHANNEL_ID` environment variable into the workflow input. Keep schedule-independent choices, like lookback window and tone, in code so the environment stays small.
+
+`import { DigestChannelIdSchema, type DigestConfig, type DigestInput, } from "./types"; const DIGEST_LOOKBACK_HOURS = 24; const DIGEST_DETAILS_URL = "https://vercel.com"; const DIGEST_CONFIG: DigestConfig = { tone: "terse", maxSections: 4, include: ["github-repositories", "github-issues"], }; export async function loadDigestChannel(): Promise<DigestInput | null> { const raw = process.env.DIGEST_CHANNEL_ID; if (!raw) { return null; } const channelId = DigestChannelIdSchema.parse(raw); return { channelId, lookbackHours: DIGEST_LOOKBACK_HOURS, detailsUrl: DIGEST_DETAILS_URL, config: DIGEST_CONFIG, }; }`
+
+## Start the workflow from cron
+
+Keep the cron route thin. It should verify the secret `CRON_SECRET`), load the single configured channel, start the workflow, and return the run id.
+
+``import { start } from "workflow/api"; import { loadDigestChannel } from "@/lib/digest/enrollment"; import { runDailyDigest } from "@/lib/digest/workflow"; export async function GET(request: Request) { const auth = request.headers.get("authorization"); if (!process.env.CRON_SECRET || auth !== `Bearer ${process.env.CRON_SECRET}`) { return new Response("Unauthorized", { status: 401 }); } const channel = await loadDigestChannel(); if (!channel) { return Response.json({ started: false, reason: "DIGEST_CHANNEL_ID is not set" }); } const run = await start(runDailyDigest, [channel]); return Response.json({ started: true, runId: run.runId }); }``
+
+### Scheduling the cron route
+
+`vercel.json` tells Vercel Cron to call the digest route every day. The route still checks `CRON_SECRET`, so only authorized cron requests can start a workflow.
+
+`{ "crons": [ { "path": "/api/cron/digest", "schedule": "0 8 * * *" } ] }`
+
+Add the `CRON_SECRET` environment variable to your Vercel project before deploying the application.
+
+## Create GitHub digest workflow
+
+Use one workflow to orchestrate the work, but keep expensive or failure-prone operations in separate steps. This makes the workflow retries and run inspection more useful.
+
+`import { fetchGitHubActivity, generateDigest, postDigest } from "./step"; import type { DigestInput } from "./types"; export async function runDailyDigest(channel: DigestInput) { "use workflow"; try { const activity = await fetchGitHubActivity(channel); const digest = await generateDigest(channel, activity); await postDigest(channel, digest); return { posted: 1, failed: 0, channelId: channel.channelId }; } catch (error) { return { posted: 0, failed: 1, channelId: channel.channelId, error: error instanceof Error ? error.message : String(error), }; } }`
+
+`import { generateText, Output } from "ai"; import { postDigestCard } from "./card"; import { buildPrompt } from "./prompt"; import { gatherProjectActivity } from "./sources"; import { DigestSchema, type Digest, type DigestInput } from "./types"; export async function fetchGitHubActivity(input: DigestInput) { "use step"; return gatherProjectActivity(input); } export async function generateDigest(input: DigestInput, activity: unknown) { "use step"; const { output } = await generateText({ model: process.env.DIGEST_MODEL ?? "anthropic/claude-haiku-4.5", output: Output.object({ schema: DigestSchema, name: "daily_digest", description: "A concise channel digest with headline and sections.", }), prompt: buildPrompt(activity, input.config), }); return output; } export async function postDigest(input: DigestInput, digest: Digest) { "use step"; return postDigestCard(input, digest); }`
+
+### Fetch GitHub issues with Search API
+
+`lib/digest/sources.ts` owns the GitHub data contract. It gets a token from Vercel Connect, discovers connector-visible repositories, counts open issues, and returns a precomputed activity payload for the model.
+
+Use the REST repository endpoints to discover connector-visible repositories. Then use batched GitHub GraphQL queries for issue counts and recent issue nodes.
+
+> Avoid the GitHub Search API for per-repository issue counts. Its quota is much lower, and a scheduled digest can exhaust it quickly when it searches once per repository.
+
+Here’s the API request flow:
+
+*   Fetch up to a bounded number of active repositories.
+    
+*   Count public and private repositories in code.
+    
+*   Query GraphQL in batches for `issues(states: OPEN) { totalCount }`.
+    
+*   Fetch recent issue nodes only for the repositories shown in the digest. Keep recent issue nodes capped, for example 10 per repository.
+    
+
+The digest payload should give the model precomputed totals, not ask it to infer them. Build the payload in a complete helper function:
+
+`type RepositorySummary = { name: string; visibility: "public" | "private"; }; type RecentIssue = { repository: string; title: string; url: string; createdAt: string; }; type IssueReport = { repository: RepositorySummary; openIssueCount: number; recentlyOpenedIssues: RecentIssue[]; }; function buildDigestActivity( repositories: RepositorySummary[], issueReports: IssueReport[], maxProcessed: number, ) { const publicRepositories = repositories.filter( (repository) => repository.visibility === "public", ); const privateRepositories = repositories.filter( (repository) => repository.visibility === "private", ); const recentlyOpened = issueReports .flatMap((report) => report.recentlyOpenedIssues) .sort((left, right) => right.createdAt.localeCompare(left.createdAt)); const openInPublicRepositories = sumOpenIssues(issueReports, "public"); const openInPrivateRepositories = sumOpenIssues(issueReports, "private"); return { repositories: { total: repositories.length, public: publicRepositories.length, private: privateRepositories.length, processed: Math.min(repositories.length, maxProcessed), maxProcessed, }, issues: { totalOpen: openInPublicRepositories + openInPrivateRepositories, openInPublicRepositories, openInPrivateRepositories, recentlyOpenedInLookback: recentlyOpened.length, recentlyOpened, byRepository: issueReports.map((report) => ({ repository: report.repository.name, visibility: report.repository.visibility, openIssueCount: report.openIssueCount, recentlyOpenedInLookback: report.recentlyOpenedIssues.length, })), }, }; } function sumOpenIssues( issueReports: IssueReport[], visibility: RepositorySummary["visibility"], ) { return issueReports .filter((report) => report.repository.visibility === visibility) .reduce((sum, report) => sum + report.openIssueCount, 0); }`
+
+This keeps the prompt focused on writing the digest rather than doing arithmetic over raw issue lists. It also makes the posted summary easier to verify when you inspect a workflow run.
+
+The source file should also throw `RetryableError` for transient GitHub failures and `FatalError` for bad configuration, so workflow retries only the failures that can recover.
+
+### Build the digest prompt
+
+`lib/digest/prompt.ts` turns the structured GitHub activity into model instructions. Keep totals and source data in the activity object, then use the prompt only to control tone and output priorities.
+
+``import type { DigestConfig } from "./types"; export function buildPrompt(activity: unknown, config: DigestConfig) { return [ `Write a ${config.tone} daily GitHub issues digest.`, `Return at most ${config.maxSections} sections.`, `Only include these source areas: ${config.include.join(", ")}.`, "Include the total number of public repositories and private repositories.", "Include the total number of open issues in public repositories and private repositories.", "If repository totals may be limited by the fetch cap, call that out briefly.", "Highlight newly opened issues, affected repositories, owners, labels, and notable themes.", "If there are no recently opened issues, still summarize the repository and open issue totals.", "Use clear labels and concise bodies.", "Return a headline and sections that match the requested schema.", JSON.stringify(activity, null, 2), ].join("\n\n"); }``
+
+## Post a Chat SDK Card
+
+Create the Slack message card in the `lib/digest/card.tsx` :
+
+``import { Actions, Card, CardText, LinkButton, Section } from "chat"; import { getBot } from "@/lib/bot"; import type { Digest, DigestInput } from "./types"; export async function postDigestCard(input: DigestInput, digest: Digest) { const channel = getBot().channel(input.channelId); await channel.post( Card({ title: digest.headline, children: [ ...digest.sections.map((section) => Section([CardText(`**${section.label}** ${section.body}`)]), ), Actions([ LinkButton({ url: input.detailsUrl ?? "https://vercel.com", label: "View details", }), ]), ], }), ); return { posted: true as const, channelId: input.channelId }; }``
+
+## Run the application locally
+
+To trigger the cron route, start the app:
+
+`pnpm dev`
+
+In another terminal, run the following curl command to trigger the cron job:
+
+`curl -H "Authorization: Bearer $CRON_SECRET" \ http://localhost:3000/api/cron/digest`
+
+To inspect workflow runs include the steps timeline and retries during development, run the following command:
+
+`pnpm exec workflow web`
+
+You now have a daily digest bot with Chat SDK, Workflow SDK, and Vercel Connect. These primitives are extensible for more comprehensible use cases like a PR review bot or an incident watchlist to help you navigate public reports on GitHub.
+
+## Troubleshooting
+
+Each item below lists a symptom, its cause, and the fix.
+
+### The cron route returns unauthorized
+
+Make sure `CRON_SECRET` is set in the environment where the cron job runs, such as production. Vercel Cron sends `Authorization: Bearer $CRON_SECRET`, and the route fails closed when the variable is missing or the header does not match.
+
+Symptom: A Vercel Cron run or manual request gets `401 Unauthorized`.
+
+Cause: `CRON_SECRET` is missing from the environment where the route runs, or the request does not include `Authorization: Bearer $CRON_SECRET`.
+
+Fix: Set `CRON_SECRET` in production and any preview environment where the cron route should run. For local tests, pull the environment with `vercel env pull` or set the variable in the shell before calling the route.
+
+### The Slack digest does not post
+
+Symptom: The workflow runs, but no message appears in Slack.
+
+Cause: The Slack app is not in the configured channel, `DIGEST_CHANNEL_ID` is not in Chat SDK channel id format, or `CONNECTOR_SLACK` is missing from the environment.
+
+Fix: Invite the Slack app to the channel, set `DIGEST_CHANNEL_ID` to a value such as `slack:C123ABC`, and confirm the Slack connector is linked to the Vercel project environment.
+
+### GitHub repositories are missing
+
+Symptom: The digest includes fewer repositories than expected.
+
+Cause: The GitHub connector is installed on a limited repository allowlist, or the connector is not linked to the environment running the workflow.
+
+Fix: Update the GitHub connector installation to include the repositories you want, then confirm `CONNECTOR_GITHUB` is available in the same Vercel environment as the workflow.
+
+### GitHub API rate limit reached
+
+Check that issue counts use GraphQL batching, not GitHub Search API calls. Search API limits are easier to hit and should not be used once per repository.
+
+Symptom: The `fetchGitHubActivity` step fails with a rate limit error.
+
+Cause: GitHub rate limits can still apply to connector tokens, especially if the workflow queries too many repositories or uses the Search API for counts.
+
+Fix: Keep repository fetching bounded, use GraphQL batching for issue counts, and avoid per-repository GitHub Search API calls. The template marks rate limits as `RetryableError` so workflow can retry after a delay.
+
+### Slack signing secret error
+
+When Slack events are routed through Vercel Connect, Connect verifies the event before forwarding it. The Slack adapter still expects a `webhookVerifier`, so provide one that delegates trust to Connect for that route. If you receive events directly from Slack, use Slack's signing secret instead.
+
+Symptom: The Slack webhook route fails with a signing secret error.
+
+Cause: The Slack adapter requires a webhook verifier, but Vercel Connect has already verified Connect-forwarded Slack events before they reach the app.
+
+Fix: For Connect-forwarded Slack events, use a verifier that delegates trust to Connect for that route. If events come directly from Slack, configure verification with Slack's signing secret instead.
+
+### Invalid JSX element: must be a Card element
+
+Use the Chat SDK function-call Card API in workflow steps instead of JSX if the generated workflow route does not recognize the JSX Card shape at runtime.
+
+Symptom: The Slack post step fails with `Invalid JSX element: must be a Card element`.
+
+Cause: The workflow route may not recognize a JSX Card shape at runtime.
+
+Fix: Use the Chat SDK function-call Card API in `lib/digest/card.tsx`, as shown above.
+
+### Local Connect token requests fail
+
+Symptom: GitHub or Slack token requests work in production but fail locally.
+
+Cause: The local `VERCEL_OIDC_TOKEN` written by `vercel env pull` has expired, or the local project is linked to the wrong Vercel project.
+
+Fix: Run `vercel link` to confirm the project, then run `vercel env pull` again.
+
+## Related resources
+
+*   [Workflow SDK documentation](https://workflow-sdk.dev)
+    
+*   [Chat SDK cards](https://chat-sdk.dev/docs/cards)
+    
+
+*   [Vercel Connect](https://vercel.com/docs/connect) and [Vercel Connect CLI](https://vercel.com/docs/cli/connect)
+    
+*   [Vercel AI Gateway](https://vercel.com/docs/ai-gateway)
+    
+*   [Vercel OIDC](https://vercel.com/docs/oidc)
+
+---
+
+[View full KB sitemap](/kb/sitemap.md)

--- a/packages/chat/resources/guides/how-to-build-a-slack-bot-with-next-js-and-redis.md
+++ b/packages/chat/resources/guides/how-to-build-a-slack-bot-with-next-js-and-redis.md
@@ -45,7 +45,7 @@ Select your workspace and paste the following manifest:
 
 `display_information: name: My Bot description: A bot built with Chat SDK features: bot_user: display_name: My Bot always_online: true oauth_config: scopes: bot: - app_mentions:read - channels:history - channels:read - chat:write - groups:history - groups:read - im:history - im:read - mpim:history - mpim:read - reactions:read - reactions:write - users:read settings: event_subscriptions: request_url: https://your-domain.com/api/webhooks/slack bot_events: - app_mention - message.channels - message.groups - message.im - message.mpim interactivity: is_enabled: true request_url: https://your-domain.com/api/webhooks/slack org_deploy_enabled: false socket_mode_enabled: false token_rotation_enabled: false`
 
-Replace [`https://your-domain.com/api/webhooks/slack`](https://your-domain.com/api/webhooks/slack) with your deployed webhook URL, then click **Create**.
+Replace `https://your-domain.com/api/webhooks/slack` with your deployed webhook URL, then click **Create**.
 
 After creating the app:
 

--- a/packages/chat/resources/guides/liveblocks-chat-sdk-ai-sdk.md
+++ b/packages/chat/resources/guides/liveblocks-chat-sdk-ai-sdk.md
@@ -43,8 +43,6 @@ Before continuing, make sure you have a React app with Liveblocks Comments up an
 
 Install the Liveblocks adapter, Chat SDK, AI SDK, and other related packages:
 
-`npm install @liveblocks/chat-sdk-adapter @liveblocks/node chat @chat-adapter/state-redis ai zod`
-
 The `chat` package is the Chat SDK core. `@liveblocks/chat-sdk-adapter` is the Liveblocks platform adapter. `ai` is the AI SDK, which includes `ToolLoopAgent`. `zod` is used to define tool input schemas. `@chat-adapter/state-redis` is the [Redis state adapter,](https://chat-sdk.dev/adapters/official/redis) which handles thread subscriptions and distributed locking.
 
 ### 3\. Create a Liveblocks project

--- a/packages/chat/resources/guides/ship-a-github-code-review-bot-with-hono-and-redis.md
+++ b/packages/chat/resources/guides/ship-a-github-code-review-bot-with-hono-and-redis.md
@@ -45,7 +45,7 @@ The `chat` package is the Chat SDK core. The `@chat-adapter/github` and `@chat-a
 
 1.  Go to your repository **Settings**, then **Webhooks**, then **Add webhook**
     
-2.  Set **Payload URL** to [`https://your-domain.com/api/webhooks/github`](https://your-domain.com/api/webhooks/github)
+2.  Set **Payload URL** to `https://your-domain.com/api/webhooks/github`
     
 3.  Set **Content type** to `application/json`
     

--- a/packages/chat/resources/guides/slack-bot-vercel-blob.md
+++ b/packages/chat/resources/guides/slack-bot-vercel-blob.md
@@ -124,18 +124,18 @@ This creates a `POST /api/webhooks/slack` endpoint. The `waitUntil` option ensur
 
 1.  Start the dev server:
     
-    `pnpm dev`
-    
-2.  Expose it with a tunnel:
-    
-    `npx ngrok http 3000`
-    
-3.  Copy the tunnel URL (for example, [`https://abc123.ngrok-free.dev`](https://abc123.ngrok-free.dev)) and update both **Event Subscriptions** and **Interactivity** Request URLs in your [Slack app settings](https://api.slack.com/apps) to [`https://abc123.ngrok-free.dev/api/webhooks/slack`](https://abc123.ngrok-free.dev/api/webhooks/slack).
-    
-4.  Invite the bot to a channel: `/invite @Files Bot`.
-    
-5.  @mention the bot and ask it to list files: "Show me what's in the bucket." The agent calls `listFiles` and streams the response back into the thread. To test a write operation end-to-end before building an approval flow, temporarily pass `requireApproval: false` to `createFileTools` in `lib/bot.ts` and ask the bot to "Upload a file called test.txt with the contents 'hello world'."
-    
+
+`pnpm dev`
+
+2\. Expose it with a tunnel:
+
+`npx ngrok http 3000`
+
+3\. Copy the tunnel URL (for example, `https://abc123.ngrok-free.dev`) and update both **Event Subscriptions** and **Interactivity** Request URLs in your [Slack app settings](https://api.slack.com/apps) to `https://abc123.ngrok-free.dev/api/webhooks/slack`.
+
+4\. Invite the bot to a channel: `/invite @Files Bot`.
+
+5\. @mention the bot and ask it to list files: "Show me what's in the bucket." The agent calls `listFiles` and streams the response back into the thread. To test a write operation end-to-end before building an approval flow, temporarily pass `requireApproval: false` to `createFileTools` in `lib/bot.ts` and ask the bot to "Upload a file called test.txt with the contents 'hello world'."
 
 ### 9\. Deploy to Vercel
 
@@ -151,7 +151,7 @@ Then deploy to production:
 
 `vercel --prod`
 
-Update the **Event Subscriptions** and **Interactivity** Request URLs in your Slack app settings to your production URL, for example [`https://my-files-bot.vercel.app/api/webhooks/slack`](https://my-files-bot.vercel.app/api/webhooks/slack).
+Update the **Event Subscriptions** and **Interactivity** Request URLs in your Slack app settings to your production URL, for example `https://your-app.vercel.app/api/webhooks/slack`.
 
 ## Configuring approval and read-only mode
 

--- a/packages/chat/resources/guides/vercel-connect.md
+++ b/packages/chat/resources/guides/vercel-connect.md
@@ -1,0 +1,210 @@
+# Give your agents secure access to third-party APIs
+
+**Author:** Ben Sabic
+
+---
+
+Agents and background services often need to call provider APIs such as Slack, GitHub, or Snowflake on behalf of your users. Doing so usually means storing long-lived provider secrets in your database or environment variables. [Vercel Connect](https://vercel.com/docs/connect) keeps those secrets out of your runtime by issuing user-authorized tokens on demand, scoped to the projects and environments that need them. You register a connector once, link it to a project, then request a token at runtime when your code calls the provider.
+
+This guide walks you through Vercel Connect from start to finish. You'll create a Slack connector, link it to a project, and choose which environments can use it. From there, you'll request scoped runtime tokens from your code with the Vercel Connect SDK or the Vercel CLI, forward Slack webhooks to your projects, and apply best practices for scopes, environments, and token handling.
+
+> **Vercel Connect is in beta and available on all plans.** Features and behavior, including available connectors and trigger forwarding, may change before general availability. Usage is subject to the [Beta Agreement](https://vercel.com/docs/release-phases/public-beta-agreement) and [Vercel Connect terms](https://vercel.com/docs/connect/legal).
+
+## Prerequisites
+
+Before you begin, make sure you have:
+
+*   Access to a Vercel team and project with Vercel Connect enabled
+    
+*   Permission to create connectors and link them to projects
+    
+*   A Slack workspace where you can install apps
+    
+*   Vercel CLI installed (`npm i -g vercel`)
+    
+
+## How Vercel Connect works
+
+Vercel Connect is built around a connector, a registered connection to a third-party provider that your whole team can reuse. You link a connector to the projects that need it, and your code requests a token from that connector at runtime instead of reading a stored secret. Vercel records each authorization and token request, so you keep an audit trail of how external access is used.
+
+Connect uses four main concepts:
+
+| Concept                | Description                                                                                                                   |
+| ---------------------- | ----------------------------------------------------------------------------------------------------------------------------- |
+| Connector              | Registered connection to a third-party provider that your team can reuse.                                                     |
+| Installation           | Provider-side installation for a specific tenant, such as a Slack workspace or GitHub organization.                           |
+| Token request          | Runtime token request, which can include options such as `installationId`, `scopes`, `resources`, and `authorizationDetails`. |
+| Connector-project link | The binding between a connector and a project, including the environments where it's enabled.                                 |
+
+### Token subject types
+
+Each token request specifies the subject it represents. One connector can issue tokens for any of three subjects:
+
+| Subject      | Acts as                                                    | When to use                                                                                             |
+| ------------ | ---------------------------------------------------------- | ------------------------------------------------------------------------------------------------------- |
+| `app`        | The application itself, using the connector's installation | Bot accounts or tenant-wide admin actions. App tokens skip the user-consent flow.                       |
+| `user`       | A specific signed-in user                                  | Acting on behalf of a user. The user authorizes the connector once before you can mint tokens for them. |
+| `jwt-bearer` | A federated identity you assert                            | Exchanging an external identity for a provider token.                                                   |
+
+In the SDK, `subject` is required. The CLI requests a `user` token by default; pass `--subject app` for an app token.
+
+### Connector types
+
+Vercel Connect has built-in support for Slack, GitHub, Snowflake, Salesforce, API key, and Custom OAuth connectors. Connectors fall into two operating models, based on who registers the credentials with the provider:
+
+| Connector    | Model            | Setup                                                                                       |
+| ------------ | ---------------- | ------------------------------------------------------------------------------------------- |
+| Slack        | Vercel Managed   | Authorize Vercel's Slack app, installed per workspace.                                      |
+| GitHub       | Vercel Managed   | Install Vercel's GitHub app, per organization or user.                                      |
+| Snowflake    | Vercel Managed   | Connect through the Snowflake Partner Connect integration.                                  |
+| Salesforce   | Vercel Managed   | Authorize Vercel's managed OAuth client against your Salesforce org.                        |
+| Custom OAuth | Customer Managed | Bring your own client ID and secret for any service URL, using OAuth 2.0 or OIDC with PKCE. |
+| API key      | Customer Managed | Supply a long-lived API key at create time.                                                 |
+
+With a Vercel Managed Connector, Vercel registers the OAuth client and you authorize it against your account or workspace, so you don't manage client secrets. With a Customer Managed Connector, you register the OAuth client, generate the API key yourself, and supply the credentials when you create the connector. For providers that support it, Vercel Assisted Setup can perform some or all of the OAuth-client registration on your behalf.
+
+From the Vercel CLI, you can create a connector using a service name, such as `slack` or `github`, or a service URL, such as `mcp.linear.app`.
+
+### How authentication works
+
+When your code requests a token, the SDK authenticates with Vercel Connect using the OIDC token that Vercel automatically injects into your deployment. Connect verifies that token against the connector's project links to confirm the project and environment are allowed to request tokens. For local development, run `vercel link` and then `vercel env pull` to download a short-lived development token into `.env.local`. For external CI/CD or non-Vercel environments, pass a [Vercel access token](https://vercel.com/docs/rest-api#creating-an-access-token) to the SDK through the `vercelToken` option.
+
+## Create a connector
+
+You can create a connector from the dashboard or the Vercel CLI.
+
+In the dashboard, open the [Connect page](https://vercel.com/d?to=%2F%5Bteam%5D%2F~%2Fconnect) in your team, click **Create Connector**, and select **Slack** as the type. Name the connector (for example, `acme-slack`) and enable trigger forwarding if you plan to receive Slack webhooks.
+
+To do the same in the terminal, run:
+
+`vercel connect create slack --name acme-slack`
+
+Add `--triggers` if you want this connector to forward incoming Slack webhooks:
+
+`vercel connect create slack --name acme-slack --triggers`
+
+You can also create GitHub, OAuth, or service-URL connectors:
+
+`vercel connect create github --name acme-github vercel connect create oauth --name acme-oauth vercel connect create mcp.linear.app --name linear-connector`
+
+## Link the connector to a project
+
+Attach the connector to the Vercel project where your app or agent runs. Choose at least one environment, such as production, and add preview or development if your workflow runs there too.
+
+If you created the connector from the CLI inside a directory that's already linked to a Vercel project, that project is attached for you, so you can skip this step. To attach a different project, or to add environments later, pass `--project`:
+
+`vercel connect attach slack/acme-slack --project my-project --environment production`
+
+Connectors are identified by their UID (for example, `slack/acme-slack`) or by their ID (for example, `scl_abc123`). To also register the project as a destination for forwarded webhooks, add `--triggers`:
+
+`vercel connect attach slack/acme-slack --triggers`
+
+For stronger isolation, consider a separate connector for each environment.
+
+## Request a runtime token
+
+Scope each token request to the workload before you request it:
+
+*   Set provider scopes only for the action you need.
+    
+*   Add `installationId` when you need to target a specific installation.
+    
+*   With the SDK, you can also pass provider-specific `resources` or `authorizationDetails`.
+    
+
+You usually don't need to set `installationId`. In most cases, the connector resolves a default installation from its tenant, which covers a private app installed in a single workspace. Set it explicitly only when the connector spans more than one installation and you need to target a specific Slack workspace or GitHub organization.
+
+Request the token from your server-side code with the SDK:
+
+`import { getToken } from '@vercel/connect'; const token = await getToken('slack/acme-slack', { subject: { type: 'app' }, scopes: ['channels:read'], });`
+
+`getToken` returns the token string, ready to use in an `Authorization` header. If you need the token's expiry, the connected workspace name, or other provider metadata, call `getTokenResponse` instead. The SDK keeps an in-process cache and refreshes tokens automatically as they approach expiry, so you can call `getToken` on each request without minting a new token every time.
+
+For a `user`\-subject token, the first request for a user who hasn't authorized the connector throws `UserAuthorizationRequiredError`. Catch it, send the user to the connector's consent URL with `startAuthorization`, then retry once they authorize.
+
+To request the same app token from the Vercel CLI:
+
+`vercel connect token slack/acme-slack --subject app --installation-id inst_... --scopes channels:read`
+
+In the CLI, `--installation-id` applies with `--subject app`. For machine-readable output that includes fields such as `expiresAt` and `installationId`, add `--format=json`.
+
+Your code now receives a runtime token scoped to the requested action, which it can use to call the provider API. Request tokens at runtime, and don't persist them in long-lived environment variables or a database.
+
+## Forward Slack webhooks to your projects
+
+Vercel Connect can forward incoming webhooks to your projects through trigger forwarding. A connector can forward verified webhooks to up to three destination projects.
+
+Enable trigger forwarding when you create a connector with `--triggers`, then register each destination project when you attach it:
+
+`vercel connect attach slack/acme-slack --triggers --trigger-branch staging --trigger-path /slack`
+
+`--trigger-branch` sets the Git branch for the destination and defaults to production. `--trigger-path` sets the path that receives forwarded webhooks and defaults to `/{service}`. Detaching a project removes its token access but doesn't remove it from the connector's trigger destinations, so manage trigger destinations separately.
+
+## Best practices
+
+*   Use a separate connector per environment. Giving production, preview, and development their own connectors ensures each has its own authorization grant, scopes, and audit trail, so a token compromised in one environment can't be replayed against another.
+    
+*   Request the minimum required scopes. Set provider scopes only for the actions the workload performs, rather than requesting broad access.
+    
+*   Keep tokens out of storage. Request tokens at runtime and avoid persisting them in long-lived environment variables or a database.
+    
+*   Target a specific installation when needed. Pass `installationId` in the SDK, or `--installation-id` with `--subject app` on the CLI, to act against a particular Slack workspace or GitHub organization.
+    
+
+## Pricing
+
+Vercel Connect is billed per token request.
+
+| Plan       | Token request pricing                                 |
+| ---------- | ----------------------------------------------------- |
+| Hobby      | 5,000 token requests per month, included at no charge |
+| Pro        | $3 per 10,000 token requests                          |
+| Enterprise | $3 per 10,000 token requests                          |
+
+See [Pricing and Limits](https://vercel.com/docs/connect/pricing) for the full table and the platform limits that apply during beta.
+
+## Vercel CLI commands
+
+The `vercel connect` command manages connectors from the terminal. Connectors are identified by their UID (`slack/my-bot`) or ID (`scl_abc123`).
+
+| Command                 | Description                                           |
+| ----------------------- | ----------------------------------------------------- |
+| `vercel connect create` | Create a connector for a service.                     |
+| `vercel connect list`   | List connectors for your team or project (also `ls`). |
+| `vercel connect token`  | Request a runtime token from a connector.             |
+| `vercel connect attach` | Attach a project to a connector.                      |
+| `vercel connect detach` | Detach a project from a connector.                    |
+| `vercel connect update` | Update connector branding such as icon and colors.    |
+| `vercel connect remove` | Delete a connector (also `rm`).                       |
+| `vercel connect open`   | Open a connector in the Vercel dashboard.             |
+
+By default, `vercel connect list` shows only connectors linked to the current project. Add `--all-projects` to list all connectors in the team. Removing a connector with attached projects fails unless you pass `--disconnect-all` to detach them first. Run `vercel connect --help` to review the current CLI surface.
+
+## Known limitations
+
+*   Trigger forwarding supports Slack only.
+    
+*   Connector branding fields can't be fully cleared after you set them.
+    
+*   Token revocation and token lifetime depend on provider support.
+    
+
+## When to use Vercel Connect or Integrations
+
+Use Vercel Connect when you need delegated runtime credentials and user authorization for agent workflows, such as running an agent that needs project-scoped access to a Slack workspace, linking a single connector to multiple projects and environments, or requesting user-authorized provider tokens at runtime instead of storing long-lived secrets.
+
+Use Vercel Integrations when you want marketplace-managed installs and provider-managed products in the Vercel Marketplace.
+
+## Related resources and next steps
+
+*   Follow [Vercel Connect quickstart](https://vercel.com/docs/connect/quickstart) for the first-setup walkthrough.
+    
+*   Read the [Vercel Connect overview](https://vercel.com/docs/connect) for concepts, limitations, and product boundaries.
+    
+*   See the [Vercel Connect CLI reference](https://vercel.com/docs/cli/connect) for every subcommand and option.
+    
+*   Explore [Vercel Integrations](https://vercel.com/docs/integrations) if you need marketplace integration installs.
+
+---
+
+[View full KB sitemap](/kb/sitemap.md)

--- a/packages/chat/resources/templates.json
+++ b/packages/chat/resources/templates.json
@@ -19,6 +19,11 @@
       "title": "Community Agent",
       "description": "Open source AI-powered Slack community management bot with a built-in Next.js admin panel. Uses Chat SDK, AI SDK, and Vercel Workflow.",
       "href": "https://vercel.com/templates/next.js/chat-sdk-community-agent"
+    },
+    {
+      "title": "Caltext",
+      "description": "iMessage calorie tracking assistant powered by AI.",
+      "href": "https://vercel.com/templates/hono/caltext"
     }
   ]
 }

--- a/packages/create-chat-sdk/_template/.agents/skills/chat-sdk/SKILL.md
+++ b/packages/create-chat-sdk/_template/.agents/skills/chat-sdk/SKILL.md
@@ -101,6 +101,10 @@ Use it for:
 - `node_modules/chat/resources/guides/how-to-build-a-slack-bot-with-next-js-and-redis.md` — This guide walks through building a Slack bot with Next.js, covering project setup, Slack app configuration, event handling, interactive features, and deployment.
 - `node_modules/chat/resources/guides/create-a-discord-support-bot-with-nuxt-and-redis.md` — This guide walks through building a Discord support bot with Nuxt, covering project setup, Discord app configuration, Gateway forwarding, AI-powered responses, and deployment.
 - `node_modules/chat/resources/guides/ship-a-github-code-review-bot-with-hono-and-redis.md` — This guide walks through building a GitHub bot that reviews pull requests on demand. When a user @mentions the bot on a PR, Chat SDK picks up the mention, spins up a Vercel Sandbox with the repo cloned, and uses AI SDK to analyze the diff.
+- `node_modules/chat/resources/guides/build-a-slack-bot-with-vercel-connect.md` — Learn how to build your very own Slackbot with Chat SDK and AI SDK. Vercel Connect supplies runtime Slack tokens and forwards triggers, so you never store a long-lived bot token.
+- `node_modules/chat/resources/guides/vercel-connect.md` — Use Vercel Connect to call provider APIs like Slack, GitHub, and Snowflake from your agents and services with short-lived, user-authorized tokens instead of long-lived secrets.
+- `node_modules/chat/resources/guides/ai-gateway-and-ai-sdk.md` — Build AI agents on Vercel with AI Gateway and AI SDK, then make them reliable, capable, and durable with Sandbox, Chat SDK, Vercel Connect, and Workflow.
+- `node_modules/chat/resources/guides/daily-digest-bot-with-chat-sdk-and-workflow-sdk.md` — Create your own daily digest bot that posts a daily digest of GitHub stats to Slack. Learn how to use Vercel Connect to set up Slack and GitHub app securely in your project.
 
 ### Templates
 
@@ -110,6 +114,7 @@ Listed in `node_modules/chat/resources/templates.json`:
 - **Durable iMessage Agent** — Durable iMessage agent powered by the Sendblue adapter. (https://vercel.com/templates/nitro/durable-imessage-ai-agent)
 - **Knowledge Agent** — Open source file-system and knowledge based agent template. Build AI agents that stay up to date with your knowledge base. (https://vercel.com/templates/nuxt/chat-sdk-knowledge-agent)
 - **Community Agent** — Open source AI-powered Slack community management bot with a built-in Next.js admin panel. Uses Chat SDK, AI SDK, and Vercel Workflow. (https://vercel.com/templates/next.js/chat-sdk-community-agent)
+- **Caltext** — iMessage calorie tracking assistant powered by AI. (https://vercel.com/templates/hono/caltext)
 
 <!-- RESOURCES:END -->
 

--- a/packages/create-chat-sdk/_template/.claude/skills/chat-sdk/SKILL.md
+++ b/packages/create-chat-sdk/_template/.claude/skills/chat-sdk/SKILL.md
@@ -101,6 +101,10 @@ Use it for:
 - `node_modules/chat/resources/guides/how-to-build-a-slack-bot-with-next-js-and-redis.md` — This guide walks through building a Slack bot with Next.js, covering project setup, Slack app configuration, event handling, interactive features, and deployment.
 - `node_modules/chat/resources/guides/create-a-discord-support-bot-with-nuxt-and-redis.md` — This guide walks through building a Discord support bot with Nuxt, covering project setup, Discord app configuration, Gateway forwarding, AI-powered responses, and deployment.
 - `node_modules/chat/resources/guides/ship-a-github-code-review-bot-with-hono-and-redis.md` — This guide walks through building a GitHub bot that reviews pull requests on demand. When a user @mentions the bot on a PR, Chat SDK picks up the mention, spins up a Vercel Sandbox with the repo cloned, and uses AI SDK to analyze the diff.
+- `node_modules/chat/resources/guides/build-a-slack-bot-with-vercel-connect.md` — Learn how to build your very own Slackbot with Chat SDK and AI SDK. Vercel Connect supplies runtime Slack tokens and forwards triggers, so you never store a long-lived bot token.
+- `node_modules/chat/resources/guides/vercel-connect.md` — Use Vercel Connect to call provider APIs like Slack, GitHub, and Snowflake from your agents and services with short-lived, user-authorized tokens instead of long-lived secrets.
+- `node_modules/chat/resources/guides/ai-gateway-and-ai-sdk.md` — Build AI agents on Vercel with AI Gateway and AI SDK, then make them reliable, capable, and durable with Sandbox, Chat SDK, Vercel Connect, and Workflow.
+- `node_modules/chat/resources/guides/daily-digest-bot-with-chat-sdk-and-workflow-sdk.md` — Create your own daily digest bot that posts a daily digest of GitHub stats to Slack. Learn how to use Vercel Connect to set up Slack and GitHub app securely in your project.
 
 ### Templates
 
@@ -110,6 +114,7 @@ Listed in `node_modules/chat/resources/templates.json`:
 - **Durable iMessage Agent** — Durable iMessage agent powered by the Sendblue adapter. (https://vercel.com/templates/nitro/durable-imessage-ai-agent)
 - **Knowledge Agent** — Open source file-system and knowledge based agent template. Build AI agents that stay up to date with your knowledge base. (https://vercel.com/templates/nuxt/chat-sdk-knowledge-agent)
 - **Community Agent** — Open source AI-powered Slack community management bot with a built-in Next.js admin panel. Uses Chat SDK, AI SDK, and Vercel Workflow. (https://vercel.com/templates/next.js/chat-sdk-community-agent)
+- **Caltext** — iMessage calorie tracking assistant powered by AI. (https://vercel.com/templates/hono/caltext)
 
 <!-- RESOURCES:END -->
 

--- a/packages/integration-tests/src/sync-resources.test.ts
+++ b/packages/integration-tests/src/sync-resources.test.ts
@@ -1,0 +1,97 @@
+import { readdirSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import { REPO_ROOT } from "./documentation-test-utils";
+
+interface Resource {
+  description: string;
+  href: string;
+  title: string;
+  type: "guide" | "template";
+}
+
+const CONFIG_PATH = "apps/docs/resources-edge-config.json";
+const GUIDES_DIR = "packages/chat/resources/guides";
+const TEMPLATES_FILE = "packages/chat/resources/templates.json";
+const SKILL_FILE = "skills/chat/SKILL.md";
+const SKILL_FILE_COPIES = [
+  "apps/docs/public/.well-known/agent-skills/chat-sdk/SKILL.md",
+  "apps/docs/public/AGENTS.md",
+  "packages/create-chat-sdk/_template/.agents/skills/chat-sdk/SKILL.md",
+  "packages/create-chat-sdk/_template/.claude/skills/chat-sdk/SKILL.md",
+] as const;
+
+const read = (path: string): string =>
+  readFileSync(join(REPO_ROOT, path), "utf-8");
+
+const slugFromHref = (href: string): string => {
+  const segment = new URL(href).pathname.split("/").filter(Boolean).pop();
+  if (!segment) {
+    throw new Error(`Cannot derive slug from href: ${href}`);
+  }
+  return segment;
+};
+
+const { resources } = JSON.parse(read(CONFIG_PATH)) as {
+  resources: Resource[];
+};
+const guides = resources.filter((r) => r.type === "guide");
+const templates = resources.filter((r) => r.type === "template");
+
+describe("resources-edge-config.json", () => {
+  it("has no duplicate guide slugs", () => {
+    const slugs = guides.map((g) => slugFromHref(g.href));
+    expect(new Set(slugs).size).toBe(slugs.length);
+  });
+});
+
+describe("synced guide files", () => {
+  it("has a non-empty markdown file for every configured guide", () => {
+    for (const guide of guides) {
+      const slug = slugFromHref(guide.href);
+      const body = read(`${GUIDES_DIR}/${slug}.md`);
+      expect(body.length).toBeGreaterThan(0);
+    }
+  });
+
+  it("contains no guide files beyond those in the config", () => {
+    const onDisk = readdirSync(join(REPO_ROOT, GUIDES_DIR))
+      .filter((name) => name.endsWith(".md"))
+      .sort();
+    const expected = guides.map((g) => `${slugFromHref(g.href)}.md`).sort();
+    expect(onDisk).toEqual(expected);
+  });
+});
+
+describe("templates.json", () => {
+  it("mirrors the templates from the config in order", () => {
+    const payload = JSON.parse(read(TEMPLATES_FILE)) as {
+      templates: { description: string; href: string; title: string }[];
+    };
+    const expected = templates.map(({ title, description, href }) => ({
+      title,
+      description,
+      href,
+    }));
+    expect(payload.templates).toEqual(expected);
+  });
+});
+
+describe("skill file copies", () => {
+  const source = read(SKILL_FILE);
+
+  for (const copyPath of SKILL_FILE_COPIES) {
+    it(`${copyPath} is an exact copy of ${SKILL_FILE}`, () => {
+      expect(read(copyPath)).toBe(source);
+    });
+  }
+
+  it("lists every configured guide and template", () => {
+    for (const guide of guides) {
+      expect(source).toContain(`${slugFromHref(guide.href)}.md`);
+    }
+    for (const template of templates) {
+      expect(source).toContain(template.title);
+    }
+  });
+});

--- a/scripts/sync-resources.ts
+++ b/scripts/sync-resources.ts
@@ -21,6 +21,24 @@ const resourcesDir = join(chatPackageRoot, "resources");
 const guidesDir = join(resourcesDir, "guides");
 const templatesFile = join(resourcesDir, "templates.json");
 const skillFile = join(repoRoot, "skills", "chat", "SKILL.md");
+const docsPublicDir = join(repoRoot, "apps", "docs", "public");
+const scaffoldTemplateDir = join(
+  repoRoot,
+  "packages",
+  "create-chat-sdk",
+  "_template"
+);
+
+/**
+ * Exact copies of {@link skillFile}: two served by the docs site and two
+ * bundled into the `create-chat-sdk` scaffold template.
+ */
+const skillFileCopies = [
+  join(docsPublicDir, ".well-known", "agent-skills", "chat-sdk", "SKILL.md"),
+  join(docsPublicDir, "AGENTS.md"),
+  join(scaffoldTemplateDir, ".agents", "skills", "chat-sdk", "SKILL.md"),
+  join(scaffoldTemplateDir, ".claude", "skills", "chat-sdk", "SKILL.md"),
+];
 
 const RESOURCES_START = "<!-- RESOURCES:START -->";
 const RESOURCES_END = "<!-- RESOURCES:END -->";
@@ -28,7 +46,144 @@ const RESOURCES_END = "<!-- RESOURCES:END -->";
 const SLUG_PATTERN = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
 const FETCH_TIMEOUT_MS = 30_000;
 const MAX_GUIDE_BYTES = 1_000_000;
+const RETRY_ATTEMPTS = 3;
+const RETRY_BASE_DELAY_MS = 500;
 
+/**
+ * Error thrown by {@link fetchGuideMarkdown}, carrying whether the failure is
+ * worth retrying.
+ */
+class FetchError extends Error {
+  readonly retryable: boolean;
+
+  /**
+   * @param message - Human-readable failure description.
+   * @param retryable - `true` for transient failures (5xx), `false` for
+   * permanent ones (4xx, bad content-type, oversized body).
+   */
+  constructor(message: string, retryable: boolean) {
+    super(message);
+    this.name = "FetchError";
+    this.retryable = retryable;
+  }
+}
+
+/**
+ * Resolves after a delay.
+ *
+ * @param ms - Milliseconds to wait.
+ * @returns A promise that resolves once the delay elapses.
+ */
+const sleep = (ms: number): Promise<void> =>
+  new Promise((resolve) => {
+    setTimeout(resolve, ms);
+  });
+
+/**
+ * Decides whether a thrown value represents a transient failure. Native fetch
+ * rejections (network errors, `AbortError` on timeout) are transient, so
+ * anything that is not an explicitly non-retryable {@link FetchError} is
+ * retried.
+ *
+ * @param error - The value thrown by the attempted operation.
+ * @returns `true` if the operation should be retried.
+ */
+const isRetryable = (error: unknown): boolean =>
+  !(error instanceof FetchError) || error.retryable;
+
+/**
+ * Runs an async operation, retrying transient failures with exponential
+ * backoff.
+ *
+ * @typeParam T - The resolved value of the operation.
+ * @param label - Identifier included in retry warnings.
+ * @param fn - The operation to run; retried up to {@link RETRY_ATTEMPTS} times.
+ * @returns The resolved value of `fn`.
+ * @throws The last error if all attempts fail or the error is non-retryable.
+ */
+const withRetry = async <T>(
+  label: string,
+  fn: () => Promise<T>
+): Promise<T> => {
+  let lastError: unknown;
+  for (let attempt = 1; attempt <= RETRY_ATTEMPTS; attempt++) {
+    try {
+      return await fn();
+    } catch (error) {
+      lastError = error;
+      if (!isRetryable(error) || attempt === RETRY_ATTEMPTS) {
+        throw error;
+      }
+      const delay = RETRY_BASE_DELAY_MS * 2 ** (attempt - 1);
+      const reason = error instanceof Error ? error.message : String(error);
+      console.warn(
+        `Attempt ${attempt}/${RETRY_ATTEMPTS} failed for ${label}: ${reason}. Retrying in ${delay}ms...`
+      );
+      await sleep(delay);
+    }
+  }
+  throw lastError;
+};
+
+/**
+ * Type guard for a single {@link Resource} entry.
+ *
+ * @param value - The parsed value to check.
+ * @returns `true` if `value` has the required string fields and a valid `type`.
+ */
+const isResource = (value: unknown): value is Resource => {
+  if (typeof value !== "object" || value === null) {
+    return false;
+  }
+  const entry = value as Record<string, unknown>;
+  return (
+    typeof entry.href === "string" &&
+    typeof entry.title === "string" &&
+    typeof entry.description === "string" &&
+    (entry.type === "guide" || entry.type === "template")
+  );
+};
+
+/**
+ * Parses and validates the raw resources-edge-config JSON.
+ *
+ * @param raw - The file contents to parse.
+ * @returns The validated resources payload.
+ * @throws If the content is not valid JSON, lacks a `resources` array, or
+ * contains an entry that fails {@link isResource}.
+ */
+const parseResourcesFile = (raw: string): ResourcesFile => {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (error) {
+    throw new Error(
+      `${sourceFile} is not valid JSON: ${
+        error instanceof Error ? error.message : String(error)
+      }`
+    );
+  }
+  const resources = (parsed as { resources?: unknown })?.resources;
+  if (!Array.isArray(resources)) {
+    throw new Error(`${sourceFile} must contain a "resources" array`);
+  }
+  for (const [index, entry] of resources.entries()) {
+    if (!isResource(entry)) {
+      throw new Error(
+        `Invalid resource at index ${index} in ${sourceFile}: ${JSON.stringify(entry)}`
+      );
+    }
+  }
+  return { resources };
+};
+
+/**
+ * Parses an href and asserts it uses the `https:` protocol.
+ *
+ * @param href - The URL string to validate.
+ * @returns The parsed {@link URL}.
+ * @throws If `href` is not a valid URL or does not use `https:`.
+ */
 const assertHttpsUrl = (href: string): URL => {
   const url = new URL(href);
   if (url.protocol !== "https:") {
@@ -37,6 +192,14 @@ const assertHttpsUrl = (href: string): URL => {
   return url;
 };
 
+/**
+ * Derives a kebab-case slug from the last path segment of an href.
+ *
+ * @param href - The guide URL to derive a slug from.
+ * @returns The validated slug.
+ * @throws If the href is not https, has no usable path segment, or the segment
+ * is not kebab-case `a-z0-9`.
+ */
 const slugFromHref = (href: string): string => {
   const url = assertHttpsUrl(href);
   const last = url.pathname.split("/").filter(Boolean).pop();
@@ -51,6 +214,14 @@ const slugFromHref = (href: string): string => {
   return last;
 };
 
+/**
+ * Fetches a guide's markdown by appending `.md` to its href.
+ *
+ * @param href - The guide URL (without the `.md` suffix).
+ * @returns The markdown body.
+ * @throws A {@link FetchError} on non-2xx responses, a non-`text/markdown`
+ * content-type, or a body exceeding {@link MAX_GUIDE_BYTES}.
+ */
 const fetchGuideMarkdown = async (href: string): Promise<string> => {
   assertHttpsUrl(href);
   const url = `${href}.md`;
@@ -58,25 +229,36 @@ const fetchGuideMarkdown = async (href: string): Promise<string> => {
     signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
   });
   if (!response.ok) {
-    throw new Error(
-      `Failed to fetch ${url}: ${response.status} ${response.statusText}`
+    throw new FetchError(
+      `Failed to fetch ${url}: ${response.status} ${response.statusText}`,
+      response.status >= 500
     );
   }
   const contentType = response.headers.get("content-type") ?? "";
   if (!contentType.includes("text/markdown")) {
-    throw new Error(
-      `Unexpected content-type for ${url}: ${contentType}. Expected text/markdown.`
+    throw new FetchError(
+      `Unexpected content-type for ${url}: ${contentType}. Expected text/markdown.`,
+      false
     );
   }
   const body = await response.text();
   if (body.length > MAX_GUIDE_BYTES) {
-    throw new Error(
-      `Guide exceeds ${MAX_GUIDE_BYTES} bytes (${body.length}): ${url}`
+    throw new FetchError(
+      `Guide exceeds ${MAX_GUIDE_BYTES} bytes (${body.length}): ${url}`,
+      false
     );
   }
   return body;
 };
 
+/**
+ * Renders the marker-delimited resources block embedded in the skill file.
+ *
+ * @param guides - Resources of type `guide`.
+ * @param templates - Resources of type `template`.
+ * @returns The block, bounded by {@link RESOURCES_START} and
+ * {@link RESOURCES_END}.
+ */
 const renderSkillBlock = (
   guides: Resource[],
   templates: Resource[]
@@ -107,6 +289,15 @@ const renderSkillBlock = (
   ].join("\n");
 };
 
+/**
+ * Rewrites the resources block in {@link skillFile} and mirrors the result to
+ * {@link skillFileCopies}.
+ *
+ * @param guides - Resources of type `guide`.
+ * @param templates - Resources of type `template`.
+ * @throws If the start/end markers are missing or out of order in the skill
+ * file.
+ */
 const updateSkillFile = async (guides: Resource[], templates: Resource[]) => {
   const existing = await readFile(skillFile, "utf8");
   const startIdx = existing.indexOf(RESOURCES_START);
@@ -123,21 +314,65 @@ const updateSkillFile = async (guides: Resource[], templates: Resource[]) => {
     await writeFile(skillFile, next, "utf8");
     console.log(`Updated ${skillFile}`);
   }
+  await syncSkillFileCopies(next);
 };
 
+/**
+ * Writes the skill-file content to every path in {@link skillFileCopies},
+ * creating parent directories and skipping paths already in sync.
+ *
+ * @param content - The exact skill-file content to mirror.
+ */
+const syncSkillFileCopies = async (content: string) => {
+  for (const copyPath of skillFileCopies) {
+    await mkdir(dirname(copyPath), { recursive: true });
+    const current = await readFile(copyPath, "utf8").catch(() => null);
+    if (current !== content) {
+      await writeFile(copyPath, content, "utf8");
+      console.log(`Updated ${copyPath}`);
+    }
+  }
+};
+
+/**
+ * Syncs the KB resources: validates the config, derives collision-free slugs,
+ * fetches every guide into memory before touching disk, then writes guides,
+ * templates, and the skill file (with its copies).
+ *
+ * @throws If validation fails, two guides resolve to the same slug, or a guide
+ * fetch fails after retries.
+ */
 const main = async () => {
   const raw = await readFile(sourceFile, "utf8");
-  const { resources } = JSON.parse(raw) as ResourcesFile;
+  const { resources } = parseResourcesFile(raw);
 
   const guides = resources.filter((r) => r.type === "guide");
   const templates = resources.filter((r) => r.type === "template");
 
+  const guidesBySlug = new Map<string, Resource>();
+  for (const guide of guides) {
+    const slug = slugFromHref(guide.href);
+    const existing = guidesBySlug.get(slug);
+    if (existing) {
+      throw new Error(
+        `Duplicate guide slug "${slug}" from ${existing.href} and ${guide.href}`
+      );
+    }
+    guidesBySlug.set(slug, guide);
+  }
+
+  const fetchedGuides: { slug: string; markdown: string }[] = [];
+  for (const [slug, guide] of guidesBySlug) {
+    const markdown = await withRetry(guide.href, () =>
+      fetchGuideMarkdown(guide.href)
+    );
+    fetchedGuides.push({ slug, markdown });
+  }
+
   await rm(resourcesDir, { recursive: true, force: true });
   await mkdir(guidesDir, { recursive: true });
 
-  for (const guide of guides) {
-    const slug = slugFromHref(guide.href);
-    const markdown = await fetchGuideMarkdown(guide.href);
+  for (const { slug, markdown } of fetchedGuides) {
     const outPath = join(guidesDir, `${slug}.md`);
     await writeFile(outPath, markdown, "utf8");
     console.log(`Wrote ${outPath}`);

--- a/skills/chat/SKILL.md
+++ b/skills/chat/SKILL.md
@@ -101,6 +101,10 @@ Use it for:
 - `node_modules/chat/resources/guides/how-to-build-a-slack-bot-with-next-js-and-redis.md` — This guide walks through building a Slack bot with Next.js, covering project setup, Slack app configuration, event handling, interactive features, and deployment.
 - `node_modules/chat/resources/guides/create-a-discord-support-bot-with-nuxt-and-redis.md` — This guide walks through building a Discord support bot with Nuxt, covering project setup, Discord app configuration, Gateway forwarding, AI-powered responses, and deployment.
 - `node_modules/chat/resources/guides/ship-a-github-code-review-bot-with-hono-and-redis.md` — This guide walks through building a GitHub bot that reviews pull requests on demand. When a user @mentions the bot on a PR, Chat SDK picks up the mention, spins up a Vercel Sandbox with the repo cloned, and uses AI SDK to analyze the diff.
+- `node_modules/chat/resources/guides/build-a-slack-bot-with-vercel-connect.md` — Learn how to build your very own Slackbot with Chat SDK and AI SDK. Vercel Connect supplies runtime Slack tokens and forwards triggers, so you never store a long-lived bot token.
+- `node_modules/chat/resources/guides/vercel-connect.md` — Use Vercel Connect to call provider APIs like Slack, GitHub, and Snowflake from your agents and services with short-lived, user-authorized tokens instead of long-lived secrets.
+- `node_modules/chat/resources/guides/ai-gateway-and-ai-sdk.md` — Build AI agents on Vercel with AI Gateway and AI SDK, then make them reliable, capable, and durable with Sandbox, Chat SDK, Vercel Connect, and Workflow.
+- `node_modules/chat/resources/guides/daily-digest-bot-with-chat-sdk-and-workflow-sdk.md` — Create your own daily digest bot that posts a daily digest of GitHub stats to Slack. Learn how to use Vercel Connect to set up Slack and GitHub app securely in your project.
 
 ### Templates
 
@@ -110,6 +114,7 @@ Listed in `node_modules/chat/resources/templates.json`:
 - **Durable iMessage Agent** — Durable iMessage agent powered by the Sendblue adapter. (https://vercel.com/templates/nitro/durable-imessage-ai-agent)
 - **Knowledge Agent** — Open source file-system and knowledge based agent template. Build AI agents that stay up to date with your knowledge base. (https://vercel.com/templates/nuxt/chat-sdk-knowledge-agent)
 - **Community Agent** — Open source AI-powered Slack community management bot with a built-in Next.js admin panel. Uses Chat SDK, AI SDK, and Vercel Workflow. (https://vercel.com/templates/next.js/chat-sdk-community-agent)
+- **Caltext** — iMessage calorie tracking assistant powered by AI. (https://vercel.com/templates/hono/caltext)
 
 <!-- RESOURCES:END -->
 


### PR DESCRIPTION
Syncs the bundled Chat SDK KB resources from Edge Config and hardens the `sync-resources` script that generates them.

- **New guides** (4): Vercel Connect, the Slack Vercel Connect bot, AI Gateway + AI SDK, and the daily digest bot. Existing guide bodies refreshed and `templates.json` regenerated.
- **Script hardening** (`scripts/sync-resources.ts`):
  - Fetch + validate all guides into memory **before** wiping the resources dir — a failed fetch now leaves the working tree untouched.
  - Validate the `resources-edge-config.json` shape with a clear error instead of a blind cast.
  - Reject duplicate guide slug collisions.
  - Retry transient fetches (5xx / network) with exponential backoff; fail fast on 4xx, bad content-type, and oversized bodies.
  - Mirror `skills/chat/SKILL.md` to **all four** committed copies (docs site `.well-known` + `AGENTS.md`, and the two `create-chat-sdk` scaffold templates).
  - TSDoc on every function.
- **Tests**: new offline consistency test in `packages/integration-tests` — every guide has a non-empty file with no orphans, `templates.json` mirrors the config, no duplicate slugs, and all four `SKILL.md` copies are byte-identical to the source.