### PR TITLE
fix(discord): Implement rehydrateAttachment

### DIFF
--- a/.changeset/discord-rehydrate-attachment.md
+++ b/.changeset/discord-rehydrate-attachment.md
@@ -1,0 +1,5 @@
+---
+"@chat-adapter/discord": patch
+---
+
+Implement `rehydrateAttachment` on the Discord adapter. Serialization strips an attachment's `fetchData` closure (queue/debounce strategies), and consumers rebuild it via `adapter.rehydrateAttachment`. The Discord adapter did not implement the method, so downstream consumers could not download inbound Discord attachments after deserialization. The Discord CDN `url` survives serialization, so `fetchData` is now rebuilt to fetch that url (preserving its signed query params), matching how the other adapters implement the method.

--- a/packages/adapter-discord/src/index.test.ts
+++ b/packages/adapter-discord/src/index.test.ts
@@ -1210,6 +1210,36 @@ describe("renderFormatted", () => {
   });
 });
 
+describe("rehydrateAttachment", () => {
+  const adapter = createDiscordAdapter({
+    botToken: "test-token",
+    publicKey: testPublicKey,
+    applicationId: "test-app-id",
+    logger: mockLogger,
+  });
+
+  it("rebuilds fetchData to download the attachment from its CDN url", async () => {
+    const url =
+      "https://cdn.discordapp.com/attachments/1/2/photo.png?ex=abc&is=def&hm=123";
+    const fetch = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValue(new Response("photo", { status: 200 }));
+
+    const attachment = adapter.rehydrateAttachment({ type: "image", url });
+    const data = await attachment.fetchData?.();
+
+    expect(data?.toString()).toBe("photo");
+    expect(fetch).toHaveBeenCalledWith(url);
+  });
+
+  it("returns the attachment unchanged when it has no url", () => {
+    const attachment = { type: "image" as const };
+    const rehydrated = adapter.rehydrateAttachment(attachment);
+    expect(rehydrated).toBe(attachment);
+    expect(rehydrated.fetchData).toBeUndefined();
+  });
+});
+
 // ============================================================================
 // Edge Cases
 // ============================================================================

--- a/packages/adapter-discord/src/index.ts
+++ b/packages/adapter-discord/src/index.ts
@@ -17,6 +17,7 @@ import type {
   ActionEvent,
   Adapter,
   AdapterPostableMessage,
+  Attachment,
   ChannelInfo,
   ChatInstance,
   EmojiValue,
@@ -1749,6 +1750,39 @@ export class DiscordAdapter implements Adapter<DiscordThreadId, unknown> {
       return "audio";
     }
     return "file";
+  }
+
+  rehydrateAttachment(attachment: Attachment): Attachment {
+    const url = attachment.fetchMetadata?.url ?? attachment.url;
+    if (!url) {
+      return attachment;
+    }
+    return {
+      ...attachment,
+      fetchData: () => this.downloadAttachment(url),
+    };
+  }
+
+  protected async downloadAttachment(url: string): Promise<Buffer> {
+    let response: Response;
+    try {
+      response = await fetch(url);
+    } catch (error) {
+      throw new NetworkError(
+        "discord",
+        "Failed to download Discord attachment",
+        error instanceof Error ? error : undefined
+      );
+    }
+
+    if (!response.ok) {
+      throw new NetworkError(
+        "discord",
+        `Failed to download Discord attachment: ${response.status}`
+      );
+    }
+
+    return Buffer.from(await response.arrayBuffer());
   }
 
   /**


### PR DESCRIPTION
## Summary

The Discord adapter never implemented `rehydrateAttachment`, so consumers couldn't rebuild an attachment's `fetchData` after a message was serialized and restored, and inbound Discord attachments couldn't be downloaded once rehydrated. Every other URL/media adapter implements it.

Discord attachment URLs are directly fetchable and survive serialization, so `fetchData` is rebuilt to fetch the URL (signed params preserved, no auth header — the links are pre-signed), reading `fetchMetadata?.url ?? attachment.url` like the other URL-based adapters. Returns the attachment unchanged when there's no URL.

Adds unit tests and a changeset.

## Test plan

- `pnpm --filter @chat-adapter/discord test` — 248 passing
- `pnpm validate`