### PR TITLE
feat(create-chat-sdk): add Vercel Connect mode

### DIFF
--- a/.changeset/create-chat-sdk-vercel-connect.md
+++ b/.changeset/create-chat-sdk-vercel-connect.md
@@ -1,0 +1,5 @@
+---
+"create-chat-sdk": minor
+---
+
+Add Vercel Connect support to the scaffolder. Pass `--connect` (or choose **Vercel Connect** at the new interactive auth-mode prompt) to authenticate the Slack, GitHub, and Linear adapters with a Vercel Connect connector instead of stored provider secrets. The generated `src/lib/bot.ts` spreads the matching helper from `@vercel/connect/chat` into the adapter factory, `@vercel/connect` is added to dependencies, and `.env.example` lists each connector UID (for example `SLACK_CONNECTOR`) plus the recommended `GITHUB_BOT_USER_ID` for GitHub, in place of native secrets.

--- a/.vercelignore
+++ b/.vercelignore
@@ -1,0 +1,8 @@
+node_modules
+**/node_modules
+.git
+.turbo
+**/.turbo
+**/.next
+**/dist
+**/coverage

--- a/.vercelignore
+++ b/.vercelignore
@@ -1,6 +1,5 @@
 node_modules
 **/node_modules
-.git
 .turbo
 **/.turbo
 **/.next

--- a/apps/docs/app/[lang]/(home)/page.tsx
+++ b/apps/docs/app/[lang]/(home)/page.tsx
@@ -45,15 +45,15 @@ export const metadata: Metadata = {
 
 const templates = [
   {
-    title: "Slack Agent Guide",
-    description: "Stream agent responses and tool calls into Slack threads.",
-    link: "https://vercel.com/kb/guide/how-to-build-an-ai-agent-for-slack-with-chat-sdk-and-ai-sdk",
-    code: `bot.onNewMention(async (thread, msg) => {
-  await thread.subscribe();
-  const result = await agent.stream({
-    prompt: msg.text,
-  });
-  await thread.post(result.fullStream);
+    title: "Vercel Connect Guide",
+    description:
+      "Authenticate a Slack bot with Vercel Connect instead of stored secrets.",
+    link: "https://vercel.com/kb/guide/build-a-slack-bot-with-vercel-connect",
+    code: `import { createSlackAdapter } from "@chat-adapter/slack";
+import { connectSlackAdapter } from "@vercel/connect/chat";
+
+const slack = createSlackAdapter({
+  ...connectSlackAdapter("slack/acme-slack"),
 });`,
   },
   {

--- a/apps/docs/content/docs/create-chat-sdk.mdx
+++ b/apps/docs/content/docs/create-chat-sdk.mdx
@@ -98,6 +98,20 @@ When the [Web adapter](/adapters/official/web) is selected, the CLI also creates
 
 When the [Discord adapter](/adapters/official/discord) is selected, the CLI also creates a Gateway listener at `/api/discord/gateway` and a `vercel.json` cron that calls it. Discord delivers slash commands and button clicks to the webhook route, but regular messages and reactions only arrive over the Gateway WebSocket, so the cron keeps that connection alive and forwards events to `/api/webhooks/discord`. Set a `CRON_SECRET` environment variable to authenticate the cron requests. The generated serverless Gateway cron requires [Vercel Pro or Enterprise](https://vercel.com/docs/cron-jobs/usage-and-pricing) because it runs every nine minutes.
 
+## Vercel Connect
+
+[Vercel Connect](/docs/vercel-connect) lets the Slack, GitHub, and Linear adapters authenticate with a connector instead of stored provider secrets. Pass `--connect` — or choose **Vercel Connect** at the interactive auth-mode prompt — to scaffold Connect wiring for any selected Slack, GitHub, or Linear adapter:
+
+```bash
+npm create chat-sdk@latest -- my-bot --adapter slack --connect -y
+```
+
+The generated `src/lib/bot.ts` spreads the matching helper from `@vercel/connect/chat` into the adapter factory, `@vercel/connect` is added to dependencies, and `.env.example` lists each connector UID (for example `SLACK_CONNECTOR`) in place of native secrets.
+
+<Callout type="info">
+  Vercel Connect provides `VERCEL_OIDC_TOKEN` at runtime. For local development, run `vercel link` then `vercel env pull` to populate it. Connect forwards inbound webhooks only to deployed URLs, so test webhook delivery against a Vercel deployment (such as a preview) rather than localhost.
+</Callout>
+
 ## Reference
 
 | Option | Description |
@@ -106,6 +120,7 @@ When the [Discord adapter](/adapters/official/discord) is selected, the CLI also
 | `-d, --description <text>` | Project description. |
 | `--adapter <values...>` | Platform or state adapters to include. |
 | `--vendor` | List only vendor-official adapters in the interactive prompt. |
+| `--connect` | Authenticate Slack, GitHub, and Linear adapters with Vercel Connect. |
 | `--pm <manager>` | Package manager to use: `npm`, `yarn`, `pnpm`, or `bun`. |
 | `-y, --yes` | Skip prompts and accept defaults. |
 | `--interactive` | Always prompt, even when a coding agent environment is detected. |

--- a/apps/docs/content/docs/meta.json
+++ b/apps/docs/content/docs/meta.json
@@ -9,6 +9,7 @@
     "threads-messages-channels",
     "handling-events",
     "posting-messages",
+    "vercel-connect",
     "error-handling",
     "testing",
     "---AI---",

--- a/apps/docs/content/docs/vercel-connect.mdx
+++ b/apps/docs/content/docs/vercel-connect.mdx
@@ -1,0 +1,162 @@
+---
+title: Vercel Connect
+description: Authenticate Slack, GitHub, and Linear adapters with Vercel Connect — short-lived runtime tokens for outbound calls and OIDC-verified inbound webhooks, with no stored provider secrets.
+type: overview
+related:
+  - /docs/usage
+  - /adapters/official/slack
+  - /adapters/official/github
+  - /adapters/official/linear
+---
+
+[Vercel Connect](https://vercel.com/docs/connect) lets your bot use a registered connector for adapter authentication instead of storing long-lived provider secrets. You register a connector once, link it to your project and environments, and your code requests scoped, short-lived tokens at runtime.
+
+The `@vercel/connect/chat` subpath ships a helper per platform that you spread into the matching `create*Adapter` factory:
+
+- `connectSlackAdapter`
+- `connectGitHubAdapter`
+- `connectLinearAdapter`
+
+Each helper wires both directions of traffic:
+
+- **Outbound** (your bot calls the provider API) — a function-form token field that resolves a fresh, short-lived token per call via `getToken`.
+- **Inbound** (the provider calls your bot) — a `webhookVerifier` that validates the Vercel OIDC token Connect attaches to [trigger-forwarded](https://vercel.com/docs/connect/concepts/triggers) webhooks, replacing the provider's native signature check.
+
+<Callout type="info">
+  Vercel Connect is in beta. Features and behavior, including available connectors and trigger forwarding, may change before general availability.
+</Callout>
+
+## Install
+
+```bash
+pnpm add @vercel/connect
+```
+
+`@vercel/connect` reads the deployment's OIDC token automatically. For local development, run `vercel link` followed by `vercel env pull` to download a short-lived token into `.env.local`.
+
+## Adapter support
+
+| Adapter | Helper | Outbound field |
+|---------|--------|----------------|
+| [Slack](/adapters/official/slack) | `connectSlackAdapter` | `botToken` |
+| [GitHub](/adapters/official/github) | `connectGitHubAdapter` | `installationToken` |
+| [Linear](/adapters/official/linear) | `connectLinearAdapter` | `accessToken` |
+
+Each helper accepts `(connector, params?, options?)`, where `params` is the [`getToken`](https://vercel.com/docs/connect/ts-sdk-reference) parameters minus `subject` (pinned to `{ type: "app" }`), letting you pass through `installationId`, `scopes`, or `validityBufferMs`.
+
+## Set up a connector
+
+1. Create a connector for the provider in the [Vercel dashboard](https://vercel.com/d?to=%2F%5Bteam%5D%2F~%2Fconnect) or with the CLI, enabling trigger forwarding so inbound webhooks reach your project:
+
+```bash
+vercel connect create slack --name acme-slack --triggers
+```
+
+2. Attach your project and register your Chat SDK webhook route (`/api/webhooks/{platform}`) as the trigger destination:
+
+```bash
+vercel connect attach slack/acme-slack \
+  --project my-bot --environment production \
+  --triggers --trigger-path /api/webhooks/slack
+```
+
+3. Pull a development token locally (deployments get `VERCEL_OIDC_TOKEN` automatically):
+
+```bash
+vercel link
+vercel env pull
+```
+
+## Wire up the adapter
+
+Spread the helper into the adapter factory. The webhook route is unchanged — Connect forwards verified events to the same handler.
+
+```typescript title="lib/bot.ts" lineNumbers
+import { Chat } from "chat";
+import { createSlackAdapter } from "@chat-adapter/slack";
+import { createRedisState } from "@chat-adapter/state-redis";
+import { connectSlackAdapter } from "@vercel/connect/chat";
+
+export const bot = new Chat({
+  userName: "mybot",
+  adapters: {
+    slack: createSlackAdapter({
+      ...connectSlackAdapter("slack/acme-slack"),
+    }),
+  },
+  state: createRedisState(),
+});
+```
+
+Replace `slack/acme-slack` with your connector UID from the Connect dashboard or `vercel connect list`. Omit `signingSecret` / `SLACK_SIGNING_SECRET` when using the helper — the OIDC `webhookVerifier` is the freshness boundary.
+
+### GitHub
+
+```typescript title="lib/bot.ts" lineNumbers
+import { createGitHubAdapter } from "@chat-adapter/github";
+import { connectGitHubAdapter } from "@vercel/connect/chat";
+
+createGitHubAdapter({
+  ...connectGitHubAdapter("github/acme-github"),
+  userName: "my-bot[bot]",
+});
+```
+
+`installationToken` is the installation access token a GitHub App would normally mint via its private-key JWT exchange — the adapter uses it directly and skips that exchange.
+
+### Linear
+
+```typescript title="lib/bot.ts" lineNumbers
+import { createLinearAdapter } from "@chat-adapter/linear";
+import { connectLinearAdapter } from "@vercel/connect/chat";
+
+createLinearAdapter({
+  ...connectLinearAdapter("linear/acme-linear"),
+  mode: "agent-sessions",
+});
+```
+
+Use `mode: "agent-sessions"` for app-actor installs. For outbound calls outside webhook handling (cron jobs, workflows), wrap them in `withInstallation()` so a request-scoped client is bound:
+
+```typescript title="lib/jobs.ts" lineNumbers
+await linear.withInstallation("org-id", async () => {
+  await linear.postMessage("linear:issue-id", "Hello from a background job");
+});
+```
+
+## Custom webhook verification
+
+Each helper attaches a default verifier that matches the deployment's project and environment automatically (`projectId` defaults to `VERCEL_PROJECT_ID`, `environment` to `VERCEL_TARGET_ENV` then `VERCEL_ENV`), so production, preview, and development each accept only their own tokens. Verification fails closed — if those values are absent, every request is rejected, and the issuer is pinned to `https://oidc.vercel.com`.
+
+To add constraints (for example to accept multiple environments), build a verifier with `createConnectWebhookVerifier` and override the field:
+
+```typescript title="lib/bot.ts" lineNumbers
+import {
+  connectSlackAdapter,
+  createConnectWebhookVerifier,
+} from "@vercel/connect/chat";
+
+createSlackAdapter({
+  ...connectSlackAdapter("slack/acme-slack"),
+  webhookVerifier: createConnectWebhookVerifier({
+    environment: ["production", "preview"],
+  }),
+});
+```
+
+<Callout type="warn">
+  Avoid hardcoding `environment: "production"` unless you only forward to production — it would reject preview and development deployments.
+</Callout>
+
+## Notes and limitations
+
+- **App-scoped tokens.** The helpers act as the application itself (`subject: { type: "app" }`). End-user OAuth is a separate concern.
+- **Freshness and replay.** OIDC verification replaces each provider's native signature (and timestamp) check, so request freshness relies on the short-lived OIDC token's expiry rather than a signed timestamp, and there is no built-in delivery de-duplication. Keep your webhook handlers idempotent.
+- **Socket Mode is incompatible.** Connect trigger forwarding is HTTP-only; it doesn't apply to the Slack adapter's Socket Mode.
+- **Testing.** Connect forwards to deployed URLs, not `localhost` — test against a preview or development deployment.
+
+## Related resources
+
+- [Vercel Connect overview](https://vercel.com/docs/connect)
+- [Vercel Connect triggers](https://vercel.com/docs/connect/concepts/triggers)
+- [`@vercel/connect` SDK reference](https://vercel.com/docs/connect/ts-sdk-reference)

--- a/packages/create-chat-sdk/README.md
+++ b/packages/create-chat-sdk/README.md
@@ -37,6 +37,16 @@ Adapter values come from the `chat/adapters` catalog. The default interactive pr
 
 When the CLI detects a coding agent environment, it announces the detection and automatically runs in non-interactive mode. Pass at least one platform adapter with `--adapter`; the state adapter defaults to `memory`. If no project name is provided, the default name is `my-bot`. Pass `--interactive` to force prompts.
 
+## Vercel Connect
+
+The Slack, GitHub, and Linear adapters can authenticate with [Vercel Connect](https://chat-sdk.dev/docs/vercel-connect) instead of stored provider secrets. Pass `--connect`, or choose **Vercel Connect** at the interactive auth-mode prompt:
+
+```bash
+npm create chat-sdk@latest -- my-bot --adapter slack --connect -y
+```
+
+The generated bot spreads the matching helper from `@vercel/connect/chat` into the adapter factory, adds `@vercel/connect` to dependencies, and lists each connector UID (such as `SLACK_CONNECTOR`) in `.env.example` instead of native secrets.
+
 ## Options
 
 ```txt
@@ -50,6 +60,8 @@ Options:
   --adapter <values...>     platform or state adapters to include
   --vendor                  list vendor-official adapters in the interactive
                             prompt
+  --connect                 authenticate Slack, GitHub, and Linear adapters
+                            with Vercel Connect
   --pm <manager>            package manager to use (npm, yarn, pnpm, bun)
   -y, --yes                 skip prompts and accept defaults
   --interactive             always prompt, even when a coding agent

--- a/packages/create-chat-sdk/docs/create-chat-sdk.mdx
+++ b/packages/create-chat-sdk/docs/create-chat-sdk.mdx
@@ -98,6 +98,20 @@ When the [Web adapter](/adapters/official/web) is selected, the CLI also creates
 
 When the [Discord adapter](/adapters/official/discord) is selected, the CLI also creates a Gateway listener at `/api/discord/gateway` and a `vercel.json` cron that calls it. Discord delivers slash commands and button clicks to the webhook route, but regular messages and reactions only arrive over the Gateway WebSocket, so the cron keeps that connection alive and forwards events to `/api/webhooks/discord`. Set a `CRON_SECRET` environment variable to authenticate the cron requests. The generated serverless Gateway cron requires [Vercel Pro or Enterprise](https://vercel.com/docs/cron-jobs/usage-and-pricing) because it runs every nine minutes.
 
+## Vercel Connect
+
+[Vercel Connect](/docs/vercel-connect) lets the Slack, GitHub, and Linear adapters authenticate with a connector instead of stored provider secrets. Pass `--connect` — or choose **Vercel Connect** at the interactive auth-mode prompt — to scaffold Connect wiring for any selected Slack, GitHub, or Linear adapter:
+
+```bash
+npm create chat-sdk@latest -- my-bot --adapter slack --connect -y
+```
+
+The generated `src/lib/bot.ts` spreads the matching helper from `@vercel/connect/chat` into the adapter factory, `@vercel/connect` is added to dependencies, and `.env.example` lists each connector UID (for example `SLACK_CONNECTOR`) in place of native secrets.
+
+<Callout type="info">
+  Vercel Connect provides `VERCEL_OIDC_TOKEN` at runtime. For local development, run `vercel link` then `vercel env pull` to populate it. Connect forwards inbound webhooks only to deployed URLs, so test webhook delivery against a Vercel deployment (such as a preview) rather than localhost.
+</Callout>
+
 ## Reference
 
 | Option | Description |
@@ -106,6 +120,7 @@ When the [Discord adapter](/adapters/official/discord) is selected, the CLI also
 | `-d, --description <text>` | Project description. |
 | `--adapter <values...>` | Platform or state adapters to include. |
 | `--vendor` | List only vendor-official adapters in the interactive prompt. |
+| `--connect` | Authenticate Slack, GitHub, and Linear adapters with Vercel Connect. |
 | `--pm <manager>` | Package manager to use: `npm`, `yarn`, `pnpm`, or `bun`. |
 | `-y, --yes` | Skip prompts and accept defaults. |
 | `--interactive` | Always prompt, even when a coding agent environment is detected. |

--- a/packages/create-chat-sdk/src/catalog/index.ts
+++ b/packages/create-chat-sdk/src/catalog/index.ts
@@ -1,5 +1,9 @@
 export { listCliPlatformAdapters } from "./display.js";
 export {
+  type AdapterConnectSpec,
+  CONNECT_CHAT_IMPORT,
+  CONNECT_PACKAGE,
+  getAdapterConnectSpec,
   getCliScaffoldSpec,
   type ScaffoldInvocation,
 } from "./scaffold-spec.js";

--- a/packages/create-chat-sdk/src/catalog/scaffold-spec.ts
+++ b/packages/create-chat-sdk/src/catalog/scaffold-spec.ts
@@ -43,9 +43,41 @@ export type ScaffoldPropertyValue =
   | { kind: "placeholder"; code: string; comment?: string };
 
 /**
+ * An extra `.env.example` entry emitted for an adapter in Vercel Connect mode.
+ */
+export interface ConnectEnvVar {
+  /** Comment describing the variable. */
+  description: string;
+  /** Environment variable name. */
+  key: string;
+}
+
+/**
+ * Vercel Connect code-generation policy for a Connect-capable adapter.
+ *
+ * When the user opts into Connect (`--connect` or the interactive auth-mode
+ * prompt), the generated bot spreads the matching helper from
+ * `@vercel/connect/chat` into the adapter factory and reads the connector UID
+ * from `connectorEnvVar`, replacing the adapter's native provider secrets.
+ */
+export interface AdapterConnectSpec {
+  /** Environment variable holding the Vercel Connect connector UID. */
+  connectorEnvVar: string;
+  /** Extra Connect-only `.env.example` entries (e.g. recommended bot ids). */
+  extraEnv?: readonly ConnectEnvVar[];
+  /** Helper exported from `@vercel/connect/chat`, e.g. `connectSlackAdapter`. */
+  helper: string;
+}
+
+/**
  * create-chat-sdk-only code generation policy for one adapter.
  */
 export interface CliScaffoldSpec {
+  /**
+   * Vercel Connect code-generation policy. Present only for adapters that
+   * support Connect (Slack, GitHub, Linear).
+   */
+  connect?: AdapterConnectSpec;
   /**
    * Additional runtime dependencies to install beyond catalog package metadata.
    */
@@ -63,6 +95,16 @@ export interface CliScaffoldSpec {
    */
   stateHint?: string;
 }
+
+/**
+ * Package added to generated `package.json` when Connect mode is selected.
+ */
+export const CONNECT_PACKAGE = "@vercel/connect";
+
+/**
+ * Subpath the generated bot imports Connect helpers from.
+ */
+export const CONNECT_CHAT_IMPORT = "@vercel/connect/chat";
 
 const env = (name: string, fallback = '""'): ScaffoldPropertyValue => ({
   kind: "env",
@@ -103,6 +145,17 @@ export const CLI_SCAFFOLD_SPEC = {
     invocation: { kind: "zero-arg" },
   },
   github: {
+    connect: {
+      connectorEnvVar: "GITHUB_CONNECTOR",
+      extraEnv: [
+        {
+          description:
+            "GitHub bot user ID - strongly recommended on serverless to prevent reply loops",
+          key: "GITHUB_BOT_USER_ID",
+        },
+      ],
+      helper: "connectGitHubAdapter",
+    },
     invocation: { kind: "zero-arg" },
   },
   ioredis: {
@@ -128,6 +181,10 @@ export const CLI_SCAFFOLD_SPEC = {
     invocation: { kind: "zero-arg" },
   },
   linear: {
+    connect: {
+      connectorEnvVar: "LINEAR_CONNECTOR",
+      helper: "connectLinearAdapter",
+    },
     invocation: { kind: "zero-arg" },
   },
   linq: {
@@ -198,6 +255,10 @@ export const CLI_SCAFFOLD_SPEC = {
     invocation: { kind: "zero-arg" },
   },
   slack: {
+    connect: {
+      connectorEnvVar: "SLACK_CONNECTOR",
+      helper: "connectSlackAdapter",
+    },
     invocation: { kind: "zero-arg" },
   },
   teams: {
@@ -256,3 +317,13 @@ export const getCliScaffoldSpec = (slug: string): CliScaffoldSpec => {
   }
   return CLI_SCAFFOLD_SPEC[slug];
 };
+
+/**
+ * Vercel Connect policy for an adapter, or `undefined` when it has none.
+ *
+ * @param slug - Catalog adapter slug.
+ * @returns The adapter's Connect spec, if it supports Vercel Connect.
+ */
+export const getAdapterConnectSpec = (
+  slug: string
+): AdapterConnectSpec | undefined => getCliScaffoldSpec(slug).connect;

--- a/packages/create-chat-sdk/src/cli/e2e.test.ts
+++ b/packages/create-chat-sdk/src/cli/e2e.test.ts
@@ -80,6 +80,44 @@ describe("CLI adapter matrix", () => {
   }
 });
 
+describe("CLI Vercel Connect mode", () => {
+  it("scaffolds Slack with Vercel Connect when --connect is passed", async () => {
+    process.exitCode = undefined;
+    const program = createProgram();
+    await program.parseAsync([
+      "node",
+      "create-chat-sdk",
+      "connect-bot",
+      "--adapter",
+      "slack",
+      "memory",
+      "--connect",
+      "-yq",
+      "--skip-install",
+      "--no-git",
+    ]);
+
+    expect(process.exitCode).toBeUndefined();
+
+    const botTs = readProjectFile("connect-bot", "src/lib/bot.ts");
+    expect(botTs).toContain(
+      'import { connectSlackAdapter } from "@vercel/connect/chat";'
+    );
+    expect(botTs).toContain(
+      '...connectSlackAdapter(process.env.SLACK_CONNECTOR ?? ""),'
+    );
+
+    const packageJson = JSON.parse(
+      readProjectFile("connect-bot", "package.json")
+    ) as { dependencies?: Record<string, string> };
+    expect(packageJson.dependencies?.["@vercel/connect"]).toBe("latest");
+
+    const envExample = readProjectFile("connect-bot", ".env.example");
+    expect(envExample).toContain("SLACK_CONNECTOR=");
+    expect(envExample).not.toContain("SLACK_SIGNING_SECRET=");
+  });
+});
+
 describe("CLI agent mode", () => {
   it("runs non-interactively when an agent environment is detected", async () => {
     vi.stubEnv("AI_AGENT", "cursor");

--- a/packages/create-chat-sdk/src/cli/e2e.test.ts
+++ b/packages/create-chat-sdk/src/cli/e2e.test.ts
@@ -104,7 +104,7 @@ describe("CLI Vercel Connect mode", () => {
       'import { connectSlackAdapter } from "@vercel/connect/chat";'
     );
     expect(botTs).toContain(
-      '...connectSlackAdapter(process.env.SLACK_CONNECTOR ?? ""),'
+      '...connectSlackAdapter(requireEnv("SLACK_CONNECTOR")),'
     );
 
     const packageJson = JSON.parse(

--- a/packages/create-chat-sdk/src/cli/program.test.ts
+++ b/packages/create-chat-sdk/src/cli/program.test.ts
@@ -66,6 +66,7 @@ describe("createProgram", () => {
     ]);
 
     expect(runCli).toHaveBeenCalledWith({
+      connect: false,
       description: "desc",
       detectedAgent: undefined,
       force: false,
@@ -78,6 +79,22 @@ describe("createProgram", () => {
       vendor: false,
       yes: true,
     });
+  });
+
+  it("passes --connect to runCli", async () => {
+    const program = createProgram();
+    await program.parseAsync([
+      "node",
+      "create-chat-sdk",
+      "my-bot",
+      "--adapter",
+      "slack",
+      "--connect",
+    ]);
+
+    expect(runCli).toHaveBeenCalledWith(
+      expect.objectContaining({ connect: true, selectedAdapters: ["slack"] })
+    );
   });
 
   it("passes --vendor to runCli", async () => {
@@ -116,6 +133,7 @@ describe("createProgram", () => {
     await program.parseAsync(["node", "create-chat-sdk", "my-bot", "-s"]);
 
     expect(runCli).toHaveBeenCalledWith({
+      connect: false,
       description: undefined,
       detectedAgent: undefined,
       force: false,
@@ -135,6 +153,7 @@ describe("createProgram", () => {
     await program.parseAsync(["node", "create-chat-sdk", "my-bot", "--no-git"]);
 
     expect(runCli).toHaveBeenCalledWith({
+      connect: false,
       description: undefined,
       detectedAgent: undefined,
       force: false,
@@ -154,6 +173,7 @@ describe("createProgram", () => {
     await program.parseAsync(["node", "create-chat-sdk", "my-bot", "-f"]);
 
     expect(runCli).toHaveBeenCalledWith({
+      connect: false,
       description: undefined,
       detectedAgent: undefined,
       force: true,
@@ -177,6 +197,7 @@ describe("createProgram", () => {
     await program.parseAsync(["node", "create-chat-sdk", "my-bot"]);
 
     expect(runCli).toHaveBeenCalledWith({
+      connect: false,
       description: undefined,
       detectedAgent: "cursor",
       force: false,
@@ -222,6 +243,7 @@ describe("createProgram", () => {
     await program.parseAsync(["node", "create-chat-sdk", "my-bot", "--yes"]);
 
     expect(runCli).toHaveBeenCalledWith({
+      connect: false,
       description: undefined,
       detectedAgent: undefined,
       force: false,
@@ -241,6 +263,7 @@ describe("createProgram", () => {
     await program.parseAsync(["node", "create-chat-sdk", "my-bot"]);
 
     expect(runCli).toHaveBeenCalledWith({
+      connect: false,
       description: undefined,
       detectedAgent: undefined,
       force: false,

--- a/packages/create-chat-sdk/src/cli/program.ts
+++ b/packages/create-chat-sdk/src/cli/program.ts
@@ -68,6 +68,10 @@ export function createProgram(): Command {
       ).conflicts(["adapter", "yes"])
     )
     .option(
+      "--connect",
+      "authenticate Slack, GitHub, and Linear adapters with Vercel Connect"
+    )
+    .option(
       "--pm <manager>",
       "package manager to use (npm, yarn, pnpm, bun)",
       parsePackageManager
@@ -100,6 +104,7 @@ export function createProgram(): Command {
         name: string | undefined,
         opts: {
           adapter?: string[];
+          connect?: boolean;
           description?: string;
           force?: boolean;
           git?: boolean;
@@ -120,6 +125,7 @@ export function createProgram(): Command {
           ? agentResult.agent.name
           : undefined;
         await runCli({
+          connect: opts.connect === true,
           description: opts.description,
           detectedAgent,
           force: opts.force ?? false,

--- a/packages/create-chat-sdk/src/cli/run.test.ts
+++ b/packages/create-chat-sdk/src/cli/run.test.ts
@@ -60,6 +60,7 @@ describe("runCli", () => {
 
     expect(intro).toHaveBeenCalled();
     expect(runPrompts).toHaveBeenCalledWith({
+      connect: undefined,
       description: undefined,
       initializeGit: true,
       install: undefined,
@@ -79,6 +80,27 @@ describe("runCli", () => {
     expect(outro).toHaveBeenCalledWith(expect.stringContaining("Done!"));
     expect(outro).toHaveBeenCalledWith(
       expect.stringContaining("Use the Chat SDK skill for agent guidance.")
+    );
+  });
+
+  it("prints Vercel Connect next steps when Connect is enabled", async () => {
+    vi.mocked(runPrompts).mockResolvedValueOnce({
+      ...config,
+      useConnect: true,
+    });
+    vi.mocked(scaffold).mockResolvedValueOnce(true);
+
+    await runCli({
+      connect: true,
+      force: false,
+      initializeGit: true,
+      quiet: false,
+      yes: true,
+    });
+
+    expect(note).toHaveBeenCalledWith(
+      expect.stringContaining("vercel env pull"),
+      "Next steps"
     );
   });
 

--- a/packages/create-chat-sdk/src/cli/run.ts
+++ b/packages/create-chat-sdk/src/cli/run.ts
@@ -5,6 +5,10 @@ import { scaffold } from "../scaffold/run.js";
 import type { PackageManager } from "../types.js";
 
 interface RunCliOptions {
+  /**
+   * Authenticate Connect-capable adapters with Vercel Connect.
+   */
+  connect?: boolean;
   description?: string;
   /**
    * Coding agent name when detection (not an explicit flag) enabled yes mode.
@@ -39,6 +43,7 @@ export async function runCli(options: RunCliOptions): Promise<void> {
 
   try {
     const config = await runPrompts({
+      connect: options.connect,
       description: options.description,
       initializeGit: options.initializeGit,
       install: options.install,
@@ -76,14 +81,20 @@ export async function runCli(options: RunCliOptions): Promise<void> {
     }
 
     if (!options.quiet) {
-      note(
-        [
-          `cd ${config.name}`,
-          "cp .env.example .env.local",
-          `${config.packageManager} run dev`,
-        ].join("\n"),
-        "Next steps"
-      );
+      const nextSteps = config.useConnect
+        ? [
+            `cd ${config.name}`,
+            "vercel link",
+            "vercel env pull .env.local",
+            "# set your connector UIDs (see .env.example)",
+            `${config.packageManager} run dev`,
+          ]
+        : [
+            `cd ${config.name}`,
+            "cp .env.example .env.local",
+            `${config.packageManager} run dev`,
+          ];
+      note(nextSteps.join("\n"), "Next steps");
 
       outro(
         `${pc.green("Done!")} Visit ${pc.cyan("https://chat-sdk.dev/docs")} for the docs. Use the Chat SDK skill for agent guidance.`

--- a/packages/create-chat-sdk/src/generators/bot.ts
+++ b/packages/create-chat-sdk/src/generators/bot.ts
@@ -61,7 +61,9 @@ const renderConnectCall = (
   adapter: CatalogAdapter,
   connect: AdapterConnectSpec
 ): string =>
-  `${adapter.factoryExport}({\n${INDENT.repeat(3)}...${connect.helper}(process.env.${connect.connectorEnvVar} ?? ""),\n${INDENT.repeat(2)}})`;
+  `${adapter.factoryExport}({\n${INDENT.repeat(3)}...${connect.helper}(requireEnv(${quote(connect.connectorEnvVar)})),\n${INDENT.repeat(2)}})`;
+
+const REQUIRE_ENV_HELPER = `const requireEnv = (name: string): string => {\n${INDENT}const value = process.env[name];\n${INDENT}if (!value) {\n${INDENT.repeat(2)}throw new Error(\`Missing required environment variable: \${name}\`);\n${INDENT}}\n${INDENT}return value;\n};`;
 
 const importLine = (adapter: CatalogAdapter): string =>
   `import { ${adapter.factoryExport} } from ${quote(adapter.packageName)};`;
@@ -112,6 +114,8 @@ export function generateBotTs(config: ProjectConfig): string {
   const adaptersBlock = adapterEntries
     ? `{\n${adapterEntries}\n${INDENT}}`
     : "{}";
+  const preamble =
+    connectHelpers.size > 0 ? `${REQUIRE_ENV_HELPER}\n\n` : "";
   const handlers = [
     "bot.onNewMention(async (thread, message) => {",
     `${INDENT}await thread.subscribe();`,
@@ -132,5 +136,5 @@ export function generateBotTs(config: ProjectConfig): string {
     );
   }
 
-  return `${imports.join("\n")}\n\nexport const bot = new Chat({\n${INDENT}userName: process.env.BOT_USERNAME ?? ${quote(config.name)},\n${INDENT}adapters: ${adaptersBlock},\n${INDENT}state: ${stateCall},\n});\n\n${handlers.join("\n")}\n`;
+  return `${imports.join("\n")}\n\n${preamble}export const bot = new Chat({\n${INDENT}userName: process.env.BOT_USERNAME ?? ${quote(config.name)},\n${INDENT}adapters: ${adaptersBlock},\n${INDENT}state: ${stateCall},\n});\n\n${handlers.join("\n")}\n`;
 }

--- a/packages/create-chat-sdk/src/generators/bot.ts
+++ b/packages/create-chat-sdk/src/generators/bot.ts
@@ -1,5 +1,7 @@
 import type { CatalogAdapter } from "chat/adapters";
 import {
+  type AdapterConnectSpec,
+  CONNECT_CHAT_IMPORT,
   getCliScaffoldSpec,
   type ScaffoldInvocation,
 } from "../catalog/index.js";
@@ -55,6 +57,12 @@ const renderFactoryCall = (
   return renderObjectInvocation(adapter.factoryExport, invocation);
 };
 
+const renderConnectCall = (
+  adapter: CatalogAdapter,
+  connect: AdapterConnectSpec
+): string =>
+  `${adapter.factoryExport}({\n${INDENT.repeat(3)}...${connect.helper}(process.env.${connect.connectorEnvVar} ?? ""),\n${INDENT.repeat(2)}})`;
+
 const importLine = (adapter: CatalogAdapter): string =>
   `import { ${adapter.factoryExport} } from ${quote(adapter.packageName)};`;
 
@@ -65,8 +73,28 @@ const importLine = (adapter: CatalogAdapter): string =>
  * @returns TypeScript source for the bot entry point.
  */
 export function generateBotTs(config: ProjectConfig): string {
+  const useConnect = config.useConnect === true;
+  const connectHelpers = new Set<string>();
+
+  const adapterEntries = config.platformAdapters
+    .map((adapter) => {
+      const spec = getCliScaffoldSpec(adapter.slug);
+      if (useConnect && spec.connect) {
+        connectHelpers.add(spec.connect.helper);
+        return `${INDENT.repeat(2)}${adapter.slug}: ${renderConnectCall(adapter, spec.connect)},`;
+      }
+      const call = renderFactoryCall(adapter, spec.invocation);
+      return `${INDENT.repeat(2)}${adapter.slug}: ${call},`;
+    })
+    .join("\n");
+
   const selectedAdapters = [...config.platformAdapters, config.stateAdapter];
   const imports = selectedAdapters.map(importLine);
+  if (connectHelpers.size > 0) {
+    imports.push(
+      `import { ${[...connectHelpers].sort().join(", ")} } from ${quote(CONNECT_CHAT_IMPORT)};`
+    );
+  }
   imports.push('import { Chat } from "chat";');
 
   const usesWeb = config.platformAdapters.some(
@@ -75,14 +103,6 @@ export function generateBotTs(config: ProjectConfig): string {
   if (usesWeb) {
     imports.push('import { getUser } from "./auth-stub";');
   }
-
-  const adapterEntries = config.platformAdapters
-    .map((adapter) => {
-      const spec = getCliScaffoldSpec(adapter.slug);
-      const call = renderFactoryCall(adapter, spec.invocation);
-      return `${INDENT.repeat(2)}${adapter.slug}: ${call},`;
-    })
-    .join("\n");
 
   const stateSpec = getCliScaffoldSpec(config.stateAdapter.slug);
   const stateCall = renderFactoryCall(

--- a/packages/create-chat-sdk/src/generators/env-example.ts
+++ b/packages/create-chat-sdk/src/generators/env-example.ts
@@ -4,7 +4,11 @@ import type {
   EnvGroup,
   EnvVar,
 } from "chat/adapters";
-import { getCliScaffoldSpec } from "../catalog/index.js";
+import {
+  type AdapterConnectSpec,
+  getAdapterConnectSpec,
+  getCliScaffoldSpec,
+} from "../catalog/index.js";
 import type { ProjectConfig } from "../types.js";
 import { needsDiscordGateway } from "./routes.js";
 
@@ -90,6 +94,54 @@ const adapterSection = (adapter: CatalogAdapter): string[] => {
   return [`# ${adapter.name}`, ...lines];
 };
 
+const connectAdapterSection = (
+  adapter: CatalogAdapter,
+  connect: AdapterConnectSpec
+): string[] => {
+  const lines = [
+    `# ${adapter.name} (Vercel Connect)`,
+    `# Vercel Connect connector UID (for example: ${adapter.slug}/your-connector)`,
+    `${connect.connectorEnvVar}=`,
+  ];
+  for (const extra of connect.extraEnv ?? []) {
+    lines.push(`# ${extra.description}`, `${extra.key}=`);
+  }
+  return lines;
+};
+
+const usesConnect = (config: ProjectConfig): boolean =>
+  config.useConnect === true &&
+  config.platformAdapters.some((adapter) =>
+    getAdapterConnectSpec(adapter.slug)
+  );
+
+const connectNoteLines = (config: ProjectConfig): string[] => {
+  if (!usesConnect(config)) {
+    return [];
+  }
+  return [
+    "# Vercel Connect",
+    "# Adapters marked (Vercel Connect) below authenticate with a connector",
+    "# instead of stored secrets. Vercel injects VERCEL_OIDC_TOKEN at runtime;",
+    "# for local development run `vercel env pull` to populate it. Set each",
+    "# connector UID below (or in your Vercel project's environment variables).",
+    "",
+  ];
+};
+
+const platformSection = (
+  adapter: CatalogAdapter,
+  config: ProjectConfig
+): string[] => {
+  const connect =
+    config.useConnect === true
+      ? getAdapterConnectSpec(adapter.slug)
+      : undefined;
+  return connect
+    ? connectAdapterSection(adapter, connect)
+    : adapterSection(adapter);
+};
+
 /**
  * Generate `.env.example` for the selected project.
  *
@@ -101,8 +153,9 @@ export function generateEnvExample(config: ProjectConfig): string {
     "# Bot Configuration",
     `BOT_USERNAME=${config.name}`,
     "",
+    ...connectNoteLines(config),
     ...config.platformAdapters.flatMap((adapter) => [
-      ...adapterSection(adapter),
+      ...platformSection(adapter, config),
       "",
     ]),
     ...discordGatewayLines(config),

--- a/packages/create-chat-sdk/src/generators/generators.test.ts
+++ b/packages/create-chat-sdk/src/generators/generators.test.ts
@@ -93,6 +93,91 @@ describe("generateBotTs", () => {
   });
 });
 
+describe("Vercel Connect generation", () => {
+  const connectConfig = (
+    platformSlugs: readonly string[],
+    stateSlug = "memory"
+  ): ProjectConfig => ({
+    ...makeConfig(platformSlugs, stateSlug),
+    useConnect: true,
+  });
+
+  it("spreads the Connect helper into the adapter factory", () => {
+    const result = generateBotTs(connectConfig(["slack"]));
+    expect(result).toContain(
+      'import { connectSlackAdapter } from "@vercel/connect/chat";'
+    );
+    expect(result).toContain("slack: createSlackAdapter({");
+    expect(result).toContain(
+      '...connectSlackAdapter(process.env.SLACK_CONNECTOR ?? ""),'
+    );
+  });
+
+  it("imports every selected Connect helper, sorted", () => {
+    const result = generateBotTs(connectConfig(["slack", "github", "linear"]));
+    expect(result).toContain(
+      'import { connectGitHubAdapter, connectLinearAdapter, connectSlackAdapter } from "@vercel/connect/chat";'
+    );
+  });
+
+  it("leaves non-Connect adapters on their native factory calls", () => {
+    const result = generateBotTs(connectConfig(["slack", "discord"]));
+    expect(result).toContain("discord: createDiscordAdapter(),");
+    expect(result).toContain("slack: createSlackAdapter({");
+  });
+
+  it("ignores Connect helpers when useConnect is false", () => {
+    const result = generateBotTs(makeConfig(["slack"]));
+    expect(result).not.toContain("@vercel/connect/chat");
+    expect(result).toContain("slack: createSlackAdapter(),");
+  });
+
+  it("adds the @vercel/connect dependency for Connect adapters", () => {
+    const result = generatePackageJson(
+      { dependencies: {} },
+      connectConfig(["slack"])
+    );
+    expect(result.dependencies?.["@vercel/connect"]).toBe("latest");
+  });
+
+  it("does not add @vercel/connect without a Connect-capable adapter", () => {
+    const result = generatePackageJson(
+      { dependencies: {} },
+      { ...makeConfig(["discord"]), useConnect: true }
+    );
+    expect(result.dependencies?.["@vercel/connect"]).toBeUndefined();
+  });
+
+  it("writes the connector env var and omits native secrets", () => {
+    const result = generateEnvExample(connectConfig(["slack"]));
+    expect(result).toContain("SLACK_CONNECTOR=");
+    expect(result).toContain("VERCEL_OIDC_TOKEN");
+    expect(result).not.toContain("SLACK_SIGNING_SECRET=");
+    expect(result).not.toContain("SLACK_BOT_TOKEN=");
+  });
+
+  it("documents GITHUB_BOT_USER_ID for serverless GitHub Connect", () => {
+    const result = generateEnvExample(connectConfig(["github"]));
+    expect(result).toContain("GITHUB_CONNECTOR=");
+    expect(result).toContain("GITHUB_BOT_USER_ID=");
+  });
+
+  it("documents Connect setup in the README", () => {
+    const result = generateReadme(connectConfig(["slack"]));
+    expect(result).toContain("Authentication (Vercel Connect)");
+    expect(result).toContain("vercel env pull");
+    expect(result).toContain("SLACK_CONNECTOR");
+  });
+
+  it("omits the README Connect section without a Connect-capable adapter", () => {
+    const result = generateReadme({
+      ...makeConfig(["discord"]),
+      useConnect: true,
+    });
+    expect(result).not.toContain("Authentication (Vercel Connect)");
+  });
+});
+
 describe("generateEnvExample", () => {
   it("includes env vars for selected adapters", () => {
     const result = generateEnvExample(makeConfig(["slack"], "redis"));

--- a/packages/create-chat-sdk/src/generators/generators.test.ts
+++ b/packages/create-chat-sdk/src/generators/generators.test.ts
@@ -109,7 +109,21 @@ describe("Vercel Connect generation", () => {
     );
     expect(result).toContain("slack: createSlackAdapter({");
     expect(result).toContain(
-      '...connectSlackAdapter(process.env.SLACK_CONNECTOR ?? ""),'
+      '...connectSlackAdapter(requireEnv("SLACK_CONNECTOR")),'
+    );
+  });
+
+  it("fails loudly on a missing connector via requireEnv", () => {
+    const result = generateBotTs(connectConfig(["slack"]));
+    expect(result).toContain("const requireEnv = (name: string): string =>");
+    expect(result).toContain(
+      "throw new Error(`Missing required environment variable: ${name}`);"
+    );
+  });
+
+  it("omits the requireEnv helper when Connect is not used", () => {
+    expect(generateBotTs(makeConfig(["slack"]))).not.toContain(
+      "const requireEnv ="
     );
   });
 

--- a/packages/create-chat-sdk/src/generators/package-json.ts
+++ b/packages/create-chat-sdk/src/generators/package-json.ts
@@ -1,4 +1,8 @@
-import { getCliScaffoldSpec } from "../catalog/index.js";
+import {
+  CONNECT_PACKAGE,
+  getAdapterConnectSpec,
+  getCliScaffoldSpec,
+} from "../catalog/index.js";
 import type { ProjectConfig } from "../types.js";
 
 /**
@@ -70,6 +74,17 @@ export function generatePackageJson(
       []) {
       dependencies[extra] = "latest";
     }
+  }
+
+  // Connect helpers ship from @vercel/connect, which is not a dependency of any
+  // adapter package, so the generated app must install it itself.
+  const usesConnect =
+    config.useConnect === true &&
+    config.platformAdapters.some((adapter) =>
+      getAdapterConnectSpec(adapter.slug)
+    );
+  if (usesConnect) {
+    dependencies[CONNECT_PACKAGE] = "latest";
   }
 
   pkg.dependencies = sortedRecord(dependencies);

--- a/packages/create-chat-sdk/src/generators/readme.ts
+++ b/packages/create-chat-sdk/src/generators/readme.ts
@@ -1,7 +1,44 @@
+import { getAdapterConnectSpec } from "../catalog/index.js";
 import type { ProjectConfig } from "../types.js";
 
 const hasAdapter = (config: ProjectConfig, slug: string): boolean =>
   config.platformAdapters.some((adapter) => adapter.slug === slug);
+
+const connectSection = (config: ProjectConfig): string => {
+  if (config.useConnect !== true) {
+    return "";
+  }
+  const connectAdapters = config.platformAdapters.flatMap((adapter) => {
+    const connect = getAdapterConnectSpec(adapter.slug);
+    return connect ? [{ adapter, connect }] : [];
+  });
+  const [first] = connectAdapters;
+  if (!first) {
+    return "";
+  }
+  const names = connectAdapters.map((entry) => entry.adapter.name).join(", ");
+  const exampleVar = first.connect.connectorEnvVar;
+  const lines = [
+    "## Authentication (Vercel Connect)",
+    "",
+    `This project authenticates ${names} with [Vercel Connect](https://chat-sdk.dev/docs/vercel-connect) instead of stored provider secrets.`,
+    "",
+    "1. Create a connector for each provider in the [Vercel dashboard](https://vercel.com/d?to=%2F%5Bteam%5D%2F~%2Fconnect) and link it to this project, enabling trigger forwarding so inbound webhooks reach your deployment.",
+    "2. Pull the runtime OIDC token for local development:",
+    "",
+    "```bash",
+    "vercel link",
+    "vercel env pull .env.local",
+    "```",
+    "",
+    `3. Set each connector UID (for example \`${exampleVar}\`) in your environment.`,
+    "",
+    "> Vercel Connect forwards inbound webhooks only to deployed URLs, so test webhook delivery against a Vercel deployment (such as a preview) rather than localhost.",
+    "",
+    "",
+  ];
+  return lines.join("\n");
+};
 
 const webhookLines = (config: ProjectConfig): string[] => {
   const lines = config.platformAdapters.map(
@@ -25,5 +62,5 @@ const webhookLines = (config: ProjectConfig): string[] => {
  * @returns Markdown README contents.
  */
 export function generateReadme(config: ProjectConfig): string {
-  return `# ${config.name}\n\n${config.description || "A chat bot built with Chat SDK."}\n\n## Getting Started\n\n1. Copy the example environment file and fill in your credentials:\n\n\`\`\`bash\ncp .env.example .env.local\n\`\`\`\n\n2. Start the dev server:\n\n\`\`\`bash\n${config.packageManager} run dev\n\`\`\`\n\n3. Expose your local server to the internet and configure platform webhook URLs.\n\n## Endpoints\n\n${webhookLines(config).join("\n")}\n\n## Project Structure\n\n\`\`\`\nsrc/\n  lib/bot.ts                              Bot configuration and handlers\n  app/api/webhooks/[platform]/route.ts    Webhook endpoint for platform adapters\n  app/api/chat/route.ts                   Web adapter endpoint when selected\n.env.example                              Required environment variables\n\`\`\`\n\n## Scripts\n\n| Command | Description |\n| --- | --- |\n| \`${config.packageManager} run dev\` | Start the development server |\n| \`${config.packageManager} run build\` | Create a production build |\n| \`${config.packageManager} run start\` | Start the production server |\n| \`${config.packageManager} run typecheck\` | Type-check the project |\n\n## Learn More\n\n- [Chat SDK Documentation](https://chat-sdk.dev/docs)\n- [Adapter Setup Guides](https://chat-sdk.dev/adapters)\n- [GitHub Repository](https://github.com/vercel/chat)\n`;
+  return `# ${config.name}\n\n${config.description || "A chat bot built with Chat SDK."}\n\n## Getting Started\n\n1. Copy the example environment file and fill in your credentials:\n\n\`\`\`bash\ncp .env.example .env.local\n\`\`\`\n\n2. Start the dev server:\n\n\`\`\`bash\n${config.packageManager} run dev\n\`\`\`\n\n3. Expose your local server to the internet and configure platform webhook URLs.\n\n${connectSection(config)}## Endpoints\n\n${webhookLines(config).join("\n")}\n\n## Project Structure\n\n\`\`\`\nsrc/\n  lib/bot.ts                              Bot configuration and handlers\n  app/api/webhooks/[platform]/route.ts    Webhook endpoint for platform adapters\n  app/api/chat/route.ts                   Web adapter endpoint when selected\n.env.example                              Required environment variables\n\`\`\`\n\n## Scripts\n\n| Command | Description |\n| --- | --- |\n| \`${config.packageManager} run dev\` | Start the development server |\n| \`${config.packageManager} run build\` | Create a production build |\n| \`${config.packageManager} run start\` | Start the production server |\n| \`${config.packageManager} run typecheck\` | Type-check the project |\n\n## Learn More\n\n- [Chat SDK Documentation](https://chat-sdk.dev/docs)\n- [Adapter Setup Guides](https://chat-sdk.dev/adapters)\n- [GitHub Repository](https://github.com/vercel/chat)\n`;
 }

--- a/packages/create-chat-sdk/src/prompts/flow.test.ts
+++ b/packages/create-chat-sdk/src/prompts/flow.test.ts
@@ -188,11 +188,91 @@ describe("runPrompts", () => {
     vi.mocked(select).mockResolvedValueOnce("memory");
     vi.mocked(confirm).mockResolvedValueOnce(CANCEL as never);
     expect(await runPrompts({ quiet: false, yes: false })).toBeNull();
+
+    vi.mocked(text).mockResolvedValueOnce("my-bot").mockResolvedValueOnce("");
+    vi.mocked(multiselect).mockResolvedValueOnce(["slack"]);
+    vi.mocked(select)
+      .mockResolvedValueOnce("memory")
+      .mockResolvedValueOnce(CANCEL as never);
+    expect(await runPrompts({ quiet: false, yes: false })).toBeNull();
   });
 
   it("validates initial names", async () => {
     await expect(
       runPrompts({ name: "bad name!", quiet: true, yes: true })
     ).rejects.toThrow("Use a valid npm package name");
+  });
+
+  it("prompts for auth mode and applies Vercel Connect when chosen", async () => {
+    vi.mocked(text).mockResolvedValueOnce("my-bot").mockResolvedValueOnce("");
+    vi.mocked(multiselect).mockResolvedValueOnce(["slack"]);
+    vi.mocked(select)
+      .mockResolvedValueOnce("memory")
+      .mockResolvedValueOnce("connect");
+    vi.mocked(confirm).mockResolvedValueOnce(true);
+
+    const result = await runPrompts({ quiet: false, yes: false });
+
+    expect(select).toHaveBeenCalledWith(
+      expect.objectContaining({
+        message: "How should adapters authenticate?",
+        options: expect.arrayContaining([
+          expect.objectContaining({ value: "connect" }),
+        ]),
+      })
+    );
+    expect(result?.useConnect).toBe(true);
+  });
+
+  it("keeps provider secrets when the auth-mode prompt selects secrets", async () => {
+    vi.mocked(text).mockResolvedValueOnce("my-bot").mockResolvedValueOnce("");
+    vi.mocked(multiselect).mockResolvedValueOnce(["slack"]);
+    vi.mocked(select)
+      .mockResolvedValueOnce("memory")
+      .mockResolvedValueOnce("secrets");
+    vi.mocked(confirm).mockResolvedValueOnce(true);
+
+    const result = await runPrompts({ quiet: false, yes: false });
+
+    expect(result?.useConnect).toBe(false);
+  });
+
+  it("does not prompt for auth mode without a Connect-capable adapter", async () => {
+    vi.mocked(text).mockResolvedValueOnce("my-bot").mockResolvedValueOnce("");
+    vi.mocked(multiselect).mockResolvedValueOnce(["discord"]);
+    vi.mocked(select).mockResolvedValueOnce("memory");
+    vi.mocked(confirm).mockResolvedValueOnce(true);
+
+    const result = await runPrompts({ quiet: false, yes: false });
+
+    expect(select).toHaveBeenCalledTimes(1);
+    expect(result?.useConnect).toBe(false);
+  });
+
+  it("enables Vercel Connect with --connect on a flagged selection", async () => {
+    const result = await runPrompts({
+      connect: true,
+      name: "my-bot",
+      quiet: true,
+      selectedAdapters: ["slack", "memory"],
+      yes: true,
+    });
+
+    expect(result?.useConnect).toBe(true);
+  });
+
+  it("ignores --connect when no Connect-capable adapter is selected", async () => {
+    const result = await runPrompts({
+      connect: true,
+      name: "my-bot",
+      quiet: false,
+      selectedAdapters: ["discord", "memory"],
+      yes: true,
+    });
+
+    expect(result?.useConnect).toBe(false);
+    expect(log.warning).toHaveBeenCalledWith(
+      expect.stringContaining("Ignoring --connect")
+    );
   });
 });

--- a/packages/create-chat-sdk/src/prompts/flow.ts
+++ b/packages/create-chat-sdk/src/prompts/flow.ts
@@ -8,6 +8,7 @@ import {
 } from "@clack/prompts";
 import { listStateAdapters } from "chat/adapters";
 import {
+  getAdapterConnectSpec,
   getCliScaffoldSpec,
   listCliPlatformAdapters,
 } from "../catalog/index.js";
@@ -23,6 +24,7 @@ import { detectPackageManager, validatePackageName } from "./validate.js";
  * config's `shouldInitializeGit` field.
  */
 interface PromptInputs {
+  connect?: boolean;
   description?: string;
   initializeGit?: boolean;
   install?: boolean;
@@ -136,6 +138,39 @@ export async function runPrompts(
     );
   }
 
+  const connectCapable = selection.platformAdapters.some((adapter) =>
+    Boolean(getAdapterConnectSpec(adapter.slug))
+  );
+  let useConnect = false;
+  if (inputs.connect) {
+    useConnect = connectCapable;
+    if (!(connectCapable || inputs.quiet)) {
+      log.warning(
+        "Ignoring --connect: Vercel Connect supports only the Slack, GitHub, and Linear adapters."
+      );
+    }
+  } else if (!(inputs.yes || flaggedSelection) && connectCapable) {
+    const authMode = await select({
+      message: "How should adapters authenticate?",
+      options: [
+        {
+          hint: "provider tokens and signing secrets via environment variables",
+          label: "Provider secrets",
+          value: "secrets",
+        },
+        {
+          hint: "short-lived tokens from a Vercel Connect connector",
+          label: "Vercel Connect",
+          value: "connect",
+        },
+      ],
+    });
+    if (isCancel(authMode)) {
+      return null;
+    }
+    useConnect = authMode === "connect";
+  }
+
   const shouldInstall =
     inputs.install ??
     (inputs.yes
@@ -158,11 +193,15 @@ export async function runPrompts(
     shouldInstall,
     shouldInitializeGit: inputs.initializeGit ?? true,
     stateAdapter: selection.stateAdapter,
+    useConnect,
   };
 
   if (!inputs.quiet && flaggedSelection) {
     log.info(`Platform adapters: ${selectedPlatformLabel(config)}`);
     log.info(`State adapter: ${config.stateAdapter.name}`);
+  }
+  if (!inputs.quiet && useConnect) {
+    log.info("Authentication: Vercel Connect");
   }
   if (
     !inputs.quiet &&

--- a/packages/create-chat-sdk/src/types.ts
+++ b/packages/create-chat-sdk/src/types.ts
@@ -43,6 +43,11 @@ export interface ProjectConfig extends AdapterSelection {
    * Whether dependencies should be installed after files are written.
    */
   shouldInstall: boolean;
+  /**
+   * Authenticate Connect-capable adapters (Slack, GitHub, Linear) with Vercel
+   * Connect instead of native provider secrets. Defaults to `false`.
+   */
+  useConnect?: boolean;
 }
 
 /**

--- a/packages/integration-tests/src/documentation-test-utils.ts
+++ b/packages/integration-tests/src/documentation-test-utils.ts
@@ -185,6 +185,8 @@ export const VALID_DOC_PACKAGES = [
   "@ai-sdk/gateway",
   "@vercel/sandbox",
   "@vercel/functions",
+  "@vercel/connect",
+  "@vercel/connect/chat",
   "workflow",
   "workflow/next",
   "workflow/api",

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -4,3 +4,5 @@ packages:
   - "examples/*"
 
 minimumReleaseAge: 2880
+minimumReleaseAgeExclude:
+  - "@vercel/connect"


### PR DESCRIPTION
Adds an opt-in Vercel Connect authentication mode to the scaffolder for the Slack, GitHub, and Linear adapters, via a `--connect` flag and a new interactive auth-mode prompt (shown only when a Connect-capable adapter is selected).

When enabled, the generated project:

- spreads the matching helper from `@vercel/connect/chat` into the adapter factory in `src/lib/bot.ts` (non-Connect adapters keep their native factory calls)
- adds `@vercel/connect` to dependencies
- lists each connector UID (for example `SLACK_CONNECTOR`) plus the recommended `GITHUB_BOT_USER_ID`, in place of native provider secrets, in `.env.example`
- documents `vercel link` / `vercel env pull` and the deployed-URL webhook caveat in the README and post-install next steps

Connect policy lives in the existing `scaffold-spec.ts` (per-adapter `connect` field), so `chat/adapters` stays the single source of adapter metadata.

Stacked on #647 (base `vercel-connect/base`).

## Companion

`@vercel/connect/chat` subpath: vercel/vercel#16826.