### PR TITLE
feat: support AI SDK v7 (ai@7) as a peer dependency

### DIFF
--- a/.changeset/support-ai-sdk-v7.md
+++ b/.changeset/support-ai-sdk-v7.md
@@ -1,0 +1,10 @@
+---
+"chat": minor
+"@chat-adapter/web": minor
+---
+
+Support AI SDK v7 as a peer dependency.
+
+- `chat` now accepts `ai@^6.0.182 || ^7.0.0` (`chat/ai` tools work with both majors).
+- `@chat-adapter/web` now accepts `ai@^6 || ^7`, `@ai-sdk/react@^3 || ^4`, `@ai-sdk/svelte@^4 || ^5`, and `@ai-sdk/vue@^3 || ^4`.
+- The `chat/ai` tool factories now declare explicit `Tool<Input, Output>` return types instead of relying on inference, so the published declarations no longer depend on `ai` internals that changed in v7. The public type surface is unchanged.

--- a/examples/nextjs-chat/package.json
+++ b/examples/nextjs-chat/package.json
@@ -11,7 +11,7 @@
     "recording:export": "tsx src/lib/recorder.ts"
   },
   "dependencies": {
-    "@ai-sdk/react": "^3.0.184",
+    "@ai-sdk/react": "^4.0.0",
     "@chat-adapter/discord": "workspace:*",
     "@chat-adapter/gchat": "workspace:*",
     "@chat-adapter/github": "workspace:*",
@@ -27,7 +27,7 @@
     "@tailwindcss/postcss": "^4.1.18",
     "@vercel/connect": "^0.3.0",
     "@vercel/oidc": "^3.7.0",
-    "ai": "^6.0.182",
+    "ai": "^7.0.0",
     "chat": "workspace:*",
     "next": "^16.2.6",
     "react": "^19.0.0",

--- a/examples/nuxt-chat/package.json
+++ b/examples/nuxt-chat/package.json
@@ -11,12 +11,12 @@
     "typecheck": "nuxt typecheck"
   },
   "dependencies": {
-    "@ai-sdk/vue": "^3.0.182",
+    "@ai-sdk/vue": "^4.0.0",
     "@chat-adapter/slack": "workspace:*",
     "@chat-adapter/state-memory": "workspace:*",
     "@chat-adapter/state-redis": "workspace:*",
     "@chat-adapter/web": "workspace:*",
-    "ai": "^6.0.182",
+    "ai": "^7.0.0",
     "chat": "workspace:*",
     "h3": "2.0.1-rc.22",
     "nuxt": "~4.4.7",

--- a/packages/adapter-web/package.json
+++ b/packages/adapter-web/package.json
@@ -43,10 +43,10 @@
     "chat": "workspace:*"
   },
   "peerDependencies": {
-    "@ai-sdk/react": "^3",
-    "@ai-sdk/svelte": "^4",
-    "@ai-sdk/vue": "^3",
-    "ai": "^6",
+    "@ai-sdk/react": "^3 || ^4",
+    "@ai-sdk/svelte": "^4 || ^5",
+    "@ai-sdk/vue": "^3 || ^4",
+    "ai": "^6 || ^7",
     "react": "^19",
     "svelte": "^5",
     "vue": "^3"
@@ -72,15 +72,15 @@
     }
   },
   "devDependencies": {
-    "@ai-sdk/react": "^3.0.184",
-    "@ai-sdk/svelte": "^4.0.182",
-    "@ai-sdk/vue": "^3.0.182",
+    "@ai-sdk/react": "^4.0.0",
+    "@ai-sdk/svelte": "^5.0.0",
+    "@ai-sdk/vue": "^4.0.0",
     "@chat-adapter/state-memory": "workspace:*",
     "@chat-adapter/tests": "workspace:*",
     "@types/node": "^25.3.2",
     "@types/react": "^19.0.1",
     "@vitest/coverage-v8": "^4.0.18",
-    "ai": "^6.0.182",
+    "ai": "^7.0.0",
     "react": "^19.0.0",
     "svelte": "^5.55.7",
     "tsup": "^8.3.5",

--- a/packages/chat/package.json
+++ b/packages/chat/package.json
@@ -56,14 +56,14 @@
   "devDependencies": {
     "@types/mdast": "^4.0.4",
     "@types/node": "^25.3.2",
-    "ai": "^6.0.182",
+    "ai": "^7.0.0",
     "tsup": "^8.3.5",
     "typescript": "^5.7.2",
     "vitest": "^4.0.18",
     "zod": "^4.3.6"
   },
   "peerDependencies": {
-    "ai": "^6.0.182",
+    "ai": "^6.0.182 || ^7.0.0",
     "zod": "^3.0.0 || ^4.0.0"
   },
   "peerDependenciesMeta": {

--- a/packages/chat/src/ai/index.test.ts
+++ b/packages/chat/src/ai/index.test.ts
@@ -1,4 +1,4 @@
-import type { ToolExecutionOptions } from "ai";
+import type { Tool } from "ai";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { Chat } from "../chat";
 import {
@@ -15,11 +15,14 @@ const NO_FETCH_CHANNEL_MESSAGES_REGEX =
   /does not support fetching channel messages/;
 const NO_LIST_THREADS_REGEX = /does not support listing threads/;
 
-// Minimal ToolExecutionOptions stub used by every test below.
+// Minimal tool execution options stub used by every test below. Derived from
+// `Tool["execute"]` so the same code typechecks against both ai v6 and v7
+// (v7 made the `ToolExecutionOptions` generic parameter required).
+type ToolExecOptions = Parameters<NonNullable<Tool["execute"]>>[1];
 const TOOL_OPTIONS = {
   toolCallId: "t1",
   messages: [],
-} as unknown as ToolExecutionOptions;
+} as unknown as ToolExecOptions;
 
 describe("createChatTools", () => {
   let chat: Chat<{ slack: Adapter }>;

--- a/packages/chat/src/ai/tools/channels.ts
+++ b/packages/chat/src/ai/tools/channels.ts
@@ -1,16 +1,33 @@
-import { tool } from "ai";
+import { type Tool, tool } from "ai";
 import { z } from "zod";
+import type { ChannelVisibility } from "../../types";
 import type { ChatBinding } from "../types";
 
-export const getChannelInfo = (chat: ChatBinding) =>
+// The explicit `Tool<Input, Output>` return type keeps the emitted
+// declarations on types exported from `ai`. Relying on inference would
+// surface `ai` internals (e.g. `ExecutableTool` from
+// `@ai-sdk/provider-utils`) that consumers cannot resolve.
+
+const GET_CHANNEL_INFO_INPUT = z.object({
+  channelId: z.string().describe("Full channel id including adapter prefix"),
+});
+
+export const getChannelInfo = (
+  chat: ChatBinding
+): Tool<
+  z.infer<typeof GET_CHANNEL_INFO_INPUT>,
+  {
+    id: string;
+    name: string | undefined;
+    isDM: boolean;
+    memberCount: number | undefined;
+    channelVisibility: ChannelVisibility | undefined;
+  }
+> =>
   tool({
     description:
       "Fetch metadata for a channel: name, member count, DM status, visibility, etc. Use to identify a channel before posting.",
-    inputSchema: z.object({
-      channelId: z
-        .string()
-        .describe("Full channel id including adapter prefix"),
-    }),
+    inputSchema: GET_CHANNEL_INFO_INPUT,
     execute: async ({ channelId }) => {
       const channel = chat.channel(channelId);
       const info = await channel.fetchMetadata();

--- a/packages/chat/src/ai/tools/messages.ts
+++ b/packages/chat/src/ai/tools/messages.ts
@@ -1,4 +1,4 @@
-import { tool } from "ai";
+import { type Tool, tool } from "ai";
 import { z } from "zod";
 import type { ChatBinding, ToolOptions } from "../types";
 
@@ -16,18 +16,28 @@ const POSTABLE_INPUT = z
 
 type PostableInput = z.infer<typeof POSTABLE_INPUT>;
 
+// Tool factories carry explicit `Tool<Input, Output>` return types so the
+// emitted declarations only reference types exported from `ai`. Relying on
+// inference would surface `ai` internals (e.g. `ExecutableTool` from
+// `@ai-sdk/provider-utils`) that consumers cannot resolve.
+
+const POST_MESSAGE_INPUT = z.object({
+  threadId: z.string().describe("Full thread id including adapter prefix"),
+  message: POSTABLE_INPUT,
+});
+
 export const postMessage = (
   chat: ChatBinding,
   { needsApproval = true }: ToolOptions = {}
-) =>
+): Tool<
+  z.infer<typeof POST_MESSAGE_INPUT>,
+  { messageId: string; threadId: string }
+> =>
   tool({
     description:
       "Post a message inside an existing thread. Use this to reply within a conversation the bot already has context for. The threadId is the full id (e.g. 'slack:C123:1234567890.123456').",
     needsApproval,
-    inputSchema: z.object({
-      threadId: z.string().describe("Full thread id including adapter prefix"),
-      message: POSTABLE_INPUT,
-    }),
+    inputSchema: POST_MESSAGE_INPUT,
     execute: async ({ threadId, message }) => {
       const thread = chat.thread(threadId);
       const sent = await thread.post(toPostable(message));
@@ -38,20 +48,23 @@ export const postMessage = (
     },
   });
 
+const POST_CHANNEL_MESSAGE_INPUT = z.object({
+  channelId: z.string().describe("Full channel id including adapter prefix"),
+  message: POSTABLE_INPUT,
+});
+
 export const postChannelMessage = (
   chat: ChatBinding,
   { needsApproval = true }: ToolOptions = {}
-) =>
+): Tool<
+  z.infer<typeof POST_CHANNEL_MESSAGE_INPUT>,
+  { messageId: string; threadId: string }
+> =>
   tool({
     description:
       "Post a top-level message to a channel (not threaded under an existing message). The channelId is the full id (e.g. 'slack:C123ABC').",
     needsApproval,
-    inputSchema: z.object({
-      channelId: z
-        .string()
-        .describe("Full channel id including adapter prefix"),
-      message: POSTABLE_INPUT,
-    }),
+    inputSchema: POST_CHANNEL_MESSAGE_INPUT,
     execute: async ({ channelId, message }) => {
       const channel = chat.channel(channelId);
       const sent = await channel.post(toPostable(message));
@@ -62,20 +75,25 @@ export const postChannelMessage = (
     },
   });
 
+const SEND_DIRECT_MESSAGE_INPUT = z.object({
+  userId: z
+    .string()
+    .describe("Platform-specific user id; the adapter is auto-detected"),
+  message: POSTABLE_INPUT,
+});
+
 export const sendDirectMessage = (
   chat: ChatBinding,
   { needsApproval = true }: ToolOptions = {}
-) =>
+): Tool<
+  z.infer<typeof SEND_DIRECT_MESSAGE_INPUT>,
+  { messageId: string; threadId: string }
+> =>
   tool({
     description:
       "Open (or reuse) a 1:1 direct-message conversation with a user and post a message in it. The userId format is platform-specific (e.g. 'U123456' for Slack, 'users/123' for Google Chat).",
     needsApproval,
-    inputSchema: z.object({
-      userId: z
-        .string()
-        .describe("Platform-specific user id; the adapter is auto-detected"),
-      message: POSTABLE_INPUT,
-    }),
+    inputSchema: SEND_DIRECT_MESSAGE_INPUT,
     execute: async ({ userId, message }) => {
       const dm = await chat.openDM(userId);
       const sent = await dm.post(toPostable(message));
@@ -86,21 +104,26 @@ export const sendDirectMessage = (
     },
   });
 
+const EDIT_MESSAGE_INPUT = z.object({
+  threadId: z.string().describe("Full thread id"),
+  messageId: z
+    .string()
+    .describe("Platform-specific message id of the message to edit"),
+  message: POSTABLE_INPUT,
+});
+
 export const editMessage = (
   chat: ChatBinding,
   { needsApproval = true }: ToolOptions = {}
-) =>
+): Tool<
+  z.infer<typeof EDIT_MESSAGE_INPUT>,
+  { messageId: string; threadId: string }
+> =>
   tool({
     description:
       "Edit a previously posted message in a thread. Replaces the existing message body. Only messages the bot itself authored can be edited on most platforms.",
     needsApproval,
-    inputSchema: z.object({
-      threadId: z.string().describe("Full thread id"),
-      messageId: z
-        .string()
-        .describe("Platform-specific message id of the message to edit"),
-      message: POSTABLE_INPUT,
-    }),
+    inputSchema: EDIT_MESSAGE_INPUT,
     execute: async ({ threadId, messageId, message }) => {
       const thread = chat.thread(threadId);
       const result = await thread.adapter.editMessage(
@@ -112,21 +135,29 @@ export const editMessage = (
     },
   });
 
+const DELETE_MESSAGE_INPUT = z.object({
+  threadId: z.string().describe("Full thread id"),
+  messageId: z
+    .string()
+    .describe("Platform-specific message id of the message to delete"),
+});
+
 export const deleteMessage = (
   chat: ChatBinding,
   { needsApproval = true }: ToolOptions = {}
-) =>
+): Tool<
+  z.infer<typeof DELETE_MESSAGE_INPUT>,
+  { deleted: boolean; messageId: string; threadId: string }
+> =>
   tool({
     description:
       "Delete a message from a thread. Only messages the bot itself authored can be deleted on most platforms.",
     needsApproval,
-    inputSchema: z.object({
-      threadId: z.string().describe("Full thread id"),
-      messageId: z
-        .string()
-        .describe("Platform-specific message id of the message to delete"),
-    }),
-    execute: async ({ threadId, messageId }) => {
+    inputSchema: DELETE_MESSAGE_INPUT,
+    execute: async ({
+      threadId,
+      messageId,
+    }): Promise<{ deleted: boolean; messageId: string; threadId: string }> => {
       const thread = chat.thread(threadId);
       await thread.adapter.deleteMessage(threadId, messageId);
       return { deleted: true, messageId, threadId };

--- a/packages/chat/src/ai/tools/reactions.ts
+++ b/packages/chat/src/ai/tools/reactions.ts
@@ -1,53 +1,82 @@
-import { tool } from "ai";
+import { type Tool, tool } from "ai";
 import { z } from "zod";
 import type { ChatBinding, ToolOptions } from "../types";
+
+// Tool factories carry explicit `Tool<Input, Output>` return types so the
+// emitted declarations only reference types exported from `ai`. Relying on
+// inference would surface `ai` internals (e.g. `ExecutableTool` from
+// `@ai-sdk/provider-utils`) that consumers cannot resolve.
+
+const ADD_REACTION_INPUT = z.object({
+  threadId: z.string().describe("Full thread id"),
+  messageId: z.string().describe("Platform-specific message id to react to"),
+  emoji: z
+    .string()
+    .describe(
+      "Emoji name or platform shortcode (e.g. 'thumbs_up', 'white_check_mark')"
+    ),
+});
 
 export const addReaction = (
   chat: ChatBinding,
   { needsApproval = true }: ToolOptions = {}
-) =>
+): Tool<
+  z.infer<typeof ADD_REACTION_INPUT>,
+  { added: boolean; emoji: string; messageId: string; threadId: string }
+> =>
   tool({
     description:
       "Add an emoji reaction to a specific message. Use a well-known emoji name (e.g. 'thumbs_up', 'heart', 'check') or a platform-native shorthand.",
     needsApproval,
-    inputSchema: z.object({
-      threadId: z.string().describe("Full thread id"),
-      messageId: z
-        .string()
-        .describe("Platform-specific message id to react to"),
-      emoji: z
-        .string()
-        .describe(
-          "Emoji name or platform shortcode (e.g. 'thumbs_up', 'white_check_mark')"
-        ),
-    }),
-    execute: async ({ threadId, messageId, emoji }) => {
+    inputSchema: ADD_REACTION_INPUT,
+    execute: async ({
+      threadId,
+      messageId,
+      emoji,
+    }): Promise<{
+      added: boolean;
+      emoji: string;
+      messageId: string;
+      threadId: string;
+    }> => {
       const thread = chat.thread(threadId);
       await thread.adapter.addReaction(threadId, messageId, emoji);
       return { added: true, emoji, messageId, threadId };
     },
   });
 
+const REMOVE_REACTION_INPUT = z.object({
+  threadId: z.string().describe("Full thread id"),
+  messageId: z
+    .string()
+    .describe("Platform-specific message id to remove the reaction from"),
+  emoji: z
+    .string()
+    .describe("Emoji name or platform shortcode previously added by the bot"),
+});
+
 export const removeReaction = (
   chat: ChatBinding,
   { needsApproval = true }: ToolOptions = {}
-) =>
+): Tool<
+  z.infer<typeof REMOVE_REACTION_INPUT>,
+  { removed: boolean; emoji: string; messageId: string; threadId: string }
+> =>
   tool({
     description:
       "Remove an emoji reaction the bot previously added to a message.",
     needsApproval,
-    inputSchema: z.object({
-      threadId: z.string().describe("Full thread id"),
-      messageId: z
-        .string()
-        .describe("Platform-specific message id to remove the reaction from"),
-      emoji: z
-        .string()
-        .describe(
-          "Emoji name or platform shortcode previously added by the bot"
-        ),
-    }),
-    execute: async ({ threadId, messageId, emoji }) => {
+    inputSchema: REMOVE_REACTION_INPUT,
+    execute: async ({
+      threadId,
+      messageId,
+      emoji,
+    }): Promise<{
+      removed: boolean;
+      emoji: string;
+      messageId: string;
+      threadId: string;
+    }> => {
       const thread = chat.thread(threadId);
       await thread.adapter.removeReaction(threadId, messageId, emoji);
       return { removed: true, emoji, messageId, threadId };

--- a/packages/chat/src/ai/tools/threads.ts
+++ b/packages/chat/src/ai/tools/threads.ts
@@ -1,7 +1,7 @@
-import { tool } from "ai";
+import { type Tool, tool } from "ai";
 import { z } from "zod";
 import type { Message } from "../../message";
-import type { ThreadSummary } from "../../types";
+import type { ChannelVisibility, ThreadSummary } from "../../types";
 import type { ChatBinding, ToolOptions } from "../types";
 
 const FETCH_DIRECTION = z
@@ -33,28 +33,42 @@ function projectMessage(message: Message) {
   };
 }
 
-export const fetchMessages = (chat: ChatBinding) =>
+type ProjectedMessage = ReturnType<typeof projectMessage>;
+
+// Tool factories carry explicit `Tool<Input, Output>` return types so the
+// emitted declarations only reference types exported from `ai`. Relying on
+// inference would surface `ai` internals (e.g. `ExecutableTool` from
+// `@ai-sdk/provider-utils`) that consumers cannot resolve.
+
+const FETCH_MESSAGES_INPUT = z.object({
+  threadId: z.string().describe("Full thread id"),
+  limit: z
+    .number()
+    .int()
+    .min(1)
+    .max(100)
+    .optional()
+    .default(20)
+    .describe("Maximum number of messages to fetch"),
+  cursor: z
+    .string()
+    .optional()
+    .describe("Pagination cursor from a previous fetchMessages call"),
+  direction: FETCH_DIRECTION.describe(
+    "'backward' (default) returns the most recent messages; 'forward' iterates from the oldest"
+  ),
+});
+
+export const fetchMessages = (
+  chat: ChatBinding
+): Tool<
+  z.infer<typeof FETCH_MESSAGES_INPUT>,
+  { messages: ProjectedMessage[]; nextCursor: string | undefined }
+> =>
   tool({
     description:
       "Fetch recent messages from a thread, ordered chronologically (oldest first within the page). Use to read the conversation before responding.",
-    inputSchema: z.object({
-      threadId: z.string().describe("Full thread id"),
-      limit: z
-        .number()
-        .int()
-        .min(1)
-        .max(100)
-        .optional()
-        .default(20)
-        .describe("Maximum number of messages to fetch"),
-      cursor: z
-        .string()
-        .optional()
-        .describe("Pagination cursor from a previous fetchMessages call"),
-      direction: FETCH_DIRECTION.describe(
-        "'backward' (default) returns the most recent messages; 'forward' iterates from the oldest"
-      ),
-    }),
+    inputSchema: FETCH_MESSAGES_INPUT,
     execute: async ({ threadId, limit, cursor, direction }) => {
       const thread = chat.thread(threadId);
       const result = await thread.adapter.fetchMessages(threadId, {
@@ -69,16 +83,23 @@ export const fetchMessages = (chat: ChatBinding) =>
     },
   });
 
-export const fetchChannelMessages = (chat: ChatBinding) =>
+const FETCH_CHANNEL_MESSAGES_INPUT = z.object({
+  channelId: z.string().describe("Full channel id"),
+  limit: z.number().int().min(1).max(100).optional().default(20),
+  cursor: z.string().optional(),
+  direction: FETCH_DIRECTION,
+});
+
+export const fetchChannelMessages = (
+  chat: ChatBinding
+): Tool<
+  z.infer<typeof FETCH_CHANNEL_MESSAGES_INPUT>,
+  { messages: ProjectedMessage[]; nextCursor: string | undefined }
+> =>
   tool({
     description:
       "Fetch top-level messages in a channel (not thread replies). Returns messages in chronological order within the page.",
-    inputSchema: z.object({
-      channelId: z.string().describe("Full channel id"),
-      limit: z.number().int().min(1).max(100).optional().default(20),
-      cursor: z.string().optional(),
-      direction: FETCH_DIRECTION,
-    }),
+    inputSchema: FETCH_CHANNEL_MESSAGES_INPUT,
     execute: async ({ channelId, limit, cursor, direction }) => {
       const adapterName = channelId.split(":")[0];
       const adapter = adapterName ? chat.getAdapter(adapterName) : undefined;
@@ -99,13 +120,26 @@ export const fetchChannelMessages = (chat: ChatBinding) =>
     },
   });
 
-export const fetchThread = (chat: ChatBinding) =>
+const FETCH_THREAD_INPUT = z.object({
+  threadId: z.string().describe("Full thread id"),
+});
+
+export const fetchThread = (
+  chat: ChatBinding
+): Tool<
+  z.infer<typeof FETCH_THREAD_INPUT>,
+  {
+    id: string;
+    channelId: string;
+    channelName: string | undefined;
+    channelVisibility: ChannelVisibility | undefined;
+    isDM: boolean;
+  }
+> =>
   tool({
     description:
       "Fetch metadata about a thread (channel id, channel name, visibility, DM status, etc).",
-    inputSchema: z.object({
-      threadId: z.string().describe("Full thread id"),
-    }),
+    inputSchema: FETCH_THREAD_INPUT,
     execute: async ({ threadId }) => {
       const thread = chat.thread(threadId);
       const info = await thread.adapter.fetchThread(threadId);
@@ -119,15 +153,30 @@ export const fetchThread = (chat: ChatBinding) =>
     },
   });
 
-export const listThreads = (chat: ChatBinding) =>
+const LIST_THREADS_INPUT = z.object({
+  channelId: z.string().describe("Full channel id"),
+  limit: z.number().int().min(1).max(100).optional().default(20),
+  cursor: z.string().optional(),
+});
+
+export const listThreads = (
+  chat: ChatBinding
+): Tool<
+  z.infer<typeof LIST_THREADS_INPUT>,
+  {
+    threads: {
+      id: string;
+      replyCount: number | undefined;
+      lastReplyAt: string | undefined;
+      rootMessage: ProjectedMessage;
+    }[];
+    nextCursor: string | undefined;
+  }
+> =>
   tool({
     description:
       "List recent threads in a channel. Returns lightweight summaries with the root message of each thread.",
-    inputSchema: z.object({
-      channelId: z.string().describe("Full channel id"),
-      limit: z.number().int().min(1).max(100).optional().default(20),
-      cursor: z.string().optional(),
-    }),
+    inputSchema: LIST_THREADS_INPUT,
     execute: async ({ channelId, limit, cursor }) => {
       const adapterName = channelId.split(":")[0];
       const adapter = adapterName ? chat.getAdapter(adapterName) : undefined;
@@ -149,13 +198,27 @@ export const listThreads = (chat: ChatBinding) =>
     },
   });
 
-export const getThreadParticipants = (chat: ChatBinding) =>
+const GET_THREAD_PARTICIPANTS_INPUT = z.object({
+  threadId: z.string().describe("Full thread id"),
+});
+
+export const getThreadParticipants = (
+  chat: ChatBinding
+): Tool<
+  z.infer<typeof GET_THREAD_PARTICIPANTS_INPUT>,
+  {
+    participants: {
+      userId: string;
+      userName: string;
+      fullName: string;
+      isBot: boolean | "unknown";
+    }[];
+  }
+> =>
   tool({
     description:
       "Return the unique non-bot participants in a thread. Useful for deciding whether to subscribe (1:1) or stay quiet (group).",
-    inputSchema: z.object({
-      threadId: z.string().describe("Full thread id"),
-    }),
+    inputSchema: GET_THREAD_PARTICIPANTS_INPUT,
     execute: async ({ threadId }) => {
       const thread = chat.thread(threadId);
       const participants = await thread.getParticipants();
@@ -170,56 +233,80 @@ export const getThreadParticipants = (chat: ChatBinding) =>
     },
   });
 
+const SUBSCRIBE_THREAD_INPUT = z.object({
+  threadId: z.string().describe("Full thread id to subscribe to"),
+});
+
 export const subscribeThread = (
   chat: ChatBinding,
   { needsApproval = true }: ToolOptions = {}
-) =>
+): Tool<
+  z.infer<typeof SUBSCRIBE_THREAD_INPUT>,
+  { subscribed: boolean; threadId: string }
+> =>
   tool({
     description:
       "Subscribe to all future messages in a thread. After subscribing, the bot will receive every message in this thread (not just @mentions).",
     needsApproval,
-    inputSchema: z.object({
-      threadId: z.string().describe("Full thread id to subscribe to"),
-    }),
-    execute: async ({ threadId }) => {
+    inputSchema: SUBSCRIBE_THREAD_INPUT,
+    execute: async ({
+      threadId,
+    }): Promise<{ subscribed: boolean; threadId: string }> => {
       const thread = chat.thread(threadId);
       await thread.subscribe();
       return { subscribed: true, threadId };
     },
   });
 
+const UNSUBSCRIBE_THREAD_INPUT = z.object({
+  threadId: z.string().describe("Full thread id to unsubscribe from"),
+});
+
 export const unsubscribeThread = (
   chat: ChatBinding,
   { needsApproval = true }: ToolOptions = {}
-) =>
+): Tool<
+  z.infer<typeof UNSUBSCRIBE_THREAD_INPUT>,
+  { subscribed: boolean; threadId: string }
+> =>
   tool({
     description:
       "Unsubscribe from a thread. The bot will stop receiving non-mention messages in this thread.",
     needsApproval,
-    inputSchema: z.object({
-      threadId: z.string().describe("Full thread id to unsubscribe from"),
-    }),
-    execute: async ({ threadId }) => {
+    inputSchema: UNSUBSCRIBE_THREAD_INPUT,
+    execute: async ({
+      threadId,
+    }): Promise<{ subscribed: boolean; threadId: string }> => {
       const thread = chat.thread(threadId);
       await thread.unsubscribe();
       return { subscribed: false, threadId };
     },
   });
 
-export const startTyping = (chat: ChatBinding) =>
+const START_TYPING_INPUT = z.object({
+  threadId: z.string().describe("Full thread id"),
+  status: z
+    .string()
+    .optional()
+    .describe(
+      "Optional human-readable status (some platforms display this, others ignore it)"
+    ),
+});
+
+export const startTyping = (
+  chat: ChatBinding
+): Tool<
+  z.infer<typeof START_TYPING_INPUT>,
+  { typing: boolean; threadId: string }
+> =>
   tool({
     description:
       "Show a typing indicator in a thread. Use this when starting a long-running operation so users know the bot is working.",
-    inputSchema: z.object({
-      threadId: z.string().describe("Full thread id"),
-      status: z
-        .string()
-        .optional()
-        .describe(
-          "Optional human-readable status (some platforms display this, others ignore it)"
-        ),
-    }),
-    execute: async ({ threadId, status }) => {
+    inputSchema: START_TYPING_INPUT,
+    execute: async ({
+      threadId,
+      status,
+    }): Promise<{ typing: boolean; threadId: string }> => {
       const thread = chat.thread(threadId);
       await thread.startTyping(status);
       return { typing: true, threadId };

--- a/packages/chat/src/ai/tools/users.ts
+++ b/packages/chat/src/ai/tools/users.ts
@@ -1,16 +1,35 @@
-import { tool } from "ai";
+import { type Tool, tool } from "ai";
 import { z } from "zod";
 import type { ChatBinding } from "../types";
 
-export const getUser = (chat: ChatBinding) =>
+// The explicit `Tool<Input, Output>` return type keeps the emitted
+// declarations on types exported from `ai`. Relying on inference would
+// surface `ai` internals (e.g. `ExecutableTool` from
+// `@ai-sdk/provider-utils`) that consumers cannot resolve.
+
+const GET_USER_INPUT = z.object({
+  userId: z
+    .string()
+    .describe("Platform-specific user id; the adapter is auto-detected"),
+});
+
+export const getUser = (
+  chat: ChatBinding
+): Tool<
+  z.infer<typeof GET_USER_INPUT>,
+  {
+    userId: string;
+    userName: string;
+    fullName: string;
+    email: string | undefined;
+    isBot: boolean;
+    avatarUrl: string | undefined;
+  } | null
+> =>
   tool({
     description:
       "Look up profile information about a user by their platform-specific id (e.g. 'U123456' for Slack, '29:...' for Teams, 'users/123' for Google Chat). Returns null if the user is unknown.",
-    inputSchema: z.object({
-      userId: z
-        .string()
-        .describe("Platform-specific user id; the adapter is auto-detected"),
-    }),
+    inputSchema: GET_USER_INPUT,
     execute: async ({ userId }) => {
       const user = await chat.getUser(userId);
       if (!user) {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -173,8 +173,8 @@ importers:
   examples/nextjs-chat:
     dependencies:
       '@ai-sdk/react':
-        specifier: ^3.0.184
-        version: 3.0.184(react@19.2.3)(zod@4.3.6)
+        specifier: ^4.0.0
+        version: 4.0.18(react@19.2.3)(zod@4.3.6)
       '@chat-adapter/discord':
         specifier: workspace:*
         version: link:../../packages/adapter-discord
@@ -216,13 +216,13 @@ importers:
         version: 4.1.18
       '@vercel/connect':
         specifier: ^0.3.0
-        version: 0.3.0(@chat-adapter/slack@packages+adapter-slack)(ai@6.0.182(zod@4.3.6))
+        version: 0.3.0(@ai-sdk/mcp@2.0.8(zod@4.3.6))(@chat-adapter/slack@packages+adapter-slack)(ai@7.0.17(zod@4.3.6))
       '@vercel/oidc':
         specifier: ^3.7.0
         version: 3.7.0
       ai:
-        specifier: ^6.0.182
-        version: 6.0.182(zod@4.3.6)
+        specifier: ^7.0.0
+        version: 7.0.17(zod@4.3.6)
       chat:
         specifier: workspace:*
         version: link:../../packages/chat
@@ -270,8 +270,8 @@ importers:
   examples/nuxt-chat:
     dependencies:
       '@ai-sdk/vue':
-        specifier: ^3.0.182
-        version: 3.0.182(vue@3.5.34(typescript@5.9.3))(zod@4.3.6)
+        specifier: ^4.0.0
+        version: 4.0.17(vue@3.5.34(typescript@5.9.3))(zod@4.3.6)
       '@chat-adapter/slack':
         specifier: workspace:*
         version: link:../../packages/adapter-slack
@@ -285,8 +285,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/adapter-web
       ai:
-        specifier: ^6.0.182
-        version: 6.0.182(zod@4.3.6)
+        specifier: ^7.0.0
+        version: 7.0.17(zod@4.3.6)
       chat:
         specifier: workspace:*
         version: link:../../packages/chat
@@ -628,14 +628,14 @@ importers:
         version: link:../chat
     devDependencies:
       '@ai-sdk/react':
-        specifier: ^3.0.184
-        version: 3.0.184(react@19.2.3)(zod@4.3.6)
+        specifier: ^4.0.0
+        version: 4.0.18(react@19.2.3)(zod@4.3.6)
       '@ai-sdk/svelte':
-        specifier: ^4.0.182
-        version: 4.0.182(svelte@5.55.7)(zod@4.3.6)
+        specifier: ^5.0.0
+        version: 5.0.17(svelte@5.55.7)(zod@4.3.6)
       '@ai-sdk/vue':
-        specifier: ^3.0.182
-        version: 3.0.182(vue@3.5.34(typescript@5.9.3))(zod@4.3.6)
+        specifier: ^4.0.0
+        version: 4.0.17(vue@3.5.34(typescript@5.9.3))(zod@4.3.6)
       '@chat-adapter/state-memory':
         specifier: workspace:*
         version: link:../state-memory
@@ -652,8 +652,8 @@ importers:
         specifier: ^4.0.18
         version: 4.0.18(vitest@4.0.18(@opentelemetry/api@1.9.0)(@types/node@25.3.2)(jiti@2.7.0)(lightningcss@1.30.2)(terser@5.48.0)(tsx@4.22.3)(yaml@2.9.0))
       ai:
-        specifier: ^6.0.182
-        version: 6.0.182(zod@4.3.6)
+        specifier: ^7.0.0
+        version: 7.0.17(zod@4.3.6)
       react:
         specifier: ^19.0.0
         version: 19.2.3
@@ -751,8 +751,8 @@ importers:
         specifier: ^25.3.2
         version: 25.3.2
       ai:
-        specifier: ^6.0.182
-        version: 6.0.182(zod@4.3.6)
+        specifier: ^7.0.0
+        version: 7.0.17(zod@4.3.6)
       tsup:
         specifier: ^8.3.5
         version: 8.5.1(@swc/core@1.15.3)(jiti@2.7.0)(postcss@8.5.16)(tsx@4.22.3)(typescript@5.9.3)(yaml@2.9.0)
@@ -984,9 +984,27 @@ packages:
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
 
+  '@ai-sdk/gateway@4.0.13':
+    resolution: {integrity: sha512-EIiMZZMEAc3yZ3nywrJfKigrkaNwqrQgGsj0QbQ6x3Y73MlQe68EElR2cm/8I5dvBci3PFyahMRe3NwR8OOb9A==}
+    engines: {node: '>=22'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
+  '@ai-sdk/mcp@2.0.8':
+    resolution: {integrity: sha512-9PmSc+ObIxGieXsSXL3ghvAYGXj83V2mFo+FuG/8F1Ujv8d3pVD+fTnh3JdY0gKAT05Ehrtz5FGH9tLJGbQnMw==}
+    engines: {node: '>=22'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
   '@ai-sdk/provider-utils@4.0.27':
     resolution: {integrity: sha512-ubkAJ+xODouwtmN1tYlvTPphH1hPOBfZaEQe8U7skGvFAnIRs9PPpsq57bC2+Ky/MB4yzhd6YOsxTAx9sGpazw==}
     engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
+  '@ai-sdk/provider-utils@5.0.5':
+    resolution: {integrity: sha512-oI0t3dvCoqWNV1I8o1Rybi2DXDvHES5r/TrwtJW90tuFLVepgJlftPxrcjh8vaSvjqC2diTuA2vXyjKAyHJm4A==}
+    engines: {node: '>=22'}
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
 
@@ -994,21 +1012,31 @@ packages:
     resolution: {integrity: sha512-Q3BZ27qfpYqnCYGvE3vt+Qi6LGOF9R5Nmzn+9JoM1lCRsD9mYaIhfJLkSunN48nfGXJ6n+XNV0J/XVpqGQl7Dw==}
     engines: {node: '>=18'}
 
+  '@ai-sdk/provider@4.0.2':
+    resolution: {integrity: sha512-pfPoy9J1B1xV7cqJ8MYHOsDYrMv5tR3+EMNfI249OhkD2uRakvav3Fo7XpD2luuN/YNCBY7KfEQc7vEV7KEtyw==}
+    engines: {node: '>=22'}
+
   '@ai-sdk/react@3.0.184':
     resolution: {integrity: sha512-k8fQ11U3+lKzUCkiitevuH0MF++b7QPX7zrPRfXfNayLRZwrwvNuqXifB/6iIyQpSLNCfzhkqG117FW2EXCI5w==}
     engines: {node: '>=18'}
     peerDependencies:
       react: ^18 || ~19.0.1 || ~19.1.2 || ^19.2.1
 
-  '@ai-sdk/svelte@4.0.182':
-    resolution: {integrity: sha512-BKu9PwxPmqEXCUMleC+cjfAe7+CN2TXc3v3pQSIs6BQMv0puXjKALyes43dD5nQa2TZ0Sl8QLxjURpq9ASQ3+w==}
-    engines: {node: '>=18'}
+  '@ai-sdk/react@4.0.18':
+    resolution: {integrity: sha512-xNLGIy8JepTiKRedRwMcnM4Y0yjBqMYO3/Uea9yiNiC/d/MMlaQPfUzMwB8bs+wHE7xQ+e0tHMgo5CjSrN5AxA==}
+    engines: {node: '>=22'}
+    peerDependencies:
+      react: ^18 || ~19.0.1 || ~19.1.2 || ^19.2.1
+
+  '@ai-sdk/svelte@5.0.17':
+    resolution: {integrity: sha512-BIKUsdg43jpUvs3KSy4VM0/4+FEMVpKRQTShzoB7U8b37GSprjfAJN4urr03nvcOmHkJiFU5+upV3fLanU3YYQ==}
+    engines: {node: '>=22'}
     peerDependencies:
       svelte: ^5.31.0
 
-  '@ai-sdk/vue@3.0.182':
-    resolution: {integrity: sha512-BLWb0LlNAXhJJgPWZxQy50++j0HkkEyXGqqtptKcZU1riRxFwu5LGrlVXsT6YRpwkwvgQBmpki0sgq6atVm+Pg==}
-    engines: {node: '>=18'}
+  '@ai-sdk/vue@4.0.17':
+    resolution: {integrity: sha512-LjSOlNc/iqopVJbXBU86bnWuTV0aO1lv57feg6OcdBZkrpTLfEYDYnBsrFeyiPGqS9DkBvDspF2BUD3tYInUqw==}
+    engines: {node: '>=22'}
     peerDependencies:
       vue: ^3.3.4
 
@@ -6142,6 +6170,9 @@ packages:
   '@workflow/rollup@4.0.4':
     resolution: {integrity: sha512-DqmSp89Y4WVoMkBWkiNll0b5mZ2WA9uwNsRuO4QOU0XHytuCnvTRGMf0ZV6fXAa3KyeXlgS1r0V8SHwt1ZQ7jg==}
 
+  '@workflow/serde@4.1.0':
+    resolution: {integrity: sha512-pav4F2BoirECWR7Nf1TKt+2eETcBj7jj4cBefQ8VXQCA6NPkaKeLfj/zMgi+3zYV5ZIBT4GuUiphsj0/b9hPQQ==}
+
   '@workflow/serde@4.1.0-beta.2':
     resolution: {integrity: sha512-8kkeoQKLDaKXefjV5dbhBj2aErfKp1Mc4pb6tj8144cF+Em5SPbyMbyLCHp+BVrFfFVCBluCtMx+jjvaFVZGww==}
 
@@ -6278,6 +6309,12 @@ packages:
   ai@6.0.182:
     resolution: {integrity: sha512-ooJdziFjYrYRcsCx107roqA8gDTI3P82nUfroNWIhVvwrkYzEN3W1l50YK+XNqkUew8AiimaW0/SLBewRXMuHQ==}
     engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
+  ai@7.0.17:
+    resolution: {integrity: sha512-kpIjNtN0tyUaxzkAs7b8YF48WZzc71dKu0HqFPSAWg/avu1Ogv50UPE9hpVMr+kb33zsEa6LrAU9DZHMNscvzw==}
+    engines: {node: '>=22'}
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
 
@@ -9531,6 +9568,10 @@ packages:
   piscina@4.9.3:
     resolution: {integrity: sha512-3e3ka9QCE8RJ5I9uszdAADZnkcYi21cqmF3gxox3u884N72qpFHCsIVhHt8cEQ9t3Auq/NqoiCEuhxlxxQuDWA==}
 
+  pkce-challenge@5.0.1:
+    resolution: {integrity: sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==}
+    engines: {node: '>=16.20.0'}
+
   pkg-types@1.3.1:
     resolution: {integrity: sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==}
 
@@ -10500,8 +10541,8 @@ packages:
     engines: {node: '>=16'}
     hasBin: true
 
-  swr@2.4.0:
-    resolution: {integrity: sha512-sUlC20T8EOt1pHmDiqueUWMmRRX03W7w5YxovWX7VR2KHEPCTMly85x05vpkP5i6Bu4h44ePSMD9Tc+G2MItFw==}
+  swr@2.4.2:
+    resolution: {integrity: sha512-ej644Y2bvkIajfR32KGeSSdBXQW+ScjGjkybZgSE7kFpk9eGnV44XY9FJylXi+W75pavSX1PVNB57W5EbhGIYw==}
     peerDependencies:
       react: ^16.11.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
@@ -11555,6 +11596,20 @@ snapshots:
       '@vercel/oidc': 3.2.0
       zod: 4.3.6
 
+  '@ai-sdk/gateway@4.0.13(zod@4.3.6)':
+    dependencies:
+      '@ai-sdk/provider': 4.0.2
+      '@ai-sdk/provider-utils': 5.0.5(zod@4.3.6)
+      '@vercel/oidc': 3.2.0
+      zod: 4.3.6
+
+  '@ai-sdk/mcp@2.0.8(zod@4.3.6)':
+    dependencies:
+      '@ai-sdk/provider': 4.0.2
+      '@ai-sdk/provider-utils': 5.0.5(zod@4.3.6)
+      pkce-challenge: 5.0.1
+      zod: 4.3.6
+
   '@ai-sdk/provider-utils@4.0.27(zod@4.3.6)':
     dependencies:
       '@ai-sdk/provider': 3.0.10
@@ -11562,7 +11617,19 @@ snapshots:
       eventsource-parser: 3.0.8
       zod: 4.3.6
 
+  '@ai-sdk/provider-utils@5.0.5(zod@4.3.6)':
+    dependencies:
+      '@ai-sdk/provider': 4.0.2
+      '@standard-schema/spec': 1.1.0
+      '@workflow/serde': 4.1.0
+      eventsource-parser: 3.0.8
+      zod: 4.3.6
+
   '@ai-sdk/provider@3.0.10':
+    dependencies:
+      json-schema: 0.4.0
+
+  '@ai-sdk/provider@4.0.2':
     dependencies:
       json-schema: 0.4.0
 
@@ -11571,23 +11638,35 @@ snapshots:
       '@ai-sdk/provider-utils': 4.0.27(zod@4.3.6)
       ai: 6.0.182(zod@4.3.6)
       react: 19.2.3
-      swr: 2.4.0(react@19.2.3)
+      swr: 2.4.2(react@19.2.3)
       throttleit: 2.1.0
     transitivePeerDependencies:
       - zod
 
-  '@ai-sdk/svelte@4.0.182(svelte@5.55.7)(zod@4.3.6)':
+  '@ai-sdk/react@4.0.18(react@19.2.3)(zod@4.3.6)':
     dependencies:
-      '@ai-sdk/provider-utils': 4.0.27(zod@4.3.6)
-      ai: 6.0.182(zod@4.3.6)
+      '@ai-sdk/mcp': 2.0.8(zod@4.3.6)
+      '@ai-sdk/provider': 4.0.2
+      '@ai-sdk/provider-utils': 5.0.5(zod@4.3.6)
+      ai: 7.0.17(zod@4.3.6)
+      react: 19.2.3
+      swr: 2.4.2(react@19.2.3)
+      throttleit: 2.1.0
+    transitivePeerDependencies:
+      - zod
+
+  '@ai-sdk/svelte@5.0.17(svelte@5.55.7)(zod@4.3.6)':
+    dependencies:
+      '@ai-sdk/provider-utils': 5.0.5(zod@4.3.6)
+      ai: 7.0.17(zod@4.3.6)
       svelte: 5.55.7
     transitivePeerDependencies:
       - zod
 
-  '@ai-sdk/vue@3.0.182(vue@3.5.34(typescript@5.9.3))(zod@4.3.6)':
+  '@ai-sdk/vue@4.0.17(vue@3.5.34(typescript@5.9.3))(zod@4.3.6)':
     dependencies:
-      '@ai-sdk/provider-utils': 4.0.27(zod@4.3.6)
-      ai: 6.0.182(zod@4.3.6)
+      '@ai-sdk/provider-utils': 5.0.5(zod@4.3.6)
+      ai: 7.0.17(zod@4.3.6)
       swrv: 1.2.0(vue@3.5.34(typescript@5.9.3))
       vue: 3.5.34(typescript@5.9.3)
     transitivePeerDependencies:
@@ -16266,12 +16345,13 @@ snapshots:
     dependencies:
       execa: 5.1.1
 
-  '@vercel/connect@0.3.0(@chat-adapter/slack@packages+adapter-slack)(ai@6.0.182(zod@4.3.6))':
+  '@vercel/connect@0.3.0(@ai-sdk/mcp@2.0.8(zod@4.3.6))(@chat-adapter/slack@packages+adapter-slack)(ai@7.0.17(zod@4.3.6))':
     dependencies:
       '@vercel/oidc': 3.7.1
     optionalDependencies:
+      '@ai-sdk/mcp': 2.0.8(zod@4.3.6)
       '@chat-adapter/slack': link:packages/adapter-slack
-      ai: 6.0.182(zod@4.3.6)
+      ai: 7.0.17(zod@4.3.6)
 
   '@vercel/edge-config-fs@0.1.0': {}
 
@@ -16909,6 +16989,8 @@ snapshots:
       - aws-crt
       - supports-color
 
+  '@workflow/serde@4.1.0': {}
+
   '@workflow/serde@4.1.0-beta.2': {}
 
   '@workflow/serde@4.1.1': {}
@@ -17125,6 +17207,13 @@ snapshots:
       '@ai-sdk/provider': 3.0.10
       '@ai-sdk/provider-utils': 4.0.27(zod@4.3.6)
       '@opentelemetry/api': 1.9.0
+      zod: 4.3.6
+
+  ai@7.0.17(zod@4.3.6):
+    dependencies:
+      '@ai-sdk/gateway': 4.0.13(zod@4.3.6)
+      '@ai-sdk/provider': 4.0.2
+      '@ai-sdk/provider-utils': 5.0.5(zod@4.3.6)
       zod: 4.3.6
 
   alien-signals@3.2.1: {}
@@ -20878,7 +20967,7 @@ snapshots:
       log-symbols: 6.0.0
       stdin-discarder: 0.2.2
       string-width: 7.2.0
-      strip-ansi: 7.1.2
+      strip-ansi: 7.2.0
 
   os-paths@4.4.0: {}
 
@@ -21157,6 +21246,8 @@ snapshots:
   piscina@4.9.3:
     optionalDependencies:
       '@napi-rs/nice': 1.1.1
+
+  pkce-challenge@5.0.1: {}
 
   pkg-types@1.3.1:
     dependencies:
@@ -22355,7 +22446,7 @@ snapshots:
       picocolors: 1.1.1
       sax: 1.6.0
 
-  swr@2.4.0(react@19.2.3):
+  swr@2.4.2(react@19.2.3):
     dependencies:
       dequal: 2.0.3
       react: 19.2.3
@@ -23337,7 +23428,7 @@ snapshots:
     dependencies:
       ansi-styles: 6.2.3
       string-width: 7.2.0
-      strip-ansi: 7.1.2
+      strip-ansi: 7.2.0
 
   wrappy@1.0.2: {}
 


### PR DESCRIPTION
Closes #690

## What

Widens the AI SDK peer dependency ranges so the Chat SDK installs cleanly next to `ai@7`:

- `chat`: `ai@^6.0.182 || ^7.0.0`
- `@chat-adapter/web`: `ai@^6 || ^7`, `@ai-sdk/react@^3 || ^4`, `@ai-sdk/svelte@^4 || ^5`, `@ai-sdk/vue@^3 || ^4`

This also unbreaks `create-chat-sdk` scaffolds, which install `ai@latest` (now v7) next to `chat` and currently hit a peer conflict out of the box.

## The one real v6 → v7 break

In v7, `tool()` with an `execute` function returns `ExecutableTool<Tool<...>>` — an internal type from `@ai-sdk/provider-utils` that `ai` does not re-export. The `chat/ai` tool factories relied on inference, so declaration emit failed with TS2742 (17 errors). The factories now declare explicit `Tool<Input, Output>` return types, which is exactly the shape the previously published `.d.ts` already had — the public type surface is unchanged, and the emitted declarations only reference types from `ai` (portable for consumers on either major).

Everything else checked out compatible:

- v7 stream parts keep `text-delta` / `finish-step` shapes, so `fromFullStream` duck-typing works unchanged; `fullStream` remains as a deprecated alias
- tool-level `needsApproval` is deprecated in v7 but still typed and honored
- `createUIMessageStream`, `createUIMessageStreamResponse`, `isTextUIPart`, `UIMessage`, `UIMessageStreamWriter`, `ChatInit`, `DefaultChatTransport` all still exported — `@chat-adapter/web` needed zero source changes

## Other changes

- devDependencies move to v7 so the workspace develops/tests against the latest major
- `examples/nextjs-chat` and `examples/nuxt-chat` move to `ai@^7` (required — mixing majors across the workspace fails typecheck, since `chat`'s d.ts resolves `ai` types from its own devDependency)
- Test-only: the `ToolExecutionOptions` stub type is now derived from `Tool["execute"]` because v7 made the generic parameter required
- Changeset included (minor for `chat` and `@chat-adapter/web`)

## Verification

The same source was verified against **both majors** (`ai@6.0.182` and `ai@7.0.17`): `tsc --noEmit` and the full test suites (`chat`: 1035 tests, `@chat-adapter/web`: 21 tests) pass on each. `pnpm validate` (knip + check + typecheck + test + build, including both examples) is green on v7.

Note for adopters: `ai@7` itself requires Node.js ≥ 22 and is ESM-only; `chat` keeps `engines.node >= 20` since `ai` is an optional peer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)