### PR TITLE
chore(examples): switch demo AI model to anthropic/claude-sonnet-5

### DIFF
--- a/examples/nextjs-chat/src/lib/bot.tsx
+++ b/examples/nextjs-chat/src/lib/bot.tsx
@@ -89,7 +89,7 @@ export const bot = new Chat<typeof adapters, ThreadState>({
 
 // AI agent for AI mode
 const agent = new ToolLoopAgent({
-  model: "xai/grok-4.5",
+  model: "anthropic/claude-sonnet-5",
   instructions:
     "You are a helpful assistant in a chat thread. Answer the user's queries in a concise manner.",
 });
@@ -620,7 +620,7 @@ bot.onAction("agent-demo", async (event) => {
   await thread.startTyping("Running agent...");
   try {
     const result = await generateText({
-      model: "xai/grok-4.5",
+      model: "anthropic/claude-sonnet-5",
       tools,
       stopWhen: ({ steps }) => steps.length >= 6,
       system: [
@@ -673,7 +673,7 @@ bot.onSlashCommand("/agent", async (event) => {
   });
 
   const toolAgent = new ToolLoopAgent({
-    model: "xai/grok-4.5",
+    model: "anthropic/claude-sonnet-5",
     tools,
     stopWhen: ({ steps }) => steps.length >= 8,
     instructions: [

--- a/examples/nuxt-chat/server/lib/bot.tsx
+++ b/examples/nuxt-chat/server/lib/bot.tsx
@@ -63,7 +63,7 @@ export const bot = new Chat<typeof adapters, ThreadState>({
 });
 
 const agent = new ToolLoopAgent({
-  model: "xai/grok-4.5",
+  model: "anthropic/claude-sonnet-5",
   instructions:
     "You are a helpful assistant in a chat thread. Answer the user's queries in a concise manner.",
 });
@@ -488,7 +488,7 @@ bot.onAction("agent-demo", async (event) => {
   await thread.startTyping("Running agent...");
   try {
     const result = await generateText({
-      model: "xai/grok-4.5",
+      model: "anthropic/claude-sonnet-5",
       tools,
       stopWhen: ({ steps }) => steps.length >= 6,
       system: [
@@ -582,7 +582,7 @@ bot.onSlashCommand("/agent", async (event) => {
   });
 
   const toolAgent = new ToolLoopAgent({
-    model: "xai/grok-4.5",
+    model: "anthropic/claude-sonnet-5",
     tools,
     stopWhen: ({ steps }) => steps.length >= 8,
     instructions: [


### PR DESCRIPTION
## Summary
- Update Next.js and Nuxt example bots from `xai/grok-4.5` to `anthropic/claude-sonnet-5` (6 model string sites total).

## Test plan
- [x] Confirm example bots still start
- [x] Trigger AI mode in an example and verify requests go to Claude Sonnet 5