### PR TITLE
chore: enforce DCO and refresh community health files

### DIFF
--- a/.github/CODE_OF_CONDUCT.md
+++ b/.github/CODE_OF_CONDUCT.md
@@ -1,3 +1,12 @@
-# Vercel Community Code of Conduct
+# Code of conduct
 
-Please see https://community.vercel.com/guidelines for the latest version.
+This project follows the [Contributor Covenant 2.1][cov]. By participating,
+you agree to uphold its standards.
+
+To report unacceptable behavior, contact the maintainers via GitHub.
+Reports are confidential. Maintainers are obligated to respect the
+privacy of the reporter.
+
+The full text is available at <https://www.contributor-covenant.org/version/2/1/code_of_conduct/>.
+
+[cov]: https://www.contributor-covenant.org/version/2/1/code_of_conduct/

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -46,6 +46,31 @@ GitHub has a guide on setting this up: [Signing commits](https://docs.github.com
 
 Verify your setup by checking that new commits show a "Verified" badge on github.com.
 
+## Developer Certificate of Origin (DCO)
+
+In addition to signing, every commit must be **signed off** to certify that you wrote the patch (or otherwise have the right to submit it under the project's license), per the [Developer Certificate of Origin](https://developercertificate.org/) (the full text is also included in this repo as [`DCO.txt`](../DCO.txt)). A [DCO check](https://github.com/apps/dco) runs on each pull request and must pass before it can be merged.
+
+Sign off by adding the `-s` flag when you commit:
+
+```bash
+git commit -s -m "feat: add a thing"
+```
+
+This appends a trailer to your commit message:
+
+```
+Signed-off-by: Your Name <your.email@example.com>
+```
+
+The name and email must match the author of the commit. To set them once:
+
+```bash
+git config user.name "Your Name"
+git config user.email "your.email@example.com"
+```
+
+If the DCO check fails on existing commits, the simplest fixes are to amend (`git commit --amend -s`) or rebase (`git rebase --signoff main`) and force-push. The DCO app also accepts a single remediation commit if you'd rather not rewrite history — follow the instructions in the failed check's details.
+
 ## Commit messages
 
 We follow [Conventional Commits](https://www.conventionalcommits.org/) — `feat:`, `fix:`, `docs:`, `chore:`, etc., optionally with a scope (e.g., `fix(slack): ...`). The release workflow's auto-generated version PRs also use this convention (`chore(release): version packages`), so keeping new commits consistent makes changelogs and release PRs predictable.

--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -1,9 +1,7 @@
 # Reporting Security Issues
 
-If you believe you have found a security vulnerability in the Chat SDK, we encourage you to let us know right away.
+If you believe you have found a security vulnerability, we encourage you to let us know right away.
 
 We will investigate all legitimate reports and do our best to quickly fix the problem.
 
-Email `security@vercel.com` to disclose any security vulnerabilities.
-
-https://vercel.com/security
+Please report any vulnerabilities in our open source repositories to responsible.disclosure@vercel.com.

--- a/.github/dco.yml
+++ b/.github/dco.yml
@@ -1,0 +1,4 @@
+require:
+  members: true
+allowRemediationCommits:
+  individual: true

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -9,6 +9,7 @@
 ## Checklist
 
 - [ ] All commits are signed and verified
+- [ ] All commits are signed off for the DCO (`git commit -s`)
 - [ ] `pnpm validate` passes
 - [ ] Changeset added (or N/A — see [CONTRIBUTING.md](./CONTRIBUTING.md))
 - [ ] Documentation updated (or N/A)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,7 +26,7 @@ pnpm --filter docs dev    # Preview the docs site (chat-sdk.dev) locally
 
 - Install dependencies with `pnpm add`, not by editing `package.json` by hand.
 - `sample-messages.md` files in adapter packages contain real-world webhook logs — useful when writing parsers or fixtures.
-- Commits must be **signed and verified** — see `.github/CONTRIBUTING.md`.
+- Commits must be **signed and verified**, and **signed off** for the DCO (`git commit -s`) — see `.github/CONTRIBUTING.md`.
 - We follow [Conventional Commits](https://www.conventionalcommits.org/) (`feat:`, `fix:`, `docs:`, `chore:`, optionally scoped). The release workflow's auto-PR uses `chore(release): version packages` — don't reuse that exact subject for unrelated commits.
 - See the Ultracite section at the bottom for the in-code style rules Biome doesn't catch automatically.
 

--- a/DCO.txt
+++ b/DCO.txt
@@ -1,0 +1,37 @@
+Developer Certificate of Origin
+Version 1.1
+
+Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
+1 Letterman Drive
+Suite D4700
+San Francisco, CA, 94129
+
+Everyone is permitted to copy and distribute verbatim copies of this
+license document, but changing it is not allowed.
+
+
+Developer's Certificate of Origin 1.1
+
+By making a contribution to this project, I certify that:
+
+(a) The contribution was created in whole or in part by me and I
+    have the right to submit it under the open source license
+    indicated in the file; or
+
+(b) The contribution is based upon previous work that, to the best
+    of my knowledge, is covered under an appropriate open source
+    license and I have the right under that license to submit that
+    work with modifications, whether created in whole or in part
+    by me, under the same open source license (unless I am
+    permitted to submit under a different license), as indicated
+    in the file; or
+
+(c) The contribution was provided directly to me by some other
+    person who certified (a), (b) or (c) and I have not modified
+    it.
+
+(d) I understand and agree that this project and the contribution
+    are public and that a record of the contribution (including all
+    personal information I submit with it, including my sign-off) is
+    maintained indefinitely and may be redistributed consistent with
+    this project or the open source license(s) involved.


### PR DESCRIPTION
- Enforce the Developer Certificate of Origin (DCO) on all commits via the DCO GitHub App (`.github/dco.yml`), with the canonical DCO 1.1 text vendored as `DCO.txt`.
- Document the sign-off requirement (`git commit -s`) in `CONTRIBUTING.md`, the PR template checklist, and `AGENTS.md`.
- Refresh community-health docs: adopt Contributor Covenant 2.1 in `CODE_OF_CONDUCT.md` and update the disclosure contact in `SECURITY.md`.

These changes align this repo with the conventions in the [eve repo](https://github.com/vercel/eve).