### PR TITLE
feat(discord): rename thread channels

### DIFF
--- a/.changeset/quiet-dingos-title.md
+++ b/.changeset/quiet-dingos-title.md
@@ -1,0 +1,5 @@
+---
+"@chat-adapter/discord": minor
+---
+
+Add support for renaming native Discord thread channels.

--- a/apps/docs/content/adapters/official/discord.mdx
+++ b/apps/docs/content/adapters/official/discord.mdx
@@ -60,10 +60,11 @@ The adapter auto-detects `DISCORD_BOT_TOKEN`, `DISCORD_PUBLIC_KEY`, `DISCORD_APP
 import { Chat } from "chat";
 import { createDiscordAdapter } from "@chat-adapter/discord";
 
+const discord = createDiscordAdapter();
 const bot = new Chat({
   userName: "mybot",
   adapters: {
-    discord: createDiscordAdapter(),
+    discord,
   },
 });
 
@@ -155,7 +156,11 @@ In **General Information**, set **Interactions Endpoint URL** to `https://your-d
 
 ### 4. Add the bot to your server
 
-In **OAuth2** then **URL Generator**, select scopes `bot` and `applications.commands`, pick the permissions your bot needs (Send Messages, Send Messages in Threads, Create Public Threads, Read Message History, Add Reactions, Attach Files), and use the generated URL to invite the bot.
+In **OAuth2** then **URL Generator**, select scopes `bot` and `applications.commands`, pick the permissions your bot needs (Send Messages, Send Messages in Threads, Create Public Threads, Manage Threads, Read Message History, Add Reactions, Attach Files), and use the generated URL to invite the bot.
+
+## Discord thread channel names
+
+Call `discord.setThreadTitle(thread.id, title)` to rename an existing Discord thread channel. The bot needs the **Manage Threads** permission.
 
 ## Advanced
 

--- a/packages/adapter-discord/AGENTS.md
+++ b/packages/adapter-discord/AGENTS.md
@@ -82,7 +82,7 @@ Main exports from `src/index.ts`:
 - `DiscordAdapter` class — implements `Adapter<DiscordThreadId,
   unknown>`. Public methods: `handleWebhook`, `postMessage`,
   `editMessage`, `deleteMessage`, `addReaction`, `removeReaction`,
-  `startTyping`, `openModal`, `fetchThread`, `listThreads`,
+  `startTyping`, `openModal`, `fetchThread`, `setThreadTitle`, `listThreads`,
   `fetchMessages`, `fetchSingleMessage`, `fetchChannelInfo`,
   `postChannelMessage`, `openDM`, `startGatewayListener`.
 - Configuration: `DiscordAdapterConfig`, `DiscordThreadId`.

--- a/packages/adapter-discord/README.md
+++ b/packages/adapter-discord/README.md
@@ -35,10 +35,11 @@ The adapter auto-detects `DISCORD_BOT_TOKEN`, `DISCORD_PUBLIC_KEY`, `DISCORD_APP
 import { Chat } from "chat";
 import { createDiscordAdapter } from "@chat-adapter/discord";
 
+const discord = createDiscordAdapter();
 const bot = new Chat({
   userName: "mybot",
   adapters: {
-    discord: createDiscordAdapter(),
+    discord,
   },
 });
 
@@ -75,7 +76,7 @@ bot.onNewMention(async (thread, message) => {
 
 1. Go to **OAuth2** then **URL Generator**
 2. Select scopes: `bot`, `applications.commands`
-3. Select bot permissions: Send Messages, Send Messages in Threads, Create Public Threads, Read Message History, Add Reactions, Attach Files
+3. Select bot permissions: Send Messages, Send Messages in Threads, Create Public Threads, Manage Threads, Read Message History, Add Reactions, Attach Files
 4. Copy the generated URL and open it to invite the bot to your server
 
 ## Architecture: HTTP Interactions vs Gateway
@@ -207,6 +208,10 @@ All options are auto-detected from environment variables when not provided.
 | `logger` | No | Logger instance (defaults to `ConsoleLogger("info")`) |
 
 *`botToken`, `publicKey`, and `applicationId` are required — either via config or env vars.
+
+## Discord thread channel names
+
+Call `discord.setThreadTitle(thread.id, title)` to rename an existing Discord thread channel. The bot needs the **Manage Threads** permission.
 
 ## Environment variables
 

--- a/packages/adapter-discord/src/index.test.ts
+++ b/packages/adapter-discord/src/index.test.ts
@@ -3279,6 +3279,30 @@ describe("fetchThread", () => {
   });
 });
 
+describe("setThreadTitle", () => {
+  it("renames Discord thread channels", async () => {
+    const spy = vi
+      .spyOn(threadIdAdapter as any, "discordFetch")
+      .mockResolvedValue(new Response(null, { status: 200 }));
+
+    await threadIdAdapter.setThreadTitle(
+      "discord:guild1:channel456:thread789",
+      "New thread title"
+    );
+    await threadIdAdapter.setThreadTitle(
+      "discord:guild1:channel456",
+      "Ignored channel title"
+    );
+
+    expect(spy).toHaveBeenCalledOnce();
+    expect(spy).toHaveBeenCalledWith("/channels/thread789", "PATCH", {
+      name: "New thread title",
+    });
+
+    spy.mockRestore();
+  });
+});
+
 describe("legacy gateway interactions", () => {
   class TestGatewayDiscordAdapter extends DiscordAdapter {
     listen(client: Client, isShuttingDown = () => false) {

--- a/packages/adapter-discord/src/index.ts
+++ b/packages/adapter-discord/src/index.ts
@@ -1609,6 +1609,17 @@ export class DiscordAdapter implements Adapter<DiscordThreadId, unknown> {
     };
   }
 
+  async setThreadTitle(threadId: string, title: string): Promise<void> {
+    const { threadId: discordThreadId } = this.decodeThreadId(threadId);
+    if (!discordThreadId) {
+      return;
+    }
+
+    await this.discordFetch(`/channels/${discordThreadId}`, "PATCH", {
+      name: title,
+    });
+  }
+
   /**
    * Open a DM with a user.
    */

--- a/packages/adapter-telegram/src/index.test.ts
+++ b/packages/adapter-telegram/src/index.test.ts
@@ -3637,7 +3637,7 @@ describe("message length limits", () => {
     const markdown = readSentBody(1).rich_message?.markdown ?? "";
     expect(Array.from(markdown).length).toBeLessThanOrEqual(32_768);
     expect(markdown.endsWith("...")).toBe(true);
-  });
+  }, 10_000);
 
   it("MarkdownV2 truncation does not leave an orphan trailing backslash before the ellipsis", async () => {
     const adapter = await createInitializedAdapter();

--- a/packages/adapter-telegram/src/index.test.ts
+++ b/packages/adapter-telegram/src/index.test.ts
@@ -3637,7 +3637,7 @@ describe("message length limits", () => {
     const markdown = readSentBody(1).rich_message?.markdown ?? "";
     expect(Array.from(markdown).length).toBeLessThanOrEqual(32_768);
     expect(markdown.endsWith("...")).toBe(true);
-  }, 10_000);
+  });
 
   it("MarkdownV2 truncation does not leave an orphan trailing backslash before the ellipsis", async () => {
     const adapter = await createInitializedAdapter();


### PR DESCRIPTION
## Summary

Add `DiscordAdapter#setThreadTitle()` to rename native Discord thread channels and document the required **Manage Threads** permission.

## Test plan

- [x] Discord adapter tests
- [x] `pnpm validate`

## Checklist

- [x] All commits are signed and verified
- [x] All commits are signed off for the DCO (`git commit -s`)
- [x] `pnpm validate` passes
- [x] Changeset added (or N/A — see [CONTRIBUTING.md](./CONTRIBUTING.md))
- [x] Documentation updated (or N/A)