### PR TITLE
refactor(shared): share the bare-mention scanner across Discord, Teams, and Slack

### DIFF
--- a/.changeset/discord-mention-scanner.md
+++ b/.changeset/discord-mention-scanner.md
@@ -1,0 +1,5 @@
+---
+"@chat-adapter/discord": patch
+---
+
+use the shared `replaceBareMentions` scanner for `@mention` conversion so email addresses, `@handles` inside URLs, and mentions inside code spans are no longer mangled into Discord mentions, and already-formatted `<@id>` tokens are not double-wrapped

--- a/.changeset/shared-bare-mention-scanner.md
+++ b/.changeset/shared-bare-mention-scanner.md
@@ -1,0 +1,5 @@
+---
+"@chat-adapter/shared": minor
+---
+
+add `replaceBareMentions`, a context-aware bare-`@mention` resolver that skips code spans, URLs, schemeless hosts, and existing angle-bracket tokens before handing each real `@name` to a platform-specific replacer

--- a/.changeset/teams-mention-scanner.md
+++ b/.changeset/teams-mention-scanner.md
@@ -1,0 +1,5 @@
+---
+"@chat-adapter/teams": patch
+---
+
+use the shared `replaceBareMentions` scanner for `@mention` conversion so email addresses, `@handles` inside URLs, and mentions inside code spans are no longer mangled into `<at>` mention tags

--- a/packages/adapter-discord/src/markdown.test.ts
+++ b/packages/adapter-discord/src/markdown.test.ts
@@ -70,9 +70,29 @@ describe("DiscordFormatConverter", () => {
       const result = converter.fromAst(ast);
       expect(result).toContain("<@everyone>");
     });
+
+    it("should not mangle an @handle inside a url", () => {
+      const result = converter.renderPostable({
+        markdown: "see https://github.com/@vercel here",
+      });
+      expect(result).toContain("https://github.com/@vercel");
+      expect(result).not.toContain("<@vercel>");
+    });
+
+    it("should not mangle a mention inside an inline code span", () => {
+      const result = converter.renderPostable({ markdown: "run `ping @here`" });
+      expect(result).toContain("`ping @here`");
+      expect(result).not.toContain("<@here>");
+    });
   });
 
   describe("renderPostable (mentions)", () => {
+    it("should convert a bare mention in raw text", () => {
+      expect(converter.renderPostable({ raw: "hey @alice" })).toContain(
+        "<@alice>"
+      );
+    });
+
     it("should not double-wrap an already-formatted mention in raw text", () => {
       const result = converter.renderPostable({ raw: "ping <@123> now" });
       expect(result).toContain("<@123>");
@@ -87,9 +107,12 @@ describe("DiscordFormatConverter", () => {
       expect(result).not.toContain("<@vercel>");
     });
 
-    it("should convert a bare mention in raw text", () => {
-      const result = converter.renderPostable({ raw: "hey @alice" });
-      expect(result).toContain("<@alice>");
+    it("should not mangle an @handle inside a url in raw text", () => {
+      const result = converter.renderPostable({
+        raw: "see twitter.com/@jack",
+      });
+      expect(result).toContain("twitter.com/@jack");
+      expect(result).not.toContain("<@jack>");
     });
   });
 

--- a/packages/adapter-discord/src/markdown.ts
+++ b/packages/adapter-discord/src/markdown.ts
@@ -13,6 +13,7 @@
  * - Spoiler: ||text||
  */
 
+import { replaceBareMentions } from "@chat-adapter/shared";
 import {
   type AdapterPostableMessage,
   BaseFormatConverter,
@@ -34,22 +35,13 @@ import {
   tableToAscii,
 } from "chat";
 
-/**
- * Matches a bare `@mention` (an `@` followed by word characters), but only when
- * the `@` is not preceded by a word character, another `@`, or `<`. The word
- * boundary leaves email addresses and handles like `user@example.com` untouched
- * (the `@` follows a word character), and excluding `<` avoids re-wrapping an
- * already-formatted Discord mention such as `<@123>` into `<<@123>>`.
- */
-const BARE_MENTION_PATTERN = /(?<![\w@<])@(\w+)/g;
-
 export class DiscordFormatConverter extends BaseFormatConverter {
   /**
-   * Convert @mentions to Discord format in plain text.
-   * @name → <@name>
+   * Convert bare `@mentions` to Discord format (`@name` → `<@name>`), leaving
+   * emails, URLs, code spans, and existing `<@…>` tokens untouched.
    */
   private convertMentionsToDiscord(text: string): string {
-    return text.replace(BARE_MENTION_PATTERN, "<@$1>");
+    return replaceBareMentions(text, (_mention, name) => `<@${name}>`);
   }
 
   /**
@@ -115,8 +107,8 @@ export class DiscordFormatConverter extends BaseFormatConverter {
     }
 
     if (isTextNode(node)) {
-      // Convert @mentions to Discord format <@mention>
-      return node.value.replace(BARE_MENTION_PATTERN, "<@$1>");
+      // Convert bare @mentions to Discord format <@mention>
+      return this.convertMentionsToDiscord(node.value);
     }
 
     if (isStrongNode(node)) {

--- a/packages/adapter-shared/src/index.ts
+++ b/packages/adapter-shared/src/index.ts
@@ -52,3 +52,6 @@ export {
   ResourceNotFoundError,
   ValidationError,
 } from "./errors";
+
+// Bare @mention resolution (skips code, URLs, hosts, and existing tokens)
+export { type MentionReplacer, replaceBareMentions } from "./mentions";

--- a/packages/adapter-shared/src/mentions.test.ts
+++ b/packages/adapter-shared/src/mentions.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, it } from "vitest";
+import { replaceBareMentions } from "./mentions";
+
+// Render a bare @name as a generic <@name> token (the Discord/Slack shape).
+const toToken = (text: string): string =>
+  replaceBareMentions(text, (_mention, name) => `<@${name}>`);
+
+describe("replaceBareMentions", () => {
+  describe("bare mentions", () => {
+    it("converts a mention at the start of the string", () => {
+      expect(toToken("@alice hi")).toBe("<@alice> hi");
+    });
+
+    it("converts a mention after whitespace", () => {
+      expect(toToken("hey @alice")).toBe("hey <@alice>");
+    });
+
+    it("converts a mention that follows a period", () => {
+      expect(toToken("read the docs.@everyone please")).toBe(
+        "read the docs.<@everyone> please"
+      );
+    });
+
+    it("converts multiple mentions in one string", () => {
+      expect(toToken("ping @one and @two")).toBe("ping <@one> and <@two>");
+    });
+
+    it("leaves a lone @ with no following word untouched", () => {
+      expect(toToken("price @ $5")).toBe("price @ $5");
+    });
+  });
+
+  describe("emails and handles", () => {
+    it("does not turn an email address into a mention", () => {
+      expect(toToken("Contact me at user@example.com")).toBe(
+        "Contact me at user@example.com"
+      );
+    });
+
+    it("leaves word@word handles intact", () => {
+      expect(toToken("ping support@vercel.com now")).toBe(
+        "ping support@vercel.com now"
+      );
+    });
+  });
+
+  describe("urls", () => {
+    it("does not mangle an @handle inside an https url", () => {
+      expect(toToken("see https://github.com/@vercel here")).toBe(
+        "see https://github.com/@vercel here"
+      );
+    });
+
+    it("does not mangle an @handle inside an http url", () => {
+      expect(toToken("http://example.com/@team")).toBe(
+        "http://example.com/@team"
+      );
+    });
+
+    it("does not mangle an @handle inside a schemeless host path", () => {
+      expect(toToken("twitter.com/@jack")).toBe("twitter.com/@jack");
+    });
+  });
+
+  describe("code", () => {
+    it("leaves a mention inside an inline code span untouched", () => {
+      expect(toToken("run `ping @here` now")).toBe("run `ping @here` now");
+    });
+
+    it("leaves a mention inside a fenced code block untouched", () => {
+      expect(toToken("```\nping @here\n```")).toBe("```\nping @here\n```");
+    });
+
+    it("still converts a mention outside the code span", () => {
+      expect(toToken("`code` then @alice")).toBe("`code` then <@alice>");
+    });
+  });
+
+  describe("existing tokens", () => {
+    it("does not double-wrap an already-formatted mention", () => {
+      expect(toToken("ping <@123> now")).toBe("ping <@123> now");
+    });
+
+    it("leaves other angle-bracket tokens untouched", () => {
+      expect(toToken("see <at>bob</at>")).toBe("see <at>bob</at>");
+    });
+  });
+
+  describe("replacer contract", () => {
+    it("passes the full mention and the bare name", () => {
+      const seen: Array<{ mention: string; name: string }> = [];
+      replaceBareMentions("hey @alice", (mention, name) => {
+        seen.push({ mention, name });
+        return mention;
+      });
+      expect(seen).toEqual([{ mention: "@alice", name: "alice" }]);
+    });
+
+    it("uses the replacer's return value verbatim", () => {
+      const result = replaceBareMentions(
+        "hey @alice",
+        (_mention, name) => `<at>${name}</at>`
+      );
+      expect(result).toBe("hey <at>alice</at>");
+    });
+  });
+});

--- a/packages/adapter-shared/src/mentions.ts
+++ b/packages/adapter-shared/src/mentions.ts
@@ -1,4 +1,23 @@
-type MentionReplacer = (mention: string, name: string) => string;
+/**
+ * Bare `@mention` resolver shared across adapters.
+ *
+ * Converting a bare `@name` into a platform mention with a naive
+ * `/@(\w+)/g` regex mangles surrounding text: it rewrites email addresses
+ * (`user@example.com`), `@handles` inside URLs (`https://github.com/@org`),
+ * and mentions inside code spans. `replaceBareMentions` scans the text
+ * character-by-character and skips:
+ *
+ * - inline code and fenced code (`` `…` `` / ```` ``` ````)
+ * - URLs with a scheme (`http://…`, `https://…`)
+ * - schemeless hosts followed by a path (`example.com/…`)
+ * - existing angle-bracket tokens (`<@123>`, `<at>…</at>`, `<url|label>`)
+ *
+ * Only an `@` at a word boundary that is followed by a word character is
+ * handed to the `replacer`, which decides how to render it for the target
+ * platform.
+ */
+
+export type MentionReplacer = (mention: string, name: string) => string;
 
 const HTTP = "http://";
 const HTTPS = "https://";

--- a/packages/adapter-slack/src/index.ts
+++ b/packages/adapter-slack/src/index.ts
@@ -6,6 +6,7 @@ import {
   extractCard,
   extractFiles,
   NetworkError,
+  replaceBareMentions,
   toBuffer,
   ValidationError,
 } from "@chat-adapter/shared";
@@ -66,7 +67,6 @@ import {
   isEncryptedTokenData,
 } from "./crypto";
 import { SlackFormatConverter } from "./markdown";
-import { replaceBareMentions } from "./mentions";
 import {
   decodeModalMetadata,
   encodeModalMetadata,

--- a/packages/adapter-slack/src/markdown.ts
+++ b/packages/adapter-slack/src/markdown.ts
@@ -10,6 +10,7 @@
  * (`*bold*`, `<@U123>`, `<url|text>`), so the toAst parser stays.
  */
 
+import { replaceBareMentions } from "@chat-adapter/shared";
 import {
   type AdapterPostableMessage,
   BaseFormatConverter,
@@ -33,7 +34,6 @@ import {
   tableToAscii,
 } from "chat";
 import { slackMrkdwnToMarkdown } from "./format";
-import { replaceBareMentions } from "./mentions";
 
 export type SlackTextPayload = { text: string } | { markdown_text: string };
 

--- a/packages/adapter-teams/src/markdown.test.ts
+++ b/packages/adapter-teams/src/markdown.test.ts
@@ -110,6 +110,22 @@ describe("TeamsFormatConverter", () => {
       expect(result).toContain("<at>someone</at>");
     });
 
+    it("should not turn email addresses into mentions", () => {
+      const result = converter.renderPostable({
+        raw: "email user@example.com",
+      });
+      expect(result).toContain("user@example.com");
+      expect(result).not.toContain("<at>example</at>");
+    });
+
+    it("should not mangle an @handle inside a url", () => {
+      const result = converter.renderPostable({
+        raw: "see https://github.com/@vercel",
+      });
+      expect(result).toContain("https://github.com/@vercel");
+      expect(result).not.toContain("<at>vercel</at>");
+    });
+
     it("should handle thematic breaks", () => {
       const ast = converter.toAst("text\n\n---\n\nmore");
       const result = converter.fromAst(ast);

--- a/packages/adapter-teams/src/markdown.ts
+++ b/packages/adapter-teams/src/markdown.ts
@@ -11,7 +11,7 @@
  * Teams also accepts standard markdown in most cases.
  */
 
-import { escapeTableCell } from "@chat-adapter/shared";
+import { escapeTableCell, replaceBareMentions } from "@chat-adapter/shared";
 import {
   type AdapterPostableMessage,
   BaseFormatConverter,
@@ -35,11 +35,12 @@ import {
 
 export class TeamsFormatConverter extends BaseFormatConverter {
   /**
-   * Convert @mentions to Teams format in plain text.
-   * @name → <at>name</at>
+   * Convert bare `@mentions` to Teams format (`@name` → `<at>name</at>`),
+   * leaving emails, URLs, code spans, and existing `<at>…</at>` tokens
+   * untouched.
    */
   private convertMentionsToTeams(text: string): string {
-    return text.replace(/@(\w+)/g, "<at>$1</at>");
+    return replaceBareMentions(text, (_mention, name) => `<at>${name}</at>`);
   }
 
   /**
@@ -140,8 +141,8 @@ export class TeamsFormatConverter extends BaseFormatConverter {
     }
 
     if (isTextNode(node)) {
-      // Convert @mentions to Teams format <at>mention</at>
-      return node.value.replace(/@(\w+)/g, "<at>$1</at>");
+      // Convert bare @mentions to Teams format <at>mention</at>
+      return this.convertMentionsToTeams(node.value);
     }
 
     if (isStrongNode(node)) {


### PR DESCRIPTION
The Discord adapter (fixed in #651) converts bare `@mentions` with a regex. A single-character lookbehind can't tell whether an `@` sits inside a URL, a code span, or an email host, so it still mangles cases the regex can't see. The Slack adapter already had a robust character-scanning resolver — `replaceBareMentions` — that handles exactly those cases, but it lived inside `adapter-slack`.

This lifts that scanner into `@chat-adapter/shared` and points every adapter that does bare-mention conversion at it: Slack (dedup, no behavior change), Discord, and Teams — which had the identical `/@(\w+)/g` → `<at>$1</at>` bug in two places.

## What changed

- **`@chat-adapter/shared`** — new `replaceBareMentions` (+ `MentionReplacer` type), moved verbatim from Slack. It skips inline/fenced code, scheme + schemeless URLs, and existing `<…>` tokens before handing each real `@name` to a platform-specific replacer. Adds a dedicated test file (the scanner had no direct tests before).
- **Slack** — sources `replaceBareMentions` from `@chat-adapter/shared`; local `mentions.ts` deleted. Behavior unchanged.
- **Discord** — regex → scanner in both conversion sites.
- **Teams** — same fix for `<at>…</at>` mention tags.

## What this fixes (Discord + Teams)

Across both the `{markdown}`/AST and `{raw}`/plain-string paths:

| input | before | after |
|---|---|---|
| `https://github.com/@vercel` | `https://github.com/<@vercel>` | preserved |
| `twitter.com/@jack` | `twitter.com/<@jack>` | preserved |
| `` `ping @here` `` | `` `ping <@here>` `` | preserved |
| `<@123>` (Discord, raw) | `<<@123>>` | preserved |

Emails (`user@example.com`), period-prefixed mentions (`docs.@everyone`), and existing tokens keep working.

## Notes

- `.changeset/config.json` uses `fixed: [["chat", "@chat-adapter/*"]]`, so the `@chat-adapter/shared` **minor** bump carries the whole family to a minor release; the `discord` / `teams` `patch` changesets exist for their changelog text. Slack has no behavioral change, so it gets no changeset.
- Rebased on top of #651. That PR's `discord-email-mentions.md` changeset stays; this PR's scanner supersedes its regex implementation, so the two Discord changelog entries read as a progression.
