### PR TITLE
feat(docs): add X logo to homepage and balance mobile logo wrap

### DIFF
--- a/apps/docs/app/[lang]/(home)/components/supported-platforms.tsx
+++ b/apps/docs/app/[lang]/(home)/components/supported-platforms.tsx
@@ -11,6 +11,7 @@ import {
   telegram,
   twilio,
   whatsapp,
+  x,
 } from "@/lib/logos";
 
 const platforms: {
@@ -25,6 +26,7 @@ const platforms: {
   { icon: whatsapp, name: "WhatsApp", slug: "whatsapp" },
   { icon: twilio, name: "Twilio", slug: "twilio" },
   { icon: messenger, name: "Messenger", slug: "messenger" },
+  { icon: x, name: "X", slug: "x" },
   { icon: github, name: "GitHub", slug: "github" },
   { icon: linear, name: "Linear", slug: "linear" },
   { icon: telegram, name: "Telegram", slug: "telegram" },
@@ -58,7 +60,7 @@ export const SupportedPlatforms = () => (
         The open-source chat toolkit designed to help developers build chat bots
         that run on Slack, Teams, Google Chat, Discord, WhatsApp, and more.
       </p>
-      <div className="mx-auto mt-2 flex flex-wrap items-center justify-center gap-3 sm:gap-4">
+      <div className="mx-auto mt-2 flex max-w-64 flex-wrap items-center justify-center gap-3 sm:max-w-none sm:gap-4">
         {platforms.map((platform) => (
           <Link
             aria-label={platform.name}


### PR DESCRIPTION
## What

- Add the new **X** adapter logo to the homepage supported-platforms grid, placed after Messenger.
- Cap the grid width on mobile (`max-w-64`, reset with `sm:max-w-none`) so the logos wrap **4 / 4 / 3** instead of orphaning a single logo (Telegram) on its own line.

## Why

We now ship an `@chat-adapter/x` adapter, so X belongs in the homepage lineup. With 11 logos, the previous flex-wrap fit 5 per row on phones, producing a lonely 5 / 5 / 1 break. Constraining the container forces even, centered rows down to 320px-wide screens.

## Notes

- The `x` logo SVG and the `/adapters/official/x` page already exist (added in a prior change from `main`); this only wires X into the homepage grid.
- Docs-only change — no changeset required.