### PR TITLE
fix(discord): don't mangle email addresses into mentions

### DIFF
--- a/.changeset/discord-email-mentions.md
+++ b/.changeset/discord-email-mentions.md
@@ -2,4 +2,4 @@
 "@chat-adapter/discord": patch
 ---
 
-prevent email addresses and word@word handles from being mangled into Discord mentions (the bare-mention regex now requires the `@` to be at a word boundary)
+fix bare-mention conversion so it no longer mangles surrounding text: email addresses and `word@word` handles are left intact (the `@` must be at a word boundary), already-formatted mentions like `<@123>` are no longer double-wrapped into `<<@123>>`, and a real mention that follows a period (e.g. `docs.@everyone`) still converts

--- a/.changeset/discord-email-mentions.md
+++ b/.changeset/discord-email-mentions.md
@@ -1,0 +1,5 @@
+---
+"@chat-adapter/discord": patch
+---
+
+prevent email addresses and word@word handles from being mangled into Discord mentions (the bare-mention regex now requires the `@` to be at a word boundary)

--- a/packages/adapter-discord/src/markdown.test.ts
+++ b/packages/adapter-discord/src/markdown.test.ts
@@ -57,6 +57,13 @@ describe("DiscordFormatConverter", () => {
       const result = converter.fromAst(ast);
       expect(result).toContain("<@someone>");
     });
+
+    it("should not turn email addresses into mentions", () => {
+      const ast = converter.toAst("Contact me at user@example.com");
+      const result = converter.fromAst(ast);
+      expect(result).toContain("user@example.com");
+      expect(result).not.toContain("<@example>");
+    });
   });
 
   describe("toAst (Discord markdown -> AST)", () => {

--- a/packages/adapter-discord/src/markdown.test.ts
+++ b/packages/adapter-discord/src/markdown.test.ts
@@ -64,6 +64,33 @@ describe("DiscordFormatConverter", () => {
       expect(result).toContain("user@example.com");
       expect(result).not.toContain("<@example>");
     });
+
+    it("should still convert a bare mention that follows a period", () => {
+      const ast = converter.toAst("read the docs.@everyone please");
+      const result = converter.fromAst(ast);
+      expect(result).toContain("<@everyone>");
+    });
+  });
+
+  describe("renderPostable (mentions)", () => {
+    it("should not double-wrap an already-formatted mention in raw text", () => {
+      const result = converter.renderPostable({ raw: "ping <@123> now" });
+      expect(result).toContain("<@123>");
+      expect(result).not.toContain("<<@123>>");
+    });
+
+    it("should leave email addresses in raw text untouched", () => {
+      const result = converter.renderPostable({
+        raw: "email support@vercel.com",
+      });
+      expect(result).toContain("support@vercel.com");
+      expect(result).not.toContain("<@vercel>");
+    });
+
+    it("should convert a bare mention in raw text", () => {
+      const result = converter.renderPostable({ raw: "hey @alice" });
+      expect(result).toContain("<@alice>");
+    });
   });
 
   describe("toAst (Discord markdown -> AST)", () => {

--- a/packages/adapter-discord/src/markdown.ts
+++ b/packages/adapter-discord/src/markdown.ts
@@ -34,13 +34,20 @@ import {
   tableToAscii,
 } from "chat";
 
+/**
+ * Matches a bare `@mention` (an `@` followed by word characters), but only when
+ * the `@` is not preceded by a word character, another `@`, or `.` — so email
+ * addresses and handles like `user@example.com` are left untouched.
+ */
+const BARE_MENTION_PATTERN = /(?<![\w@.])@(\w+)/g;
+
 export class DiscordFormatConverter extends BaseFormatConverter {
   /**
    * Convert @mentions to Discord format in plain text.
    * @name → <@name>
    */
   private convertMentionsToDiscord(text: string): string {
-    return text.replace(/@(\w+)/g, "<@$1>");
+    return text.replace(BARE_MENTION_PATTERN, "<@$1>");
   }
 
   /**
@@ -107,7 +114,7 @@ export class DiscordFormatConverter extends BaseFormatConverter {
 
     if (isTextNode(node)) {
       // Convert @mentions to Discord format <@mention>
-      return node.value.replace(/@(\w+)/g, "<@$1>");
+      return node.value.replace(BARE_MENTION_PATTERN, "<@$1>");
     }
 
     if (isStrongNode(node)) {

--- a/packages/adapter-discord/src/markdown.ts
+++ b/packages/adapter-discord/src/markdown.ts
@@ -36,10 +36,12 @@ import {
 
 /**
  * Matches a bare `@mention` (an `@` followed by word characters), but only when
- * the `@` is not preceded by a word character, another `@`, or `.` — so email
- * addresses and handles like `user@example.com` are left untouched.
+ * the `@` is not preceded by a word character, another `@`, or `<`. The word
+ * boundary leaves email addresses and handles like `user@example.com` untouched
+ * (the `@` follows a word character), and excluding `<` avoids re-wrapping an
+ * already-formatted Discord mention such as `<@123>` into `<<@123>>`.
  */
-const BARE_MENTION_PATTERN = /(?<![\w@.])@(\w+)/g;
+const BARE_MENTION_PATTERN = /(?<![\w@<])@(\w+)/g;
 
 export class DiscordFormatConverter extends BaseFormatConverter {
   /**


### PR DESCRIPTION
## Bug

The Discord adapter converts `@mentions` with `/@(\w+)/g` in two places — `DiscordFormatConverter.convertMentionsToDiscord` (plain/`raw` messages) and the text-node branch of `nodeToDiscordMarkdown` (markdown/AST messages):

```ts
text.replace(/@(\w+)/g, "<@$1>");
```

That pattern matches `@word` even when the `@` is preceded by a word character, so it rewrites **email addresses** and `word@word` handles into broken mentions:

| input | before | after |
|---|---|---|
| `Contact me at user@example.com` | `Contact me at user<@example>.com` | `Contact me at user@example.com` |
| `ping support@vercel.com` | `ping support<@vercel>.com` | `ping support@vercel.com` |
| `hey @alice` | `hey <@alice>` | `hey <@alice>` (unchanged) |

The Slack adapter already guards against exactly this with a word-boundary check (`replaceBareMentions`); the Discord converter didn't.

## Fix

Introduce a shared top-level `BARE_MENTION_PATTERN = /(?<![\w@.])@(\w+)/g` (per AGENTS.md, regex literals live at top level) with a negative lookbehind, so only an `@` at a word boundary becomes a mention. Emails/handles are left intact; real bare mentions still convert. Used in both conversion sites.

## Test

Adds a regression test in `markdown.test.ts` asserting `Contact me at user@example.com` round-trips through `toAst`/`fromAst` without becoming a mention. Includes a changeset (`@chat-adapter/discord` patch). Commit is signed (Verified) and DCO signed-off.