### PR TITLE
chore: scope CODEOWNERS to package source

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,6 @@
-* @vercel/chat-sdk
+/packages/ @vercel/chat-sdk
+
+**/*.md
 
 /.github/workflows/release.yml @cramforce
 /.changeset/config.json        @cramforce


### PR DESCRIPTION
Scopes code-owner review to package source so routine app, example, docs, and Markdown changes stop pinning `@vercel/chat-sdk` as a required reviewer.

- `/packages/ @vercel/chat-sdk` — package source is owned by the team
- `**/*.md` — Markdown is unowned everywhere (last-match-wins), including inside `/packages/`
- Sensitive files (`release.yml`, `.changeset/config.json`, `CODEOWNERS`) stay owned by `@cramforce`

Everything outside `/packages/` (`apps/`, `examples/`, root files) is intentionally left unowned. This removes the repo-wide default owner, so new top-level paths are unowned until a rule is added — the trade for a low-maintenance allowlist.