### PR TITLE
fix(state-pg): setIfNotExists TTL expiry

### DIFF
--- a/.changeset/state-pg-set-if-not-exists-ttl.md
+++ b/.changeset/state-pg-set-if-not-exists-ttl.md
@@ -1,0 +1,5 @@
+---
+"@chat-adapter/state-pg": patch
+---
+
+Fix `setIfNotExists()` so it can claim a cache key whose existing row has expired. Previously the query used `ON CONFLICT DO NOTHING`, so an expired row in `chat_state_cache` still blocked acquisition until opportunistic cleanup deleted it — diverging from the memory and Redis adapters, which treat expired entries as absent. Keys stored without a TTL remain permanent and are never overwritten.

--- a/packages/state-pg/src/index.test.ts
+++ b/packages/state-pg/src/index.test.ts
@@ -439,6 +439,30 @@ describe("PostgresStateAdapter", () => {
         expect(result).toBe(true);
       });
 
+      it("should allow setIfNotExists to replace expired keys", async () => {
+        queryRows = [{ cache_key: "key" }];
+        const result = await adapter.setIfNotExists("key", "value", 5000);
+
+        expect(result).toBe(true);
+        expect(pool.query).toHaveBeenCalledWith(
+          expect.stringContaining(
+            "ON CONFLICT (key_prefix, cache_key) DO UPDATE"
+          ),
+          ["chat-sdk", "key", '"value"', expect.any(Date)]
+        );
+
+        const calls = (pool.query as ReturnType<typeof vi.fn>).mock.calls;
+        const setIfNotExistsCall = calls.find(
+          (c: unknown[]) =>
+            typeof c[0] === "string" &&
+            c[0].includes("INSERT INTO chat_state_cache") &&
+            c[0].includes("WHERE chat_state_cache.expires_at IS NOT NULL") &&
+            c[0].includes("chat_state_cache.expires_at <= now()")
+        );
+
+        expect(setIfNotExistsCall).toBeTruthy();
+      });
+
       it("should delete a value without throwing", async () => {
         await adapter.delete("key");
       });

--- a/packages/state-pg/src/index.test.ts
+++ b/packages/state-pg/src/index.test.ts
@@ -446,21 +446,11 @@ describe("PostgresStateAdapter", () => {
         expect(result).toBe(true);
         expect(pool.query).toHaveBeenCalledWith(
           expect.stringContaining(
-            "ON CONFLICT (key_prefix, cache_key) DO UPDATE"
+            `WHERE chat_state_cache.expires_at IS NOT NULL
+           AND chat_state_cache.expires_at <= now()`
           ),
           ["chat-sdk", "key", '"value"', expect.any(Date)]
         );
-
-        const calls = (pool.query as ReturnType<typeof vi.fn>).mock.calls;
-        const setIfNotExistsCall = calls.find(
-          (c: unknown[]) =>
-            typeof c[0] === "string" &&
-            c[0].includes("INSERT INTO chat_state_cache") &&
-            c[0].includes("WHERE chat_state_cache.expires_at IS NOT NULL") &&
-            c[0].includes("chat_state_cache.expires_at <= now()")
-        );
-
-        expect(setIfNotExistsCall).toBeTruthy();
       });
 
       it("should delete a value without throwing", async () => {

--- a/packages/state-pg/src/index.ts
+++ b/packages/state-pg/src/index.ts
@@ -260,7 +260,12 @@ export class PostgresStateAdapter implements StateAdapter {
     const result = await this.pool.query(
       `INSERT INTO chat_state_cache (key_prefix, cache_key, value, expires_at)
        VALUES ($1, $2, $3, $4)
-       ON CONFLICT (key_prefix, cache_key) DO NOTHING
+       ON CONFLICT (key_prefix, cache_key) DO UPDATE
+         SET value = EXCLUDED.value,
+             expires_at = EXCLUDED.expires_at,
+             updated_at = now()
+         WHERE chat_state_cache.expires_at IS NOT NULL
+           AND chat_state_cache.expires_at <= now()
        RETURNING cache_key`,
       [this.keyPrefix, key, serialized, expiresAt]
     );


### PR DESCRIPTION
## Summary

Fixes the Postgres state adapter so `setIfNotExists()` can claim a cache key whose existing row has expired.

Previously the method used `ON CONFLICT DO NOTHING`, so an expired row in `chat_state_cache` still blocked acquisition until a separate cleanup deleted it. That diverged from the memory adapter behavior and from the expected lease semantics for cache-backed coordination.

The new query keeps active rows protected, but replaces rows whose `expires_at` is in the past.

## Validation

- `pnpm --filter @chat-adapter/state-pg test`
- `pnpm --filter @chat-adapter/state-pg typecheck`
- `pnpm exec ultracite check packages/state-pg/src/index.ts packages/state-pg/src/index.test.ts`
