### PR TITLE
feat(tests): add Vercel Connect webhook contract helper

### DIFF
--- a/.changeset/tests-connect-contract.md
+++ b/.changeset/tests-connect-contract.md
@@ -1,0 +1,5 @@
+---
+"@chat-adapter/tests": minor
+---
+
+Add `connectWebhookContract`, a shared Vitest suite for verifying an adapter's Vercel Connect webhook verification. Given a small per-adapter descriptor (how to build the adapter in Connect mode and craft an inbound webhook), it asserts the behavior every Connect-capable adapter shares: a `webhookVerifier` replaces the native signature/secret check and gates inbound requests — accept (`200`) on a truthy result, reject (`401`) on a thrown error or falsy result — and is invoked with the request and raw body. Connect-capable adapters can opt in with ~10 lines.

--- a/.vercelignore
+++ b/.vercelignore
@@ -1,0 +1,8 @@
+node_modules
+**/node_modules
+.git
+.turbo
+**/.turbo
+**/.next
+**/dist
+**/coverage

--- a/.vercelignore
+++ b/.vercelignore
@@ -1,6 +1,5 @@
 node_modules
 **/node_modules
-.git
 .turbo
 **/.turbo
 **/.next

--- a/apps/docs/content/docs/meta.json
+++ b/apps/docs/content/docs/meta.json
@@ -9,6 +9,7 @@
     "threads-messages-channels",
     "handling-events",
     "posting-messages",
+    "vercel-connect",
     "error-handling",
     "testing",
     "---AI---",

--- a/apps/docs/content/docs/vercel-connect.mdx
+++ b/apps/docs/content/docs/vercel-connect.mdx
@@ -1,0 +1,162 @@
+---
+title: Vercel Connect
+description: Authenticate Slack, GitHub, and Linear adapters with Vercel Connect — short-lived runtime tokens for outbound calls and OIDC-verified inbound webhooks, with no stored provider secrets.
+type: overview
+related:
+  - /docs/usage
+  - /adapters/official/slack
+  - /adapters/official/github
+  - /adapters/official/linear
+---
+
+[Vercel Connect](https://vercel.com/docs/connect) lets your bot use a registered connector for adapter authentication instead of storing long-lived provider secrets. You register a connector once, link it to your project and environments, and your code requests scoped, short-lived tokens at runtime.
+
+The `@vercel/connect/chat` subpath ships a helper per platform that you spread into the matching `create*Adapter` factory:
+
+- `connectSlackAdapter`
+- `connectGitHubAdapter`
+- `connectLinearAdapter`
+
+Each helper wires both directions of traffic:
+
+- **Outbound** (your bot calls the provider API) — a function-form token field that resolves a fresh, short-lived token per call via `getToken`.
+- **Inbound** (the provider calls your bot) — a `webhookVerifier` that validates the Vercel OIDC token Connect attaches to [trigger-forwarded](https://vercel.com/docs/connect/concepts/triggers) webhooks, replacing the provider's native signature check.
+
+<Callout type="info">
+  Vercel Connect is in beta. Features and behavior, including available connectors and trigger forwarding, may change before general availability.
+</Callout>
+
+## Install
+
+```bash
+pnpm add @vercel/connect
+```
+
+`@vercel/connect` reads the deployment's OIDC token automatically. For local development, run `vercel link` followed by `vercel env pull` to download a short-lived token into `.env.local`.
+
+## Adapter support
+
+| Adapter | Helper | Outbound field |
+|---------|--------|----------------|
+| [Slack](/adapters/official/slack) | `connectSlackAdapter` | `botToken` |
+| [GitHub](/adapters/official/github) | `connectGitHubAdapter` | `installationToken` |
+| [Linear](/adapters/official/linear) | `connectLinearAdapter` | `accessToken` |
+
+Each helper accepts `(connector, params?, options?)`, where `params` is the [`getToken`](https://vercel.com/docs/connect/ts-sdk-reference) parameters minus `subject` (pinned to `{ type: "app" }`), letting you pass through `installationId`, `scopes`, or `validityBufferMs`.
+
+## Set up a connector
+
+1. Create a connector for the provider in the [Vercel dashboard](https://vercel.com/d?to=%2F%5Bteam%5D%2F~%2Fconnect) or with the CLI, enabling trigger forwarding so inbound webhooks reach your project:
+
+```bash
+vercel connect create slack --name acme-slack --triggers
+```
+
+2. Attach your project and register your Chat SDK webhook route (`/api/webhooks/{platform}`) as the trigger destination:
+
+```bash
+vercel connect attach slack/acme-slack \
+  --project my-bot --environment production \
+  --triggers --trigger-path /api/webhooks/slack
+```
+
+3. Pull a development token locally (deployments get `VERCEL_OIDC_TOKEN` automatically):
+
+```bash
+vercel link
+vercel env pull
+```
+
+## Wire up the adapter
+
+Spread the helper into the adapter factory. The webhook route is unchanged — Connect forwards verified events to the same handler.
+
+```typescript title="lib/bot.ts" lineNumbers
+import { Chat } from "chat";
+import { createSlackAdapter } from "@chat-adapter/slack";
+import { createRedisState } from "@chat-adapter/state-redis";
+import { connectSlackAdapter } from "@vercel/connect/chat";
+
+export const bot = new Chat({
+  userName: "mybot",
+  adapters: {
+    slack: createSlackAdapter({
+      ...connectSlackAdapter("slack/acme-slack"),
+    }),
+  },
+  state: createRedisState(),
+});
+```
+
+Replace `slack/acme-slack` with your connector UID from the Connect dashboard or `vercel connect list`. Omit `signingSecret` / `SLACK_SIGNING_SECRET` when using the helper — the OIDC `webhookVerifier` is the freshness boundary.
+
+### GitHub
+
+```typescript title="lib/bot.ts" lineNumbers
+import { createGitHubAdapter } from "@chat-adapter/github";
+import { connectGitHubAdapter } from "@vercel/connect/chat";
+
+createGitHubAdapter({
+  ...connectGitHubAdapter("github/acme-github"),
+  userName: "my-bot[bot]",
+});
+```
+
+`installationToken` is the installation access token a GitHub App would normally mint via its private-key JWT exchange — the adapter uses it directly and skips that exchange.
+
+### Linear
+
+```typescript title="lib/bot.ts" lineNumbers
+import { createLinearAdapter } from "@chat-adapter/linear";
+import { connectLinearAdapter } from "@vercel/connect/chat";
+
+createLinearAdapter({
+  ...connectLinearAdapter("linear/acme-linear"),
+  mode: "agent-sessions",
+});
+```
+
+Use `mode: "agent-sessions"` for app-actor installs. For outbound calls outside webhook handling (cron jobs, workflows), wrap them in `withInstallation()` so a request-scoped client is bound:
+
+```typescript title="lib/jobs.ts" lineNumbers
+await linear.withInstallation("org-id", async () => {
+  await linear.postMessage("linear:issue-id", "Hello from a background job");
+});
+```
+
+## Custom webhook verification
+
+Each helper attaches a default verifier that matches the deployment's project and environment automatically (`projectId` defaults to `VERCEL_PROJECT_ID`, `environment` to `VERCEL_TARGET_ENV` then `VERCEL_ENV`), so production, preview, and development each accept only their own tokens. Verification fails closed — if those values are absent, every request is rejected, and the issuer is pinned to `https://oidc.vercel.com`.
+
+To add constraints (for example to accept multiple environments), build a verifier with `createConnectWebhookVerifier` and override the field:
+
+```typescript title="lib/bot.ts" lineNumbers
+import {
+  connectSlackAdapter,
+  createConnectWebhookVerifier,
+} from "@vercel/connect/chat";
+
+createSlackAdapter({
+  ...connectSlackAdapter("slack/acme-slack"),
+  webhookVerifier: createConnectWebhookVerifier({
+    environment: ["production", "preview"],
+  }),
+});
+```
+
+<Callout type="warn">
+  Avoid hardcoding `environment: "production"` unless you only forward to production — it would reject preview and development deployments.
+</Callout>
+
+## Notes and limitations
+
+- **App-scoped tokens.** The helpers act as the application itself (`subject: { type: "app" }`). End-user OAuth is a separate concern.
+- **Freshness and replay.** OIDC verification replaces each provider's native signature (and timestamp) check, so request freshness relies on the short-lived OIDC token's expiry rather than a signed timestamp, and there is no built-in delivery de-duplication. Keep your webhook handlers idempotent.
+- **Socket Mode is incompatible.** Connect trigger forwarding is HTTP-only; it doesn't apply to the Slack adapter's Socket Mode.
+- **Testing.** Connect forwards to deployed URLs, not `localhost` — test against a preview or development deployment.
+
+## Related resources
+
+- [Vercel Connect overview](https://vercel.com/docs/connect)
+- [Vercel Connect triggers](https://vercel.com/docs/connect/concepts/triggers)
+- [`@vercel/connect` SDK reference](https://vercel.com/docs/connect/ts-sdk-reference)

--- a/packages/integration-tests/src/documentation-test-utils.ts
+++ b/packages/integration-tests/src/documentation-test-utils.ts
@@ -185,6 +185,8 @@ export const VALID_DOC_PACKAGES = [
   "@ai-sdk/gateway",
   "@vercel/sandbox",
   "@vercel/functions",
+  "@vercel/connect",
+  "@vercel/connect/chat",
   "workflow",
   "workflow/next",
   "workflow/api",

--- a/packages/tests/src/connect-contract.test.ts
+++ b/packages/tests/src/connect-contract.test.ts
@@ -1,0 +1,45 @@
+import type { Adapter } from "chat";
+import { vi } from "vitest";
+import {
+  type ConnectWebhookVerifier,
+  connectWebhookContract,
+} from "./connect-contract";
+import { createMockAdapter } from "./factories";
+
+/**
+ * Minimal adapter that honors the Connect webhook-verifier contract. Used to
+ * self-test the shared runner without depending on a real adapter package.
+ */
+function createFakeConnectAdapter(options: {
+  webhookVerifier: ConnectWebhookVerifier;
+}): Adapter {
+  return createMockAdapter("fake", {
+    initialize: vi.fn().mockResolvedValue(undefined),
+    handleWebhook: async (request: Request) => {
+      const body = await request.text();
+      try {
+        const verified = await options.webhookVerifier(request, body);
+        return new Response(verified ? "ok" : "unauthorized", {
+          status: verified ? 200 : 401,
+        });
+      } catch {
+        return new Response("unauthorized", { status: 401 });
+      }
+    },
+  });
+}
+
+const makeWebhookRequest = () =>
+  new Request("https://example.com/api/webhooks/fake", {
+    method: "POST",
+    body: "{}",
+  });
+
+// Running the contract against a compliant fake exercises every assertion and
+// proves the runner works (and documents the expected adapter shape).
+connectWebhookContract({
+  name: "fake",
+  createAdapter: createFakeConnectAdapter,
+  createAdapterWithSecretAndVerifier: createFakeConnectAdapter,
+  makeWebhookRequest,
+});

--- a/packages/tests/src/connect-contract.ts
+++ b/packages/tests/src/connect-contract.ts
@@ -1,0 +1,144 @@
+import type { Adapter, ChatInstance } from "chat";
+import { describe, expect, it, vi } from "vitest";
+import { createMockChatInstance } from "./factories";
+
+/**
+ * Webhook verifier shape shared by Vercel Connect-capable adapters: it
+ * receives the incoming request and its raw body; a truthy result accepts the
+ * request, while a thrown error or a falsy result rejects it (the adapter
+ * responds `401`). Used in place of the platform's native signature/secret
+ * check when webhooks arrive via Vercel Connect trigger forwarding.
+ */
+export type ConnectWebhookVerifier = (
+  request: Request,
+  body: string
+) => Promise<unknown> | unknown;
+
+/**
+ * Per-adapter hooks the {@link connectWebhookContract} runner needs.
+ *
+ * The contract only exercises inbound verification, so `createAdapter` should
+ * stub any outbound token (e.g. `accessToken: () => Promise.resolve("t")`) and
+ * pre-seed whatever the adapter needs to dispatch without hitting the network.
+ */
+export interface ConnectWebhookContractDescriptor {
+  /**
+   * Build the adapter in Vercel Connect mode using the supplied verifier and
+   * no native webhook secret.
+   */
+  createAdapter(options: { webhookVerifier: ConnectWebhookVerifier }): Adapter;
+  /**
+   * Optionally build the adapter with BOTH a native secret and a verifier, to
+   * assert the verifier takes precedence. Omit if there is no secret mode.
+   */
+  createAdapterWithSecretAndVerifier?(options: {
+    webhookVerifier: ConnectWebhookVerifier;
+  }): Adapter;
+  /** Mock chat instance to initialize against. Defaults to `createMockChatInstance()`. */
+  createChat?(): ChatInstance;
+  /**
+   * Build an inbound webhook request the adapter should accept once verified
+   * (no native signature header — the verifier is the only gate).
+   */
+  makeWebhookRequest(): Promise<Request> | Request;
+  /** Label for the describe block, typically the adapter name. */
+  name: string;
+}
+
+/**
+ * Shared Vitest suite for an adapter's Vercel Connect webhook verification.
+ *
+ * Call it at the top level of an adapter's test file with a descriptor that
+ * knows how to build the adapter in Connect mode and craft an inbound webhook.
+ * It asserts the behavior every Connect-capable adapter shares: a
+ * `webhookVerifier` replaces the native signature/secret check and gates
+ * inbound requests — accept (`200`) on a truthy result, reject (`401`) on a
+ * thrown error or a falsy result — and is invoked with the request and raw body.
+ *
+ * ```ts
+ * connectWebhookContract({
+ *   name: "github",
+ *   createAdapter: ({ webhookVerifier }) =>
+ *     new GitHubAdapter({ installationToken: "t", webhookVerifier, botUserId: 1, logger }),
+ *   makeWebhookRequest: () =>
+ *     makeWebhookRequest(JSON.stringify(payload), "issue_comment"),
+ * });
+ * ```
+ */
+export function connectWebhookContract(
+  descriptor: ConnectWebhookContractDescriptor
+): void {
+  async function build(options: {
+    verifier: ConnectWebhookVerifier;
+    withSecret?: boolean;
+  }): Promise<Adapter> {
+    const chat = descriptor.createChat?.() ?? createMockChatInstance();
+    const factory =
+      options.withSecret && descriptor.createAdapterWithSecretAndVerifier
+        ? descriptor.createAdapterWithSecretAndVerifier
+        : descriptor.createAdapter;
+    const adapter = factory({ webhookVerifier: options.verifier });
+    await adapter.initialize(chat);
+    return adapter;
+  }
+
+  describe(`Vercel Connect webhook contract (${descriptor.name})`, () => {
+    it("constructs with a webhookVerifier and no native secret", () => {
+      expect(() =>
+        descriptor.createAdapter({ webhookVerifier: () => true })
+      ).not.toThrow();
+    });
+
+    it("accepts the request (200) when the verifier passes", async () => {
+      const verifier = vi.fn(() => true);
+      const adapter = await build({ verifier });
+      const response = await adapter.handleWebhook(
+        await descriptor.makeWebhookRequest()
+      );
+      expect(response.status).toBe(200);
+      expect(verifier).toHaveBeenCalled();
+    });
+
+    it("invokes the verifier with the request and raw body", async () => {
+      const verifier = vi.fn(() => true);
+      const adapter = await build({ verifier });
+      await adapter.handleWebhook(await descriptor.makeWebhookRequest());
+      expect(verifier).toHaveBeenCalledWith(
+        expect.any(Request),
+        expect.any(String)
+      );
+    });
+
+    it("rejects (401) when the verifier throws", async () => {
+      const adapter = await build({
+        verifier: () => {
+          throw new Error("invalid token");
+        },
+      });
+      const response = await adapter.handleWebhook(
+        await descriptor.makeWebhookRequest()
+      );
+      expect(response.status).toBe(401);
+    });
+
+    it("rejects (401) when the verifier returns falsy", async () => {
+      const adapter = await build({ verifier: () => false });
+      const response = await adapter.handleWebhook(
+        await descriptor.makeWebhookRequest()
+      );
+      expect(response.status).toBe(401);
+    });
+
+    if (descriptor.createAdapterWithSecretAndVerifier) {
+      it("uses the verifier in place of a configured native secret", async () => {
+        const verifier = vi.fn(() => true);
+        const adapter = await build({ verifier, withSecret: true });
+        const response = await adapter.handleWebhook(
+          await descriptor.makeWebhookRequest()
+        );
+        expect(response.status).toBe(200);
+        expect(verifier).toHaveBeenCalled();
+      });
+    }
+  });
+}

--- a/packages/tests/src/index.ts
+++ b/packages/tests/src/index.ts
@@ -1,4 +1,9 @@
 export {
+  type ConnectWebhookContractDescriptor,
+  type ConnectWebhookVerifier,
+  connectWebhookContract,
+} from "./connect-contract";
+export {
   createMockAdapter,
   createMockChatInstance,
   createMockLogger,

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -4,3 +4,5 @@ packages:
   - "examples/*"
 
 minimumReleaseAge: 2880
+minimumReleaseAgeExclude:
+  - "@vercel/connect"


### PR DESCRIPTION
Adds `connectWebhookContract` to `@chat-adapter/tests`: a shared Vitest suite that verifies a Connect-capable adapter's webhook verification. Given a small per-adapter descriptor, it asserts the behavior every Connect adapter shares — a `webhookVerifier` replaces the native signature/secret check and gates inbound requests (`200` on a truthy result, `401` on a thrown error or falsy result) and is invoked with the request and raw body.

The helper depends only on `chat` types and is self-tested against a fake adapter, so it lives entirely under `packages/tests`.

Stacked on #647 (base `vercel-connect/base`).

## Follow-up

The Slack, GitHub, and Linear adapters don't consume this helper yet — they still have their own inline `webhookVerifier` tests. Migrating those to `connectWebhookContract` will happen as part of the ongoing effort to port adapter tests over to `@chat-adapter/tests`, which is where the helper becomes real shared coverage.

## Companion

`@vercel/connect/chat` subpath: vercel/vercel#16826.