### PR TITLE
fix(chat): detect mentions in skipped queued messages

### DIFF
--- a/.changeset/grumpy-lights-stay.md
+++ b/.changeset/grumpy-lights-stay.md
@@ -1,0 +1,5 @@
+---
+"chat": patch
+---
+
+detect bot mentions in skipped queue and burst messages

--- a/packages/chat/src/chat.test.ts
+++ b/packages/chat/src/chat.test.ts
@@ -3409,6 +3409,58 @@ describe("Chat", () => {
         totalSinceLastHandler: 3,
       });
     });
+
+    it("should call onNewMention when a skipped queued message mentions the bot", async () => {
+      const state = createMockState();
+      const adapter = createMockAdapter("slack");
+
+      const queueChat = new Chat({
+        userName: "testbot",
+        adapters: { slack: adapter },
+        state,
+        logger: mockLogger,
+        concurrency: "queue",
+      });
+
+      await queueChat.webhooks.slack(
+        new Request("http://test.com", { method: "POST" })
+      );
+
+      const handler = vi.fn().mockResolvedValue(undefined);
+      queueChat.onNewMention(handler);
+
+      await state.acquireLock("slack:C123:1234.5678", 30000);
+
+      await queueChat.handleIncomingMessage(
+        adapter,
+        "slack:C123:1234.5678",
+        createTestMessage("msg-q-skip-mention-1", "Hey @slack-bot")
+      );
+      await queueChat.handleIncomingMessage(
+        adapter,
+        "slack:C123:1234.5678",
+        createTestMessage("msg-q-skip-mention-2", "please help")
+      );
+
+      await state.forceReleaseLock("slack:C123:1234.5678");
+      await queueChat.handleIncomingMessage(
+        adapter,
+        "slack:C123:1234.5678",
+        createTestMessage("msg-q-skip-mention-3", "trigger")
+      );
+
+      expect(handler).toHaveBeenCalledTimes(1);
+      const message = handler.mock.calls[0][1];
+      const context = handler.mock.calls[0][2];
+      expect(message.text).toBe("please help");
+      expect(message.isMention).toBe(false);
+      expect(
+        context?.skipped.map((skipped) => ({
+          text: skipped.text,
+          isMention: skipped.isMention,
+        }))
+      ).toEqual([{ text: "Hey @slack-bot", isMention: true }]);
+    });
   });
 
   describe("concurrency: queue attachment rehydration", () => {
@@ -4184,6 +4236,60 @@ describe("Chat", () => {
             totalSinceLastHandler: 3,
           },
         ]);
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it("should call onNewMention when a skipped burst message mentions the bot", async () => {
+      vi.useFakeTimers();
+      try {
+        const state = createMockState();
+        const adapter = createMockAdapter("slack");
+
+        const burstChat = new Chat({
+          userName: "testbot",
+          adapters: { slack: adapter },
+          state,
+          logger: mockLogger,
+          concurrency: {
+            strategy: "burst",
+            debounceMs: 100,
+          },
+        });
+
+        await burstChat.webhooks.slack(
+          new Request("http://test.com", { method: "POST" })
+        );
+
+        const handler = vi.fn().mockResolvedValue(undefined);
+        burstChat.onNewMention(handler);
+
+        const promise = burstChat.handleIncomingMessage(
+          adapter,
+          "slack:C123:1234.5678",
+          createTestMessage("msg-burst-skip-mention-1", "Hey @slack-bot")
+        );
+        await burstChat.handleIncomingMessage(
+          adapter,
+          "slack:C123:1234.5678",
+          createTestMessage("msg-burst-skip-mention-2", "please help")
+        );
+
+        await vi.advanceTimersByTimeAsync(150);
+        await promise;
+
+        expect(handler).toHaveBeenCalledTimes(1);
+        const message = handler.mock.calls[0][1];
+        const context = handler.mock.calls[0][2];
+        expect(message.text).toBe("please help");
+        expect(message.isMention).toBe(false);
+        expect(
+          context?.skipped.map((skipped) => ({
+            text: skipped.text,
+            isMention: skipped.isMention,
+          }))
+        ).toEqual([{ text: "Hey @slack-bot", isMention: true }]);
       } finally {
         vi.useRealTimers();
       }

--- a/packages/chat/src/chat.ts
+++ b/packages/chat/src/chat.ts
@@ -2424,10 +2424,7 @@ export class Chat<
     message: Message,
     context?: MessageContext
   ): Promise<void> {
-    // Set isMention on the message for handler access
-    // Preserve existing isMention if already set (e.g., from Gateway detection)
-    message.isMention =
-      message.isMention || this.detectMention(adapter, message);
+    const hasMention = this.setMentionFlags(adapter, message, context);
 
     // Check subscription status (needed for createThread optimization)
     const isSubscribed = await this._stateAdapter.isSubscribed(threadId);
@@ -2503,7 +2500,7 @@ export class Chat<
     }
 
     // Check for @-mention of bot
-    if (message.isMention) {
+    if (message.isMention || hasMention) {
       this.logger.debug("Bot mentioned", {
         threadId,
         text: message.text.slice(0, 100),
@@ -2542,6 +2539,24 @@ export class Chat<
         text: message.text.slice(0, 100),
       });
     }
+  }
+
+  private setMentionFlags(
+    adapter: Adapter,
+    message: Message,
+    context?: MessageContext
+  ): boolean {
+    message.isMention =
+      message.isMention || this.detectMention(adapter, message);
+
+    let hasMention = message.isMention === true;
+    for (const skipped of context?.skipped ?? []) {
+      skipped.isMention =
+        skipped.isMention || this.detectMention(adapter, skipped);
+      hasMention = hasMention || skipped.isMention === true;
+    }
+
+    return hasMention;
   }
 
   private createThread(


### PR DESCRIPTION
## summary

fixes #613

detects bot mentions across queued and burst skipped messages before routing handlers

this makes `onNewMention` fire when an earlier skipped message mentions the bot and the latest collapsed message does not, while preserving `message.isMention` on the latest message

adds regression coverage for both `queue` and `burst`
