### PR TITLE
fix(chat): preserve skipped mention routing

### DIFF
--- a/.changeset/social-loops-try.md
+++ b/.changeset/social-loops-try.md
@@ -1,0 +1,5 @@
+---
+"chat": patch
+---
+
+preserve skipped mention routing for debounce and message patterns

--- a/packages/chat/src/chat.test.ts
+++ b/packages/chat/src/chat.test.ts
@@ -3461,6 +3461,58 @@ describe("Chat", () => {
         }))
       ).toEqual([{ text: "Hey @slack-bot", isMention: true }]);
     });
+
+    it("should continue to message patterns when skipped queued mention has no handler", async () => {
+      const state = createMockState();
+      const adapter = createMockAdapter("slack");
+
+      const queueChat = new Chat({
+        userName: "testbot",
+        adapters: { slack: adapter },
+        state,
+        logger: mockLogger,
+        concurrency: "queue",
+      });
+
+      await queueChat.webhooks.slack(
+        new Request("http://test.com", { method: "POST" })
+      );
+
+      const handler = vi.fn().mockResolvedValue(undefined);
+      queueChat.onNewMessage(HELP_REGEX, handler);
+
+      await state.acquireLock("slack:C123:1234.5678", 30000);
+
+      await queueChat.handleIncomingMessage(
+        adapter,
+        "slack:C123:1234.5678",
+        createTestMessage("msg-q-pattern-1", "Hey @slack-bot")
+      );
+      await queueChat.handleIncomingMessage(
+        adapter,
+        "slack:C123:1234.5678",
+        createTestMessage("msg-q-pattern-2", "please help")
+      );
+
+      await state.forceReleaseLock("slack:C123:1234.5678");
+      await queueChat.handleIncomingMessage(
+        adapter,
+        "slack:C123:1234.5678",
+        createTestMessage("msg-q-pattern-3", "trigger")
+      );
+
+      expect(handler).toHaveBeenCalledTimes(1);
+      const message = handler.mock.calls[0][1];
+      const context = handler.mock.calls[0][2];
+      expect(message.text).toBe("please help");
+      expect(message.isMention).toBe(false);
+      expect(
+        context?.skipped.map((skipped) => ({
+          text: skipped.text,
+          isMention: skipped.isMention,
+        }))
+      ).toEqual([{ text: "Hey @slack-bot", isMention: true }]);
+    });
   });
 
   describe("concurrency: queue attachment rehydration", () => {
@@ -4157,6 +4209,57 @@ describe("Chat", () => {
       expect(handler.mock.calls[0][1].text).toBe("Hey @slack-bot third");
 
       vi.useRealTimers();
+    });
+
+    it("should call onNewMention when a skipped debounced message mentions the bot", async () => {
+      vi.useFakeTimers();
+      try {
+        const state = createMockState();
+        const adapter = createMockAdapter("slack");
+
+        const debounceChat = new Chat({
+          userName: "testbot",
+          adapters: { slack: adapter },
+          state,
+          logger: mockLogger,
+          concurrency: { strategy: "debounce", debounceMs: 100 },
+        });
+
+        await debounceChat.webhooks.slack(
+          new Request("http://test.com", { method: "POST" })
+        );
+
+        const handler = vi.fn().mockResolvedValue(undefined);
+        debounceChat.onNewMention(handler);
+
+        const promise = debounceChat.handleIncomingMessage(
+          adapter,
+          "slack:C123:1234.5678",
+          createTestMessage("msg-d-skip-mention-1", "Hey @slack-bot")
+        );
+        await debounceChat.handleIncomingMessage(
+          adapter,
+          "slack:C123:1234.5678",
+          createTestMessage("msg-d-skip-mention-2", "please help")
+        );
+
+        await vi.advanceTimersByTimeAsync(150);
+        await promise;
+
+        expect(handler).toHaveBeenCalledTimes(1);
+        const message = handler.mock.calls[0][1];
+        const context = handler.mock.calls[0][2];
+        expect(message.text).toBe("please help");
+        expect(message.isMention).toBe(false);
+        expect(
+          context?.skipped.map((skipped) => ({
+            text: skipped.text,
+            isMention: skipped.isMention,
+          }))
+        ).toEqual([{ text: "Hey @slack-bot", isMention: true }]);
+      } finally {
+        vi.useRealTimers();
+      }
     });
   });
 

--- a/packages/chat/src/chat.ts
+++ b/packages/chat/src/chat.ts
@@ -2139,7 +2139,7 @@ export class Chat<
 
     if (!lock) {
       // Lock is busy — enqueue this message for later processing
-      const effectiveMaxSize = strategy === "debounce" ? 1 : maxQueueSize;
+      const effectiveMaxSize = maxQueueSize;
       const depth = await this._stateAdapter.queueDepth(lockKey);
 
       if (
@@ -2195,7 +2195,7 @@ export class Chat<
             enqueuedAt: Date.now(),
             expiresAt: Date.now() + queueEntryTtlMs,
           },
-          1
+          maxQueueSize
         );
         this.logger.info("message-debouncing", {
           threadId,
@@ -2245,37 +2245,50 @@ export class Chat<
     lockKey: string
   ): Promise<void> {
     const { debounceMs } = this._concurrencyConfig;
+    const skipped: Message[] = [];
 
     while (true) {
       await sleep(debounceMs);
       await this._stateAdapter.extendLock(lock, DEFAULT_LOCK_TTL_MS);
 
-      // Atomically take the pending message
-      const entry = await this._stateAdapter.dequeue(lockKey);
-      if (!entry) {
+      // Atomically take pending messages
+      const pending: Array<{ message: Message; expiresAt: number }> = [];
+      while (true) {
+        const entry = await this._stateAdapter.dequeue(lockKey);
+        if (!entry) {
+          break;
+        }
+        const msg = this.rehydrateMessage(entry.message, adapter);
+        if (Date.now() <= entry.expiresAt) {
+          pending.push({ message: msg, expiresAt: entry.expiresAt });
+        } else {
+          this.logger.info("message-expired", {
+            threadId,
+            lockKey,
+            messageId: msg.id,
+          });
+        }
+      }
+
+      if (pending.length === 0) {
         break;
       }
 
-      // Reconstruct Message instance after JSON roundtrip through state adapter
-      const msg = this.rehydrateMessage(entry.message, adapter);
-
-      if (Date.now() > entry.expiresAt) {
-        this.logger.info("message-expired", {
-          threadId,
-          lockKey,
-          messageId: msg.id,
-        });
-        continue;
+      const latest = pending.at(-1);
+      if (!latest) {
+        break;
       }
+      skipped.push(...pending.slice(0, -1).map((entry) => entry.message));
 
       // Check if anything new arrived during sleep
       const depth = await this._stateAdapter.queueDepth(lockKey);
       if (depth > 0) {
         // Newer message superseded this one — loop again
+        skipped.push(latest.message);
         this.logger.info("message-superseded", {
           threadId,
           lockKey,
-          droppedId: msg.id,
+          droppedId: latest.message.id,
         });
         continue;
       }
@@ -2284,9 +2297,12 @@ export class Chat<
       this.logger.info("message-dequeued", {
         threadId,
         lockKey,
-        messageId: msg.id,
+        messageId: latest.message.id,
       });
-      await this.dispatchToHandlers(adapter, threadId, msg);
+      await this.dispatchToHandlers(adapter, threadId, latest.message, {
+        skipped,
+        totalSinceLastHandler: skipped.length + 1,
+      });
       break;
     }
   }
@@ -2500,7 +2516,7 @@ export class Chat<
     }
 
     // Check for @-mention of bot
-    if (message.isMention || hasMention) {
+    if (message.isMention || (hasMention && this.mentionHandlers.length > 0)) {
       this.logger.debug("Bot mentioned", {
         threadId,
         text: message.text.slice(0, 100),


### PR DESCRIPTION
## summary

fixes skipped mention routing for collapsed concurrency messages

queue and burst already passed skipped message context, but mention routing could still swallow message pattern handlers when no `onNewMention` handler was registered

this also makes debounce preserve skipped context so an earlier debounced bot mention can still route to `onNewMention` when the latest message does not mention the bot
