### PR TITLE
fix(slack): recover expired native streams

### DIFF
--- a/.changeset/slack-stream-expiry.md
+++ b/.changeset/slack-stream-expiry.md
@@ -1,0 +1,5 @@
+---
+"@chat-adapter/slack": patch
+---
+
+Recover expired Slack native streams with `chat.update` so buffered markdown is not dropped when Slack returns `message_not_in_streaming_state`.

--- a/packages/adapter-slack/package.json
+++ b/packages/adapter-slack/package.json
@@ -45,7 +45,7 @@
   "dependencies": {
     "@chat-adapter/shared": "workspace:*",
     "@slack/socket-mode": "^2.0.5",
-    "@slack/web-api": "^7.14.0",
+    "@slack/web-api": "^7.17.0",
     "chat": "workspace:*"
   },
   "devDependencies": {

--- a/packages/adapter-slack/src/index.test.ts
+++ b/packages/adapter-slack/src/index.test.ts
@@ -8052,6 +8052,107 @@ describe("stream with empty threadTs", () => {
       expect.objectContaining({ token: "xoxb-test-token" })
     );
   });
+
+  it("falls back to chat.update when a stream append expires", async () => {
+    const adapter = createSlackAdapter({
+      botToken: "xoxb-test-token",
+      signingSecret: "test-signing-secret",
+      logger: mockLogger,
+    });
+    const expiredError = Object.assign(new Error("stream expired"), {
+      code: "slack_webapi_platform_error",
+      data: { error: "message_not_in_streaming_state", ok: false },
+    });
+    const append = vi
+      .fn()
+      .mockResolvedValueOnce({ ok: true, ts: "1234567890.111111" })
+      .mockRejectedValueOnce(expiredError);
+    const stop = vi.fn().mockResolvedValue({
+      ok: true,
+      ts: "1234567890.111111",
+    });
+    const update = vi.fn().mockResolvedValue({
+      ok: true,
+      ts: "1234567890.111111",
+    });
+    mockClientMethod(
+      adapter,
+      "chatStream",
+      vi.fn().mockReturnValue({ append, stop, ts: "1234567890.111111" })
+    );
+    mockClientMethod(adapter, "chat.update", update);
+
+    async function* expiringStream() {
+      yield "hello\n\n";
+      yield "world";
+    }
+
+    const result = await adapter.stream(
+      "slack:C123:1234567890.000000",
+      expiringStream(),
+      {
+        recipientUserId: "U123",
+        recipientTeamId: "T123",
+      }
+    );
+
+    expect(result?.id).toBe("1234567890.111111");
+    expect(stop).not.toHaveBeenCalled();
+    expect(update).toHaveBeenCalledWith({
+      channel: "C123",
+      markdown_text: "hello\n\nworld",
+      token: "xoxb-test-token",
+      ts: "1234567890.111111",
+    });
+  });
+
+  it("falls back to chat.update when stopping an expired stream fails", async () => {
+    const adapter = createSlackAdapter({
+      botToken: "xoxb-test-token",
+      signingSecret: "test-signing-secret",
+      logger: mockLogger,
+    });
+    const expiredError = Object.assign(new Error("stream expired"), {
+      code: "slack_webapi_platform_error",
+      data: { error: "message_not_in_streaming_state", ok: false },
+    });
+    const append = vi.fn().mockResolvedValue(null);
+    const stop = vi.fn().mockRejectedValue(expiredError);
+    const update = vi.fn().mockResolvedValue({
+      ok: true,
+      ts: "1234567890.111111",
+    });
+    mockClientMethod(
+      adapter,
+      "chatStream",
+      vi.fn().mockReturnValue({ append, stop, ts: "1234567890.111111" })
+    );
+    mockClientMethod(adapter, "chat.update", update);
+
+    async function* shortStream() {
+      yield "hello world";
+    }
+
+    const result = await adapter.stream(
+      "slack:C123:1234567890.000000",
+      shortStream(),
+      {
+        recipientUserId: "U123",
+        recipientTeamId: "T123",
+      }
+    );
+
+    expect(result?.id).toBe("1234567890.111111");
+    expect(stop).toHaveBeenCalledWith(
+      expect.objectContaining({ token: "xoxb-test-token" })
+    );
+    expect(update).toHaveBeenCalledWith({
+      channel: "C123",
+      markdown_text: "hello world",
+      token: "xoxb-test-token",
+      ts: "1234567890.111111",
+    });
+  });
 });
 
 describe("scheduleMessage with empty threadTs", () => {

--- a/packages/adapter-slack/src/index.ts
+++ b/packages/adapter-slack/src/index.ts
@@ -78,6 +78,16 @@ import { verifySlackRequest } from "./webhook/index";
 
 const SLACK_USER_ID_PATTERN = /^[A-Z0-9_]+$/;
 const SLACK_USER_ID_EXACT_PATTERN = /^U[A-Z0-9]+$/;
+const SLACK_STREAM_EXPIRED_ERROR = "message_not_in_streaming_state";
+
+function isSlackStreamExpiredError(error: unknown): boolean {
+  const slackError = error as { code?: string; data?: { error?: string } };
+
+  return (
+    slackError.code === "slack_webapi_platform_error" &&
+    slackError.data?.error === SLACK_STREAM_EXPIRED_ERROR
+  );
+}
 
 // Slack expects block_suggestion responses within 3s. Leave headroom for
 // network latency so the HTTP response lands before Slack gives up.
@@ -3989,15 +3999,91 @@ export class SlackAdapter implements Adapter<SlackThreadId, unknown> {
     });
 
     let lastAppended = "";
+    let streamExpired = false;
     const renderer = new StreamingMarkdownRenderer({
       wrapTablesForAppend: false,
     });
+
+    const markStreamExpired = (error: unknown): void => {
+      if (streamExpired) {
+        return;
+      }
+      streamExpired = true;
+      this.logger.warn(
+        "Slack stream expired; falling back to chat.update for final content",
+        { error }
+      );
+    };
+
+    const runSlackStreamRequest = async <T>(
+      request: () => Promise<T>,
+      onUnhandledError?: (error: unknown) => void
+    ): Promise<T | null> => {
+      if (streamExpired) {
+        return null;
+      }
+
+      try {
+        return await request();
+      } catch (error) {
+        if (isSlackStreamExpiredError(error)) {
+          markStreamExpired(error);
+          return null;
+        }
+        if (onUnhandledError) {
+          onUnhandledError(error);
+          return null;
+        }
+        this.handleSlackError(error);
+      }
+    };
+
+    const updateExpiredStream = async (
+      markdownText: string
+    ): Promise<RawMessage<unknown>> => {
+      const messageTs = streamer.ts;
+      if (!messageTs) {
+        throw new Error(
+          "Slack stream expired before a message timestamp was available"
+        );
+      }
+
+      const payload = options?.stopBlocks
+        ? {
+            blocks: options.stopBlocks as ChatStopStreamArguments["blocks"],
+            text: markdownText,
+          }
+        : { markdown_text: markdownText };
+
+      try {
+        const result = await this._client.chat.update({
+          channel,
+          ts: messageTs,
+          token,
+          ...payload,
+        });
+
+        this.logger.debug("Slack: stream completed via chat.update fallback", {
+          messageId: result.ts,
+        });
+
+        return {
+          id: result.ts as string,
+          threadId,
+          raw: result,
+        };
+      } catch (error) {
+        this.handleSlackError(error);
+      }
+    };
 
     const flushMarkdownDelta = async (delta: string): Promise<void> => {
       if (delta.length === 0) {
         return;
       }
-      await streamer.append({ markdown_text: delta, token });
+      await runSlackStreamRequest(() =>
+        streamer.append({ markdown_text: delta, token })
+      );
     };
 
     /**
@@ -4022,21 +4108,25 @@ export class SlackAdapter implements Adapter<SlackThreadId, unknown> {
       await flushMarkdownDelta(delta);
       lastAppended = committable;
 
-      try {
-        // biome-ignore lint/suspicious/noExplicitAny: chunks not in ChatAppendStreamArguments for older @slack/web-api
-        await streamer.append({ chunks: [chunk], token } as any);
-      } catch (error) {
-        // Structured chunks may fail if the app doesn't have the required
-        // Assistant scopes/features. Disable for the rest of this stream
-        // to avoid repeated failures and log once.
-        structuredChunksSupported = false;
-        this.logger.warn(
-          "Structured streaming chunk failed, falling back to text-only streaming. " +
-            "Ensure your Slack app manifest includes assistant_view, assistant:write scope, " +
-            "and @slack/web-api >= 7.14.0",
-          { chunkType: chunk.type, error }
-        );
+      if (streamExpired) {
+        return;
       }
+
+      await runSlackStreamRequest(
+        () => streamer.append({ chunks: [chunk], token }),
+        (error) => {
+          // Structured chunks may fail if the app doesn't have the required
+          // Assistant scopes/features. Disable for the rest of this stream
+          // to avoid repeated failures and log once.
+          structuredChunksSupported = false;
+          this.logger.warn(
+            "Structured streaming chunk failed, falling back to text-only streaming. " +
+              "Ensure your Slack app manifest includes assistant_view, assistant:write scope, " +
+              "and @slack/web-api >= 7.14.0",
+            { chunkType: chunk.type, error }
+          );
+        }
+      );
     };
 
     const pushTextAndFlush = async (text: string): Promise<void> => {
@@ -4064,14 +4154,28 @@ export class SlackAdapter implements Adapter<SlackThreadId, unknown> {
     const finalDelta = finalCommittable.slice(lastAppended.length);
     await flushMarkdownDelta(finalDelta);
 
-    const result = await streamer.stop({
-      token,
-      ...(options?.stopBlocks
-        ? {
-            blocks: options.stopBlocks as ChatStopStreamArguments["blocks"],
-          }
-        : {}),
-    });
+    if (streamExpired) {
+      return updateExpiredStream(finalCommittable);
+    }
+
+    const result = await runSlackStreamRequest(() =>
+      streamer.stop({
+        token,
+        ...(options?.stopBlocks
+          ? {
+              blocks: options.stopBlocks as ChatStopStreamArguments["blocks"],
+            }
+          : {}),
+      })
+    );
+
+    if (streamExpired) {
+      return updateExpiredStream(finalCommittable);
+    }
+    if (!result) {
+      throw new Error("Slack stream stopped without a response");
+    }
+
     const messageTs = (result.message?.ts ?? result.ts) as string;
 
     this.logger.debug("Slack: stream complete", { messageId: messageTs });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -481,8 +481,8 @@ importers:
         specifier: ^2.0.5
         version: 2.0.6
       '@slack/web-api':
-        specifier: ^7.14.0
-        version: 7.14.1
+        specifier: ^7.17.0
+        version: 7.17.0
       chat:
         specifier: workspace:*
         version: link:../chat
@@ -3476,10 +3476,6 @@ packages:
     resolution: {integrity: sha512-tlqY9xq5ukxTUZBmoOp+m61cqwQD5pHJtFY3Mn8CA8ps6yghLH/Hw8UPdqg4OLmFW3IFlcXnQNmo/dh8HzXYIQ==}
     engines: {node: '>=18'}
 
-  '@slack/logger@4.0.0':
-    resolution: {integrity: sha512-Wz7QYfPAlG/DR+DfABddUZeNgoeY7d1J39OCR2jR+v7VBsB8ezulDK5szTnDDPDwLH5IWhLvXIHlCFZV7MSKgA==}
-    engines: {node: '>= 18', npm: '>= 8.6.0'}
-
   '@slack/logger@4.0.1':
     resolution: {integrity: sha512-6cmdPrV/RYfd2U0mDGiMK8S7OJqpCTm7enMLRR3edccsPX8j7zXTLnaEF4fhxxJJTAIOil6+qZrnUPTuaLvwrQ==}
     engines: {node: '>= 18', npm: '>= 8.6.0'}
@@ -3488,20 +3484,12 @@ packages:
     resolution: {integrity: sha512-Aj5RO3MoYVJ+b2tUjHUXuA3tiIaCUMOf1Ss5tPiz29XYVUi6qNac2A8ulcU1pUPERpXVHTmT1XW6HzQIO74daQ==}
     engines: {node: '>= 18', npm: '>= 8.6.0'}
 
-  '@slack/types@2.20.0':
-    resolution: {integrity: sha512-PVF6P6nxzDMrzPC8fSCsnwaI+kF8YfEpxf3MqXmdyjyWTYsZQURpkK7WWUWvP5QpH55pB7zyYL9Qem/xSgc5VA==}
+  '@slack/types@2.21.1':
+    resolution: {integrity: sha512-I8vmSjNYWsaxuWPx6dz4yeh0h7vRBWbgAMK14LEmblbZ404BtrPbXs6jDPx4cYgGf8msDGF4A9opLZBu21FViQ==}
     engines: {node: '>= 12.13.0', npm: '>= 6.12.0'}
 
-  '@slack/types@2.20.1':
-    resolution: {integrity: sha512-eWX2mdt1ktpn8+40iiMc404uGrih+2fxiky3zBcPjtXKj6HLRdYlmhrPkJi7JTJm8dpXR6BWVWEDBXtaWMKD6A==}
-    engines: {node: '>= 12.13.0', npm: '>= 6.12.0'}
-
-  '@slack/web-api@7.14.1':
-    resolution: {integrity: sha512-RoygyteJeFswxDPJjUMESn9dldWVMD2xUcHHd9DenVavSfVC6FeVnSdDerOO7m8LLvw4Q132nQM4hX8JiF7dng==}
-    engines: {node: '>= 18', npm: '>= 8.6.0'}
-
-  '@slack/web-api@7.15.1':
-    resolution: {integrity: sha512-y+TAF7TszcmFzbVtBkFqAdBwKSoD+8shkNxhp4WIfFwXmCKdFje9WD6evROApPa2FTy1v1uc9yBaJs3609PPgg==}
+  '@slack/web-api@7.17.0':
+    resolution: {integrity: sha512-jejr34a8B4L5AS713wOAx1LAqNkW16HVMDEa6sYBvFDc/llUBl8hXaiI4BwF+Al+Sug19Vn2O7iokTVIhVvZ1Q==}
     engines: {node: '>= 18', npm: '>= 8.6.0'}
 
   '@smithy/config-resolver@4.4.17':
@@ -10999,10 +10987,6 @@ snapshots:
 
   '@sindresorhus/merge-streams@4.0.0': {}
 
-  '@slack/logger@4.0.0':
-    dependencies:
-      '@types/node': 25.9.2
-
   '@slack/logger@4.0.1':
     dependencies:
       '@types/node': 25.9.2
@@ -11010,7 +10994,7 @@ snapshots:
   '@slack/socket-mode@2.0.6':
     dependencies:
       '@slack/logger': 4.0.1
-      '@slack/web-api': 7.15.1
+      '@slack/web-api': 7.17.0
       '@types/node': 25.9.2
       '@types/ws': 8.18.1
       eventemitter3: 5.0.1
@@ -11021,32 +11005,12 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@slack/types@2.20.0': {}
+  '@slack/types@2.21.1': {}
 
-  '@slack/types@2.20.1': {}
-
-  '@slack/web-api@7.14.1':
-    dependencies:
-      '@slack/logger': 4.0.0
-      '@slack/types': 2.20.0
-      '@types/node': 25.9.2
-      '@types/retry': 0.12.0
-      axios: 1.16.1
-      eventemitter3: 5.0.1
-      form-data: 4.0.5
-      is-electron: 2.2.2
-      is-stream: 2.0.1
-      p-queue: 6.6.2
-      p-retry: 4.6.2
-      retry: 0.13.1
-    transitivePeerDependencies:
-      - debug
-      - supports-color
-
-  '@slack/web-api@7.15.1':
+  '@slack/web-api@7.17.0':
     dependencies:
       '@slack/logger': 4.0.1
-      '@slack/types': 2.20.1
+      '@slack/types': 2.21.1
       '@types/node': 25.9.2
       '@types/retry': 0.12.0
       axios: 1.16.1
@@ -11928,6 +11892,14 @@ snapshots:
       '@vitest/utils': 4.1.8
       chai: 6.2.2
       tinyrainbow: 3.1.0
+
+  '@vitest/mocker@4.0.18(vite@7.3.3(@types/node@25.3.2)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.22.3))':
+    dependencies:
+      '@vitest/spy': 4.0.18
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 7.3.3(@types/node@25.3.2)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.22.3)
 
   '@vitest/mocker@4.0.18(vite@7.3.3(@types/node@25.9.2)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.22.3))':
     dependencies:
@@ -16828,7 +16800,7 @@ snapshots:
   vitest@4.0.18(@opentelemetry/api@1.9.0)(@types/node@25.3.2)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.22.3):
     dependencies:
       '@vitest/expect': 4.0.18
-      '@vitest/mocker': 4.0.18(vite@7.3.3(@types/node@25.9.2)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.22.3))
+      '@vitest/mocker': 4.0.18(vite@7.3.3(@types/node@25.3.2)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.22.3))
       '@vitest/pretty-format': 4.0.18
       '@vitest/runner': 4.0.18
       '@vitest/snapshot': 4.0.18


### PR DESCRIPTION
## Summary

Fixes #637.

Slack can close a native streamed message server-side before `SlackAdapter.stream()` has finished consuming a long-running response. When Slack returns `message_not_in_streaming_state`, the adapter now stops using the expired native stream, keeps consuming the remaining text, and writes the final accumulated markdown back to the same Slack message via `chat.update` using the stream timestamp exposed by `@slack/web-api`.

This preserves buffered markdown that may not have reached Slack yet, including text still held by `ChatStreamer`'s internal buffer. The PR also bumps `@slack/web-api` to `^7.17.0` for the `ChatStreamer.ts` getter and adds regression coverage for both append-time and stop-time stream expiry.

## Test plan

- `pnpm --filter @chat-adapter/slack typecheck`
- `pnpm --filter @chat-adapter/slack exec vitest run src/index.test.ts -t "stream with empty threadTs"`
- `pnpm --filter @chat-adapter/slack test`
- `pnpm validate`

## Checklist

- [x] All commits are signed and verified
- [x] `pnpm validate` passes
- [x] Changeset added (or N/A — see [CONTRIBUTING.md](./CONTRIBUTING.md))
- [x] Documentation updated (or N/A)
