### PR TITLE
docs: refresh agent docs, README badges, and Chat SDK skill

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -48,7 +48,7 @@ Verify your setup by checking that new commits show a "Verified" badge on github
 
 ## Developer Certificate of Origin (DCO)
 
-In addition to signing, every commit must be **signed off** to certify that you wrote the patch (or otherwise have the right to submit it under the project's license), per the [Developer Certificate of Origin](https://developercertificate.org/) (the full text is also included in this repo as [`DCO.txt`](../DCO.txt)). A [DCO check](https://github.com/apps/dco) runs on each pull request and must pass before it can be merged.
+In addition to signing, every commit must be **signed off** to certify that you wrote the patch (or otherwise have the right to submit it under the project's license), per the [Developer Certificate of Origin](https://developercertificate.org/).
 
 Sign off by adding the `-s` flag when you commit:
 
@@ -73,7 +73,9 @@ If the DCO check fails on existing commits, the simplest fixes are to amend (`gi
 
 ## Commit messages
 
-We follow [Conventional Commits](https://www.conventionalcommits.org/) — `feat:`, `fix:`, `docs:`, `chore:`, etc., optionally with a scope (e.g., `fix(slack): ...`). The release workflow's auto-generated version PRs also use this convention (`chore(release): version packages`), so keeping new commits consistent makes changelogs and release PRs predictable.
+We follow [Conventional Commits](https://www.conventionalcommits.org/) — `feat:`, `fix:`, `docs:`, `chore:`, etc., optionally with a scope (e.g., `fix(slack): ...`).
+
+The release workflow's auto-generated version PRs also use this convention (`chore(release): version packages`), so keeping new commits consistent makes changelogs and release PRs predictable.
 
 ## Development
 
@@ -155,7 +157,7 @@ pnpm --filter docs dev
 
 ## Preview Branch Testing
 
-The example app includes a middleware that can proxy webhook requests to a preview branch deployment. This allows testing preview branches with real webhook traffic from Slack/Teams/GChat.
+The example app includes a proxy that can forward webhook requests to a preview branch deployment. This allows testing preview branches with real webhook traffic from Slack/Teams/GChat.
 
 ### Setup
 
@@ -169,6 +171,6 @@ Clear the URL on the settings page.
 
 ### Files
 
-- `examples/nextjs-chat/src/middleware.ts` - The proxy middleware
+- `examples/nextjs-chat/src/proxy.ts` - The proxy logic
 - `examples/nextjs-chat/src/app/settings/page.tsx` - Settings UI
 - `examples/nextjs-chat/src/app/api/settings/preview-branch/route.ts` - API to get/set the URL

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,131 +1,98 @@
-# CLAUDE.md
+# AGENTS.md
 
-Guidance for Claude Code (claude.ai/code) when working in this repository.
+Guidance for coding agents working in this repository. For PR workflow, signed commits, and changeset rules, see [.github/CONTRIBUTING.md](.github/CONTRIBUTING.md).
 
-## Build commands
+## Commands
 
 ```bash
 pnpm install
-pnpm build           # Build all packages (Turborepo)
-pnpm typecheck       # Type-check all packages
-pnpm check           # Lint and format check (ultracite/biome)
-pnpm fix             # Auto-fix lint/format issues
-pnpm knip            # Check for unused exports/dependencies
-pnpm konsistent      # Enforce adapter/state-package shape conventions (see .github/konsistent.json)
-pnpm test            # Run all tests
-pnpm validate        # knip + check + typecheck + test + build. ALWAYS run before declaring a task done.
-pnpm dev             # Watch mode
+pnpm validate        # knip + check + typecheck + test + build — run before declaring work done
+pnpm check           # lint/format (Ultracite/Biome)
+pnpm fix             # auto-fix lint/format issues
+pnpm typecheck
+pnpm test            # all package tests via Turborepo (includes integration-tests)
+pnpm test:workspace  # single Vitest run across unit-test packages only
+pnpm build
+pnpm dev             # watch mode
+pnpm knip            # unused exports/dependencies
+pnpm konsistent      # adapter/state package shape (see .github/konsistent.json)
 
 # Per-package
 pnpm --filter chat test
 pnpm --filter @chat-adapter/slack build
-pnpm --filter docs dev    # Preview the docs site (chat-sdk.dev) locally
+pnpm --filter docs dev    # preview chat-sdk.dev locally
 ```
 
-## Code style
+Install dependencies with `pnpm add`, not by editing `package.json` by hand.
 
-- Install dependencies with `pnpm add`, not by editing `package.json` by hand.
-- `sample-messages.md` files in adapter packages contain real-world webhook logs — useful when writing parsers or fixtures.
-- Commits must be **signed and verified**, and **signed off** for the DCO (`git commit -s`) — see `.github/CONTRIBUTING.md`.
-- We follow [Conventional Commits](https://www.conventionalcommits.org/) (`feat:`, `fix:`, `docs:`, `chore:`, optionally scoped). The release workflow's auto-PR uses `chore(release): version packages` — don't reuse that exact subject for unrelated commits.
-- See the Ultracite section at the bottom for the in-code style rules Biome doesn't catch automatically.
+## Monorepo layout
+
+pnpm + Turborepo monorepo. Packages are ESM (`"type": "module"`), TypeScript, bundled with **tsup**.
+
+| Path | Role |
+| --- | --- |
+| `packages/chat` | Core SDK (`chat`): `Chat`, types, mdast markdown, `chat/adapters` catalog |
+| `packages/adapter-*` | Platform adapters (slack, teams, gchat, discord, telegram, whatsapp, github, linear, web, messenger, twilio, …) |
+| `packages/adapter-shared` | Shared adapter utilities |
+| `packages/state-*` | State adapters (memory, redis, ioredis, pg) |
+| `packages/create-chat-sdk` | `create-chat-sdk` CLI scaffold |
+| `packages/tests` | `@chat-adapter/tests` — Vitest factories/matchers for adapter tests |
+| `packages/integration-tests` | Replay + emulator tests; needs credentials for live API tests |
+| `apps/docs` | fumadocs site (chat-sdk.dev) |
+| `examples/*` | Example bots; `package.json` `name` must be `example-*` (private, no changeset) |
+
+When editing a specific package, read its **AGENTS.md** if present (most adapters, state packages, `create-chat-sdk`, and `packages/chat/src/adapters/` have one).
 
 ## Architecture
 
-pnpm monorepo, Turborepo orchestrated. All packages are ESM (`"type": "module"`), TypeScript, bundled with **tsup**.
-
-### Packages
-
-- `packages/chat` — core SDK (`chat` npm package): `Chat` class, types, mdast-based markdown utilities
-- `packages/adapter-{slack,teams,gchat,discord,telegram,whatsapp,github,linear,zoom}` — platform adapters
-- `packages/adapter-shared` — utilities shared across adapters
-- `packages/state-{memory,redis,ioredis,pg}` — state adapters
-- `packages/integration-tests` — integration tests against real platform APIs
-- `apps/docs` — fumadocs-based docs site (chat-sdk.dev)
-- `examples/*` — standalone example apps (e.g. `examples/nextjs-chat`). Each example's `package.json` `name` must follow the `example-*` convention so changesets ignores it automatically (see Releases). This is enforced by a test in `packages/integration-tests`.
-
 ### Core concepts
 
-1. **Chat** (`packages/chat/src/chat.ts`) — main entry point; coordinates adapters and handlers.
-2. **Adapter** — platform-specific implementation: webhook verification + parsing, normalized format conversion, `FormatConverter` for markdown ↔ platform AST.
-3. **StateAdapter** — persistence for subscriptions, distributed locks, key/value cache, lists, and queues.
-4. **Thread** — conversation thread with `post()`, `subscribe()`, `startTyping()`, `setState()`, etc.
+1. **Chat** (`packages/chat/src/chat.ts`) — coordinates adapters and handlers.
+2. **Adapter** — webhook verification, parsing, and a `FormatConverter` for markdown ↔ platform format.
+3. **StateAdapter** — subscriptions, distributed locks, key/value cache, lists, queues.
+4. **Thread** — conversation handle: `post()`, `subscribe()`, `startTyping()`, `setState()`, etc.
 5. **Message** — normalized message: `text`, `formatted` (mdast AST), `raw` (platform-specific).
 
-### Thread ID format
+### Thread IDs
 
 `{adapter}:{channel}:{thread}` — e.g. `slack:C123ABC:1234567890.123456`. Some adapters base64-encode IDs that contain delimiters (Teams, Google Chat).
 
 ### Webhook flow
 
 1. Platform → `/api/webhooks/{platform}`
-2. Adapter verifies, parses, calls `chat.handleIncomingMessage()`
-3. `Chat` acquires a thread lock, then routes to `onSubscribedMessage`, `onNewMention`, or `onNewMessage` handlers depending on context.
-4. Handler receives `Thread` and `Message`.
+2. Adapter verifies and parses; calls `chat.handleIncomingMessage()`
+3. `Chat` acquires a thread lock, then routes to `onSubscribedMessage`, `onNewMention`, or `onNewMessage`
+4. Handler receives `Thread` and `Message`
 
 ### Formatting
 
-Messages use **mdast** as the canonical format. Each adapter's `FormatConverter` provides:
-
-- `toAst(platformText)` — platform → mdast
-- `fromAst(ast)` — mdast → platform
-- `renderPostable(message)` — `PostableMessage` → platform string
+**mdast** is the canonical message format. Each adapter's `FormatConverter` implements `toAst`, `fromAst`, and `renderPostable`.
 
 ### Adapter catalog
 
-`packages/chat/src/adapters/index.ts` powers the zero-dependency `chat/adapters` subpath. Keep this static catalog in sync when adding or changing official and vendor-official adapters. Catalog entries should match `apps/docs/adapters.json`, include package metadata and peer dependencies, and describe env vars, credential modes, secrets, and constructor-only config. For official adapters, exclude workspace dependencies, `chat`, and `@chat-adapter/shared` from peer deps; for vendor-official adapters, mirror the MDX install instructions. Do not import adapter packages or platform SDKs from this module.
+`packages/chat/src/adapters/index.ts` powers the zero-dependency `chat/adapters` subpath. See [packages/chat/src/adapters/AGENTS.md](packages/chat/src/adapters/AGENTS.md) when adding or changing catalog entries — keep it in sync with `apps/docs/adapters.json`.
+
+## Working on adapters and state packages
+
+- Run `pnpm konsistent` after changing public exports; conventions are documented in [.github/CONTRIBUTING.md](.github/CONTRIBUTING.md#package-conventions).
+- `sample-messages.md` in adapter packages holds real webhook payloads — extend it when fixing parsers or adding event support.
+- Adapter factory/config naming: `create${Name}Adapter`, `${Name}Adapter`, `${Name}AdapterConfig` (see konsistent config for `gchat` → `GoogleChat` etc.).
 
 ## Testing
 
-`packages/chat/src/mock-adapter.ts` exports test utilities:
+`packages/chat/src/mock-adapter.ts`:
 
-- `createMockAdapter(name)` — `Adapter` with `vi.fn()` mocks
-- `createMockState()` — in-memory subscriptions/locks/cache
-- `createTestMessage(id, text, overrides?)`
-- `mockLogger`
+- `createMockAdapter(name)`, `createMockState()`, `createTestMessage()`, `mockLogger`
 
-For production-traffic-driven testing, see `packages/integration-tests/fixtures/replay/README.md` (recording / export / replay workflow). Recordings are tagged with the deployed git SHA and exported via `pnpm recording:list` / `pnpm recording:export <session-id>` from `examples/nextjs-chat`.
+For production-traffic replay tests, see [packages/integration-tests/fixtures/replay/README.md](packages/integration-tests/fixtures/replay/README.md). Recordings export via `pnpm recording:list` / `pnpm recording:export <session-id>` from `examples/nextjs-chat`.
 
-## Documentation
+## Docs and releases
 
-User-facing docs live in `apps/docs/content/docs/` (rendered at chat-sdk.dev/docs). When changing behavior, public APIs, or env vars, update the relevant page in the same PR. Preview locally with `pnpm --filter docs dev`.
+- User-facing docs: `apps/docs/content/` → [chat-sdk.dev/docs](https://chat-sdk.dev/docs). Update relevant pages when behavior, public APIs, or env vars change.
+- Behavioral package changes need a changeset (`pnpm changeset`). Docs-only, tests-only, CI, and `examples/*` changes do not.
 
-## Releases
+## Code style
 
-Uses Changesets with fixed versioning (every package shares one version). Every PR that changes a package's behavior must include a changeset (`pnpm changeset`). Full rules in `.github/CONTRIBUTING.md`.
+Ultracite (Biome) via `pnpm check` / `pnpm fix`. Most issues auto-fix.
 
-Example apps (`examples/*`) are private and never published. The `ignore` list in `.changeset/config.json` uses an `example-*` glob, so any example named `example-*` is excluded from versioning and publishing automatically — no changeset and no config edit needed when adding one.
-
-## Environment variables
-
-Key env vars (see `turbo.json` for the full list):
-
-- `SLACK_BOT_TOKEN`, `SLACK_SIGNING_SECRET`
-- `TEAMS_APP_ID`, `TEAMS_APP_PASSWORD`, `TEAMS_APP_TENANT_ID`
-- `GOOGLE_CHAT_CREDENTIALS` or `GOOGLE_CHAT_USE_ADC`
-- `WHATSAPP_ACCESS_TOKEN`, `WHATSAPP_APP_SECRET`, `WHATSAPP_PHONE_NUMBER_ID`, `WHATSAPP_VERIFY_TOKEN`
-- `REDIS_URL` — Redis state adapter
-- `POSTGRES_URL` / `DATABASE_URL` — PostgreSQL state adapter
-- `BOT_USERNAME` — default bot username
-
-## Community health files
-
-- `.github/CONTRIBUTING.md` — dev setup, signed commits, conventional commits, changesets, docs preview, building your own adapter
-- `.github/SUPPORT.md` — where to send help/usage questions
-- `.github/SECURITY.md` — private vulnerability reporting
-- `.github/ISSUE_TEMPLATE/` — bug, feature, docs, and adapter-request templates
-- `.github/CODEOWNERS` — `@vercel/chat-sdk` owns everything; release plumbing is locked to `@cramforce`
-
-## Ultracite code standards
-
-This project uses [Ultracite](https://github.com/haydenbleasel/ultracite) (Biome-based). `pnpm check` / `pnpm fix` run it across the monorepo. Most issues auto-fix.
-
-Beyond what Biome enforces:
-
-- **Type safety** — prefer `unknown` over `any`; `as const` for literals; named constants over magic numbers.
-- **Modern JS/TS** — `for...of` over `.forEach`; `?.` and `??`; `const` by default; template literals; destructure.
-- **Async** — always `await` returned promises; no async Promise executors.
-- **React** — function components only; hooks at top level; stable `key`s (prefer IDs over indices); no components defined inside other components; semantic HTML and ARIA; `<Image>` over `<img>`; ref-as-prop in React 19+.
-- **Errors** — throw `Error` objects with descriptive messages; early returns over nested conditionals; no `console.log` / `debugger` / `alert` in shipped code.
-- **Performance** — top-level regex literals; no spread-in-accumulator loops; specific imports over barrel files.
-- **Security** — `rel="noopener"` on `target="_blank"`; avoid `dangerouslySetInnerHTML`; never `eval()` or assign to `document.cookie`.
+Beyond Biome: prefer `unknown` over `any`; top-level regex literals; `for...of` over `.forEach`; always `await` returned promises; no `console.log` / `debugger` in shipped code; throw descriptive `Error` objects. React (docs/examples): function components, stable keys, semantic HTML/ARIA.

--- a/README.md
+++ b/README.md
@@ -1,21 +1,20 @@
 # Chat SDK
 
-[![npm version](https://img.shields.io/npm/v/chat)](https://www.npmjs.com/package/chat)
-[![npm downloads](https://img.shields.io/npm/dm/chat)](https://www.npmjs.com/package/chat)
-[![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](https://opensource.org/licenses/MIT)
+[![Agent Stack](https://img.shields.io/badge/Agent%20Stack-000?style=flat-square&logo=vercel&logoColor=FFF&labelColor=000&color=000)](https://vercel.com/kb/agent-stack)
+[![MIT License](https://img.shields.io/badge/License-MIT-000?style=flat-square&logo=opensourceinitiative&logoColor=white&labelColor=000&color=000)](LICENSE)
 
-A unified TypeScript SDK for building chat bots across Slack, Microsoft Teams, Google Chat, Discord, Telegram, GitHub, Linear, and WhatsApp. Write your bot logic once, deploy everywhere.
+Unified TypeScript SDK for building chat bots across Slack, Microsoft Teams, Google Chat, Discord, Telegram, GitHub, Linear, WhatsApp, and more. **Write your bot logic once, deploy everywhere.**
 
 ## Installation
 
 ```bash
-npm install chat
+npm i chat
 ```
 
-Install adapters for your platforms:
+Install one or more adapters for your platforms:
 
 ```bash
-npm install @chat-adapter/slack @chat-adapter/teams @chat-adapter/gchat @chat-adapter/discord @chat-adapter/telegram
+npm install @chat-adapter/slack @chat-adapter/teams @chat-adapter/gchat
 ```
 
 ## CLI
@@ -57,7 +56,7 @@ See the [Getting Started guide](https://chat-sdk.dev/docs/getting-started) for a
 
 ## Adapters
 
-Browse official, vendor-official, and community adapters on [chat-sdk.dev/adapters](https://chat-sdk.dev/adapters). A cross-platform feature matrix is available at [chat-sdk.dev/docs/adapters](https://chat-sdk.dev/docs/adapters).
+Browse official, vendor-official, and community adapters on [chat-sdk.dev/adapters](https://chat-sdk.dev/adapters). Learn how to [build your own adapter](https://chat-sdk.dev/docs/contributing/building).
 
 ## Features
 
@@ -83,28 +82,30 @@ npx skills add vercel/chat
 
 The skill references bundled documentation in `node_modules/chat/docs`, plus adapter guides and starter templates in the published package.
 
-You can also install the [Vercel Plugin](https://vercel.com/docs/agent-resources/vercel-plugin) for a broader agent toolkit — it includes the Chat SDK skill alongside specialist agents, agent slash commands, and more:
+You can also install the [Vercel Plugin](https://vercel.com/plugin) for a broader agent toolkit. It includes the Chat SDK skill alongside specialist agents, slash commands, and more:
 
 ```bash
 npx plugins add vercel/vercel-plugin
 ```
 
-The plugin is optional; the skill alone is enough to build with Chat SDK.
-
 For agent-readable documentation, see [chat-sdk.dev/llms.txt](https://chat-sdk.dev/llms.txt) (page index) or [chat-sdk.dev/llms-full.txt](https://chat-sdk.dev/llms-full.txt) (full text).
 
 ## Documentation
 
-Full documentation is available at [chat-sdk.dev/docs](https://chat-sdk.dev/docs).
+Full documentation is available at [chat-sdk.dev/docs](https://chat-sdk.dev/docs) and guides are available in the [Vercel Knowledge Base](https://vercel.com/kb/chat-sdk).
 
 ## Contributing
 
-See [CONTRIBUTING.md](./.github/CONTRIBUTING.md) for development setup and the release process.
+See [CONTRIBUTING.md](./.github/CONTRIBUTING.md) for guidance on contributing to Chat SDK.
 
 ## Support
 
-For help or questions, see [SUPPORT.md](./.github/SUPPORT.md). To report a security vulnerability, see [SECURITY.md](./.github/SECURITY.md).
+For help or questions, see [SUPPORT.md](./.github/SUPPORT.md).
+
+To report a security vulnerability, see [SECURITY.md](./.github/SECURITY.md).
 
 ## License
 
 MIT
+
+[![Made by Vercel](https://img.shields.io/badge/Made%20By%20Vercel-000?style=flat-square&logo=vercel&logoColor=white&labelColor=000&color=000)](https://vercel.com)

--- a/apps/docs/public/.well-known/agent-skills/chat-sdk/SKILL.md
+++ b/apps/docs/public/.well-known/agent-skills/chat-sdk/SKILL.md
@@ -1,90 +1,24 @@
 ---
 name: chat-sdk
 description: Build multi-platform chat bots with Chat SDK (`chat` npm package). Use when developers want to scaffold a bot with create-chat-sdk, build a Slack, Teams, Google Chat, Discord, Telegram, GitHub, Linear, or WhatsApp bot, handle mentions, direct messages, subscribed threads, reactions, slash commands, cards, modals, files, or AI streaming, set up webhook routes or multi-adapter bots, send rich cards or streamed AI responses to chat platforms, or build a custom adapter or state adapter.
+license: MIT
 ---
 
 # Chat SDK
 
-Unified TypeScript SDK for building chat bots across Slack, Teams, Google Chat, Discord, Telegram, GitHub, Linear, and WhatsApp. Write bot logic once, deploy everywhere.
+Unified TypeScript SDK for building chat bots across Slack, Microsoft Teams, Google Chat, Discord, Telegram, GitHub, Linear, WhatsApp, and more. Write your bot logic once, deploy everywhere.
 
 ## Scaffold a new project
 
-Use `create-chat-sdk` with explicit adapters so coding agents can scaffold a webhook-only Next.js bot project without prompts:
+Use `create-chat-sdk` to scaffold a basic Next.js bot project without prompts. Run `npx create-chat-sdk --help` to see the available options and how the CLI works.
 
-```bash
-npm create chat-sdk@latest -- my-bot --adapter slack memory -y
-```
+## Start with Chat SDK documentation
 
-Non-interactive example:
+When Chat SDK is installed in a user's project, inspect the published docs that ship in `node_modules/chat/docs/`, the resources in `node_modules/chat/resources/`, and the available open source templates in `node_modules/chat/resources/templates.json`.
 
-```bash
-npm create chat-sdk@latest -- my-bot --adapter slack redis -d "My bot" --pm pnpm -y
-```
+If those paths do not exist, the `chat` package is not installed in the project yet. The user can install it with `npm i chat`.
 
-With npm, the `--` separator is required — npm consumes the flags itself instead of forwarding them to the CLI. `pnpm create` and `yarn create` forward flags without it.
-
-Key flags:
-- `--adapter <values...>` — platform or state adapters from `chat/adapters`
-- `-d, --description <text>` — project description
-- `--pm <manager>` — package manager (`npm`, `yarn`, `pnpm`, `bun`)
-- `-y, --yes` — skip prompts and accept defaults
-- `--interactive` — always prompt, even when a coding agent environment is detected
-- `-f, --force` — overwrite generated files in an existing directory
-- `-s, --skip-install` — skip dependency installation
-- `--no-git` — skip git repository initialization
-- `-q, --quiet` — suppress non-essential output
-
-When `create-chat-sdk` detects a coding agent environment, it automatically uses non-interactive defaults. Pass at least one platform adapter with `--adapter`; the state adapter defaults to `memory`. If no project name is provided, it uses `my-bot`.
-
-Generated projects include `src/lib/bot.ts`, `src/app/api/webhooks/[platform]/route.ts`, `.env.example`, `next.config.ts`, and adapter dependencies. If the Web adapter is selected, the CLI also creates `src/app/api/chat/route.ts` and `src/lib/auth-stub.ts`.
-
-## Start with published sources
-
-When Chat SDK is installed in a user project, inspect the published files that ship in `node_modules`:
-
-```
-node_modules/chat/docs/                    # bundled docs
-node_modules/chat/dist/index.d.ts          # core API types
-node_modules/chat/dist/adapters/index.d.ts # static adapter catalog types
-node_modules/chat/dist/jsx-runtime.d.ts    # JSX runtime types
-node_modules/chat/docs/contributing/       # adapter-authoring docs
-node_modules/chat/resources/guides/        # framework/platform guides (markdown)
-node_modules/chat/resources/templates.json # starter templates (title, description, href)
-```
-
-If one of the paths below does not exist, that package is not installed in the project yet.
-
-Read these before writing code:
-- `node_modules/chat/docs/getting-started.mdx` — install and setup
-- `node_modules/chat/docs/usage.mdx` — `Chat` config and lifecycle
-- `node_modules/chat/docs/handling-events.mdx` — event routing and handlers
-- `node_modules/chat/docs/threads-messages-channels.mdx` — thread/channel/message model
-- `node_modules/chat/docs/posting-messages.mdx` — post, edit, delete, schedule
-- `node_modules/chat/docs/streaming.mdx` — AI SDK integration and streaming semantics
-- `node_modules/chat/docs/cards.mdx` — JSX cards
-- `node_modules/chat/docs/actions.mdx` — button/select interactions
-- `node_modules/chat/docs/modals.mdx` — modal submit/close flows
-- `node_modules/chat/docs/slash-commands.mdx` — slash command routing
-- `node_modules/chat/docs/direct-messages.mdx` — DM behavior and `openDM()`
-- `node_modules/chat/docs/files.mdx` — attachments/uploads
-- `node_modules/chat/docs/state-adapters.mdx` — persistence, locking, dedupe
-- `node_modules/chat/docs/adapters.mdx` — cross-platform feature matrix
-- `node_modules/chat/docs/api/chat.mdx` — exact `Chat` API
-- `node_modules/chat/docs/api/thread.mdx` — exact `Thread` API
-- `node_modules/chat/docs/api/message.mdx` — exact `Message` API
-- `node_modules/chat/docs/api/modals.mdx` — modal element and event details
-
-For the specific adapter or state package you are using, inspect that installed package's `dist/index.d.ts` export surface in `node_modules`.
-
-## Adapter catalog subpath
-
-Chat SDK exposes a zero-dependency static catalog at `chat/adapters`. Agents can import `ADAPTERS`, `ADAPTER_NAMES`, `getAdapter`, `isAdapterSlug`, `listEnvVars`, `getSecretEnvVars`, and metadata types like `CatalogAdapter` and `AdapterSlug` from this subpath without importing any adapter implementation package.
-
-Use it for:
-- Listing official and vendor-official adapter slugs, names, npm packages, groups, and platform vs state types.
-- Building setup or onboarding flows that need package names, peer dependencies, and install guidance before any adapter is installed.
-- Discovering required, optional, and credential-mode environment variables for an adapter, including which variables are secrets.
-- Keeping vendor-official adapter docs and metadata aligned with the catalog when adding or updating a listed adapter.
+You can also find the docs on the [Chat SDK website](https://chat-sdk.dev/docs) and in the [Vercel knowledge base](https://vercel.com/kb/chat-sdk).
 
 ## Available resources
 
@@ -118,123 +52,20 @@ Listed in `node_modules/chat/resources/templates.json`:
 
 <!-- RESOURCES:END -->
 
-## Quick start
+## Chat SDK adapters
 
-```typescript
-import { Chat } from "chat";
-import { createSlackAdapter } from "@chat-adapter/slack";
-import { createRedisState } from "@chat-adapter/state-redis";
+### Adapter directory
 
-const bot = new Chat({
-  userName: "mybot",
-  adapters: {
-    slack: createSlackAdapter(),
-  },
-  state: createRedisState(),
-  dedupeTtlMs: 600_000,
-});
+See the 'Official Adapters', 'Vendor-Official Adapters', and 'Community Adapters' sections in the [Chat SDK llms.txt file](https://chat-sdk.dev/llms.txt) for the current list of official, vendor-official, and community adapters.
 
-bot.onNewMention(async (thread) => {
-  await thread.subscribe();
-  await thread.post("Hello! I'm listening to this thread.");
-});
+### Adapter catalog subpath
 
-bot.onSubscribedMessage(async (thread, message) => {
-  await thread.post(`You said: ${message.text}`);
-});
-```
+Chat SDK exposes a zero-dependency static catalog at `chat/adapters`.
 
-## Core concepts
+Agents can import `ADAPTERS`, `ADAPTER_NAMES`, `getAdapter`, `isAdapterSlug`, `listEnvVars`, `getSecretEnvVars`, and metadata types like `CatalogAdapter` and `AdapterSlug` from this subpath without importing any adapter implementation package.
 
-- **Chat** — main entry point; coordinates adapters, routing, locks, and state
-- **Adapters** — platform-specific integrations for Slack, Teams, Google Chat, Discord, Telegram, GitHub, Linear, and WhatsApp
-- **State adapters** — persistence for subscriptions, locks, dedupe, and thread state
-- **Thread** — conversation context with `post()`, `stream()`, `subscribe()`, `setState()`, `startTyping()`
-- **Message** — normalized content with `text`, `formatted`, attachments, author info, and platform `raw`
-- **Channel** — container for threads and top-level posts
-
-## Event handlers
-
-| Handler | Trigger |
-|---------|---------|
-| `onNewMention` | Bot @-mentioned in an unsubscribed thread |
-| `onDirectMessage` | New DM in an unsubscribed DM thread |
-| `onSubscribedMessage` | Any message in a subscribed thread |
-| `onNewMessage(regex)` | Regex match in an unsubscribed thread |
-| `onReaction(emojis?)` | Emoji added or removed |
-| `onAction(actionIds?)` | Button clicks and select/radio interactions |
-| `onModalSubmit(callbackId?)` | Modal form submitted |
-| `onModalClose(callbackId?)` | Modal dismissed/cancelled |
-| `onSlashCommand(commands?)` | Slash command invocation |
-| `onAssistantThreadStarted` | Slack assistant thread opened |
-| `onAssistantContextChanged` | Slack assistant context changed |
-| `onAppHomeOpened` | Slack App Home opened |
-| `onMemberJoinedChannel` | Slack member joined channel event |
-
-Read `node_modules/chat/docs/handling-events.mdx`, `node_modules/chat/docs/actions.mdx`, `node_modules/chat/docs/modals.mdx`, and `node_modules/chat/docs/slash-commands.mdx` before wiring handlers. `onDirectMessage` behavior is documented in `node_modules/chat/docs/direct-messages.mdx`.
-
-## Streaming
-
-Pass any `AsyncIterable<string>` to `thread.post()`. For AI SDK, prefer `result.fullStream` over `result.textStream` when available so step boundaries are preserved.
-
-```typescript
-import { ToolLoopAgent } from "ai";
-
-const agent = new ToolLoopAgent({ model: "anthropic/claude-4.5-sonnet" });
-
-bot.onNewMention(async (thread, message) => {
-  const result = await agent.stream({ prompt: message.text });
-  await thread.post(result.fullStream);
-});
-```
-
-Key details:
-- `streamingUpdateIntervalMs` controls post+edit fallback cadence
-- `fallbackStreamingPlaceholderText` defaults to `"..."`; set `null` to disable
-- Structured `StreamChunk` support is Slack-only; other adapters ignore non-text chunks
-
-## Cards and modals (JSX)
-
-Set `jsxImportSource: "chat"` in `tsconfig.json`.
-
-Card components:
-- `Card`, `CardText`, `Section`, `Fields`, `Field`, `Button`, `CardLink`, `LinkButton`, `Actions`, `Select`, `SelectOption`, `RadioSelect`, `Table`, `Image`, `Divider`
-
-Modal components:
-- `Modal`, `TextInput`, `Select`, `SelectOption`, `RadioSelect`
-
-`Button` and `Modal` accept a `callbackUrl` prop — when triggered, the SDK POSTs the action payload to that URL in addition to firing any `onAction` / `onModalSubmit` handler. Use this for webhook-based workflow flows. See `node_modules/chat/docs/actions.mdx` and `node_modules/chat/docs/modals.mdx`.
-
-```tsx
-await thread.post(
-  <Card title="Order #1234">
-    <CardText>Your order has been received.</CardText>
-    <Actions>
-      <Button id="approve" style="primary">Approve</Button>
-      <Button id="reject" style="danger">Reject</Button>
-    </Actions>
-  </Card>
-);
-```
-
-## Adapter inventory
-
-See [chat-sdk.dev/adapters](https://chat-sdk.dev/adapters) for the current list of official, vendor-official, and community adapters, including package names and authors. For the exact factory function and config types of an installed adapter, inspect its `dist/index.d.ts` in `node_modules`.
-
-## Building a custom adapter
-
-Read these published docs first:
-- `node_modules/chat/docs/contributing/building.mdx`
-- `node_modules/chat/docs/contributing/testing.mdx`
-- `node_modules/chat/docs/contributing/publishing.mdx`
-
-Also inspect:
-- `node_modules/chat/dist/index.d.ts` — `Adapter` and related interfaces
-- `node_modules/@chat-adapter/shared/dist/index.d.ts` — shared errors and utilities
-- Installed official adapter `dist/index.d.ts` files — reference implementations for config and APIs
-
-A custom adapter needs request verification, webhook parsing, message/thread/channel operations, ID encoding/decoding, and a format converter. Use `BaseFormatConverter` from `chat` and shared utilities from `@chat-adapter/shared`.
-
-## Webhook setup
-
-Each registered adapter exposes `bot.webhooks.<name>`. Wire those directly to your HTTP framework routes. See `node_modules/chat/resources/guides/how-to-build-a-slack-bot-with-next-js-and-redis.md` and `node_modules/chat/resources/guides/create-a-discord-support-bot-with-nuxt-and-redis.md` for framework-specific route patterns.
+Use it for:
+- Listing official and vendor-official adapter slugs, names, npm packages, groups, and platform vs state types.
+- Building setup or onboarding flows that need package names, peer dependencies, and install guidance before any adapter is installed.
+- Discovering required, optional, and credential-mode environment variables for an adapter, including which variables are secrets.
+- Keeping vendor-official adapter docs and metadata aligned with the catalog when adding or updating a listed adapter.

--- a/apps/docs/public/.well-known/agent-skills/index.json
+++ b/apps/docs/public/.well-known/agent-skills/index.json
@@ -5,7 +5,7 @@
       "type": "skill-md",
       "description": "Build multi-platform chat bots with Chat SDK (`chat` npm package). Use when developers want to build a Slack, Teams, Google Chat, Discord, Telegram, GitHub, Linear, or WhatsApp bot with a single TypeScript codebase.",
       "url": "/.well-known/agent-skills/chat-sdk/SKILL.md",
-      "digest": "sha256:744ef0e7467adbba0c59a9b187059037454965fc283927dc30a9f919f0ac648d"
+      "digest": "sha256:6e896ea626060baf607f2f87191c3967a20deae16155b9571a345f7fed91e50f"
     }
   ]
 }

--- a/apps/docs/public/AGENTS.md
+++ b/apps/docs/public/AGENTS.md
@@ -1,90 +1,24 @@
 ---
 name: chat-sdk
 description: Build multi-platform chat bots with Chat SDK (`chat` npm package). Use when developers want to scaffold a bot with create-chat-sdk, build a Slack, Teams, Google Chat, Discord, Telegram, GitHub, Linear, or WhatsApp bot, handle mentions, direct messages, subscribed threads, reactions, slash commands, cards, modals, files, or AI streaming, set up webhook routes or multi-adapter bots, send rich cards or streamed AI responses to chat platforms, or build a custom adapter or state adapter.
+license: MIT
 ---
 
 # Chat SDK
 
-Unified TypeScript SDK for building chat bots across Slack, Teams, Google Chat, Discord, Telegram, GitHub, Linear, and WhatsApp. Write bot logic once, deploy everywhere.
+Unified TypeScript SDK for building chat bots across Slack, Microsoft Teams, Google Chat, Discord, Telegram, GitHub, Linear, WhatsApp, and more. Write your bot logic once, deploy everywhere.
 
 ## Scaffold a new project
 
-Use `create-chat-sdk` with explicit adapters so coding agents can scaffold a webhook-only Next.js bot project without prompts:
+Use `create-chat-sdk` to scaffold a basic Next.js bot project without prompts. Run `npx create-chat-sdk --help` to see the available options and how the CLI works.
 
-```bash
-npm create chat-sdk@latest -- my-bot --adapter slack memory -y
-```
+## Start with Chat SDK documentation
 
-Non-interactive example:
+When Chat SDK is installed in a user's project, inspect the published docs that ship in `node_modules/chat/docs/`, the resources in `node_modules/chat/resources/`, and the available open source templates in `node_modules/chat/resources/templates.json`.
 
-```bash
-npm create chat-sdk@latest -- my-bot --adapter slack redis -d "My bot" --pm pnpm -y
-```
+If those paths do not exist, the `chat` package is not installed in the project yet. The user can install it with `npm i chat`.
 
-With npm, the `--` separator is required — npm consumes the flags itself instead of forwarding them to the CLI. `pnpm create` and `yarn create` forward flags without it.
-
-Key flags:
-- `--adapter <values...>` — platform or state adapters from `chat/adapters`
-- `-d, --description <text>` — project description
-- `--pm <manager>` — package manager (`npm`, `yarn`, `pnpm`, `bun`)
-- `-y, --yes` — skip prompts and accept defaults
-- `--interactive` — always prompt, even when a coding agent environment is detected
-- `-f, --force` — overwrite generated files in an existing directory
-- `-s, --skip-install` — skip dependency installation
-- `--no-git` — skip git repository initialization
-- `-q, --quiet` — suppress non-essential output
-
-When `create-chat-sdk` detects a coding agent environment, it automatically uses non-interactive defaults. Pass at least one platform adapter with `--adapter`; the state adapter defaults to `memory`. If no project name is provided, it uses `my-bot`.
-
-Generated projects include `src/lib/bot.ts`, `src/app/api/webhooks/[platform]/route.ts`, `.env.example`, `next.config.ts`, and adapter dependencies. If the Web adapter is selected, the CLI also creates `src/app/api/chat/route.ts` and `src/lib/auth-stub.ts`.
-
-## Start with published sources
-
-When Chat SDK is installed in a user project, inspect the published files that ship in `node_modules`:
-
-```
-node_modules/chat/docs/                    # bundled docs
-node_modules/chat/dist/index.d.ts          # core API types
-node_modules/chat/dist/adapters/index.d.ts # static adapter catalog types
-node_modules/chat/dist/jsx-runtime.d.ts    # JSX runtime types
-node_modules/chat/docs/contributing/       # adapter-authoring docs
-node_modules/chat/resources/guides/        # framework/platform guides (markdown)
-node_modules/chat/resources/templates.json # starter templates (title, description, href)
-```
-
-If one of the paths below does not exist, that package is not installed in the project yet.
-
-Read these before writing code:
-- `node_modules/chat/docs/getting-started.mdx` — install and setup
-- `node_modules/chat/docs/usage.mdx` — `Chat` config and lifecycle
-- `node_modules/chat/docs/handling-events.mdx` — event routing and handlers
-- `node_modules/chat/docs/threads-messages-channels.mdx` — thread/channel/message model
-- `node_modules/chat/docs/posting-messages.mdx` — post, edit, delete, schedule
-- `node_modules/chat/docs/streaming.mdx` — AI SDK integration and streaming semantics
-- `node_modules/chat/docs/cards.mdx` — JSX cards
-- `node_modules/chat/docs/actions.mdx` — button/select interactions
-- `node_modules/chat/docs/modals.mdx` — modal submit/close flows
-- `node_modules/chat/docs/slash-commands.mdx` — slash command routing
-- `node_modules/chat/docs/direct-messages.mdx` — DM behavior and `openDM()`
-- `node_modules/chat/docs/files.mdx` — attachments/uploads
-- `node_modules/chat/docs/state-adapters.mdx` — persistence, locking, dedupe
-- `node_modules/chat/docs/adapters.mdx` — cross-platform feature matrix
-- `node_modules/chat/docs/api/chat.mdx` — exact `Chat` API
-- `node_modules/chat/docs/api/thread.mdx` — exact `Thread` API
-- `node_modules/chat/docs/api/message.mdx` — exact `Message` API
-- `node_modules/chat/docs/api/modals.mdx` — modal element and event details
-
-For the specific adapter or state package you are using, inspect that installed package's `dist/index.d.ts` export surface in `node_modules`.
-
-## Adapter catalog subpath
-
-Chat SDK exposes a zero-dependency static catalog at `chat/adapters`. Agents can import `ADAPTERS`, `ADAPTER_NAMES`, `getAdapter`, `isAdapterSlug`, `listEnvVars`, `getSecretEnvVars`, and metadata types like `CatalogAdapter` and `AdapterSlug` from this subpath without importing any adapter implementation package.
-
-Use it for:
-- Listing official and vendor-official adapter slugs, names, npm packages, groups, and platform vs state types.
-- Building setup or onboarding flows that need package names, peer dependencies, and install guidance before any adapter is installed.
-- Discovering required, optional, and credential-mode environment variables for an adapter, including which variables are secrets.
-- Keeping vendor-official adapter docs and metadata aligned with the catalog when adding or updating a listed adapter.
+You can also find the docs on the [Chat SDK website](https://chat-sdk.dev/docs) and in the [Vercel knowledge base](https://vercel.com/kb/chat-sdk).
 
 ## Available resources
 
@@ -118,123 +52,20 @@ Listed in `node_modules/chat/resources/templates.json`:
 
 <!-- RESOURCES:END -->
 
-## Quick start
+## Chat SDK adapters
 
-```typescript
-import { Chat } from "chat";
-import { createSlackAdapter } from "@chat-adapter/slack";
-import { createRedisState } from "@chat-adapter/state-redis";
+### Adapter directory
 
-const bot = new Chat({
-  userName: "mybot",
-  adapters: {
-    slack: createSlackAdapter(),
-  },
-  state: createRedisState(),
-  dedupeTtlMs: 600_000,
-});
+See the 'Official Adapters', 'Vendor-Official Adapters', and 'Community Adapters' sections in the [Chat SDK llms.txt file](https://chat-sdk.dev/llms.txt) for the current list of official, vendor-official, and community adapters.
 
-bot.onNewMention(async (thread) => {
-  await thread.subscribe();
-  await thread.post("Hello! I'm listening to this thread.");
-});
+### Adapter catalog subpath
 
-bot.onSubscribedMessage(async (thread, message) => {
-  await thread.post(`You said: ${message.text}`);
-});
-```
+Chat SDK exposes a zero-dependency static catalog at `chat/adapters`.
 
-## Core concepts
+Agents can import `ADAPTERS`, `ADAPTER_NAMES`, `getAdapter`, `isAdapterSlug`, `listEnvVars`, `getSecretEnvVars`, and metadata types like `CatalogAdapter` and `AdapterSlug` from this subpath without importing any adapter implementation package.
 
-- **Chat** — main entry point; coordinates adapters, routing, locks, and state
-- **Adapters** — platform-specific integrations for Slack, Teams, Google Chat, Discord, Telegram, GitHub, Linear, and WhatsApp
-- **State adapters** — persistence for subscriptions, locks, dedupe, and thread state
-- **Thread** — conversation context with `post()`, `stream()`, `subscribe()`, `setState()`, `startTyping()`
-- **Message** — normalized content with `text`, `formatted`, attachments, author info, and platform `raw`
-- **Channel** — container for threads and top-level posts
-
-## Event handlers
-
-| Handler | Trigger |
-|---------|---------|
-| `onNewMention` | Bot @-mentioned in an unsubscribed thread |
-| `onDirectMessage` | New DM in an unsubscribed DM thread |
-| `onSubscribedMessage` | Any message in a subscribed thread |
-| `onNewMessage(regex)` | Regex match in an unsubscribed thread |
-| `onReaction(emojis?)` | Emoji added or removed |
-| `onAction(actionIds?)` | Button clicks and select/radio interactions |
-| `onModalSubmit(callbackId?)` | Modal form submitted |
-| `onModalClose(callbackId?)` | Modal dismissed/cancelled |
-| `onSlashCommand(commands?)` | Slash command invocation |
-| `onAssistantThreadStarted` | Slack assistant thread opened |
-| `onAssistantContextChanged` | Slack assistant context changed |
-| `onAppHomeOpened` | Slack App Home opened |
-| `onMemberJoinedChannel` | Slack member joined channel event |
-
-Read `node_modules/chat/docs/handling-events.mdx`, `node_modules/chat/docs/actions.mdx`, `node_modules/chat/docs/modals.mdx`, and `node_modules/chat/docs/slash-commands.mdx` before wiring handlers. `onDirectMessage` behavior is documented in `node_modules/chat/docs/direct-messages.mdx`.
-
-## Streaming
-
-Pass any `AsyncIterable<string>` to `thread.post()`. For AI SDK, prefer `result.fullStream` over `result.textStream` when available so step boundaries are preserved.
-
-```typescript
-import { ToolLoopAgent } from "ai";
-
-const agent = new ToolLoopAgent({ model: "anthropic/claude-4.5-sonnet" });
-
-bot.onNewMention(async (thread, message) => {
-  const result = await agent.stream({ prompt: message.text });
-  await thread.post(result.fullStream);
-});
-```
-
-Key details:
-- `streamingUpdateIntervalMs` controls post+edit fallback cadence
-- `fallbackStreamingPlaceholderText` defaults to `"..."`; set `null` to disable
-- Structured `StreamChunk` support is Slack-only; other adapters ignore non-text chunks
-
-## Cards and modals (JSX)
-
-Set `jsxImportSource: "chat"` in `tsconfig.json`.
-
-Card components:
-- `Card`, `CardText`, `Section`, `Fields`, `Field`, `Button`, `CardLink`, `LinkButton`, `Actions`, `Select`, `SelectOption`, `RadioSelect`, `Table`, `Image`, `Divider`
-
-Modal components:
-- `Modal`, `TextInput`, `Select`, `SelectOption`, `RadioSelect`
-
-`Button` and `Modal` accept a `callbackUrl` prop — when triggered, the SDK POSTs the action payload to that URL in addition to firing any `onAction` / `onModalSubmit` handler. Use this for webhook-based workflow flows. See `node_modules/chat/docs/actions.mdx` and `node_modules/chat/docs/modals.mdx`.
-
-```tsx
-await thread.post(
-  <Card title="Order #1234">
-    <CardText>Your order has been received.</CardText>
-    <Actions>
-      <Button id="approve" style="primary">Approve</Button>
-      <Button id="reject" style="danger">Reject</Button>
-    </Actions>
-  </Card>
-);
-```
-
-## Adapter inventory
-
-See [chat-sdk.dev/adapters](https://chat-sdk.dev/adapters) for the current list of official, vendor-official, and community adapters, including package names and authors. For the exact factory function and config types of an installed adapter, inspect its `dist/index.d.ts` in `node_modules`.
-
-## Building a custom adapter
-
-Read these published docs first:
-- `node_modules/chat/docs/contributing/building.mdx`
-- `node_modules/chat/docs/contributing/testing.mdx`
-- `node_modules/chat/docs/contributing/publishing.mdx`
-
-Also inspect:
-- `node_modules/chat/dist/index.d.ts` — `Adapter` and related interfaces
-- `node_modules/@chat-adapter/shared/dist/index.d.ts` — shared errors and utilities
-- Installed official adapter `dist/index.d.ts` files — reference implementations for config and APIs
-
-A custom adapter needs request verification, webhook parsing, message/thread/channel operations, ID encoding/decoding, and a format converter. Use `BaseFormatConverter` from `chat` and shared utilities from `@chat-adapter/shared`.
-
-## Webhook setup
-
-Each registered adapter exposes `bot.webhooks.<name>`. Wire those directly to your HTTP framework routes. See `node_modules/chat/resources/guides/how-to-build-a-slack-bot-with-next-js-and-redis.md` and `node_modules/chat/resources/guides/create-a-discord-support-bot-with-nuxt-and-redis.md` for framework-specific route patterns.
+Use it for:
+- Listing official and vendor-official adapter slugs, names, npm packages, groups, and platform vs state types.
+- Building setup or onboarding flows that need package names, peer dependencies, and install guidance before any adapter is installed.
+- Discovering required, optional, and credential-mode environment variables for an adapter, including which variables are secrets.
+- Keeping vendor-official adapter docs and metadata aligned with the catalog when adding or updating a listed adapter.

--- a/packages/adapter-discord/README.md
+++ b/packages/adapter-discord/README.md
@@ -4,8 +4,8 @@
 
 > npm package: [`@chat-adapter/discord`](https://www.npmjs.com/package/@chat-adapter/discord)
 
-[![npm version](https://img.shields.io/npm/v/@chat-adapter/discord)](https://www.npmjs.com/package/@chat-adapter/discord)
-[![npm downloads](https://img.shields.io/npm/dm/@chat-adapter/discord)](https://www.npmjs.com/package/@chat-adapter/discord)
+[![Agent Stack](https://img.shields.io/badge/Agent%20Stack-000?style=flat-square&logo=vercel&logoColor=FFF&labelColor=000&color=000)](https://vercel.com/kb/agent-stack)
+[![MIT License](https://img.shields.io/badge/License-MIT-000?style=flat-square&logo=opensourceinitiative&logoColor=white&labelColor=000&color=000)](../../LICENSE)
 
 Discord adapter for [Chat SDK](https://chat-sdk.dev). Configure with HTTP Interactions and Gateway WebSocket support.
 

--- a/packages/adapter-gchat/README.md
+++ b/packages/adapter-gchat/README.md
@@ -4,8 +4,8 @@
 
 > npm package: [`@chat-adapter/gchat`](https://www.npmjs.com/package/@chat-adapter/gchat)
 
-[![npm version](https://img.shields.io/npm/v/@chat-adapter/gchat)](https://www.npmjs.com/package/@chat-adapter/gchat)
-[![npm downloads](https://img.shields.io/npm/dm/@chat-adapter/gchat)](https://www.npmjs.com/package/@chat-adapter/gchat)
+[![Agent Stack](https://img.shields.io/badge/Agent%20Stack-000?style=flat-square&logo=vercel&logoColor=FFF&labelColor=000&color=000)](https://vercel.com/kb/agent-stack)
+[![MIT License](https://img.shields.io/badge/License-MIT-000?style=flat-square&logo=opensourceinitiative&logoColor=white&labelColor=000&color=000)](../../LICENSE)
 
 Google Chat adapter for [Chat SDK](https://chat-sdk.dev). Configure with service account authentication and optional Pub/Sub.
 

--- a/packages/adapter-github/README.md
+++ b/packages/adapter-github/README.md
@@ -4,8 +4,8 @@
 
 > npm package: [`@chat-adapter/github`](https://www.npmjs.com/package/@chat-adapter/github)
 
-[![npm version](https://img.shields.io/npm/v/@chat-adapter/github)](https://www.npmjs.com/package/@chat-adapter/github)
-[![npm downloads](https://img.shields.io/npm/dm/@chat-adapter/github)](https://www.npmjs.com/package/@chat-adapter/github)
+[![Agent Stack](https://img.shields.io/badge/Agent%20Stack-000?style=flat-square&logo=vercel&logoColor=FFF&labelColor=000&color=000)](https://vercel.com/kb/agent-stack)
+[![MIT License](https://img.shields.io/badge/License-MIT-000?style=flat-square&logo=opensourceinitiative&logoColor=white&labelColor=000&color=000)](../../LICENSE)
 
 GitHub adapter for [Chat SDK](https://chat-sdk.dev). Respond to @mentions in PR and issue comment threads.
 

--- a/packages/adapter-linear/README.md
+++ b/packages/adapter-linear/README.md
@@ -4,8 +4,8 @@
 
 > npm package: [`@chat-adapter/linear`](https://www.npmjs.com/package/@chat-adapter/linear)
 
-[![npm version](https://img.shields.io/npm/v/@chat-adapter/linear)](https://www.npmjs.com/package/@chat-adapter/linear)
-[![npm downloads](https://img.shields.io/npm/dm/@chat-adapter/linear)](https://www.npmjs.com/package/@chat-adapter/linear)
+[![Agent Stack](https://img.shields.io/badge/Agent%20Stack-000?style=flat-square&logo=vercel&logoColor=FFF&labelColor=000&color=000)](https://vercel.com/kb/agent-stack)
+[![MIT License](https://img.shields.io/badge/License-MIT-000?style=flat-square&logo=opensourceinitiative&logoColor=white&labelColor=000&color=000)](../../LICENSE)
 
 Linear adapter for [Chat SDK](https://chat-sdk.dev). Respond to @mentions in issue comment threads and Linear app-actor agent sessions.
 

--- a/packages/adapter-messenger/README.md
+++ b/packages/adapter-messenger/README.md
@@ -4,8 +4,8 @@
 
 > npm package: [`@chat-adapter/messenger`](https://www.npmjs.com/package/@chat-adapter/messenger)
 
-[![npm version](https://img.shields.io/npm/v/@chat-adapter/messenger)](https://www.npmjs.com/package/@chat-adapter/messenger)
-[![npm downloads](https://img.shields.io/npm/dm/@chat-adapter/messenger)](https://www.npmjs.com/package/@chat-adapter/messenger)
+[![Agent Stack](https://img.shields.io/badge/Agent%20Stack-000?style=flat-square&logo=vercel&logoColor=FFF&labelColor=000&color=000)](https://vercel.com/kb/agent-stack)
+[![MIT License](https://img.shields.io/badge/License-MIT-000?style=flat-square&logo=opensourceinitiative&logoColor=white&labelColor=000&color=000)](../../LICENSE)
 
 Facebook Messenger adapter for [Chat SDK](https://chat-sdk.dev), using the [Messenger Platform API](https://developers.facebook.com/docs/messenger-platform).
 

--- a/packages/adapter-shared/README.md
+++ b/packages/adapter-shared/README.md
@@ -2,8 +2,8 @@
 
 > npm package: [`@chat-adapter/shared`](https://www.npmjs.com/package/@chat-adapter/shared)
 
-[![npm version](https://img.shields.io/npm/v/@chat-adapter/shared)](https://www.npmjs.com/package/@chat-adapter/shared)
-[![npm downloads](https://img.shields.io/npm/dm/@chat-adapter/shared)](https://www.npmjs.com/package/@chat-adapter/shared)
+[![Agent Stack](https://img.shields.io/badge/Agent%20Stack-000?style=flat-square&logo=vercel&logoColor=FFF&labelColor=000&color=000)](https://vercel.com/kb/agent-stack)
+[![MIT License](https://img.shields.io/badge/License-MIT-000?style=flat-square&logo=opensourceinitiative&logoColor=white&labelColor=000&color=000)](../../LICENSE)
 
 Shared utilities for [Chat SDK](https://chat-sdk.dev) adapters. Provides common helpers used across adapter implementations.
 

--- a/packages/adapter-slack/README.md
+++ b/packages/adapter-slack/README.md
@@ -4,8 +4,8 @@
 
 > npm package: [`@chat-adapter/slack`](https://www.npmjs.com/package/@chat-adapter/slack)
 
-[![npm version](https://img.shields.io/npm/v/@chat-adapter/slack)](https://www.npmjs.com/package/@chat-adapter/slack)
-[![npm downloads](https://img.shields.io/npm/dm/@chat-adapter/slack)](https://www.npmjs.com/package/@chat-adapter/slack)
+[![Agent Stack](https://img.shields.io/badge/Agent%20Stack-000?style=flat-square&logo=vercel&logoColor=FFF&labelColor=000&color=000)](https://vercel.com/kb/agent-stack)
+[![MIT License](https://img.shields.io/badge/License-MIT-000?style=flat-square&logo=opensourceinitiative&logoColor=white&labelColor=000&color=000)](../../LICENSE)
 
 Slack adapter for [Chat SDK](https://chat-sdk.dev). Configure single-workspace or multi-workspace OAuth deployments.
 

--- a/packages/adapter-teams/README.md
+++ b/packages/adapter-teams/README.md
@@ -4,8 +4,8 @@
 
 > npm package: [`@chat-adapter/teams`](https://www.npmjs.com/package/@chat-adapter/teams)
 
-[![npm version](https://img.shields.io/npm/v/@chat-adapter/teams)](https://www.npmjs.com/package/@chat-adapter/teams)
-[![npm downloads](https://img.shields.io/npm/dm/@chat-adapter/teams)](https://www.npmjs.com/package/@chat-adapter/teams)
+[![Agent Stack](https://img.shields.io/badge/Agent%20Stack-000?style=flat-square&logo=vercel&logoColor=FFF&labelColor=000&color=000)](https://vercel.com/kb/agent-stack)
+[![MIT License](https://img.shields.io/badge/License-MIT-000?style=flat-square&logo=opensourceinitiative&logoColor=white&labelColor=000&color=000)](../../LICENSE)
 
 Microsoft Teams adapter for [Chat SDK](https://chat-sdk.dev).
 

--- a/packages/adapter-telegram/README.md
+++ b/packages/adapter-telegram/README.md
@@ -4,8 +4,8 @@
 
 > npm package: [`@chat-adapter/telegram`](https://www.npmjs.com/package/@chat-adapter/telegram)
 
-[![npm version](https://img.shields.io/npm/v/@chat-adapter/telegram)](https://www.npmjs.com/package/@chat-adapter/telegram)
-[![npm downloads](https://img.shields.io/npm/dm/@chat-adapter/telegram)](https://www.npmjs.com/package/@chat-adapter/telegram)
+[![Agent Stack](https://img.shields.io/badge/Agent%20Stack-000?style=flat-square&logo=vercel&logoColor=FFF&labelColor=000&color=000)](https://vercel.com/kb/agent-stack)
+[![MIT License](https://img.shields.io/badge/License-MIT-000?style=flat-square&logo=opensourceinitiative&logoColor=white&labelColor=000&color=000)](../../LICENSE)
 
 Telegram adapter for [Chat SDK](https://chat-sdk.dev). Configure for bot webhooks and messaging.
 

--- a/packages/adapter-twilio/README.md
+++ b/packages/adapter-twilio/README.md
@@ -4,8 +4,8 @@
 
 > npm package: [`@chat-adapter/twilio`](https://www.npmjs.com/package/@chat-adapter/twilio)
 
-[![npm version](https://img.shields.io/npm/v/@chat-adapter/twilio)](https://www.npmjs.com/package/@chat-adapter/twilio)
-[![npm downloads](https://img.shields.io/npm/dm/@chat-adapter/twilio)](https://www.npmjs.com/package/@chat-adapter/twilio)
+[![Agent Stack](https://img.shields.io/badge/Agent%20Stack-000?style=flat-square&logo=vercel&logoColor=FFF&labelColor=000&color=000)](https://vercel.com/kb/agent-stack)
+[![MIT License](https://img.shields.io/badge/License-MIT-000?style=flat-square&logo=opensourceinitiative&logoColor=white&labelColor=000&color=000)](../../LICENSE)
 
 Twilio adapter for [Chat SDK](https://chat-sdk.dev). Build SMS and MMS bots with Twilio Messaging webhooks and the Messages API.
 

--- a/packages/adapter-web/README.md
+++ b/packages/adapter-web/README.md
@@ -4,8 +4,8 @@
 
 > npm package: [`@chat-adapter/web`](https://www.npmjs.com/package/@chat-adapter/web)
 
-[![npm version](https://img.shields.io/npm/v/@chat-adapter/web)](https://www.npmjs.com/package/@chat-adapter/web)
-[![npm downloads](https://img.shields.io/npm/dm/@chat-adapter/web)](https://www.npmjs.com/package/@chat-adapter/web)
+[![Agent Stack](https://img.shields.io/badge/Agent%20Stack-000?style=flat-square&logo=vercel&logoColor=FFF&labelColor=000&color=000)](https://vercel.com/kb/agent-stack)
+[![MIT License](https://img.shields.io/badge/License-MIT-000?style=flat-square&logo=opensourceinitiative&logoColor=white&labelColor=000&color=000)](../../LICENSE)
 
 Web adapter for [Chat SDK](https://chat-sdk.dev). Lets a chat-sdk bot serve a browser chat UI alongside Slack, Teams, Discord, etc. — the same `bot.onDirectMessage(...)` handler fires for every platform.
 

--- a/packages/adapter-whatsapp/README.md
+++ b/packages/adapter-whatsapp/README.md
@@ -4,8 +4,8 @@
 
 > npm package: [`@chat-adapter/whatsapp`](https://www.npmjs.com/package/@chat-adapter/whatsapp)
 
-[![npm version](https://img.shields.io/npm/v/@chat-adapter/whatsapp)](https://www.npmjs.com/package/@chat-adapter/whatsapp)
-[![npm downloads](https://img.shields.io/npm/dm/@chat-adapter/whatsapp)](https://www.npmjs.com/package/@chat-adapter/whatsapp)
+[![Agent Stack](https://img.shields.io/badge/Agent%20Stack-000?style=flat-square&logo=vercel&logoColor=FFF&labelColor=000&color=000)](https://vercel.com/kb/agent-stack)
+[![MIT License](https://img.shields.io/badge/License-MIT-000?style=flat-square&logo=opensourceinitiative&logoColor=white&labelColor=000&color=000)](../../LICENSE)
 
 WhatsApp Business Cloud adapter for [Chat SDK](https://chat-sdk.dev), using the [WhatsApp Business Cloud API](https://developers.facebook.com/docs/whatsapp/cloud-api).
 

--- a/packages/chat/README.md
+++ b/packages/chat/README.md
@@ -2,8 +2,8 @@
 
 > npm package: [`chat`](https://www.npmjs.com/package/chat)
 
-[![npm version](https://img.shields.io/npm/v/chat)](https://www.npmjs.com/package/chat)
-[![npm downloads](https://img.shields.io/npm/dm/chat)](https://www.npmjs.com/package/chat)
+[![Agent Stack](https://img.shields.io/badge/Agent%20Stack-000?style=flat-square&logo=vercel&logoColor=FFF&labelColor=000&color=000)](https://vercel.com/kb/agent-stack)
+[![MIT License](https://img.shields.io/badge/License-MIT-000?style=flat-square&logo=opensourceinitiative&logoColor=white&labelColor=000&color=000)](../../LICENSE)
 
 Universal TypeScript SDK for building multi-platform chat bots and AI agents on Slack, Teams, Google Chat, Discord, WhatsApp, and more. Provides the `Chat` class, event handlers, JSX cards, emoji helpers, and type-safe message formatting.
 

--- a/packages/create-chat-sdk/README.md
+++ b/packages/create-chat-sdk/README.md
@@ -2,8 +2,8 @@
 
 > npm package: [`create-chat-sdk`](https://www.npmjs.com/package/create-chat-sdk)
 
-[![npm version](https://img.shields.io/npm/v/create-chat-sdk)](https://www.npmjs.com/package/create-chat-sdk)
-[![npm downloads](https://img.shields.io/npm/dm/create-chat-sdk)](https://www.npmjs.com/package/create-chat-sdk)
+[![Agent Stack](https://img.shields.io/badge/Agent%20Stack-000?style=flat-square&logo=vercel&logoColor=FFF&labelColor=000&color=000)](https://vercel.com/kb/agent-stack)
+[![MIT License](https://img.shields.io/badge/License-MIT-000?style=flat-square&logo=opensourceinitiative&logoColor=white&labelColor=000&color=000)](../../LICENSE)
 
 Scaffold a webhook-only [Chat SDK](https://chat-sdk.dev) bot project from the command line.
 

--- a/packages/create-chat-sdk/_template/.agents/skills/chat-sdk/SKILL.md
+++ b/packages/create-chat-sdk/_template/.agents/skills/chat-sdk/SKILL.md
@@ -1,90 +1,24 @@
 ---
 name: chat-sdk
 description: Build multi-platform chat bots with Chat SDK (`chat` npm package). Use when developers want to scaffold a bot with create-chat-sdk, build a Slack, Teams, Google Chat, Discord, Telegram, GitHub, Linear, or WhatsApp bot, handle mentions, direct messages, subscribed threads, reactions, slash commands, cards, modals, files, or AI streaming, set up webhook routes or multi-adapter bots, send rich cards or streamed AI responses to chat platforms, or build a custom adapter or state adapter.
+license: MIT
 ---
 
 # Chat SDK
 
-Unified TypeScript SDK for building chat bots across Slack, Teams, Google Chat, Discord, Telegram, GitHub, Linear, and WhatsApp. Write bot logic once, deploy everywhere.
+Unified TypeScript SDK for building chat bots across Slack, Microsoft Teams, Google Chat, Discord, Telegram, GitHub, Linear, WhatsApp, and more. Write your bot logic once, deploy everywhere.
 
 ## Scaffold a new project
 
-Use `create-chat-sdk` with explicit adapters so coding agents can scaffold a webhook-only Next.js bot project without prompts:
+Use `create-chat-sdk` to scaffold a basic Next.js bot project without prompts. Run `npx create-chat-sdk --help` to see the available options and how the CLI works.
 
-```bash
-npm create chat-sdk@latest -- my-bot --adapter slack memory -y
-```
+## Start with Chat SDK documentation
 
-Non-interactive example:
+When Chat SDK is installed in a user's project, inspect the published docs that ship in `node_modules/chat/docs/`, the resources in `node_modules/chat/resources/`, and the available open source templates in `node_modules/chat/resources/templates.json`.
 
-```bash
-npm create chat-sdk@latest -- my-bot --adapter slack redis -d "My bot" --pm pnpm -y
-```
+If those paths do not exist, the `chat` package is not installed in the project yet. The user can install it with `npm i chat`.
 
-With npm, the `--` separator is required — npm consumes the flags itself instead of forwarding them to the CLI. `pnpm create` and `yarn create` forward flags without it.
-
-Key flags:
-- `--adapter <values...>` — platform or state adapters from `chat/adapters`
-- `-d, --description <text>` — project description
-- `--pm <manager>` — package manager (`npm`, `yarn`, `pnpm`, `bun`)
-- `-y, --yes` — skip prompts and accept defaults
-- `--interactive` — always prompt, even when a coding agent environment is detected
-- `-f, --force` — overwrite generated files in an existing directory
-- `-s, --skip-install` — skip dependency installation
-- `--no-git` — skip git repository initialization
-- `-q, --quiet` — suppress non-essential output
-
-When `create-chat-sdk` detects a coding agent environment, it automatically uses non-interactive defaults. Pass at least one platform adapter with `--adapter`; the state adapter defaults to `memory`. If no project name is provided, it uses `my-bot`.
-
-Generated projects include `src/lib/bot.ts`, `src/app/api/webhooks/[platform]/route.ts`, `.env.example`, `next.config.ts`, and adapter dependencies. If the Web adapter is selected, the CLI also creates `src/app/api/chat/route.ts` and `src/lib/auth-stub.ts`.
-
-## Start with published sources
-
-When Chat SDK is installed in a user project, inspect the published files that ship in `node_modules`:
-
-```
-node_modules/chat/docs/                    # bundled docs
-node_modules/chat/dist/index.d.ts          # core API types
-node_modules/chat/dist/adapters/index.d.ts # static adapter catalog types
-node_modules/chat/dist/jsx-runtime.d.ts    # JSX runtime types
-node_modules/chat/docs/contributing/       # adapter-authoring docs
-node_modules/chat/resources/guides/        # framework/platform guides (markdown)
-node_modules/chat/resources/templates.json # starter templates (title, description, href)
-```
-
-If one of the paths below does not exist, that package is not installed in the project yet.
-
-Read these before writing code:
-- `node_modules/chat/docs/getting-started.mdx` — install and setup
-- `node_modules/chat/docs/usage.mdx` — `Chat` config and lifecycle
-- `node_modules/chat/docs/handling-events.mdx` — event routing and handlers
-- `node_modules/chat/docs/threads-messages-channels.mdx` — thread/channel/message model
-- `node_modules/chat/docs/posting-messages.mdx` — post, edit, delete, schedule
-- `node_modules/chat/docs/streaming.mdx` — AI SDK integration and streaming semantics
-- `node_modules/chat/docs/cards.mdx` — JSX cards
-- `node_modules/chat/docs/actions.mdx` — button/select interactions
-- `node_modules/chat/docs/modals.mdx` — modal submit/close flows
-- `node_modules/chat/docs/slash-commands.mdx` — slash command routing
-- `node_modules/chat/docs/direct-messages.mdx` — DM behavior and `openDM()`
-- `node_modules/chat/docs/files.mdx` — attachments/uploads
-- `node_modules/chat/docs/state-adapters.mdx` — persistence, locking, dedupe
-- `node_modules/chat/docs/adapters.mdx` — cross-platform feature matrix
-- `node_modules/chat/docs/api/chat.mdx` — exact `Chat` API
-- `node_modules/chat/docs/api/thread.mdx` — exact `Thread` API
-- `node_modules/chat/docs/api/message.mdx` — exact `Message` API
-- `node_modules/chat/docs/api/modals.mdx` — modal element and event details
-
-For the specific adapter or state package you are using, inspect that installed package's `dist/index.d.ts` export surface in `node_modules`.
-
-## Adapter catalog subpath
-
-Chat SDK exposes a zero-dependency static catalog at `chat/adapters`. Agents can import `ADAPTERS`, `ADAPTER_NAMES`, `getAdapter`, `isAdapterSlug`, `listEnvVars`, `getSecretEnvVars`, and metadata types like `CatalogAdapter` and `AdapterSlug` from this subpath without importing any adapter implementation package.
-
-Use it for:
-- Listing official and vendor-official adapter slugs, names, npm packages, groups, and platform vs state types.
-- Building setup or onboarding flows that need package names, peer dependencies, and install guidance before any adapter is installed.
-- Discovering required, optional, and credential-mode environment variables for an adapter, including which variables are secrets.
-- Keeping vendor-official adapter docs and metadata aligned with the catalog when adding or updating a listed adapter.
+You can also find the docs on the [Chat SDK website](https://chat-sdk.dev/docs) and in the [Vercel knowledge base](https://vercel.com/kb/chat-sdk).
 
 ## Available resources
 
@@ -118,123 +52,20 @@ Listed in `node_modules/chat/resources/templates.json`:
 
 <!-- RESOURCES:END -->
 
-## Quick start
+## Chat SDK adapters
 
-```typescript
-import { Chat } from "chat";
-import { createSlackAdapter } from "@chat-adapter/slack";
-import { createRedisState } from "@chat-adapter/state-redis";
+### Adapter directory
 
-const bot = new Chat({
-  userName: "mybot",
-  adapters: {
-    slack: createSlackAdapter(),
-  },
-  state: createRedisState(),
-  dedupeTtlMs: 600_000,
-});
+See the 'Official Adapters', 'Vendor-Official Adapters', and 'Community Adapters' sections in the [Chat SDK llms.txt file](https://chat-sdk.dev/llms.txt) for the current list of official, vendor-official, and community adapters.
 
-bot.onNewMention(async (thread) => {
-  await thread.subscribe();
-  await thread.post("Hello! I'm listening to this thread.");
-});
+### Adapter catalog subpath
 
-bot.onSubscribedMessage(async (thread, message) => {
-  await thread.post(`You said: ${message.text}`);
-});
-```
+Chat SDK exposes a zero-dependency static catalog at `chat/adapters`.
 
-## Core concepts
+Agents can import `ADAPTERS`, `ADAPTER_NAMES`, `getAdapter`, `isAdapterSlug`, `listEnvVars`, `getSecretEnvVars`, and metadata types like `CatalogAdapter` and `AdapterSlug` from this subpath without importing any adapter implementation package.
 
-- **Chat** — main entry point; coordinates adapters, routing, locks, and state
-- **Adapters** — platform-specific integrations for Slack, Teams, Google Chat, Discord, Telegram, GitHub, Linear, and WhatsApp
-- **State adapters** — persistence for subscriptions, locks, dedupe, and thread state
-- **Thread** — conversation context with `post()`, `stream()`, `subscribe()`, `setState()`, `startTyping()`
-- **Message** — normalized content with `text`, `formatted`, attachments, author info, and platform `raw`
-- **Channel** — container for threads and top-level posts
-
-## Event handlers
-
-| Handler | Trigger |
-|---------|---------|
-| `onNewMention` | Bot @-mentioned in an unsubscribed thread |
-| `onDirectMessage` | New DM in an unsubscribed DM thread |
-| `onSubscribedMessage` | Any message in a subscribed thread |
-| `onNewMessage(regex)` | Regex match in an unsubscribed thread |
-| `onReaction(emojis?)` | Emoji added or removed |
-| `onAction(actionIds?)` | Button clicks and select/radio interactions |
-| `onModalSubmit(callbackId?)` | Modal form submitted |
-| `onModalClose(callbackId?)` | Modal dismissed/cancelled |
-| `onSlashCommand(commands?)` | Slash command invocation |
-| `onAssistantThreadStarted` | Slack assistant thread opened |
-| `onAssistantContextChanged` | Slack assistant context changed |
-| `onAppHomeOpened` | Slack App Home opened |
-| `onMemberJoinedChannel` | Slack member joined channel event |
-
-Read `node_modules/chat/docs/handling-events.mdx`, `node_modules/chat/docs/actions.mdx`, `node_modules/chat/docs/modals.mdx`, and `node_modules/chat/docs/slash-commands.mdx` before wiring handlers. `onDirectMessage` behavior is documented in `node_modules/chat/docs/direct-messages.mdx`.
-
-## Streaming
-
-Pass any `AsyncIterable<string>` to `thread.post()`. For AI SDK, prefer `result.fullStream` over `result.textStream` when available so step boundaries are preserved.
-
-```typescript
-import { ToolLoopAgent } from "ai";
-
-const agent = new ToolLoopAgent({ model: "anthropic/claude-4.5-sonnet" });
-
-bot.onNewMention(async (thread, message) => {
-  const result = await agent.stream({ prompt: message.text });
-  await thread.post(result.fullStream);
-});
-```
-
-Key details:
-- `streamingUpdateIntervalMs` controls post+edit fallback cadence
-- `fallbackStreamingPlaceholderText` defaults to `"..."`; set `null` to disable
-- Structured `StreamChunk` support is Slack-only; other adapters ignore non-text chunks
-
-## Cards and modals (JSX)
-
-Set `jsxImportSource: "chat"` in `tsconfig.json`.
-
-Card components:
-- `Card`, `CardText`, `Section`, `Fields`, `Field`, `Button`, `CardLink`, `LinkButton`, `Actions`, `Select`, `SelectOption`, `RadioSelect`, `Table`, `Image`, `Divider`
-
-Modal components:
-- `Modal`, `TextInput`, `Select`, `SelectOption`, `RadioSelect`
-
-`Button` and `Modal` accept a `callbackUrl` prop — when triggered, the SDK POSTs the action payload to that URL in addition to firing any `onAction` / `onModalSubmit` handler. Use this for webhook-based workflow flows. See `node_modules/chat/docs/actions.mdx` and `node_modules/chat/docs/modals.mdx`.
-
-```tsx
-await thread.post(
-  <Card title="Order #1234">
-    <CardText>Your order has been received.</CardText>
-    <Actions>
-      <Button id="approve" style="primary">Approve</Button>
-      <Button id="reject" style="danger">Reject</Button>
-    </Actions>
-  </Card>
-);
-```
-
-## Adapter inventory
-
-See [chat-sdk.dev/adapters](https://chat-sdk.dev/adapters) for the current list of official, vendor-official, and community adapters, including package names and authors. For the exact factory function and config types of an installed adapter, inspect its `dist/index.d.ts` in `node_modules`.
-
-## Building a custom adapter
-
-Read these published docs first:
-- `node_modules/chat/docs/contributing/building.mdx`
-- `node_modules/chat/docs/contributing/testing.mdx`
-- `node_modules/chat/docs/contributing/publishing.mdx`
-
-Also inspect:
-- `node_modules/chat/dist/index.d.ts` — `Adapter` and related interfaces
-- `node_modules/@chat-adapter/shared/dist/index.d.ts` — shared errors and utilities
-- Installed official adapter `dist/index.d.ts` files — reference implementations for config and APIs
-
-A custom adapter needs request verification, webhook parsing, message/thread/channel operations, ID encoding/decoding, and a format converter. Use `BaseFormatConverter` from `chat` and shared utilities from `@chat-adapter/shared`.
-
-## Webhook setup
-
-Each registered adapter exposes `bot.webhooks.<name>`. Wire those directly to your HTTP framework routes. See `node_modules/chat/resources/guides/how-to-build-a-slack-bot-with-next-js-and-redis.md` and `node_modules/chat/resources/guides/create-a-discord-support-bot-with-nuxt-and-redis.md` for framework-specific route patterns.
+Use it for:
+- Listing official and vendor-official adapter slugs, names, npm packages, groups, and platform vs state types.
+- Building setup or onboarding flows that need package names, peer dependencies, and install guidance before any adapter is installed.
+- Discovering required, optional, and credential-mode environment variables for an adapter, including which variables are secrets.
+- Keeping vendor-official adapter docs and metadata aligned with the catalog when adding or updating a listed adapter.

--- a/packages/create-chat-sdk/_template/.claude/skills/chat-sdk/SKILL.md
+++ b/packages/create-chat-sdk/_template/.claude/skills/chat-sdk/SKILL.md
@@ -1,90 +1,24 @@
 ---
 name: chat-sdk
 description: Build multi-platform chat bots with Chat SDK (`chat` npm package). Use when developers want to scaffold a bot with create-chat-sdk, build a Slack, Teams, Google Chat, Discord, Telegram, GitHub, Linear, or WhatsApp bot, handle mentions, direct messages, subscribed threads, reactions, slash commands, cards, modals, files, or AI streaming, set up webhook routes or multi-adapter bots, send rich cards or streamed AI responses to chat platforms, or build a custom adapter or state adapter.
+license: MIT
 ---
 
 # Chat SDK
 
-Unified TypeScript SDK for building chat bots across Slack, Teams, Google Chat, Discord, Telegram, GitHub, Linear, and WhatsApp. Write bot logic once, deploy everywhere.
+Unified TypeScript SDK for building chat bots across Slack, Microsoft Teams, Google Chat, Discord, Telegram, GitHub, Linear, WhatsApp, and more. Write your bot logic once, deploy everywhere.
 
 ## Scaffold a new project
 
-Use `create-chat-sdk` with explicit adapters so coding agents can scaffold a webhook-only Next.js bot project without prompts:
+Use `create-chat-sdk` to scaffold a basic Next.js bot project without prompts. Run `npx create-chat-sdk --help` to see the available options and how the CLI works.
 
-```bash
-npm create chat-sdk@latest -- my-bot --adapter slack memory -y
-```
+## Start with Chat SDK documentation
 
-Non-interactive example:
+When Chat SDK is installed in a user's project, inspect the published docs that ship in `node_modules/chat/docs/`, the resources in `node_modules/chat/resources/`, and the available open source templates in `node_modules/chat/resources/templates.json`.
 
-```bash
-npm create chat-sdk@latest -- my-bot --adapter slack redis -d "My bot" --pm pnpm -y
-```
+If those paths do not exist, the `chat` package is not installed in the project yet. The user can install it with `npm i chat`.
 
-With npm, the `--` separator is required — npm consumes the flags itself instead of forwarding them to the CLI. `pnpm create` and `yarn create` forward flags without it.
-
-Key flags:
-- `--adapter <values...>` — platform or state adapters from `chat/adapters`
-- `-d, --description <text>` — project description
-- `--pm <manager>` — package manager (`npm`, `yarn`, `pnpm`, `bun`)
-- `-y, --yes` — skip prompts and accept defaults
-- `--interactive` — always prompt, even when a coding agent environment is detected
-- `-f, --force` — overwrite generated files in an existing directory
-- `-s, --skip-install` — skip dependency installation
-- `--no-git` — skip git repository initialization
-- `-q, --quiet` — suppress non-essential output
-
-When `create-chat-sdk` detects a coding agent environment, it automatically uses non-interactive defaults. Pass at least one platform adapter with `--adapter`; the state adapter defaults to `memory`. If no project name is provided, it uses `my-bot`.
-
-Generated projects include `src/lib/bot.ts`, `src/app/api/webhooks/[platform]/route.ts`, `.env.example`, `next.config.ts`, and adapter dependencies. If the Web adapter is selected, the CLI also creates `src/app/api/chat/route.ts` and `src/lib/auth-stub.ts`.
-
-## Start with published sources
-
-When Chat SDK is installed in a user project, inspect the published files that ship in `node_modules`:
-
-```
-node_modules/chat/docs/                    # bundled docs
-node_modules/chat/dist/index.d.ts          # core API types
-node_modules/chat/dist/adapters/index.d.ts # static adapter catalog types
-node_modules/chat/dist/jsx-runtime.d.ts    # JSX runtime types
-node_modules/chat/docs/contributing/       # adapter-authoring docs
-node_modules/chat/resources/guides/        # framework/platform guides (markdown)
-node_modules/chat/resources/templates.json # starter templates (title, description, href)
-```
-
-If one of the paths below does not exist, that package is not installed in the project yet.
-
-Read these before writing code:
-- `node_modules/chat/docs/getting-started.mdx` — install and setup
-- `node_modules/chat/docs/usage.mdx` — `Chat` config and lifecycle
-- `node_modules/chat/docs/handling-events.mdx` — event routing and handlers
-- `node_modules/chat/docs/threads-messages-channels.mdx` — thread/channel/message model
-- `node_modules/chat/docs/posting-messages.mdx` — post, edit, delete, schedule
-- `node_modules/chat/docs/streaming.mdx` — AI SDK integration and streaming semantics
-- `node_modules/chat/docs/cards.mdx` — JSX cards
-- `node_modules/chat/docs/actions.mdx` — button/select interactions
-- `node_modules/chat/docs/modals.mdx` — modal submit/close flows
-- `node_modules/chat/docs/slash-commands.mdx` — slash command routing
-- `node_modules/chat/docs/direct-messages.mdx` — DM behavior and `openDM()`
-- `node_modules/chat/docs/files.mdx` — attachments/uploads
-- `node_modules/chat/docs/state-adapters.mdx` — persistence, locking, dedupe
-- `node_modules/chat/docs/adapters.mdx` — cross-platform feature matrix
-- `node_modules/chat/docs/api/chat.mdx` — exact `Chat` API
-- `node_modules/chat/docs/api/thread.mdx` — exact `Thread` API
-- `node_modules/chat/docs/api/message.mdx` — exact `Message` API
-- `node_modules/chat/docs/api/modals.mdx` — modal element and event details
-
-For the specific adapter or state package you are using, inspect that installed package's `dist/index.d.ts` export surface in `node_modules`.
-
-## Adapter catalog subpath
-
-Chat SDK exposes a zero-dependency static catalog at `chat/adapters`. Agents can import `ADAPTERS`, `ADAPTER_NAMES`, `getAdapter`, `isAdapterSlug`, `listEnvVars`, `getSecretEnvVars`, and metadata types like `CatalogAdapter` and `AdapterSlug` from this subpath without importing any adapter implementation package.
-
-Use it for:
-- Listing official and vendor-official adapter slugs, names, npm packages, groups, and platform vs state types.
-- Building setup or onboarding flows that need package names, peer dependencies, and install guidance before any adapter is installed.
-- Discovering required, optional, and credential-mode environment variables for an adapter, including which variables are secrets.
-- Keeping vendor-official adapter docs and metadata aligned with the catalog when adding or updating a listed adapter.
+You can also find the docs on the [Chat SDK website](https://chat-sdk.dev/docs) and in the [Vercel knowledge base](https://vercel.com/kb/chat-sdk).
 
 ## Available resources
 
@@ -118,123 +52,20 @@ Listed in `node_modules/chat/resources/templates.json`:
 
 <!-- RESOURCES:END -->
 
-## Quick start
+## Chat SDK adapters
 
-```typescript
-import { Chat } from "chat";
-import { createSlackAdapter } from "@chat-adapter/slack";
-import { createRedisState } from "@chat-adapter/state-redis";
+### Adapter directory
 
-const bot = new Chat({
-  userName: "mybot",
-  adapters: {
-    slack: createSlackAdapter(),
-  },
-  state: createRedisState(),
-  dedupeTtlMs: 600_000,
-});
+See the 'Official Adapters', 'Vendor-Official Adapters', and 'Community Adapters' sections in the [Chat SDK llms.txt file](https://chat-sdk.dev/llms.txt) for the current list of official, vendor-official, and community adapters.
 
-bot.onNewMention(async (thread) => {
-  await thread.subscribe();
-  await thread.post("Hello! I'm listening to this thread.");
-});
+### Adapter catalog subpath
 
-bot.onSubscribedMessage(async (thread, message) => {
-  await thread.post(`You said: ${message.text}`);
-});
-```
+Chat SDK exposes a zero-dependency static catalog at `chat/adapters`.
 
-## Core concepts
+Agents can import `ADAPTERS`, `ADAPTER_NAMES`, `getAdapter`, `isAdapterSlug`, `listEnvVars`, `getSecretEnvVars`, and metadata types like `CatalogAdapter` and `AdapterSlug` from this subpath without importing any adapter implementation package.
 
-- **Chat** — main entry point; coordinates adapters, routing, locks, and state
-- **Adapters** — platform-specific integrations for Slack, Teams, Google Chat, Discord, Telegram, GitHub, Linear, and WhatsApp
-- **State adapters** — persistence for subscriptions, locks, dedupe, and thread state
-- **Thread** — conversation context with `post()`, `stream()`, `subscribe()`, `setState()`, `startTyping()`
-- **Message** — normalized content with `text`, `formatted`, attachments, author info, and platform `raw`
-- **Channel** — container for threads and top-level posts
-
-## Event handlers
-
-| Handler | Trigger |
-|---------|---------|
-| `onNewMention` | Bot @-mentioned in an unsubscribed thread |
-| `onDirectMessage` | New DM in an unsubscribed DM thread |
-| `onSubscribedMessage` | Any message in a subscribed thread |
-| `onNewMessage(regex)` | Regex match in an unsubscribed thread |
-| `onReaction(emojis?)` | Emoji added or removed |
-| `onAction(actionIds?)` | Button clicks and select/radio interactions |
-| `onModalSubmit(callbackId?)` | Modal form submitted |
-| `onModalClose(callbackId?)` | Modal dismissed/cancelled |
-| `onSlashCommand(commands?)` | Slash command invocation |
-| `onAssistantThreadStarted` | Slack assistant thread opened |
-| `onAssistantContextChanged` | Slack assistant context changed |
-| `onAppHomeOpened` | Slack App Home opened |
-| `onMemberJoinedChannel` | Slack member joined channel event |
-
-Read `node_modules/chat/docs/handling-events.mdx`, `node_modules/chat/docs/actions.mdx`, `node_modules/chat/docs/modals.mdx`, and `node_modules/chat/docs/slash-commands.mdx` before wiring handlers. `onDirectMessage` behavior is documented in `node_modules/chat/docs/direct-messages.mdx`.
-
-## Streaming
-
-Pass any `AsyncIterable<string>` to `thread.post()`. For AI SDK, prefer `result.fullStream` over `result.textStream` when available so step boundaries are preserved.
-
-```typescript
-import { ToolLoopAgent } from "ai";
-
-const agent = new ToolLoopAgent({ model: "anthropic/claude-4.5-sonnet" });
-
-bot.onNewMention(async (thread, message) => {
-  const result = await agent.stream({ prompt: message.text });
-  await thread.post(result.fullStream);
-});
-```
-
-Key details:
-- `streamingUpdateIntervalMs` controls post+edit fallback cadence
-- `fallbackStreamingPlaceholderText` defaults to `"..."`; set `null` to disable
-- Structured `StreamChunk` support is Slack-only; other adapters ignore non-text chunks
-
-## Cards and modals (JSX)
-
-Set `jsxImportSource: "chat"` in `tsconfig.json`.
-
-Card components:
-- `Card`, `CardText`, `Section`, `Fields`, `Field`, `Button`, `CardLink`, `LinkButton`, `Actions`, `Select`, `SelectOption`, `RadioSelect`, `Table`, `Image`, `Divider`
-
-Modal components:
-- `Modal`, `TextInput`, `Select`, `SelectOption`, `RadioSelect`
-
-`Button` and `Modal` accept a `callbackUrl` prop — when triggered, the SDK POSTs the action payload to that URL in addition to firing any `onAction` / `onModalSubmit` handler. Use this for webhook-based workflow flows. See `node_modules/chat/docs/actions.mdx` and `node_modules/chat/docs/modals.mdx`.
-
-```tsx
-await thread.post(
-  <Card title="Order #1234">
-    <CardText>Your order has been received.</CardText>
-    <Actions>
-      <Button id="approve" style="primary">Approve</Button>
-      <Button id="reject" style="danger">Reject</Button>
-    </Actions>
-  </Card>
-);
-```
-
-## Adapter inventory
-
-See [chat-sdk.dev/adapters](https://chat-sdk.dev/adapters) for the current list of official, vendor-official, and community adapters, including package names and authors. For the exact factory function and config types of an installed adapter, inspect its `dist/index.d.ts` in `node_modules`.
-
-## Building a custom adapter
-
-Read these published docs first:
-- `node_modules/chat/docs/contributing/building.mdx`
-- `node_modules/chat/docs/contributing/testing.mdx`
-- `node_modules/chat/docs/contributing/publishing.mdx`
-
-Also inspect:
-- `node_modules/chat/dist/index.d.ts` — `Adapter` and related interfaces
-- `node_modules/@chat-adapter/shared/dist/index.d.ts` — shared errors and utilities
-- Installed official adapter `dist/index.d.ts` files — reference implementations for config and APIs
-
-A custom adapter needs request verification, webhook parsing, message/thread/channel operations, ID encoding/decoding, and a format converter. Use `BaseFormatConverter` from `chat` and shared utilities from `@chat-adapter/shared`.
-
-## Webhook setup
-
-Each registered adapter exposes `bot.webhooks.<name>`. Wire those directly to your HTTP framework routes. See `node_modules/chat/resources/guides/how-to-build-a-slack-bot-with-next-js-and-redis.md` and `node_modules/chat/resources/guides/create-a-discord-support-bot-with-nuxt-and-redis.md` for framework-specific route patterns.
+Use it for:
+- Listing official and vendor-official adapter slugs, names, npm packages, groups, and platform vs state types.
+- Building setup or onboarding flows that need package names, peer dependencies, and install guidance before any adapter is installed.
+- Discovering required, optional, and credential-mode environment variables for an adapter, including which variables are secrets.
+- Keeping vendor-official adapter docs and metadata aligned with the catalog when adding or updating a listed adapter.

--- a/packages/integration-tests/src/docs-skills.test.ts
+++ b/packages/integration-tests/src/docs-skills.test.ts
@@ -17,19 +17,15 @@ describe("Chat SDK agent skill", () => {
       const skill = readFileSync(join(REPO_ROOT, skillPath), "utf-8");
 
       expect(skill).toContain("chat/adapters");
-      expect(skill).toContain("node_modules/chat/dist/adapters/index.d.ts");
       expect(skill).toContain("getSecretEnvVars");
+      expect(skill).toContain("chat-sdk.dev/llms.txt");
     });
 
-    it(`${skillPath} documents an agent-safe scaffold command`, () => {
+    it(`${skillPath} points agents at create-chat-sdk help`, () => {
       const skill = readFileSync(join(REPO_ROOT, skillPath), "utf-8");
 
-      expect(skill).toContain(
-        "npm create chat-sdk@latest -- my-bot --adapter slack memory -y"
-      );
-      expect(skill).toContain(
-        "Pass at least one platform adapter with `--adapter`"
-      );
+      expect(skill).toContain("npx create-chat-sdk --help");
+      expect(skill).toContain("license: MIT");
     });
   }
 });

--- a/packages/state-ioredis/README.md
+++ b/packages/state-ioredis/README.md
@@ -2,8 +2,8 @@
 
 > npm package: [`@chat-adapter/state-ioredis`](https://www.npmjs.com/package/@chat-adapter/state-ioredis)
 
-[![npm version](https://img.shields.io/npm/v/@chat-adapter/state-ioredis)](https://www.npmjs.com/package/@chat-adapter/state-ioredis)
-[![npm downloads](https://img.shields.io/npm/dm/@chat-adapter/state-ioredis)](https://www.npmjs.com/package/@chat-adapter/state-ioredis)
+[![Agent Stack](https://img.shields.io/badge/Agent%20Stack-000?style=flat-square&logo=vercel&logoColor=FFF&labelColor=000&color=000)](https://vercel.com/kb/agent-stack)
+[![MIT License](https://img.shields.io/badge/License-MIT-000?style=flat-square&logo=opensourceinitiative&logoColor=white&labelColor=000&color=000)](../../LICENSE)
 
 Alternative Redis state adapter for [Chat SDK](https://chat-sdk.dev) using [ioredis](https://www.npmjs.com/package/ioredis). Use this if you already have ioredis in your project or need Redis Cluster/Sentinel support.
 

--- a/packages/state-memory/README.md
+++ b/packages/state-memory/README.md
@@ -2,8 +2,8 @@
 
 > npm package: [`@chat-adapter/state-memory`](https://www.npmjs.com/package/@chat-adapter/state-memory)
 
-[![npm version](https://img.shields.io/npm/v/@chat-adapter/state-memory)](https://www.npmjs.com/package/@chat-adapter/state-memory)
-[![npm downloads](https://img.shields.io/npm/dm/@chat-adapter/state-memory)](https://www.npmjs.com/package/@chat-adapter/state-memory)
+[![Agent Stack](https://img.shields.io/badge/Agent%20Stack-000?style=flat-square&logo=vercel&logoColor=FFF&labelColor=000&color=000)](https://vercel.com/kb/agent-stack)
+[![MIT License](https://img.shields.io/badge/License-MIT-000?style=flat-square&logo=opensourceinitiative&logoColor=white&labelColor=000&color=000)](../../LICENSE)
 
 In-memory state adapter for [Chat SDK](https://chat-sdk.dev). For development and testing only — state is lost on restart.
 

--- a/packages/state-pg/README.md
+++ b/packages/state-pg/README.md
@@ -2,8 +2,8 @@
 
 > npm package: [`@chat-adapter/state-pg`](https://www.npmjs.com/package/@chat-adapter/state-pg)
 
-[![npm version](https://img.shields.io/npm/v/@chat-adapter/state-pg)](https://www.npmjs.com/package/@chat-adapter/state-pg)
-[![npm downloads](https://img.shields.io/npm/dm/@chat-adapter/state-pg)](https://www.npmjs.com/package/@chat-adapter/state-pg)
+[![Agent Stack](https://img.shields.io/badge/Agent%20Stack-000?style=flat-square&logo=vercel&logoColor=FFF&labelColor=000&color=000)](https://vercel.com/kb/agent-stack)
+[![MIT License](https://img.shields.io/badge/License-MIT-000?style=flat-square&logo=opensourceinitiative&logoColor=white&labelColor=000&color=000)](../../LICENSE)
 
 Production PostgreSQL state adapter for [Chat SDK](https://chat-sdk.dev) built with [pg](https://www.npmjs.com/package/pg) (node-postgres). Use this when PostgreSQL is your primary datastore and you want state persistence without a separate Redis dependency.
 

--- a/packages/state-redis/README.md
+++ b/packages/state-redis/README.md
@@ -2,8 +2,8 @@
 
 > npm package: [`@chat-adapter/state-redis`](https://www.npmjs.com/package/@chat-adapter/state-redis)
 
-[![npm version](https://img.shields.io/npm/v/@chat-adapter/state-redis)](https://www.npmjs.com/package/@chat-adapter/state-redis)
-[![npm downloads](https://img.shields.io/npm/dm/@chat-adapter/state-redis)](https://www.npmjs.com/package/@chat-adapter/state-redis)
+[![Agent Stack](https://img.shields.io/badge/Agent%20Stack-000?style=flat-square&logo=vercel&logoColor=FFF&labelColor=000&color=000)](https://vercel.com/kb/agent-stack)
+[![MIT License](https://img.shields.io/badge/License-MIT-000?style=flat-square&logo=opensourceinitiative&logoColor=white&labelColor=000&color=000)](../../LICENSE)
 
 Production state adapter for [Chat SDK](https://chat-sdk.dev) using the official [redis](https://www.npmjs.com/package/redis) package.
 

--- a/packages/tests/README.md
+++ b/packages/tests/README.md
@@ -2,8 +2,8 @@
 
 > npm package: [`@chat-adapter/tests`](https://www.npmjs.com/package/@chat-adapter/tests)
 
-[![npm version](https://img.shields.io/npm/v/@chat-adapter/tests)](https://www.npmjs.com/package/@chat-adapter/tests)
-[![npm downloads](https://img.shields.io/npm/dm/@chat-adapter/tests)](https://www.npmjs.com/package/@chat-adapter/tests)
+[![Agent Stack](https://img.shields.io/badge/Agent%20Stack-000?style=flat-square&logo=vercel&logoColor=FFF&labelColor=000&color=000)](https://vercel.com/kb/agent-stack)
+[![MIT License](https://img.shields.io/badge/License-MIT-000?style=flat-square&logo=opensourceinitiative&logoColor=white&labelColor=000&color=000)](../../LICENSE)
 
 Vitest factories, matchers, and setup utilities for testing [Chat SDK](https://chat-sdk.dev) adapters and bots.
 

--- a/skills/chat/SKILL.md
+++ b/skills/chat/SKILL.md
@@ -1,90 +1,24 @@
 ---
 name: chat-sdk
 description: Build multi-platform chat bots with Chat SDK (`chat` npm package). Use when developers want to scaffold a bot with create-chat-sdk, build a Slack, Teams, Google Chat, Discord, Telegram, GitHub, Linear, or WhatsApp bot, handle mentions, direct messages, subscribed threads, reactions, slash commands, cards, modals, files, or AI streaming, set up webhook routes or multi-adapter bots, send rich cards or streamed AI responses to chat platforms, or build a custom adapter or state adapter.
+license: MIT
 ---
 
 # Chat SDK
 
-Unified TypeScript SDK for building chat bots across Slack, Teams, Google Chat, Discord, Telegram, GitHub, Linear, and WhatsApp. Write bot logic once, deploy everywhere.
+Unified TypeScript SDK for building chat bots across Slack, Microsoft Teams, Google Chat, Discord, Telegram, GitHub, Linear, WhatsApp, and more. Write your bot logic once, deploy everywhere.
 
 ## Scaffold a new project
 
-Use `create-chat-sdk` with explicit adapters so coding agents can scaffold a webhook-only Next.js bot project without prompts:
+Use `create-chat-sdk` to scaffold a basic Next.js bot project without prompts. Run `npx create-chat-sdk --help` to see the available options and how the CLI works.
 
-```bash
-npm create chat-sdk@latest -- my-bot --adapter slack memory -y
-```
+## Start with Chat SDK documentation
 
-Non-interactive example:
+When Chat SDK is installed in a user's project, inspect the published docs that ship in `node_modules/chat/docs/`, the resources in `node_modules/chat/resources/`, and the available open source templates in `node_modules/chat/resources/templates.json`.
 
-```bash
-npm create chat-sdk@latest -- my-bot --adapter slack redis -d "My bot" --pm pnpm -y
-```
+If those paths do not exist, the `chat` package is not installed in the project yet. The user can install it with `npm i chat`.
 
-With npm, the `--` separator is required — npm consumes the flags itself instead of forwarding them to the CLI. `pnpm create` and `yarn create` forward flags without it.
-
-Key flags:
-- `--adapter <values...>` — platform or state adapters from `chat/adapters`
-- `-d, --description <text>` — project description
-- `--pm <manager>` — package manager (`npm`, `yarn`, `pnpm`, `bun`)
-- `-y, --yes` — skip prompts and accept defaults
-- `--interactive` — always prompt, even when a coding agent environment is detected
-- `-f, --force` — overwrite generated files in an existing directory
-- `-s, --skip-install` — skip dependency installation
-- `--no-git` — skip git repository initialization
-- `-q, --quiet` — suppress non-essential output
-
-When `create-chat-sdk` detects a coding agent environment, it automatically uses non-interactive defaults. Pass at least one platform adapter with `--adapter`; the state adapter defaults to `memory`. If no project name is provided, it uses `my-bot`.
-
-Generated projects include `src/lib/bot.ts`, `src/app/api/webhooks/[platform]/route.ts`, `.env.example`, `next.config.ts`, and adapter dependencies. If the Web adapter is selected, the CLI also creates `src/app/api/chat/route.ts` and `src/lib/auth-stub.ts`.
-
-## Start with published sources
-
-When Chat SDK is installed in a user project, inspect the published files that ship in `node_modules`:
-
-```
-node_modules/chat/docs/                    # bundled docs
-node_modules/chat/dist/index.d.ts          # core API types
-node_modules/chat/dist/adapters/index.d.ts # static adapter catalog types
-node_modules/chat/dist/jsx-runtime.d.ts    # JSX runtime types
-node_modules/chat/docs/contributing/       # adapter-authoring docs
-node_modules/chat/resources/guides/        # framework/platform guides (markdown)
-node_modules/chat/resources/templates.json # starter templates (title, description, href)
-```
-
-If one of the paths below does not exist, that package is not installed in the project yet.
-
-Read these before writing code:
-- `node_modules/chat/docs/getting-started.mdx` — install and setup
-- `node_modules/chat/docs/usage.mdx` — `Chat` config and lifecycle
-- `node_modules/chat/docs/handling-events.mdx` — event routing and handlers
-- `node_modules/chat/docs/threads-messages-channels.mdx` — thread/channel/message model
-- `node_modules/chat/docs/posting-messages.mdx` — post, edit, delete, schedule
-- `node_modules/chat/docs/streaming.mdx` — AI SDK integration and streaming semantics
-- `node_modules/chat/docs/cards.mdx` — JSX cards
-- `node_modules/chat/docs/actions.mdx` — button/select interactions
-- `node_modules/chat/docs/modals.mdx` — modal submit/close flows
-- `node_modules/chat/docs/slash-commands.mdx` — slash command routing
-- `node_modules/chat/docs/direct-messages.mdx` — DM behavior and `openDM()`
-- `node_modules/chat/docs/files.mdx` — attachments/uploads
-- `node_modules/chat/docs/state-adapters.mdx` — persistence, locking, dedupe
-- `node_modules/chat/docs/adapters.mdx` — cross-platform feature matrix
-- `node_modules/chat/docs/api/chat.mdx` — exact `Chat` API
-- `node_modules/chat/docs/api/thread.mdx` — exact `Thread` API
-- `node_modules/chat/docs/api/message.mdx` — exact `Message` API
-- `node_modules/chat/docs/api/modals.mdx` — modal element and event details
-
-For the specific adapter or state package you are using, inspect that installed package's `dist/index.d.ts` export surface in `node_modules`.
-
-## Adapter catalog subpath
-
-Chat SDK exposes a zero-dependency static catalog at `chat/adapters`. Agents can import `ADAPTERS`, `ADAPTER_NAMES`, `getAdapter`, `isAdapterSlug`, `listEnvVars`, `getSecretEnvVars`, and metadata types like `CatalogAdapter` and `AdapterSlug` from this subpath without importing any adapter implementation package.
-
-Use it for:
-- Listing official and vendor-official adapter slugs, names, npm packages, groups, and platform vs state types.
-- Building setup or onboarding flows that need package names, peer dependencies, and install guidance before any adapter is installed.
-- Discovering required, optional, and credential-mode environment variables for an adapter, including which variables are secrets.
-- Keeping vendor-official adapter docs and metadata aligned with the catalog when adding or updating a listed adapter.
+You can also find the docs on the [Chat SDK website](https://chat-sdk.dev/docs) and in the [Vercel knowledge base](https://vercel.com/kb/chat-sdk).
 
 ## Available resources
 
@@ -118,123 +52,20 @@ Listed in `node_modules/chat/resources/templates.json`:
 
 <!-- RESOURCES:END -->
 
-## Quick start
+## Chat SDK adapters
 
-```typescript
-import { Chat } from "chat";
-import { createSlackAdapter } from "@chat-adapter/slack";
-import { createRedisState } from "@chat-adapter/state-redis";
+### Adapter directory
 
-const bot = new Chat({
-  userName: "mybot",
-  adapters: {
-    slack: createSlackAdapter(),
-  },
-  state: createRedisState(),
-  dedupeTtlMs: 600_000,
-});
+See the 'Official Adapters', 'Vendor-Official Adapters', and 'Community Adapters' sections in the [Chat SDK llms.txt file](https://chat-sdk.dev/llms.txt) for the current list of official, vendor-official, and community adapters.
 
-bot.onNewMention(async (thread) => {
-  await thread.subscribe();
-  await thread.post("Hello! I'm listening to this thread.");
-});
+### Adapter catalog subpath
 
-bot.onSubscribedMessage(async (thread, message) => {
-  await thread.post(`You said: ${message.text}`);
-});
-```
+Chat SDK exposes a zero-dependency static catalog at `chat/adapters`.
 
-## Core concepts
+Agents can import `ADAPTERS`, `ADAPTER_NAMES`, `getAdapter`, `isAdapterSlug`, `listEnvVars`, `getSecretEnvVars`, and metadata types like `CatalogAdapter` and `AdapterSlug` from this subpath without importing any adapter implementation package.
 
-- **Chat** — main entry point; coordinates adapters, routing, locks, and state
-- **Adapters** — platform-specific integrations for Slack, Teams, Google Chat, Discord, Telegram, GitHub, Linear, and WhatsApp
-- **State adapters** — persistence for subscriptions, locks, dedupe, and thread state
-- **Thread** — conversation context with `post()`, `stream()`, `subscribe()`, `setState()`, `startTyping()`
-- **Message** — normalized content with `text`, `formatted`, attachments, author info, and platform `raw`
-- **Channel** — container for threads and top-level posts
-
-## Event handlers
-
-| Handler | Trigger |
-|---------|---------|
-| `onNewMention` | Bot @-mentioned in an unsubscribed thread |
-| `onDirectMessage` | New DM in an unsubscribed DM thread |
-| `onSubscribedMessage` | Any message in a subscribed thread |
-| `onNewMessage(regex)` | Regex match in an unsubscribed thread |
-| `onReaction(emojis?)` | Emoji added or removed |
-| `onAction(actionIds?)` | Button clicks and select/radio interactions |
-| `onModalSubmit(callbackId?)` | Modal form submitted |
-| `onModalClose(callbackId?)` | Modal dismissed/cancelled |
-| `onSlashCommand(commands?)` | Slash command invocation |
-| `onAssistantThreadStarted` | Slack assistant thread opened |
-| `onAssistantContextChanged` | Slack assistant context changed |
-| `onAppHomeOpened` | Slack App Home opened |
-| `onMemberJoinedChannel` | Slack member joined channel event |
-
-Read `node_modules/chat/docs/handling-events.mdx`, `node_modules/chat/docs/actions.mdx`, `node_modules/chat/docs/modals.mdx`, and `node_modules/chat/docs/slash-commands.mdx` before wiring handlers. `onDirectMessage` behavior is documented in `node_modules/chat/docs/direct-messages.mdx`.
-
-## Streaming
-
-Pass any `AsyncIterable<string>` to `thread.post()`. For AI SDK, prefer `result.fullStream` over `result.textStream` when available so step boundaries are preserved.
-
-```typescript
-import { ToolLoopAgent } from "ai";
-
-const agent = new ToolLoopAgent({ model: "anthropic/claude-4.5-sonnet" });
-
-bot.onNewMention(async (thread, message) => {
-  const result = await agent.stream({ prompt: message.text });
-  await thread.post(result.fullStream);
-});
-```
-
-Key details:
-- `streamingUpdateIntervalMs` controls post+edit fallback cadence
-- `fallbackStreamingPlaceholderText` defaults to `"..."`; set `null` to disable
-- Structured `StreamChunk` support is Slack-only; other adapters ignore non-text chunks
-
-## Cards and modals (JSX)
-
-Set `jsxImportSource: "chat"` in `tsconfig.json`.
-
-Card components:
-- `Card`, `CardText`, `Section`, `Fields`, `Field`, `Button`, `CardLink`, `LinkButton`, `Actions`, `Select`, `SelectOption`, `RadioSelect`, `Table`, `Image`, `Divider`
-
-Modal components:
-- `Modal`, `TextInput`, `Select`, `SelectOption`, `RadioSelect`
-
-`Button` and `Modal` accept a `callbackUrl` prop — when triggered, the SDK POSTs the action payload to that URL in addition to firing any `onAction` / `onModalSubmit` handler. Use this for webhook-based workflow flows. See `node_modules/chat/docs/actions.mdx` and `node_modules/chat/docs/modals.mdx`.
-
-```tsx
-await thread.post(
-  <Card title="Order #1234">
-    <CardText>Your order has been received.</CardText>
-    <Actions>
-      <Button id="approve" style="primary">Approve</Button>
-      <Button id="reject" style="danger">Reject</Button>
-    </Actions>
-  </Card>
-);
-```
-
-## Adapter inventory
-
-See [chat-sdk.dev/adapters](https://chat-sdk.dev/adapters) for the current list of official, vendor-official, and community adapters, including package names and authors. For the exact factory function and config types of an installed adapter, inspect its `dist/index.d.ts` in `node_modules`.
-
-## Building a custom adapter
-
-Read these published docs first:
-- `node_modules/chat/docs/contributing/building.mdx`
-- `node_modules/chat/docs/contributing/testing.mdx`
-- `node_modules/chat/docs/contributing/publishing.mdx`
-
-Also inspect:
-- `node_modules/chat/dist/index.d.ts` — `Adapter` and related interfaces
-- `node_modules/@chat-adapter/shared/dist/index.d.ts` — shared errors and utilities
-- Installed official adapter `dist/index.d.ts` files — reference implementations for config and APIs
-
-A custom adapter needs request verification, webhook parsing, message/thread/channel operations, ID encoding/decoding, and a format converter. Use `BaseFormatConverter` from `chat` and shared utilities from `@chat-adapter/shared`.
-
-## Webhook setup
-
-Each registered adapter exposes `bot.webhooks.<name>`. Wire those directly to your HTTP framework routes. See `node_modules/chat/resources/guides/how-to-build-a-slack-bot-with-next-js-and-redis.md` and `node_modules/chat/resources/guides/create-a-discord-support-bot-with-nuxt-and-redis.md` for framework-specific route patterns.
+Use it for:
+- Listing official and vendor-official adapter slugs, names, npm packages, groups, and platform vs state types.
+- Building setup or onboarding flows that need package names, peer dependencies, and install guidance before any adapter is installed.
+- Discovering required, optional, and credential-mode environment variables for an adapter, including which variables are secrets.
+- Keeping vendor-official adapter docs and metadata aligned with the catalog when adding or updating a listed adapter.


### PR DESCRIPTION
- Replace npm version/download badges with Agent Stack and MIT badges on the root README and all published package READMEs
- Streamline root `AGENTS.md`: fix title, add an accurate monorepo map, trim duplicated CONTRIBUTING/Ultracite/env-var content, and link to package-level `AGENTS.md` files
- Slim the Chat SDK agent skill (`skills/chat/SKILL.md` and published copies) to defer to bundled docs, chat-sdk.dev, Vercel KB, and `llms.txt` instead of inlining CLI flags, quick-start code, and API tables
- Polish root README copy (install examples, adapter/build links, Vercel Plugin URL, Vercel KB link, “Made by Vercel” badge)
- Minor `CONTRIBUTING.md` fixes: simplify DCO wording, correct preview-branch proxy file references (`proxy.ts` vs middleware)