### PR TITLE
fix(slack): process Socket Mode retry envelopes instead of dropping them

### DIFF
--- a/.changeset/dedupe-ttl-outlives-retries.md
+++ b/.changeset/dedupe-ttl-outlives-retries.md
@@ -1,0 +1,5 @@
+---
+"chat": patch
+---
+
+Raise the default message dedupe TTL from 5 to 10 minutes so it outlives the longest platform redelivery window. Slack's Events API retries up to ~5 minutes after the original delivery — exactly at the old TTL boundary, where a retried event could miss the expired dedupe entry from its first processing and be handled twice. Configurable behavior is unchanged (`dedupeTtlMs` still overrides).

--- a/.changeset/slack-process-retries.md
+++ b/.changeset/slack-process-retries.md
@@ -1,0 +1,5 @@
+---
+"@chat-adapter/slack": patch
+---
+
+Process Slack Socket Mode retry envelopes instead of discarding them. Slack redelivers an event (immediately, +1 min, +5 min) when a prior delivery wasn't acknowledged — including events sent while the app had no open socket, e.g. during a restart or a routine connection refresh. The adapter previously acked and dropped every envelope with `retry_num > 0`, so such events were permanently lost even though Slack redelivered them. Retries are now routed like first deliveries (logged at info with `retry_num`/`retry_reason`); `Chat.processMessage`'s message-id dedupe drops true duplicates.

--- a/apps/docs/content/docs/api/chat.mdx
+++ b/apps/docs/content/docs/api/chat.mdx
@@ -27,9 +27,9 @@ const bot = new Chat(config);
       type: 'Record<string, Adapter>',
     },
     dedupeTtlMs: {
-      description: 'TTL for message deduplication entries in milliseconds. Increase if webhook cold starts cause platform retries after the default window.',
+      description: 'TTL for message deduplication entries in milliseconds. The default outlives the last Slack event retry (~5 minutes after original delivery); increase it if your platform redelivers later than that.',
       type: 'number',
-      default: '300000',
+      default: '600000',
     },
     state: {
       description: 'State adapter for subscriptions, locking, and caching.',

--- a/apps/docs/content/docs/usage.mdx
+++ b/apps/docs/content/docs/usage.mdx
@@ -71,7 +71,7 @@ Your event handlers work identically across all registered adapters — the SDK 
 | `adapters` | `Record<string, Adapter>` | *required* | Map of adapter name to adapter instance |
 | `state` | `StateAdapter` | *required* | State adapter for subscriptions and locking |
 | `logger` | `Logger \| LogLevel` | `"info"` | Logger instance or log level (`"debug"`, `"info"`, `"warn"`, `"error"`, `"silent"`) |
-| `dedupeTtlMs` | `number` | `300000` | TTL in ms for message deduplication (5 minutes) |
+| `dedupeTtlMs` | `number` | `600000` | TTL in ms for message deduplication (10 minutes) |
 | `concurrency` | `"drop" \| "queue" \| "debounce" \| "burst" \| "concurrent" \| ConcurrencyConfig` | `"drop"` | Strategy for overlapping messages on the same thread |
 | `streamingUpdateIntervalMs` | `number` | `500` | Update interval in ms for post+edit streaming |
 | `fallbackStreamingPlaceholderText` | `string \| null` | `"..."` | Placeholder text while streaming starts. Set to `null` to skip |

--- a/packages/adapter-slack/src/index.test.ts
+++ b/packages/adapter-slack/src/index.test.ts
@@ -7212,6 +7212,7 @@ describe("socket mode - routeSocketEvent", () => {
       body: Record<string, unknown>;
       type: string;
       retry_num?: number;
+      retry_reason?: string;
     }) => Promise<void>;
 
     return { adapter, chatInstance, slackEventHandler };
@@ -7307,11 +7308,12 @@ describe("socket mode - routeSocketEvent", () => {
     expect(ack).toHaveBeenCalled();
   });
 
-  it("skips retries", async () => {
+  it("processes retries like first deliveries (dedupe drops true duplicates)", async () => {
     const { chatInstance, slackEventHandler } = await createSocketAdapter();
+    const ack = vi.fn().mockResolvedValue(undefined);
 
     await slackEventHandler({
-      ack: vi.fn().mockResolvedValue(undefined),
+      ack,
       type: "events_api",
       body: {
         event: {
@@ -7323,9 +7325,15 @@ describe("socket mode - routeSocketEvent", () => {
         },
       },
       retry_num: 1,
+      retry_reason: "timeout",
     });
 
-    expect(chatInstance.processMessage).not.toHaveBeenCalled();
+    // A retry may be the ONLY delivery the app ever sees (e.g. the original
+    // was sent while no socket was connected during a restart), so it must be
+    // routed normally; Chat.processMessage dedupes by message id when the
+    // original WAS handled.
+    expect(ack).toHaveBeenCalled();
+    expect(chatInstance.processMessage).toHaveBeenCalled();
   });
 
   it("acks events_api before processing", async () => {
@@ -7794,6 +7802,7 @@ describe("routeSocketEvent with options", () => {
       body: Record<string, unknown>;
       type: string;
       retry_num?: number;
+      retry_reason?: string;
     }) => Promise<void>;
 
     return { adapter, chatInstance, slackEventHandler };

--- a/packages/adapter-slack/src/index.ts
+++ b/packages/adapter-slack/src/index.ts
@@ -1766,11 +1766,19 @@ export class SlackAdapter implements Adapter<SlackThreadId, unknown> {
 
     this.socketClient.on(
       "slack_event",
-      async ({ ack, body, type, retry_num }) => {
+      async ({ ack, body, type, retry_num, retry_reason }) => {
         if (retry_num && retry_num > 0) {
-          await ack();
-          this.logger.debug("Skipping socket mode retry", { retry_num });
-          return;
+          // Slack redelivers an event when a prior delivery wasn't acked —
+          // including events sent while the app had no open socket (restart,
+          // deploy, connection refresh). Route it like a first delivery:
+          // processMessage() dedupes by message id, so an already-handled
+          // duplicate is dropped there, while a genuinely missed event is
+          // recovered instead of being lost.
+          this.logger.info("Processing socket mode retry", {
+            retry_num,
+            retry_reason,
+            type,
+          });
         }
 
         await this.routeSocketEvent(
@@ -1930,35 +1938,42 @@ export class SlackAdapter implements Adapter<SlackThreadId, unknown> {
     const client = new SocketModeClient({ appToken });
     let isShuttingDown = false;
 
-    client.on("slack_event", async ({ ack, body, type, retry_num }) => {
-      if (isShuttingDown) {
-        return;
-      }
+    client.on(
+      "slack_event",
+      async ({ ack, body, type, retry_num, retry_reason }) => {
+        if (isShuttingDown) {
+          return;
+        }
 
-      if (retry_num && retry_num > 0) {
-        await ack();
-        this.logger.debug("Skipping socket mode retry", { retry_num });
-        return;
-      }
+        if (retry_num && retry_num > 0) {
+          // See startSocketMode: retries are routed like first deliveries and
+          // deduped downstream, so missed-while-disconnected events recover.
+          this.logger.info("Processing socket mode retry", {
+            retry_num,
+            retry_reason,
+            type,
+          });
+        }
 
-      const eventType = type as string;
-      if (webhookUrl) {
-        await ack();
-        await this.forwardSocketEvent(webhookUrl, {
-          type: "socket_event",
-          eventType,
-          body: body as Record<string, unknown>,
-          timestamp: Date.now(),
-        });
-      } else {
-        await this.routeSocketEvent(
-          body as Record<string, unknown>,
-          eventType,
-          ack,
-          options
-        );
+        const eventType = type as string;
+        if (webhookUrl) {
+          await ack();
+          await this.forwardSocketEvent(webhookUrl, {
+            type: "socket_event",
+            eventType,
+            body: body as Record<string, unknown>,
+            timestamp: Date.now(),
+          });
+        } else {
+          await this.routeSocketEvent(
+            body as Record<string, unknown>,
+            eventType,
+            ack,
+            options
+          );
+        }
       }
-    });
+    );
 
     try {
       await client.start();

--- a/packages/chat/src/chat.test.ts
+++ b/packages/chat/src/chat.test.ts
@@ -328,7 +328,7 @@ describe("Chat", () => {
       expect(handler).toHaveBeenCalledTimes(1);
     });
 
-    it("should use default dedupe TTL of 5 minutes", async () => {
+    it("should use default dedupe TTL of 10 minutes", async () => {
       const handler = vi.fn().mockResolvedValue(undefined);
       chat.onNewMention(handler);
 
@@ -342,7 +342,7 @@ describe("Chat", () => {
       expect(mockState.setIfNotExists).toHaveBeenCalledWith(
         "dedupe:slack:msg-1",
         true,
-        300_000
+        600_000
       );
     });
 

--- a/packages/chat/src/chat.ts
+++ b/packages/chat/src/chat.ts
@@ -80,8 +80,13 @@ const DISCORD_SNOWFLAKE_REGEX = /^\d{17,19}$/;
 const LINEAR_UUID_REGEX =
   /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 const NUMERIC_REGEX = /^\d+$/;
-/** TTL for message deduplication entries */
-const DEDUPE_TTL_MS = 5 * 60 * 1000; // 5 minutes
+/**
+ * TTL for message deduplication entries. Must outlive the longest platform
+ * redelivery window so a retried event still hits the dedupe entry from its
+ * first processing — Slack's Events API retries up to ~5 minutes after the
+ * original delivery.
+ */
+const DEDUPE_TTL_MS = 10 * 60 * 1000; // 10 minutes
 const MODAL_CONTEXT_TTL_MS = 24 * 60 * 60 * 1000; // 24 hours
 
 /** Server-side stored modal context */


### PR DESCRIPTION
Fixes #666

## Summary

Both `slack_event` handlers (`startSocketMode` and `runSocketModeListener`) ack and discard every envelope with `retry_num > 0`. Slack retries an event (immediately, +1 min, +5 min) when a prior delivery wasn't acked — including events that arrived while the app had **no open socket** (restart, deploy, or Slack's routine connection refreshes). For those, the retry is the only delivery the app ever sees, so dropping it permanently loses the event (production incident details in #666).

- **`@chat-adapter/slack`**: route retry envelopes through `routeSocketEvent` like first deliveries (it acks per envelope type, preserving the 3s ack window), and log them at info with `retry_num` / `retry_reason` so redelivery is observable. Duplicate protection is unchanged and sufficient: `Chat.processMessage` dedupes on `message.id` (the Slack event `ts`, identical on a retry) via `state.setIfNotExists`.
- **`chat`**: raise the default `DEDUPE_TTL_MS` from 5 to 10 minutes. Slack's final retry fires ~5 minutes after the original delivery — exactly at the old TTL boundary, where the dedupe entry from the first processing could expire just before the retry arrives and cause a double-process. `dedupeTtlMs` config still overrides.

Behavior note for review: apps that relied on retries being invisible will now see redelivered events flow through — deduped when already handled, processed when not. That is the intended semantic: at-least-once delivery from Slack, exactly-once handling via the SDK's dedupe.

## Test plan

- Replaced the `"skips retries"` test with `"processes retries like first deliveries (dedupe drops true duplicates)"` — asserts a `retry_num: 1` envelope is acked and reaches `processMessage`.
- Updated the default-TTL test to 10 minutes; the custom-`dedupeTtlMs` test is unchanged.
- `pnpm validate` passes end to end (knip, check, typecheck, test, build); `pnpm --filter chat --filter @chat-adapter/slack test` = 1028 + 506 passing.

## Checklist

- [x] All commits are signed and verified
- [x] `pnpm validate` passes
- [x] Changeset added (patch for `@chat-adapter/slack`, patch for `chat`)
- [x] Documentation updated (`usage.mdx` and `api/chat.mdx` — `dedupeTtlMs` default and rationale)