### PR TITLE
Fix Slack native stream rollover

### DIFF
--- a/.changeset/slack-stream-rollover.md
+++ b/.changeset/slack-stream-rollover.md
@@ -1,0 +1,5 @@
+---
+"@chat-adapter/slack": patch
+---
+
+Recover Slack native streams reactively by starting a fresh streamed message when Slack reports the current stream is no longer in streaming state.

--- a/packages/adapter-slack/package.json
+++ b/packages/adapter-slack/package.json
@@ -45,7 +45,7 @@
   "dependencies": {
     "@chat-adapter/shared": "workspace:*",
     "@slack/socket-mode": "^2.0.5",
-    "@slack/web-api": "^7.14.0",
+    "@slack/web-api": "^7.17.0",
     "chat": "workspace:*"
   },
   "devDependencies": {

--- a/packages/adapter-slack/src/index.test.ts
+++ b/packages/adapter-slack/src/index.test.ts
@@ -17,6 +17,16 @@ import { createSlackAdapter, SlackAdapter } from "./index";
 
 const FILE_ID_PATTERN = /^file-/;
 
+function createStreamExpiredError(): Error & {
+  code: string;
+  data: { error: string; ok: false };
+} {
+  return Object.assign(new Error("message_not_in_streaming_state"), {
+    code: "slack_webapi_platform_error",
+    data: { error: "message_not_in_streaming_state", ok: false as const },
+  });
+}
+
 // Mock @slack/socket-mode
 const mockSocketStart = vi.fn().mockResolvedValue({});
 const mockSocketDisconnect = vi.fn().mockResolvedValue(undefined);
@@ -3643,8 +3653,10 @@ interface MockableClient {
     postEphemeral: ReturnType<typeof vi.fn>;
     update: ReturnType<typeof vi.fn>;
     delete: ReturnType<typeof vi.fn>;
+    startStream: ReturnType<typeof vi.fn>;
+    appendStream: ReturnType<typeof vi.fn>;
+    stopStream: ReturnType<typeof vi.fn>;
   };
-  chatStream: ReturnType<typeof vi.fn>;
   conversations: {
     open: ReturnType<typeof vi.fn>;
     replies: ReturnType<typeof vi.fn>;
@@ -7918,6 +7930,37 @@ describe("routeSocketEvent with options", () => {
 // ============================================================================
 
 describe("stream with empty threadTs", () => {
+  function mockStreamMethods(
+    adapter: SlackAdapter,
+    options?: {
+      startStream?: ReturnType<typeof vi.fn>;
+      appendStream?: ReturnType<typeof vi.fn>;
+      stopStream?: ReturnType<typeof vi.fn>;
+      update?: ReturnType<typeof vi.fn>;
+    }
+  ) {
+    const startStream =
+      options?.startStream ??
+      vi.fn().mockResolvedValue({ ok: true, ts: "1234567890.111111" });
+    const appendStream =
+      options?.appendStream ??
+      vi.fn().mockResolvedValue({ ok: true, ts: "1234567890.111111" });
+    const stopStream =
+      options?.stopStream ??
+      vi.fn().mockResolvedValue({
+        ok: true,
+        ts: "1234567890.111111",
+      });
+    const update = options?.update ?? vi.fn();
+
+    mockClientMethod(adapter, "chat.startStream", startStream);
+    mockClientMethod(adapter, "chat.appendStream", appendStream);
+    mockClientMethod(adapter, "chat.stopStream", stopStream);
+    mockClientMethod(adapter, "chat.update", update);
+
+    return { appendStream, startStream, stopStream, update };
+  }
+
   it("delegates to fallback before consuming the stream", async () => {
     const adapter = createSlackAdapter({
       botToken: "xoxb-test-token",
@@ -7962,13 +8005,7 @@ describe("stream with empty threadTs", () => {
       signingSecret: "test-signing-secret",
       logger: mockLogger,
     });
-    const append = vi.fn().mockResolvedValue(null);
-    const stop = vi.fn().mockResolvedValue({
-      ok: true,
-      ts: "1234567890.111111",
-    });
-    const chatStream = vi.fn().mockReturnValue({ append, stop });
-    mockClientMethod(adapter, "chatStream", chatStream);
+    const { startStream } = mockStreamMethods(adapter);
 
     async function* stream() {
       yield "hello";
@@ -7976,28 +8013,27 @@ describe("stream with empty threadTs", () => {
 
     await adapter.stream("slack:D123:1234567890.000000", stream());
 
-    expect(chatStream).toHaveBeenCalledWith({
-      channel: "D123",
-      thread_ts: "1234567890.000000",
-    });
+    expect(startStream).toHaveBeenCalledWith(
+      expect.objectContaining({
+        channel: "D123",
+        thread_ts: "1234567890.000000",
+        token: "xoxb-test-token",
+      })
+    );
   });
 
-  it("passes token on stream stop", async () => {
+  it("passes token on direct stream start, append, and stop", async () => {
     const adapter = createSlackAdapter({
       botToken: "xoxb-test-token",
       signingSecret: "test-signing-secret",
       logger: mockLogger,
     });
-    const append = vi.fn().mockResolvedValue(null);
-    const stop = vi.fn().mockResolvedValue({
-      ok: true,
-      ts: "1234567890.111111",
-    });
-    const chatStream = vi.fn().mockReturnValue({ append, stop });
-    mockClientMethod(adapter, "chatStream", chatStream);
+    const { appendStream, startStream, stopStream } =
+      mockStreamMethods(adapter);
 
     async function* shortStream() {
-      yield "hello";
+      yield "hello\n";
+      yield "world\n";
     }
 
     await adapter.stream("slack:C123:1234567890.000000", shortStream(), {
@@ -8005,29 +8041,24 @@ describe("stream with empty threadTs", () => {
       recipientTeamId: "T123",
     });
 
-    expect(stop).toHaveBeenCalledWith(
-      expect.objectContaining({
-        token: "xoxb-test-token",
-      })
+    expect(startStream).toHaveBeenCalledWith(
+      expect.objectContaining({ token: "xoxb-test-token" })
+    );
+    expect(appendStream).toHaveBeenCalledWith(
+      expect.objectContaining({ token: "xoxb-test-token" })
+    );
+    expect(stopStream).toHaveBeenCalledWith(
+      expect.objectContaining({ token: "xoxb-test-token" })
     );
   });
 
-  it("passes token on every stream append", async () => {
+  it("passes token on every structured stream append", async () => {
     const adapter = createSlackAdapter({
       botToken: "xoxb-test-token",
       signingSecret: "test-signing-secret",
       logger: mockLogger,
     });
-    const append = vi.fn().mockResolvedValue({ ok: true });
-    const stop = vi.fn().mockResolvedValue({
-      ok: true,
-      ts: "1234567890.111111",
-    });
-    mockClientMethod(
-      adapter,
-      "chatStream",
-      vi.fn().mockReturnValue({ append, stop })
-    );
+    const { appendStream, startStream } = mockStreamMethods(adapter);
 
     async function* chunkStream() {
       yield {
@@ -8051,15 +8082,290 @@ describe("stream with empty threadTs", () => {
       recipientTeamId: "T123",
     });
 
-    expect(append).toHaveBeenCalledTimes(2);
-    expect(append).toHaveBeenNthCalledWith(
+    expect(startStream).toHaveBeenCalledWith(
+      expect.objectContaining({ token: "xoxb-test-token" })
+    );
+    expect(appendStream).toHaveBeenCalledTimes(1);
+    expect(appendStream).toHaveBeenCalledWith(
+      expect.objectContaining({ token: "xoxb-test-token" })
+    );
+  });
+
+  it("rolls to a fresh stream and retries only the pending markdown delta", async () => {
+    const adapter = createSlackAdapter({
+      botToken: "xoxb-test-token",
+      signingSecret: "test-signing-secret",
+      logger: mockLogger,
+    });
+    const startStream = vi
+      .fn()
+      .mockResolvedValueOnce({ ok: true, ts: "1234567890.111111" })
+      .mockResolvedValueOnce({ ok: true, ts: "1234567890.222222" });
+    const appendStream = vi
+      .fn()
+      .mockRejectedValueOnce(createStreamExpiredError());
+    const stopStream = vi.fn().mockResolvedValue({
+      ok: true,
+      ts: "1234567890.222222",
+    });
+    mockStreamMethods(adapter, { appendStream, startStream, stopStream });
+
+    async function* textStream() {
+      yield "first\n";
+      yield "second\n";
+    }
+
+    const result = await adapter.stream(
+      "slack:C123:1234567890.000000",
+      textStream(),
+      {
+        recipientUserId: "U123",
+        recipientTeamId: "T123",
+      }
+    );
+
+    expect(startStream).toHaveBeenCalledTimes(2);
+    expect(startStream).toHaveBeenNthCalledWith(
       1,
-      expect.objectContaining({ token: "xoxb-test-token" })
+      expect.objectContaining({
+        chunks: [{ type: "markdown_text", text: "first\n" }],
+      })
     );
-    expect(append).toHaveBeenNthCalledWith(
+    expect(appendStream).toHaveBeenCalledWith(
+      expect.objectContaining({
+        chunks: [{ type: "markdown_text", text: "second\n" }],
+        ts: "1234567890.111111",
+      })
+    );
+    expect(startStream).toHaveBeenNthCalledWith(
       2,
-      expect.objectContaining({ token: "xoxb-test-token" })
+      expect.objectContaining({
+        chunks: [{ type: "markdown_text", text: "second\n" }],
+      })
     );
+    expect(stopStream).toHaveBeenCalledWith(
+      expect.objectContaining({ ts: "1234567890.222222" })
+    );
+    expect(result?.id).toBe("1234567890.222222");
+  });
+
+  it("falls back to updating the current message when rollovers are exhausted", async () => {
+    const adapter = createSlackAdapter({
+      botToken: "xoxb-test-token",
+      signingSecret: "test-signing-secret",
+      logger: mockLogger,
+    });
+    const startStream = vi
+      .fn()
+      .mockResolvedValueOnce({ ok: true, ts: "1234567890.111111" })
+      .mockRejectedValue(createStreamExpiredError());
+    const appendStream = vi.fn().mockRejectedValue(createStreamExpiredError());
+    const update = vi
+      .fn()
+      .mockResolvedValue({ ok: true, ts: "1234567890.111111" });
+    mockStreamMethods(adapter, { appendStream, startStream, update });
+
+    async function* textStream() {
+      yield "first\n";
+      yield "second\n";
+    }
+
+    const result = await adapter.stream(
+      "slack:C123:1234567890.000000",
+      textStream(),
+      {
+        recipientUserId: "U123",
+        recipientTeamId: "T123",
+      }
+    );
+
+    expect(update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        channel: "C123",
+        text: "first\nsecond\n",
+        token: "xoxb-test-token",
+        ts: "1234567890.111111",
+      })
+    );
+    expect(result?.id).toBe("1234567890.111111");
+  });
+
+  it("updates only the latest stream segment after a successful rollover", async () => {
+    const adapter = createSlackAdapter({
+      botToken: "xoxb-test-token",
+      signingSecret: "test-signing-secret",
+      logger: mockLogger,
+    });
+    const startStream = vi
+      .fn()
+      .mockResolvedValueOnce({ ok: true, ts: "1234567890.111111" })
+      .mockResolvedValueOnce({ ok: true, ts: "1234567890.222222" });
+    const appendStream = vi
+      .fn()
+      .mockRejectedValueOnce(createStreamExpiredError())
+      .mockResolvedValueOnce({ ok: true, ts: "1234567890.222222" });
+    const stopStream = vi.fn().mockRejectedValue(createStreamExpiredError());
+    const update = vi
+      .fn()
+      .mockResolvedValue({ ok: true, ts: "1234567890.222222" });
+    mockStreamMethods(adapter, {
+      appendStream,
+      startStream,
+      stopStream,
+      update,
+    });
+
+    async function* textStream() {
+      yield "first\n";
+      yield "second\n";
+      yield "third\n";
+    }
+
+    await adapter.stream("slack:C123:1234567890.000000", textStream(), {
+      recipientUserId: "U123",
+      recipientTeamId: "T123",
+      stopBlocks: [
+        {
+          text: { text: "done", type: "plain_text" },
+          type: "section",
+        },
+      ],
+    });
+
+    expect(update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        blocks: [
+          {
+            text: { text: "done", type: "plain_text" },
+            type: "section",
+          },
+        ],
+        text: "second\nthird\n",
+        ts: "1234567890.222222",
+      })
+    );
+  });
+
+  it("re-seeds the latest structured chunks when rolling streams", async () => {
+    const adapter = createSlackAdapter({
+      botToken: "xoxb-test-token",
+      signingSecret: "test-signing-secret",
+      logger: mockLogger,
+    });
+    const taskChunk = {
+      details: "working",
+      id: "task-1",
+      status: "in_progress" as const,
+      title: "Task one",
+      type: "task_update" as const,
+    };
+    const startStream = vi
+      .fn()
+      .mockResolvedValueOnce({ ok: true, ts: "1234567890.111111" })
+      .mockResolvedValueOnce({ ok: true, ts: "1234567890.222222" });
+    const appendStream = vi
+      .fn()
+      .mockResolvedValueOnce({ ok: true, ts: "1234567890.111111" })
+      .mockRejectedValueOnce(createStreamExpiredError())
+      .mockResolvedValueOnce({ ok: true, ts: "1234567890.222222" });
+    const stopStream = vi.fn().mockResolvedValue({
+      ok: true,
+      ts: "1234567890.222222",
+    });
+    mockStreamMethods(adapter, { appendStream, startStream, stopStream });
+
+    async function* chunkStream() {
+      yield taskChunk;
+      yield "hello\n";
+      yield "world\n";
+    }
+
+    await adapter.stream("slack:C123:1234567890.000000", chunkStream(), {
+      recipientUserId: "U123",
+      recipientTeamId: "T123",
+    });
+
+    expect(startStream).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({ chunks: [taskChunk] })
+    );
+    expect(appendStream).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        chunks: [{ type: "markdown_text", text: "world\n" }],
+        ts: "1234567890.222222",
+      })
+    );
+  });
+
+  it("does not reject when Slack expires the stream before stop", async () => {
+    const adapter = createSlackAdapter({
+      botToken: "xoxb-test-token",
+      signingSecret: "test-signing-secret",
+      logger: mockLogger,
+    });
+    const stopStream = vi.fn().mockRejectedValue(createStreamExpiredError());
+    const update = vi.fn();
+    mockStreamMethods(adapter, { stopStream, update });
+
+    async function* textStream() {
+      yield "hello\n";
+    }
+
+    const result = await adapter.stream(
+      "slack:C123:1234567890.000000",
+      textStream(),
+      {
+        recipientUserId: "U123",
+        recipientTeamId: "T123",
+      }
+    );
+
+    expect(stopStream).toHaveBeenCalledTimes(1);
+    expect(update).not.toHaveBeenCalled();
+    expect(result?.id).toBe("1234567890.111111");
+  });
+
+  it("still rejects non-expiry stream append errors", async () => {
+    const adapter = createSlackAdapter({
+      botToken: "xoxb-test-token",
+      signingSecret: "test-signing-secret",
+      logger: mockLogger,
+    });
+    const appendStream = vi.fn().mockRejectedValue(new Error("boom"));
+    mockStreamMethods(adapter, { appendStream });
+
+    async function* textStream() {
+      yield "first\n";
+      yield "second\n";
+    }
+
+    await expect(
+      adapter.stream("slack:C123:1234567890.000000", textStream(), {
+        recipientUserId: "U123",
+        recipientTeamId: "T123",
+      })
+    ).rejects.toThrow("boom");
+  });
+
+  it("still rejects non-expiry stream stop errors", async () => {
+    const adapter = createSlackAdapter({
+      botToken: "xoxb-test-token",
+      signingSecret: "test-signing-secret",
+      logger: mockLogger,
+    });
+    const stopStream = vi.fn().mockRejectedValue(new Error("boom"));
+    mockStreamMethods(adapter, { stopStream });
+
+    async function* textStream() {
+      yield "hello\n";
+    }
+
+    await expect(
+      adapter.stream("slack:C123:1234567890.000000", textStream(), {
+        recipientUserId: "U123",
+        recipientTeamId: "T123",
+      })
+    ).rejects.toThrow("boom");
   });
 });
 

--- a/packages/adapter-slack/src/index.ts
+++ b/packages/adapter-slack/src/index.ts
@@ -11,7 +11,12 @@ import {
   ValidationError,
 } from "@chat-adapter/shared";
 import { SocketModeClient } from "@slack/socket-mode";
-import { type ChatStopStreamArguments, WebClient } from "@slack/web-api";
+import {
+  type ChatAppendStreamArguments,
+  type ChatStartStreamArguments,
+  type ChatStopStreamArguments,
+  WebClient,
+} from "@slack/web-api";
 import type {
   ActionEvent,
   Adapter,
@@ -78,6 +83,17 @@ import { verifySlackRequest } from "./webhook/index";
 
 const SLACK_USER_ID_PATTERN = /^[A-Z0-9_]+$/;
 const SLACK_USER_ID_EXACT_PATTERN = /^U[A-Z0-9]+$/;
+const SLACK_STREAM_EXPIRED_ERROR = "message_not_in_streaming_state";
+const MAX_SLACK_STREAM_ROLLOVERS = 5;
+
+function isSlackStreamExpiredError(error: unknown): boolean {
+  const slackError = error as { code?: string; data?: { error?: string } };
+
+  return (
+    slackError.code === "slack_webapi_platform_error" &&
+    slackError.data?.error === SLACK_STREAM_EXPIRED_ERROR
+  );
+}
 
 // Slack expects block_suggestion responses within 3s. Leave headroom for
 // network latency so the HTTP response lands before Slack gives up.
@@ -3989,9 +4005,30 @@ export class SlackAdapter implements Adapter<SlackThreadId, unknown> {
     this.logger.debug("Slack: starting stream", { channel, threadTs });
 
     const token = await this.getToken();
-    const streamer = this._client.chatStream({
+    let currentStreamTs: string | undefined;
+    let lastKnownMessageTs: string | undefined;
+    let currentMessageStartOffset = 0;
+    let lastConfirmedOffset = 0;
+    let rolloverCount = 0;
+    let fallbackToUpdate = false;
+    let structuredChunksSupported = true;
+    const latestStructuredChunks = new Map<string, StreamChunk>();
+    const renderer = new StreamingMarkdownRenderer({
+      wrapTablesForAppend: false,
+    });
+
+    type StreamPayload = Pick<
+      ChatAppendStreamArguments,
+      "chunks" | "markdown_text"
+    >;
+
+    const baseStartStreamArgs = (): Omit<
+      ChatStartStreamArguments,
+      "chunks" | "markdown_text"
+    > => ({
       channel,
       thread_ts: threadTs,
+      token,
       ...(options?.recipientUserId && {
         recipient_user_id: options.recipientUserId,
       }),
@@ -4003,16 +4040,164 @@ export class SlackAdapter implements Adapter<SlackThreadId, unknown> {
       }),
     });
 
-    let lastAppended = "";
-    const renderer = new StreamingMarkdownRenderer({
-      wrapTablesForAppend: false,
-    });
+    const getMessageTs = (): string => {
+      const messageTs = currentStreamTs ?? lastKnownMessageTs;
+      if (!messageTs) {
+        throw new Error(
+          "Slack stream expired before a message timestamp was available"
+        );
+      }
+      return messageTs;
+    };
 
-    const flushMarkdownDelta = async (delta: string): Promise<void> => {
-      if (delta.length === 0) {
+    const updateCurrentStreamMessage = async (
+      markdownText: string
+    ): Promise<RawMessage<unknown>> => {
+      const messageTs = getMessageTs();
+      const currentMessageText = markdownText.slice(currentMessageStartOffset);
+      const payload = options?.stopBlocks
+        ? {
+            blocks: options.stopBlocks as ChatStopStreamArguments["blocks"],
+            text: currentMessageText,
+          }
+        : { text: currentMessageText };
+
+      try {
+        const result = await this._client.chat.update({
+          channel,
+          ts: messageTs,
+          token,
+          ...payload,
+        });
+
+        this.logger.debug("Slack: stream completed via chat.update fallback", {
+          messageId: result.ts,
+        });
+
+        return {
+          id: result.ts as string,
+          threadId,
+          raw: result,
+        };
+      } catch (error) {
+        this.handleSlackError(error);
+      }
+    };
+
+    const startStream = async (payload: StreamPayload): Promise<void> => {
+      const result = await this._client.chat.startStream({
+        ...baseStartStreamArgs(),
+        ...payload,
+      } as ChatStartStreamArguments);
+      currentStreamTs = result.ts as string;
+      lastKnownMessageTs = currentStreamTs;
+      currentMessageStartOffset = lastConfirmedOffset;
+    };
+
+    const appendToStream = async (payload: StreamPayload): Promise<void> => {
+      if (!currentStreamTs) {
+        await startStream(payload);
         return;
       }
-      await streamer.append({ markdown_text: delta, token });
+
+      const result = await this._client.chat.appendStream({
+        channel,
+        ts: currentStreamTs,
+        token,
+        ...payload,
+      } as ChatAppendStreamArguments);
+      lastKnownMessageTs =
+        (result.ts as string | undefined) ?? lastKnownMessageTs;
+    };
+
+    const rememberStructuredChunk = (chunk: StreamChunk): void => {
+      if (chunk.type === "markdown_text") {
+        return;
+      }
+      const key =
+        chunk.type === "task_update" ? `${chunk.type}:${chunk.id}` : chunk.type;
+      latestStructuredChunks.set(key, chunk);
+    };
+
+    const appendLatestStructuredChunks = async (): Promise<void> => {
+      if (!structuredChunksSupported || latestStructuredChunks.size === 0) {
+        return;
+      }
+
+      try {
+        await appendToStream({
+          chunks: [
+            ...latestStructuredChunks.values(),
+          ] as ChatAppendStreamArguments["chunks"],
+        });
+      } catch (error) {
+        if (isSlackStreamExpiredError(error)) {
+          fallbackToUpdate = true;
+          this.logger.warn(
+            "Slack stream expired while re-seeding structured chunks; falling back to chat.update",
+            { error }
+          );
+          return;
+        }
+
+        structuredChunksSupported = false;
+        this.logger.warn(
+          "Structured streaming chunk failed while re-seeding a rolled Slack stream. " +
+            "Continuing with text-only streaming.",
+          { error }
+        );
+      }
+    };
+
+    const rollStream = async (error: unknown): Promise<void> => {
+      if (fallbackToUpdate) {
+        return;
+      }
+
+      if (rolloverCount >= MAX_SLACK_STREAM_ROLLOVERS) {
+        fallbackToUpdate = true;
+        this.logger.warn(
+          "Slack stream expired after the rollover limit; falling back to chat.update",
+          { error, maxRollovers: MAX_SLACK_STREAM_ROLLOVERS }
+        );
+        return;
+      }
+
+      const expiredMessageTs = getMessageTs();
+      lastKnownMessageTs = expiredMessageTs;
+      currentStreamTs = undefined;
+      rolloverCount++;
+      this.logger.warn("Slack stream expired; rolling to a fresh stream", {
+        error,
+        expiredMessageTs,
+        rolloverCount,
+      });
+
+      await appendLatestStructuredChunks();
+    };
+
+    const appendMarkdownDelta = async (delta: string): Promise<boolean> => {
+      if (delta.length === 0 || fallbackToUpdate) {
+        return !fallbackToUpdate;
+      }
+
+      while (!fallbackToUpdate) {
+        try {
+          await appendToStream({
+            chunks: [{ type: "markdown_text", text: delta }],
+          } as StreamPayload);
+          lastConfirmedOffset += delta.length;
+          return true;
+        } catch (error) {
+          if (!isSlackStreamExpiredError(error)) {
+            this.handleSlackError(error);
+          }
+
+          await rollStream(error);
+        }
+      }
+
+      return false;
     };
 
     /**
@@ -4025,22 +4210,32 @@ export class SlackAdapter implements Adapter<SlackThreadId, unknown> {
      * app manifest), the error is logged and the chunk is silently skipped.
      * Text streaming continues unaffected.
      */
-    let structuredChunksSupported = true;
     const sendStructuredChunk = async (chunk: StreamChunk): Promise<void> => {
-      if (!structuredChunksSupported) {
+      rememberStructuredChunk(chunk);
+
+      if (!structuredChunksSupported || fallbackToUpdate) {
         return;
       }
 
       // Flush any buffered markdown before sending the structured chunk
       const committable = renderer.getCommittableText();
-      const delta = committable.slice(lastAppended.length);
-      await flushMarkdownDelta(delta);
-      lastAppended = committable;
+      const delta = committable.slice(lastConfirmedOffset);
+      await appendMarkdownDelta(delta);
+
+      if (fallbackToUpdate) {
+        return;
+      }
 
       try {
-        // biome-ignore lint/suspicious/noExplicitAny: chunks not in ChatAppendStreamArguments for older @slack/web-api
-        await streamer.append({ chunks: [chunk], token } as any);
+        await appendToStream({
+          chunks: [chunk] as ChatAppendStreamArguments["chunks"],
+        });
       } catch (error) {
+        if (isSlackStreamExpiredError(error)) {
+          await rollStream(error);
+          return;
+        }
+
         // Structured chunks may fail if the app doesn't have the required
         // Assistant scopes/features. Disable for the rest of this stream
         // to avoid repeated failures and log once.
@@ -4048,7 +4243,7 @@ export class SlackAdapter implements Adapter<SlackThreadId, unknown> {
         this.logger.warn(
           "Structured streaming chunk failed, falling back to text-only streaming. " +
             "Ensure your Slack app manifest includes assistant_view, assistant:write scope, " +
-            "and @slack/web-api >= 7.14.0",
+            "and @slack/web-api >= 7.17.0",
           { chunkType: chunk.type, error }
         );
       }
@@ -4057,9 +4252,8 @@ export class SlackAdapter implements Adapter<SlackThreadId, unknown> {
     const pushTextAndFlush = async (text: string): Promise<void> => {
       renderer.push(text);
       const committable = renderer.getCommittableText();
-      const delta = committable.slice(lastAppended.length);
-      await flushMarkdownDelta(delta);
-      lastAppended = committable;
+      const delta = committable.slice(lastConfirmedOffset);
+      await appendMarkdownDelta(delta);
     };
 
     for await (const chunk of textStream) {
@@ -4076,26 +4270,61 @@ export class SlackAdapter implements Adapter<SlackThreadId, unknown> {
     // Flush any remaining buffered content (e.g. held table rows at end of stream).
     renderer.finish();
     const finalCommittable = renderer.getCommittableText();
-    const finalDelta = finalCommittable.slice(lastAppended.length);
-    await flushMarkdownDelta(finalDelta);
+    const finalDelta = finalCommittable.slice(lastConfirmedOffset);
+    await appendMarkdownDelta(finalDelta);
 
-    const result = await streamer.stop({
-      token,
-      ...(options?.stopBlocks
-        ? {
-            blocks: options.stopBlocks as ChatStopStreamArguments["blocks"],
-          }
-        : {}),
-    });
-    const messageTs = (result.message?.ts ?? result.ts) as string;
+    if (fallbackToUpdate) {
+      return updateCurrentStreamMessage(finalCommittable);
+    }
 
-    this.logger.debug("Slack: stream complete", { messageId: messageTs });
+    try {
+      const messageTs = getMessageTs();
+      const result = await this._client.chat.stopStream({
+        channel,
+        ts: messageTs,
+        token,
+        ...(options?.stopBlocks
+          ? {
+              blocks: options.stopBlocks as ChatStopStreamArguments["blocks"],
+            }
+          : {}),
+      });
+      const resultMessageTs = (result.message?.ts ?? result.ts) as string;
+      lastKnownMessageTs = resultMessageTs;
+      currentStreamTs = resultMessageTs;
 
-    return {
-      id: messageTs,
-      threadId,
-      raw: result,
-    };
+      this.logger.debug("Slack: stream complete", {
+        messageId: resultMessageTs,
+      });
+
+      return {
+        id: resultMessageTs,
+        threadId,
+        raw: result,
+      };
+    } catch (error) {
+      if (!isSlackStreamExpiredError(error)) {
+        this.handleSlackError(error);
+      }
+
+      if (
+        options?.stopBlocks ||
+        finalCommittable.length > lastConfirmedOffset
+      ) {
+        return updateCurrentStreamMessage(finalCommittable);
+      }
+
+      const messageTs = getMessageTs();
+      this.logger.debug("Slack: stream complete after Slack finalized it", {
+        messageId: messageTs,
+      });
+
+      return {
+        id: messageTs,
+        threadId,
+        raw: { ok: true, ts: messageTs },
+      };
+    }
   }
 
   /**

--- a/packages/integration-tests/src/replay-streaming.test.ts
+++ b/packages/integration-tests/src/replay-streaming.test.ts
@@ -113,8 +113,8 @@ describe("Streaming Replay Tests", () => {
       // Verify initial message was sent
       expectSentMessage(ctx.mockClient, "AI Mode Enabled!");
 
-      // Verify native streaming was used (chatStream called for the AI response)
-      expect(ctx.mockClient.chatStream).toHaveBeenCalled();
+      // Verify native streaming was used for the AI response.
+      expect(ctx.mockClient.chat.startStream).toHaveBeenCalled();
     });
 
     it("should stream response to follow-up message in AI mode", async () => {
@@ -131,7 +131,7 @@ describe("Streaming Replay Tests", () => {
       });
 
       // Verify native streaming was used for the response
-      expect(ctx.mockClient.chatStream).toHaveBeenCalled();
+      expect(ctx.mockClient.chat.startStream).toHaveBeenCalled();
     });
 
     it("should handle AI mention with file attachment", async () => {
@@ -144,7 +144,7 @@ describe("Streaming Replay Tests", () => {
       });
 
       expect(aiModeEnabled).toBe(true);
-      expect(ctx.mockClient.chatStream).toHaveBeenCalled();
+      expect(ctx.mockClient.chat.startStream).toHaveBeenCalled();
     });
 
     it("should ignore a prompt message posted by the bot", async () => {
@@ -153,7 +153,7 @@ describe("Streaming Replay Tests", () => {
       expect(ctx.captured.mentionMessage).toBeNull();
       expect(ctx.captured.followUpMessage).toBeNull();
       expect(ctx.mockClient.chat.postMessage).not.toHaveBeenCalled();
-      expect(ctx.mockClient.chatStream).not.toHaveBeenCalled();
+      expect(ctx.mockClient.chat.startStream).not.toHaveBeenCalled();
     });
 
     it("should stream structured chunks for a block_actions continuation", async () => {
@@ -183,7 +183,7 @@ describe("Streaming Replay Tests", () => {
       );
       expect(capturedAction.thread?.channelId).toBe("slack:C08REALCHAN1");
 
-      expect(ctx.mockClient.chatStream).toHaveBeenCalledWith(
+      expect(ctx.mockClient.chat.startStream).toHaveBeenCalledWith(
         expect.objectContaining({
           channel: "C08REALCHAN1",
           recipient_team_id: "T08REALTEAM1",
@@ -192,10 +192,11 @@ describe("Streaming Replay Tests", () => {
         })
       );
 
-      const streamer = ctx.mockClient.chatStream.mock.results.at(-1)?.value as {
-        append: ReturnType<typeof vi.fn>;
-      };
-      const hasStructuredAppend = streamer.append.mock.calls.some((call) => {
+      const streamCalls = [
+        ...ctx.mockClient.chat.startStream.mock.calls,
+        ...ctx.mockClient.chat.appendStream.mock.calls,
+      ];
+      const hasStructuredAppend = streamCalls.some((call) => {
         const [payload] = call as [{ chunks?: Array<{ type?: string }> }];
         return (
           Array.isArray(payload.chunks) &&
@@ -226,7 +227,7 @@ describe("Streaming Replay Tests", () => {
       });
       expect(ctx.captured.followUpMessage?.author.userId).toBe("U08REALUSER1");
 
-      expect(ctx.mockClient.chatStream).toHaveBeenCalledWith(
+      expect(ctx.mockClient.chat.startStream).toHaveBeenCalledWith(
         expect.objectContaining({
           channel: "C08REALCHAN1",
           recipient_team_id: "T08REALTEAM1",

--- a/packages/integration-tests/src/slack-utils.ts
+++ b/packages/integration-tests/src/slack-utils.ts
@@ -114,8 +114,10 @@ interface MockSlackClientShape {
     postEphemeral: MockFn;
     update: MockFn;
     delete: MockFn;
+    startStream: MockFn;
+    appendStream: MockFn;
+    stopStream: MockFn;
   };
-  chatStream: MockFn;
   clearMocks: () => void;
   conversations: {
     info: MockFn;
@@ -158,17 +160,23 @@ export function createMockSlackClient(): MockSlackClientShape {
         channel: "C123456",
       }),
       delete: vi.fn().mockResolvedValue({ ok: true }),
-    },
-    // Mock chatStream for streaming support - returns streamer object with append/stop
-    chatStream: vi.fn().mockImplementation(() => ({
-      append: vi.fn().mockResolvedValue(undefined),
-      stop: vi.fn().mockResolvedValue({
+      startStream: vi.fn().mockResolvedValue({
+        ok: true,
+        ts: "1234567890.123456",
+        channel: "C123456",
+      }),
+      appendStream: vi.fn().mockResolvedValue({
+        ok: true,
+        ts: "1234567890.123456",
+        channel: "C123456",
+      }),
+      stopStream: vi.fn().mockResolvedValue({
         ok: true,
         ts: "1234567890.123456",
         channel: "C123456",
         message: { ts: "1234567890.123456" },
       }),
-    })),
+    },
     reactions: {
       add: vi.fn().mockResolvedValue({ ok: true }),
       remove: vi.fn().mockResolvedValue({ ok: true }),
@@ -221,7 +229,9 @@ export function createMockSlackClient(): MockSlackClientShape {
       client.chat.postEphemeral.mockClear();
       client.chat.update.mockClear();
       client.chat.delete.mockClear();
-      client.chatStream.mockClear();
+      client.chat.startStream.mockClear();
+      client.chat.appendStream.mockClear();
+      client.chat.stopStream.mockClear();
       client.reactions.add.mockClear();
       client.reactions.remove.mockClear();
       client.conversations.info.mockClear();

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -487,8 +487,8 @@ importers:
         specifier: ^2.0.5
         version: 2.0.6
       '@slack/web-api':
-        specifier: ^7.14.0
-        version: 7.14.1
+        specifier: ^7.17.0
+        version: 7.18.0
       chat:
         specifier: workspace:*
         version: link:../chat
@@ -3838,10 +3838,6 @@ packages:
     resolution: {integrity: sha512-tlqY9xq5ukxTUZBmoOp+m61cqwQD5pHJtFY3Mn8CA8ps6yghLH/Hw8UPdqg4OLmFW3IFlcXnQNmo/dh8HzXYIQ==}
     engines: {node: '>=18'}
 
-  '@slack/logger@4.0.0':
-    resolution: {integrity: sha512-Wz7QYfPAlG/DR+DfABddUZeNgoeY7d1J39OCR2jR+v7VBsB8ezulDK5szTnDDPDwLH5IWhLvXIHlCFZV7MSKgA==}
-    engines: {node: '>= 18', npm: '>= 8.6.0'}
-
   '@slack/logger@4.0.1':
     resolution: {integrity: sha512-6cmdPrV/RYfd2U0mDGiMK8S7OJqpCTm7enMLRR3edccsPX8j7zXTLnaEF4fhxxJJTAIOil6+qZrnUPTuaLvwrQ==}
     engines: {node: '>= 18', npm: '>= 8.6.0'}
@@ -3850,20 +3846,12 @@ packages:
     resolution: {integrity: sha512-Aj5RO3MoYVJ+b2tUjHUXuA3tiIaCUMOf1Ss5tPiz29XYVUi6qNac2A8ulcU1pUPERpXVHTmT1XW6HzQIO74daQ==}
     engines: {node: '>= 18', npm: '>= 8.6.0'}
 
-  '@slack/types@2.20.0':
-    resolution: {integrity: sha512-PVF6P6nxzDMrzPC8fSCsnwaI+kF8YfEpxf3MqXmdyjyWTYsZQURpkK7WWUWvP5QpH55pB7zyYL9Qem/xSgc5VA==}
+  '@slack/types@2.21.1':
+    resolution: {integrity: sha512-I8vmSjNYWsaxuWPx6dz4yeh0h7vRBWbgAMK14LEmblbZ404BtrPbXs6jDPx4cYgGf8msDGF4A9opLZBu21FViQ==}
     engines: {node: '>= 12.13.0', npm: '>= 6.12.0'}
 
-  '@slack/types@2.20.1':
-    resolution: {integrity: sha512-eWX2mdt1ktpn8+40iiMc404uGrih+2fxiky3zBcPjtXKj6HLRdYlmhrPkJi7JTJm8dpXR6BWVWEDBXtaWMKD6A==}
-    engines: {node: '>= 12.13.0', npm: '>= 6.12.0'}
-
-  '@slack/web-api@7.14.1':
-    resolution: {integrity: sha512-RoygyteJeFswxDPJjUMESn9dldWVMD2xUcHHd9DenVavSfVC6FeVnSdDerOO7m8LLvw4Q132nQM4hX8JiF7dng==}
-    engines: {node: '>= 18', npm: '>= 8.6.0'}
-
-  '@slack/web-api@7.15.1':
-    resolution: {integrity: sha512-y+TAF7TszcmFzbVtBkFqAdBwKSoD+8shkNxhp4WIfFwXmCKdFje9WD6evROApPa2FTy1v1uc9yBaJs3609PPgg==}
+  '@slack/web-api@7.18.0':
+    resolution: {integrity: sha512-EWBsKUhOFFp87beQg/ToSC+asWB7BrGHuh7uPC1ZI9vr41GjS+3WmmyWIMqs+mF6U+mh4d6HhtFlv67TrJFsvw==}
     engines: {node: '>= 18', npm: '>= 8.6.0'}
 
   '@smithy/config-resolver@4.4.17':
@@ -11779,10 +11767,6 @@ snapshots:
 
   '@sindresorhus/merge-streams@4.0.0': {}
 
-  '@slack/logger@4.0.0':
-    dependencies:
-      '@types/node': 25.9.2
-
   '@slack/logger@4.0.1':
     dependencies:
       '@types/node': 25.9.2
@@ -11790,7 +11774,7 @@ snapshots:
   '@slack/socket-mode@2.0.6':
     dependencies:
       '@slack/logger': 4.0.1
-      '@slack/web-api': 7.15.1
+      '@slack/web-api': 7.18.0
       '@types/node': 25.9.2
       '@types/ws': 8.18.1
       eventemitter3: 5.0.1
@@ -11801,32 +11785,12 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@slack/types@2.20.0': {}
+  '@slack/types@2.21.1': {}
 
-  '@slack/types@2.20.1': {}
-
-  '@slack/web-api@7.14.1':
-    dependencies:
-      '@slack/logger': 4.0.0
-      '@slack/types': 2.20.0
-      '@types/node': 25.9.2
-      '@types/retry': 0.12.0
-      axios: 1.16.1
-      eventemitter3: 5.0.1
-      form-data: 4.0.5
-      is-electron: 2.2.2
-      is-stream: 2.0.1
-      p-queue: 6.6.2
-      p-retry: 4.6.2
-      retry: 0.13.1
-    transitivePeerDependencies:
-      - debug
-      - supports-color
-
-  '@slack/web-api@7.15.1':
+  '@slack/web-api@7.18.0':
     dependencies:
       '@slack/logger': 4.0.1
-      '@slack/types': 2.20.1
+      '@slack/types': 2.21.1
       '@types/node': 25.9.2
       '@types/retry': 0.12.0
       axios: 1.16.1
@@ -12736,14 +12700,6 @@ snapshots:
       '@vitest/utils': 4.1.8
       chai: 6.2.2
       tinyrainbow: 3.1.0
-
-  '@vitest/mocker@4.0.18(vite@7.3.3(@types/node@25.3.2)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.22.3))':
-    dependencies:
-      '@vitest/spy': 4.0.18
-      estree-walker: 3.0.3
-      magic-string: 0.30.21
-    optionalDependencies:
-      vite: 7.3.3(@types/node@25.3.2)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.22.3)
 
   '@vitest/mocker@4.0.18(vite@7.3.3(@types/node@25.9.2)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.22.3))':
     dependencies:
@@ -17675,7 +17631,7 @@ snapshots:
   vitest@4.0.18(@opentelemetry/api@1.9.0)(@types/node@25.3.2)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.22.3):
     dependencies:
       '@vitest/expect': 4.0.18
-      '@vitest/mocker': 4.0.18(vite@7.3.3(@types/node@25.3.2)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.22.3))
+      '@vitest/mocker': 4.0.18(vite@7.3.3(@types/node@25.9.2)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.22.3))
       '@vitest/pretty-format': 4.0.18
       '@vitest/runner': 4.0.18
       '@vitest/snapshot': 4.0.18


### PR DESCRIPTION
Fixes #671

## What problems was I solving

Slack native streamed messages can stop accepting `chat.appendStream` / `chat.stopStream` calls while a long-running agent turn is still producing output. Slack reports that state as `message_not_in_streaming_state`; previously the adapter rejected and dropped later output.

This PR makes the Slack adapter treat that documented error as the recovery boundary: when the current native streamed message is no longer streamable, the adapter continues the turn in a fresh streamed message in the same thread and retries only the pending chunk.

## What user-facing changes did I ship

- [packages/adapter-slack/src/index.ts](https://github.com/vercel/chat/pull/672/files#diff-58a1ceb0817cf057cbb93be75aeea1543612f0deb4757c768bc9acecbc5636c5) — Slack native streams now recover reactively from `message_not_in_streaming_state` by starting a fresh stream and retrying only the pending markdown delta.
- [packages/adapter-slack/src/index.ts](https://github.com/vercel/chat/pull/672/files#diff-58a1ceb0817cf057cbb93be75aeea1543612f0deb4757c768bc9acecbc5636c5) — The adapter now calls `chat.startStream`, `chat.appendStream`, and `chat.stopStream` directly instead of going through `ChatStreamer`, so it owns stream lifecycle and confirmed-offset bookkeeping explicitly.
- [packages/adapter-slack/src/index.ts](https://github.com/vercel/chat/pull/672/files#diff-58a1ceb0817cf057cbb93be75aeea1543612f0deb4757c768bc9acecbc5636c5) — Latest structured task/plan chunks are re-seeded on rollover; fallback updates only the current message segment to avoid duplicating text already emitted in earlier rolled messages.
- [packages/adapter-slack/package.json](https://github.com/vercel/chat/pull/672/files#diff-47881123d78314450ff001368c44fbc372b2c39877816a231c632a236a58917d) — Keeps the Slack Web API floor at `^7.17.0` for the native stream chunk API surface used by the adapter.

## How I implemented it

- Removed the `ChatStreamer`/`buffer_size: 1` path and the open-code-fence-prefix workaround from the PR.
- Added direct native stream state tracking:
  - active Slack stream `ts`
  - last known message `ts`
  - current message start offset
  - last confirmed markdown offset
  - latest structured chunk snapshots
  - bounded rollover count
- On append expiry, the adapter starts a new stream in the same thread, optionally re-seeds latest structured chunks, and retries exactly the pending delta.
- On stop expiry, the adapter treats an already-flushed stream as complete; if final blocks or unconfirmed tail need recovery, it uses `chat.update` on the latest stream segment rather than duplicating the full cumulative answer.
- Updated adapter and integration tests to mock/assert direct Web API streaming methods instead of `chatStream()`.
- Added a patch changeset for `@chat-adapter/slack`.

## How to verify it

### Manual testing

- [ ] Start a Slack native stream, let Slack report `message_not_in_streaming_state`, and confirm later deltas continue in a fresh streamed message.
- [ ] Confirm task/plan progress chunks still appear after a rollover.
- [ ] Confirm stop-time expiry does not truncate an already-flushed response.

### Automated tests

```bash
pnpm --filter @chat-adapter/slack... build
pnpm --filter @chat-adapter/slack... typecheck
pnpm --filter @chat-adapter/slack test
pnpm check
pnpm validate
```

All of the above passed locally after the refactor.

## Changelog

`@chat-adapter/slack` now recovers expired Slack native streams by reactively rolling long-running replies onto fresh streamed messages without dropping pending text.
