### PR TITLE
feat(slack): support data table and data visualization blocks

### DIFF
--- a/.changeset/slack-data-tables-charts.md
+++ b/.changeset/slack-data-tables-charts.md
@@ -1,0 +1,14 @@
+---
+"chat": minor
+"@chat-adapter/slack": minor
+---
+
+Add chart support and richer table rendering, with native Slack data table and data visualization blocks.
+
+- New core `ChartElement` and `Chart()` builder (JSX supported) with pie, bar, area, and line charts, mirroring Slack's data visualization model: pie charts take `segments`, series charts take named `series` plotted against shared `categories` with optional `xLabel`/`yLabel`.
+- `TableElement` / `Table()` gain optional `caption` (accessible table description) and `pageSize` (rows per page) fields.
+- Charts degrade gracefully on platforms without native chart support: the underlying data renders as a text table via the shared card fallback (new `chartElementToFallbackText` helper).
+- Slack adapter: card tables now render as [data table blocks](https://docs.slack.dev/reference/block-kit/blocks/data-table-block) by default — paginated and sortable — instead of plain table blocks. Header-only tables keep the plain table block; tables exceeding Slack limits (100 data rows, 20 columns, 10,000 characters) fall back to ASCII as before.
+- Slack adapter: card charts render as [data visualization blocks](https://docs.slack.dev/reference/block-kit/blocks/data-visualization-block). Charts violating Slack constraints (50-character title, 12 segments/series, 20 categories, 20-character labels, one data point per category, max 2 charts per message) fall back to a text rendering instead of being rejected by the API.
+- The `@chat-adapter/slack/blocks` subpath gets the same treatment: `SlackChartElement` types, `chart` card children, data table rendering, and matching limits.
+- `postMessage` now surfaces Slack's per-block validation details when the API rejects blocks (`invalid_blocks`), instead of the bare "An API error occurred" message.

--- a/apps/docs/content/adapters/official/slack.mdx
+++ b/apps/docs/content/adapters/official/slack.mdx
@@ -27,6 +27,9 @@ features:
   tables:
     status: yes
     label: Block Kit
+  charts:
+    status: yes
+    label: Block Kit
   fields: yes
   imagesInCards: yes
   modals: yes
@@ -519,6 +522,38 @@ settings:
       - app_home_opened
       - app_context_changed
 ```
+
+### Tables and charts
+
+Card [`Table`](/docs/cards#table) elements render as Slack [data table blocks](https://docs.slack.dev/reference/block-kit/blocks/data-table-block) — paginated and sortable, with optional `caption` and `pageSize` props. Tables that exceed Slack's limits (100 data rows, 20 columns, 10,000 characters across all cells) fall back to ASCII text, and header-only tables render as a plain table block.
+
+Card [`Chart`](/docs/cards#chart) elements render as Slack [data visualization blocks](https://docs.slack.dev/reference/block-kit/blocks/data-visualization-block) with pie, bar, area, and line chart support:
+
+```tsx
+await thread.post(
+  <Card title="Usage report">
+    <Chart
+      title="Daily Active Users"
+      chart={{
+        type: "line",
+        categories: ["Mon", "Tue", "Wed"],
+        series: [
+          {
+            name: "Web",
+            data: [
+              { label: "Mon", value: 120 },
+              { label: "Tue", value: 135 },
+              { label: "Wed", value: 128 },
+            ],
+          },
+        ],
+      }}
+    />
+  </Card>
+);
+```
+
+Charts that violate Slack's constraints (50-character title, 12 segments/series, 20 categories, 20-character labels, one data point per category, at most 2 charts per message) fall back to a text rendering of the data instead of being rejected by the Slack API.
 
 ## Feature support
 

--- a/apps/docs/content/docs/api/cards.mdx
+++ b/apps/docs/content/docs/api/cards.mdx
@@ -7,7 +7,7 @@ type: reference
 Card components render natively on each platform — Block Kit on Slack, Adaptive Cards on Teams, Embeds on Discord, and Google Chat Cards.
 
 ```typescript
-import { Card, Text, CardLink, Button, Actions, Section, Fields, Field, Divider, Image, LinkButton, Table } from "chat";
+import { Card, Text, CardLink, Button, Actions, Section, Fields, Field, Divider, Image, LinkButton, Table, Chart } from "chat";
 ```
 
 All components support both function-call and JSX syntax. Function-call syntax is recommended for better type inference.
@@ -260,10 +260,52 @@ Table({
       description: 'Column alignment.',
       type: '"left" | "center" | "right"[]',
     },
+    caption: {
+      description: 'Accessible table caption (used by platforms with native table support).',
+      type: 'string',
+    },
+    pageSize: {
+      description: 'Rows per page on platforms that paginate tables (Slack: 1-100, default 5).',
+      type: 'number',
+    },
   }}
 />
 
-On platforms with native table support (Teams, GitHub, Linear), tables render as formatted tables. On other platforms (Slack, Google Chat, Discord, Telegram), tables render as padded ASCII text.
+On platforms with native table support (Slack, Teams, GitHub, Linear), tables render as formatted tables. On Slack, tables render as paginated, sortable data table blocks. On other platforms (Google Chat, Discord, Telegram), tables render as padded ASCII text.
+
+## Chart
+
+Data visualization with pie, bar, area, and line charts.
+
+```typescript
+Chart({
+  title: "My Favorite Candy Bars",
+  chart: {
+    type: "pie",
+    segments: [
+      { label: "Kit Kat", value: 45 },
+      { label: "Twix", value: 28 },
+    ],
+  },
+})
+```
+
+<TypeTable
+  type={{
+    title: {
+      description: 'Chart title (Slack: max 50 characters).',
+      type: 'string',
+    },
+    chart: {
+      description: 'Chart definition, discriminated by chart type ("pie" | "bar" | "area" | "line").',
+      type: 'ChartDefinition',
+    },
+  }}
+/>
+
+Pie charts take `segments` (label + value, rendered as percentages of the total). Bar, area, and line charts take `series` (named lists of data points) plotted against shared `categories`, with optional `xLabel`/`yLabel` axis titles.
+
+On Slack, charts render as native data visualization blocks. On other platforms, charts fall back to the underlying data rendered as a text table.
 
 ## Divider
 
@@ -287,3 +329,4 @@ The `children` array in `Card` and `Section` accepts these element types:
 | `SectionElement` | `Section()` |
 | `FieldsElement` | `Fields()` |
 | `TableElement` | `Table()` |
+| `ChartElement` | `Chart()` |

--- a/apps/docs/content/docs/cards.mdx
+++ b/apps/docs/content/docs/cards.mdx
@@ -199,7 +199,7 @@ Radio button group for mutually exclusive choices.
 
 ### Table
 
-Structured data display with column headers and rows. Renders as a native table on platforms that support it (Teams, GitHub, Linear) and as padded ASCII text elsewhere.
+Structured data display with column headers and rows. Renders as a native table on platforms that support it (Slack, Teams, GitHub, Linear) and as padded ASCII text elsewhere.
 
 ```tsx title="lib/bot.tsx" lineNumbers
 <Table
@@ -220,6 +220,69 @@ Optional column alignment:
   align={["left", "right"]}
 />
 ```
+
+On Slack, tables render as paginated, sortable [data tables](https://docs.slack.dev/reference/block-kit/blocks/data-table-block). The optional `caption` (accessible table description) and `pageSize` (rows per page, 1–100) props tune that rendering and are ignored on other platforms:
+
+```tsx title="lib/bot.tsx"
+<Table
+  headers={["Name", "Score"]}
+  rows={[["Alice", "98"], ["Bob", "87"]]}
+  caption="Quarterly review scores"
+  pageSize={10}
+/>
+```
+
+### Chart
+
+Data visualization with pie, bar, area, and line charts. Renders as a native [data visualization](https://docs.slack.dev/reference/block-kit/blocks/data-visualization-block) on Slack; other platforms fall back to the chart's data rendered as a text table.
+
+```tsx title="lib/bot.tsx" lineNumbers
+<Chart
+  title="My Favorite Candy Bars"
+  chart={{
+    type: "pie",
+    segments: [
+      { label: "Kit Kat", value: 45 },
+      { label: "Twix", value: 28 },
+      { label: "Crunch", value: 18 },
+    ],
+  }}
+/>
+```
+
+Bar, area, and line charts take named series plotted against shared categories:
+
+```tsx title="lib/bot.tsx" lineNumbers
+<Chart
+  title="Daily Active Users"
+  chart={{
+    type: "line",
+    categories: ["Mon", "Tue", "Wed"],
+    xLabel: "Day",
+    yLabel: "Users",
+    series: [
+      {
+        name: "Web",
+        data: [
+          { label: "Mon", value: 120 },
+          { label: "Tue", value: 135 },
+          { label: "Wed", value: 128 },
+        ],
+      },
+      {
+        name: "Mobile",
+        data: [
+          { label: "Mon", value: 80 },
+          { label: "Tue", value: 95 },
+          { label: "Wed", value: 90 },
+        ],
+      },
+    ],
+  }}
+/>
+```
+
+Slack enforces a 50-character title, up to 12 segments or series, up to 20 categories, 20-character labels, and at most 2 charts per message. Charts that exceed these limits fall back to a text rendering of the data instead of being rejected by the API.
 
 ### Image
 

--- a/apps/docs/content/docs/platform-adapters.mdx
+++ b/apps/docs/content/docs/platform-adapters.mdx
@@ -36,7 +36,8 @@ Ready to build your own? Follow the [building](/docs/contributing/building) guid
 | Buttons | <Check /> | <Check /> | <Check /> | <Check /> | <Warn /> Inline keyboard callbacks | <Cross /> | <Cross /> | <Check /> Interactive replies | <Warn /> Max 3, postback |
 | Link buttons | <Check /> | <Check /> | <Check /> | <Check /> | <Warn /> Inline keyboard URLs | <Cross /> | <Cross /> | <Cross /> | <Check /> |
 | Select menus | <Check /> | <Cross /> | <Check /> | <Cross /> | <Cross /> | <Cross /> | <Cross /> | <Cross /> | <Cross /> |
-| Tables | <Check /> Block Kit | <Check /> GFM | <Warn /> ASCII | <Check /> GFM | <Warn /> Native messages / ASCII cards | <Check /> GFM | <Check /> GFM | <Cross /> | <Warn /> ASCII |
+| Tables | <Check /> Block Kit data table | <Check /> GFM | <Warn /> ASCII | <Check /> GFM | <Warn /> Native messages / ASCII cards | <Check /> GFM | <Check /> GFM | <Cross /> | <Warn /> ASCII |
+| Charts | <Check /> Block Kit | <Warn /> Text fallback | <Warn /> Text fallback | <Warn /> Text fallback | <Warn /> Text fallback | <Warn /> Text fallback | <Warn /> Text fallback | <Warn /> Text fallback | <Warn /> Text fallback |
 | Fields | <Check /> | <Check /> | <Check /> | <Check /> | <Check /> | <Check /> | <Check /> | <Warn /> Template variables | <Warn /> ASCII |
 | Images in cards | <Check /> | <Check /> | <Check /> | <Check /> | <Cross /> | <Check /> | <Cross /> | <Check /> | <Check /> |
 | Modals | <Check /> | <Check /> | <Cross /> | <Cross /> | <Cross /> | <Cross /> | <Cross /> | <Cross /> | <Cross /> |

--- a/apps/docs/content/docs/slack-primitives.mdx
+++ b/apps/docs/content/docs/slack-primitives.mdx
@@ -275,6 +275,37 @@ await postSlackMessage({
 
 Use the full Chat SDK card JSX when you want cross-platform rendering. Use `@chat-adapter/slack/blocks` when you are building a Slack-only runtime and want Block Kit output directly.
 
+Card children support the same element types as the cross-platform card model, including `table` (rendered as a paginated, sortable [data table block](https://docs.slack.dev/reference/block-kit/blocks/data-table-block) with optional `caption` and `pageSize`) and `chart` (rendered as a [data visualization block](https://docs.slack.dev/reference/block-kit/blocks/data-visualization-block)):
+
+```typescript
+const report = {
+  children: [
+    {
+      caption: "Quarterly scores",
+      headers: ["Name", "Score"],
+      pageSize: 10,
+      rows: [["Alice", "98"], ["Bob", "87"]],
+      type: "table",
+    },
+    {
+      chart: {
+        segments: [
+          { label: "Web", value: 45 },
+          { label: "Mobile", value: 35 },
+        ],
+        type: "pie",
+      },
+      title: "Traffic by Platform",
+      type: "chart",
+    },
+  ],
+  title: "Usage Report",
+  type: "card",
+} as const;
+```
+
+Tables and charts that exceed Slack limits (100 data rows / 20 columns / 10,000 characters for tables; 12 segments or series, 20 categories, 20-character labels, 50-character titles, and 2 charts per message for charts) fall back to a text rendering instead of being rejected by the Slack API.
+
 The blocks subpath also includes small input request helpers for Slack-only runtimes:
 
 ```typescript

--- a/apps/docs/lib/adapter-features.ts
+++ b/apps/docs/lib/adapter-features.ts
@@ -40,6 +40,7 @@ export const PLATFORM_FEATURE_CATEGORIES: AdapterFeatureCategory[] = [
       { key: "linkButtons", label: "Link buttons" },
       { key: "selectMenus", label: "Select menus" },
       { key: "tables", label: "Tables" },
+      { key: "charts", label: "Charts" },
       { key: "fields", label: "Fields" },
       { key: "imagesInCards", label: "Images in cards" },
       { key: "modals", label: "Modals" },

--- a/examples/nextjs-chat/src/lib/bot.tsx
+++ b/examples/nextjs-chat/src/lib/bot.tsx
@@ -8,6 +8,7 @@ import {
   Button,
   Card,
   CardLink,
+  Chart,
   Chat,
   Divider,
   emoji,
@@ -172,6 +173,7 @@ bot.onNewMention(async (thread, message) => {
         <Button id="channel-info">Channel Info (Slack)</Button>
         <Button id="pin-message">Pin Message (Slack)</Button>
         <Button id="show-table">Show Table</Button>
+        <Button id="show-charts">Show Charts</Button>
         <Button id="agent-demo">Run Agent Demo</Button>
         <Button id="who-am-i">Who Am I</Button>
         <Button actionType="modal" id="report" value="bug">
@@ -545,7 +547,9 @@ bot.onAction("show-table", async (event) => {
     <Card title={`${emoji.memo} Team Directory`}>
       <Text>Here's the current team roster:</Text>
       <Table
+        caption="Team roster"
         headers={["Name", "Role", "Location", "Status"]}
+        pageSize={3}
         rows={[
           ["Alice Chen", "Engineering Lead", "San Francisco", "Active"],
           ["Bob Smith", "Designer", "New York", "Active"],
@@ -553,6 +557,59 @@ bot.onAction("show-table", async (event) => {
           ["Dan Lee", "Backend Engineer", "Tokyo", "Active"],
           ["Eve Park", "Frontend Engineer", "Seoul", "Active"],
         ]}
+      />
+    </Card>
+  );
+});
+
+bot.onAction("show-charts", async (event) => {
+  if (!event.thread) {
+    return;
+  }
+  await event.thread.post(
+    <Card title={`${emoji.chart_up} Usage Report`}>
+      <Text>Native charts on Slack, text tables everywhere else:</Text>
+      <Chart
+        chart={{
+          type: "pie",
+          segments: [
+            { label: "Web", value: 45 },
+            { label: "Mobile", value: 35 },
+            { label: "API", value: 20 },
+          ],
+        }}
+        title="Traffic by Platform"
+      />
+      <Chart
+        chart={{
+          type: "line",
+          categories: ["Mon", "Tue", "Wed", "Thu", "Fri"],
+          series: [
+            {
+              name: "Web",
+              data: [
+                { label: "Mon", value: 120 },
+                { label: "Tue", value: 135 },
+                { label: "Wed", value: 128 },
+                { label: "Thu", value: 150 },
+                { label: "Fri", value: 142 },
+              ],
+            },
+            {
+              name: "Mobile",
+              data: [
+                { label: "Mon", value: 80 },
+                { label: "Tue", value: 95 },
+                { label: "Wed", value: 90 },
+                { label: "Thu", value: 105 },
+                { label: "Fri", value: 98 },
+              ],
+            },
+          ],
+          xLabel: "Day",
+          yLabel: "Users",
+        }}
+        title="Daily Active Users"
       />
     </Card>
   );

--- a/packages/adapter-slack/README.md
+++ b/packages/adapter-slack/README.md
@@ -398,7 +398,8 @@ SLACK_API_URL=...                    # Optional, for GovSlack or a self-hosted g
 | Buttons | Yes |
 | Link buttons | Yes |
 | Select menus | Yes |
-| Tables | Block Kit |
+| Tables | Block Kit data table (paginated, sortable) |
+| Charts | Block Kit data visualization (pie, bar, area, line) |
 | Fields | Yes |
 | Images in cards | Yes |
 | Modals | Yes |

--- a/packages/adapter-slack/src/blocks/index.test.ts
+++ b/packages/adapter-slack/src/blocks/index.test.ts
@@ -403,6 +403,10 @@ describe("Slack Block Kit primitives", () => {
     );
 
     expect(blocks[0].type).toBe("section");
+    const text = (blocks[0] as { text: { text: string } }).text.text;
+    expect(text.length).toBeLessThanOrEqual(3000);
+    // Closing code fence survives truncation
+    expect(text.endsWith("\n```")).toBe(true);
   });
 
   it("converts pie charts to data_visualization blocks", () => {

--- a/packages/adapter-slack/src/blocks/index.test.ts
+++ b/packages/adapter-slack/src/blocks/index.test.ts
@@ -338,7 +338,7 @@ describe("Slack Block Kit primitives", () => {
       type: "section",
     });
     expect(blocks[1]).toEqual({
-      column_settings: [{ align: "left" }, { align: "right" }],
+      caption: "Table",
       rows: [
         [
           { text: "Name", type: "raw_text" },
@@ -349,8 +349,196 @@ describe("Slack Block Kit primitives", () => {
           { text: "10", type: "raw_text" },
         ],
       ],
+      type: "data_table",
+    });
+  });
+
+  it("passes table caption and clamped page_size through", () => {
+    const blocks = cardToSlackBlocks(
+      card([
+        {
+          caption: "Scores",
+          headers: ["Name"],
+          pageSize: 0,
+          rows: [["Ada"]],
+          type: "table",
+        },
+      ])
+    );
+
+    expect(blocks[0]).toEqual({
+      caption: "Scores",
+      page_size: 1,
+      rows: [
+        [{ text: "Name", type: "raw_text" }],
+        [{ text: "Ada", type: "raw_text" }],
+      ],
+      type: "data_table",
+    });
+  });
+
+  it("renders header-only tables as a plain table block", () => {
+    const blocks = cardToSlackBlocks(
+      card([
+        {
+          align: ["left"],
+          headers: ["Name"],
+          rows: [],
+          type: "table",
+        },
+      ])
+    );
+
+    expect(blocks[0]).toEqual({
+      column_settings: [{ align: "left" }],
+      rows: [[{ text: "Name", type: "raw_text" }]],
       type: "table",
     });
+  });
+
+  it("falls back to ASCII when combined table cells exceed the character limit", () => {
+    const bigCell = "x".repeat(10_001);
+    const blocks = cardToSlackBlocks(
+      card([{ headers: ["A"], rows: [[bigCell]], type: "table" }])
+    );
+
+    expect(blocks[0].type).toBe("section");
+  });
+
+  it("converts pie charts to data_visualization blocks", () => {
+    const blocks = cardToSlackBlocks(
+      card([
+        {
+          chart: {
+            segments: [
+              { label: "Kit Kat", value: 45 },
+              { label: "Twix", value: 28 },
+            ],
+            type: "pie",
+          },
+          title: "Candy Bars",
+          type: "chart",
+        },
+      ])
+    );
+
+    expect(blocks[0]).toEqual({
+      chart: {
+        segments: [
+          { label: "Kit Kat", value: 45 },
+          { label: "Twix", value: 28 },
+        ],
+        type: "pie",
+      },
+      title: "Candy Bars",
+      type: "data_visualization",
+    });
+  });
+
+  it("converts series charts with axis config and normalized point order", () => {
+    const blocks = cardToSlackBlocks(
+      card([
+        {
+          chart: {
+            categories: ["Mon", "Tue"],
+            series: [
+              {
+                data: [
+                  { label: "Tue", value: 60 },
+                  { label: "Mon", value: 50 },
+                ],
+                name: "Mobile",
+              },
+            ],
+            type: "line",
+            xLabel: "Day",
+            yLabel: "Users",
+          },
+          title: "DAU",
+          type: "chart",
+        },
+      ])
+    );
+
+    expect(blocks[0]).toEqual({
+      chart: {
+        axis_config: {
+          categories: ["Mon", "Tue"],
+          x_label: "Day",
+          y_label: "Users",
+        },
+        series: [
+          {
+            data: [
+              { label: "Mon", value: 50 },
+              { label: "Tue", value: 60 },
+            ],
+            name: "Mobile",
+          },
+        ],
+        type: "line",
+      },
+      title: "DAU",
+      type: "data_visualization",
+    });
+  });
+
+  it("falls back to a text section for invalid charts", () => {
+    const blocks = cardToSlackBlocks(
+      card([
+        {
+          chart: {
+            segments: [{ label: "Zero", value: 0 }],
+            type: "pie",
+          },
+          title: "Bad Pie",
+          type: "chart",
+        },
+      ])
+    );
+
+    expect(blocks[0].type).toBe("section");
+    expect((blocks[0] as { text: { text: string } }).text.text).toContain(
+      "Bad Pie"
+    );
+  });
+
+  it("falls back to a text section from the third chart in one message", () => {
+    const pie = (title: string) => ({
+      chart: {
+        segments: [{ label: "A", value: 1 }],
+        type: "pie" as const,
+      },
+      title,
+      type: "chart" as const,
+    });
+    const blocks = cardToSlackBlocks(
+      card([pie("One"), pie("Two"), pie("Three")])
+    );
+
+    expect(blocks.map((b) => b.type)).toEqual([
+      "data_visualization",
+      "data_visualization",
+      "section",
+    ]);
+  });
+
+  it("includes chart data in Slack fallback text", () => {
+    const text = cardToSlackFallbackText(
+      card([
+        {
+          chart: {
+            segments: [{ label: "Kit Kat", value: 45 }],
+            type: "pie",
+          },
+          title: "Candy Bars",
+          type: "chart",
+        },
+      ])
+    );
+
+    expect(text).toContain("Candy Bars");
+    expect(text).toContain("Kit Kat");
   });
 
   it("falls back to ASCII tables after one native table", () => {

--- a/packages/adapter-slack/src/blocks/index.ts
+++ b/packages/adapter-slack/src/blocks/index.ts
@@ -378,11 +378,7 @@ function tableToBlocks(
   ) {
     return [
       {
-        text: mrkdwn(
-          `\`\`\`\n${tableToAscii(element)}\n\`\`\``,
-          (value) => value,
-          LIMITS.sectionText
-        ),
+        text: fencedFallbackText(tableToAscii(element)),
         type: "section",
       },
     ];
@@ -441,13 +437,24 @@ function chartToBlock(
   // Slack rejects invalid charts (and >2 charts per message) outright
   // rather than truncating them, so render the underlying data as text.
   return {
-    text: mrkdwn(
-      `\`\`\`\n${chartToAscii(element)}\n\`\`\``,
-      (value) => value,
-      LIMITS.sectionText
-    ),
+    text: fencedFallbackText(chartToAscii(element)),
     type: "section",
   };
+}
+
+/**
+ * Wrap ASCII fallback content in a fenced code block, truncating the content
+ * so the section text stays within Slack's limit while keeping the closing
+ * fence intact.
+ */
+function fencedFallbackText(content: string): SlackTextObject {
+  const fence = (body: string) => `\`\`\`\n${body}\n\`\`\``;
+  const budget = LIMITS.sectionText - fence("").length;
+  const text =
+    content.length > budget
+      ? fence(`${content.slice(0, budget - 1)}…`)
+      : fence(content);
+  return { text, type: "mrkdwn" };
 }
 
 function chartToDataVisualization(

--- a/packages/adapter-slack/src/blocks/index.ts
+++ b/packages/adapter-slack/src/blocks/index.ts
@@ -9,6 +9,7 @@ import type {
   SlackButtonStyle,
   SlackCardChild,
   SlackCardElement,
+  SlackChartElement,
   SlackFieldsElement,
   SlackImageElement,
   SlackLinkButtonElement,
@@ -31,16 +32,23 @@ export type {
   SlackButtonStyle,
   SlackCardChild,
   SlackCardElement,
+  SlackChartDataPoint,
+  SlackChartDefinition,
+  SlackChartElement,
+  SlackChartSegment,
+  SlackChartSeries,
   SlackDividerElement,
   SlackFieldElement,
   SlackFieldsElement,
   SlackImageElement,
   SlackLinkButtonElement,
   SlackLinkElement,
+  SlackPieChartDefinition,
   SlackRadioSelectElement,
   SlackSectionElement,
   SlackSelectElement,
   SlackSelectOptionElement,
+  SlackSeriesChartDefinition,
   SlackTableAlignment,
   SlackTableElement,
   SlackTextElement,
@@ -57,6 +65,7 @@ export function cardToSlackBlocks(
 ): SlackBlock[] {
   const blocks: SlackBlock[] = [];
   const state = {
+    chartCount: 0,
     convertEmoji: options.convertEmoji ?? convertSlackEmojiPlaceholders,
     maxBlocks: options.maxBlocks ?? LIMITS.blocks,
     usedTable: false,
@@ -122,6 +131,7 @@ export function convertSlackEmojiPlaceholders(text: string): string {
 function cardChildToSlackBlocks(
   child: SlackCardChild,
   state: {
+    chartCount: number;
     convertEmoji: (text: string) => string;
     maxBlocks: number;
     usedTable: boolean;
@@ -130,6 +140,8 @@ function cardChildToSlackBlocks(
   switch (child.type) {
     case "actions":
       return [actionsToBlock(child, state.convertEmoji)];
+    case "chart":
+      return [chartToBlock(child, state)];
     case "divider":
       return [{ type: "divider" }];
     case "fields":
@@ -355,10 +367,14 @@ function tableToBlocks(
     usedTable: boolean;
   }
 ): SlackBlock[] {
+  const cellCharCount = [element.headers, ...element.rows]
+    .flat()
+    .reduce((total, cell) => total + cell.length, 0);
   if (
     state.usedTable ||
     element.rows.length + 1 > LIMITS.tableRows ||
-    element.headers.length > LIMITS.tableColumns
+    element.headers.length > LIMITS.tableColumns ||
+    cellCharCount > LIMITS.tableChars
   ) {
     return [
       {
@@ -372,20 +388,181 @@ function tableToBlocks(
     ];
   }
   state.usedTable = true;
+  const rows = [
+    element.headers.map((header) => rawText(header, state.convertEmoji)),
+    ...element.rows.map((row) =>
+      row.map((cell) => rawText(cell, state.convertEmoji))
+    ),
+  ];
+  // The data table block requires a header row plus at least one data row;
+  // fall back to the plain table block for header-only tables.
+  if (element.rows.length === 0) {
+    return [
+      compact({
+        column_settings: element.align
+          ?.slice(0, LIMITS.tableColumns)
+          .map((align) => (align ? { align } : null)),
+        rows,
+        type: "table",
+      }),
+    ];
+  }
   return [
     compact({
-      column_settings: element.align
-        ?.slice(0, LIMITS.tableColumns)
-        .map((align) => (align ? { align } : null)),
-      rows: [
-        element.headers.map((header) => rawText(header, state.convertEmoji)),
-        ...element.rows.map((row) =>
-          row.map((cell) => rawText(cell, state.convertEmoji))
-        ),
-      ],
-      type: "table",
+      caption: state.convertEmoji(element.caption || "Table"),
+      page_size:
+        element.pageSize === undefined
+          ? undefined
+          : Math.min(
+              LIMITS.tablePageSize,
+              Math.max(1, Math.floor(element.pageSize))
+            ),
+      rows,
+      type: "data_table",
     }),
   ];
+}
+
+function chartToBlock(
+  element: SlackChartElement,
+  state: {
+    chartCount: number;
+    convertEmoji: (text: string) => string;
+  }
+): SlackBlock {
+  const block =
+    state.chartCount < LIMITS.chartsPerMessage
+      ? chartToDataVisualization(element, state.convertEmoji)
+      : null;
+  if (block) {
+    state.chartCount += 1;
+    return block;
+  }
+  // Slack rejects invalid charts (and >2 charts per message) outright
+  // rather than truncating them, so render the underlying data as text.
+  return {
+    text: mrkdwn(
+      `\`\`\`\n${chartToAscii(element)}\n\`\`\``,
+      (value) => value,
+      LIMITS.sectionText
+    ),
+    type: "section",
+  };
+}
+
+function chartToDataVisualization(
+  element: SlackChartElement,
+  convertEmoji: (text: string) => string
+): SlackBlock | null {
+  const title = convertEmoji(element.title);
+  if (title.length === 0 || title.length > LIMITS.chartTitle) {
+    return null;
+  }
+
+  const { chart } = element;
+
+  if (chart.type === "pie") {
+    const validSegments =
+      chart.segments.length >= 1 &&
+      chart.segments.length <= LIMITS.chartSegments &&
+      chart.segments.every(
+        (segment) => isValidChartLabel(segment.label) && segment.value > 0
+      );
+    if (!validSegments) {
+      return null;
+    }
+    return {
+      chart: {
+        segments: chart.segments.map((segment) => ({
+          label: segment.label,
+          value: segment.value,
+        })),
+        type: "pie",
+      },
+      title,
+      type: "data_visualization",
+    };
+  }
+
+  const { categories, series } = chart;
+  const validShape =
+    categories.length >= 1 &&
+    categories.length <= LIMITS.chartDataPoints &&
+    categories.every((category) => isValidChartLabel(category)) &&
+    new Set(categories).size === categories.length &&
+    series.length >= 1 &&
+    series.length <= LIMITS.chartSeries &&
+    series.every((s) => isValidChartLabel(s.name)) &&
+    new Set(series.map((s) => s.name)).size === series.length &&
+    (chart.xLabel === undefined || chart.xLabel.length <= LIMITS.chartTitle) &&
+    (chart.yLabel === undefined || chart.yLabel.length <= LIMITS.chartTitle);
+  if (!validShape) {
+    return null;
+  }
+
+  // Each series needs exactly one data point per category; normalize
+  // point order to the category order Slack expects.
+  const normalizedSeries: { data: unknown[]; name: string }[] = [];
+  for (const s of series) {
+    if (s.data.length !== categories.length) {
+      return null;
+    }
+    const byLabel = new Map(s.data.map((point) => [point.label, point]));
+    const data: unknown[] = [];
+    for (const category of categories) {
+      const point = byLabel.get(category);
+      if (!point) {
+        return null;
+      }
+      data.push({ label: category, value: point.value });
+    }
+    normalizedSeries.push({ data, name: s.name });
+  }
+
+  return {
+    chart: {
+      axis_config: compact({
+        categories,
+        x_label: chart.xLabel,
+        y_label: chart.yLabel,
+      }),
+      series: normalizedSeries,
+      type: chart.type,
+    },
+    title,
+    type: "data_visualization",
+  };
+}
+
+function isValidChartLabel(label: string): boolean {
+  return label.length >= 1 && label.length <= LIMITS.chartLabel;
+}
+
+function chartToAscii(element: SlackChartElement): string {
+  const { chart, title } = element;
+  if (chart.type === "pie") {
+    const table = tableToAscii({
+      headers: ["Label", "Value"],
+      rows: chart.segments.map((segment) => [
+        segment.label,
+        String(segment.value),
+      ]),
+      type: "table",
+    });
+    return `${title}\n${table}`;
+  }
+  const table = tableToAscii({
+    headers: [chart.xLabel ?? "", ...chart.series.map((s) => s.name)],
+    rows: chart.categories.map((category) => [
+      category,
+      ...chart.series.map((s) => {
+        const point = s.data.find((p) => p.label === category);
+        return point ? String(point.value) : "";
+      }),
+    ]),
+    type: "table",
+  });
+  return `${title}\n${table}`;
 }
 
 function cardChildToFallbackText(
@@ -395,6 +572,8 @@ function cardChildToFallbackText(
   switch (child.type) {
     case "actions":
       return undefined;
+    case "chart":
+      return chartToAscii(child);
     case "divider":
       return "---";
     case "fields":

--- a/packages/adapter-slack/src/blocks/limits.ts
+++ b/packages/adapter-slack/src/blocks/limits.ts
@@ -6,6 +6,13 @@ export const LIMITS = {
   buttonText: 75,
   buttonUrl: 3000,
   buttonValue: 2000,
+  chartDataPoints: 20,
+  chartLabel: 20,
+  // Undocumented: Slack rejects messages with >2 data_visualization blocks
+  chartsPerMessage: 2,
+  chartSegments: 12,
+  chartSeries: 12,
+  chartTitle: 50,
   fields: 10,
   fieldText: 2000,
   headerText: 150,
@@ -18,7 +25,9 @@ export const LIMITS = {
   placeholder: 150,
   radioOptions: 10,
   sectionText: 3000,
+  tableChars: 10_000,
   tableColumns: 20,
+  tablePageSize: 100,
   tableRows: 100,
   textObject: 3000,
 } as const;

--- a/packages/adapter-slack/src/blocks/types.ts
+++ b/packages/adapter-slack/src/blocks/types.ts
@@ -12,6 +12,7 @@ export interface SlackCardElement {
 
 export type SlackCardChild =
   | SlackActionsElement
+  | SlackChartElement
   | SlackDividerElement
   | SlackFieldsElement
   | SlackImageElement
@@ -111,9 +112,63 @@ export interface SlackFieldsElement {
 
 export interface SlackTableElement {
   align?: SlackTableAlignment[];
+  /** Accessible table caption for the data table block */
+  caption?: string;
   headers: string[];
+  /** Rows per page (1-100; Slack defaults to 5) */
+  pageSize?: number;
   rows: string[][];
   type: "table";
+}
+
+export interface SlackChartSegment {
+  /** Legend label (max 20 characters) */
+  label: string;
+  /** Segment value; must be greater than 0 */
+  value: number;
+}
+
+export interface SlackChartDataPoint {
+  /** Category label; must match an entry in the chart's `categories` */
+  label: string;
+  /** Y-axis value (negative values are permitted) */
+  value: number;
+}
+
+export interface SlackChartSeries {
+  /** One data point per category */
+  data: SlackChartDataPoint[];
+  /** Legend label; unique within the chart (max 20 characters) */
+  name: string;
+}
+
+export interface SlackPieChartDefinition {
+  /** Pie segments (1-12) */
+  segments: SlackChartSegment[];
+  type: "pie";
+}
+
+export interface SlackSeriesChartDefinition {
+  /** X-axis category labels in display order (max 20 characters each) */
+  categories: string[];
+  /** Data series (1-12); each series needs one point per category */
+  series: SlackChartSeries[];
+  type: "area" | "bar" | "line";
+  /** X-axis title (max 50 characters) */
+  xLabel?: string;
+  /** Y-axis title (max 50 characters) */
+  yLabel?: string;
+}
+
+export type SlackChartDefinition =
+  | SlackPieChartDefinition
+  | SlackSeriesChartDefinition;
+
+export interface SlackChartElement {
+  chart: SlackChartDefinition;
+  /** Chart title (max 50 characters) */
+  title: string;
+  type: "chart";
 }
 
 export interface SlackTextObject {

--- a/packages/adapter-slack/src/cards.test.ts
+++ b/packages/adapter-slack/src/cards.test.ts
@@ -891,6 +891,19 @@ describe("cardToBlockKit with data tables", () => {
     expect(blocks[0].type).toBe("section");
     expect(blocks[0].text.text).toContain("```");
   });
+
+  it("truncates ASCII fallback to Slack's 3,000-char section limit", () => {
+    const bigCell = "x".repeat(5001);
+    const card = Card({
+      children: [Table({ headers: ["A"], rows: [[bigCell], [bigCell]] })],
+    });
+
+    const text = (cardToBlockKit(card)[0] as { text: { text: string } }).text
+      .text;
+    expect(text.length).toBeLessThanOrEqual(3000);
+    // Closing code fence survives truncation
+    expect(text.endsWith("\n```")).toBe(true);
+  });
 });
 
 describe("cardToBlockKit with charts", () => {

--- a/packages/adapter-slack/src/cards.test.ts
+++ b/packages/adapter-slack/src/cards.test.ts
@@ -4,6 +4,7 @@ import {
   Card,
   CardLink,
   CardText,
+  Chart,
   Divider,
   Field,
   Fields,
@@ -761,7 +762,7 @@ describe("cardToBlockKit with CardLink", () => {
     });
   });
 
-  it("converts a card with table element to Block Kit Table", () => {
+  it("converts a card with table element to a Block Kit data table", () => {
     const card = Card({
       children: [
         Table({
@@ -776,7 +777,9 @@ describe("cardToBlockKit with CardLink", () => {
 
     const blocks = cardToBlockKit(card);
     expect(blocks).toHaveLength(1);
-    expect(blocks[0].type).toBe("table");
+    expect(blocks[0].type).toBe("data_table");
+    expect(blocks[0].caption).toBe("Table");
+    expect(blocks[0].page_size).toBeUndefined();
     // First row is headers, subsequent rows are data
     expect(blocks[0].rows).toEqual([
       [
@@ -810,7 +813,7 @@ describe("cardToBlockKit with CardLink", () => {
 
     const blocks = cardToBlockKit(card);
     expect(blocks).toHaveLength(2);
-    expect(blocks[0].type).toBe("table");
+    expect(blocks[0].type).toBe("data_table");
     // Second table falls back to ASCII in a section block
     expect(blocks[1].type).toBe("section");
     expect(blocks[1].text.text).toContain("```");
@@ -831,7 +834,7 @@ describe("cardToBlockKit with CardLink", () => {
 
     const blocks = cardToBlockKit(card);
     const tableBlock = blocks[0];
-    expect(tableBlock.type).toBe("table");
+    expect(tableBlock.type).toBe("data_table");
     // Every cell must have non-empty text (Slack rejects empty strings)
     for (const row of tableBlock.rows) {
       for (const cell of row) {
@@ -841,5 +844,267 @@ describe("cardToBlockKit with CardLink", () => {
     // Empty cells become a space
     expect(tableBlock.rows[0][1].text).toBe(" "); // empty header
     expect(tableBlock.rows[2][1].text).toBe(" "); // empty data cell
+  });
+});
+
+describe("cardToBlockKit with data tables", () => {
+  it("passes caption and clamped page_size through", () => {
+    const card = Card({
+      children: [
+        Table({
+          headers: ["Name"],
+          rows: [["Ada"]],
+          caption: "People",
+          pageSize: 250,
+        }),
+      ],
+    });
+
+    const blocks = cardToBlockKit(card);
+    expect(blocks[0].type).toBe("data_table");
+    expect(blocks[0].caption).toBe("People");
+    expect(blocks[0].page_size).toBe(100);
+  });
+
+  it("renders header-only tables as a plain table block", () => {
+    const card = Card({
+      children: [Table({ headers: ["Name", "Age"], rows: [] })],
+    });
+
+    const blocks = cardToBlockKit(card);
+    expect(blocks[0].type).toBe("table");
+    expect(blocks[0].rows).toEqual([
+      [
+        { type: "raw_text", text: "Name" },
+        { type: "raw_text", text: "Age" },
+      ],
+    ]);
+  });
+
+  it("falls back to ASCII when combined cells exceed 10,000 characters", () => {
+    const bigCell = "x".repeat(5001);
+    const card = Card({
+      children: [Table({ headers: ["A"], rows: [[bigCell], [bigCell]] })],
+    });
+
+    const blocks = cardToBlockKit(card);
+    expect(blocks[0].type).toBe("section");
+    expect(blocks[0].text.text).toContain("```");
+  });
+});
+
+describe("cardToBlockKit with charts", () => {
+  it("converts a pie chart to a data_visualization block", () => {
+    const card = Card({
+      children: [
+        Chart({
+          title: "Candy Bars",
+          chart: {
+            type: "pie",
+            segments: [
+              { label: "Kit Kat", value: 45 },
+              { label: "Twix", value: 28 },
+            ],
+          },
+        }),
+      ],
+    });
+
+    const blocks = cardToBlockKit(card);
+    expect(blocks).toHaveLength(1);
+    expect(blocks[0]).toEqual({
+      type: "data_visualization",
+      title: "Candy Bars",
+      chart: {
+        type: "pie",
+        segments: [
+          { label: "Kit Kat", value: 45 },
+          { label: "Twix", value: 28 },
+        ],
+      },
+    });
+  });
+
+  it("converts a bar chart with axis config and normalizes point order", () => {
+    const card = Card({
+      children: [
+        Chart({
+          title: "DAU",
+          chart: {
+            type: "bar",
+            categories: ["Mon", "Tue"],
+            xLabel: "Day",
+            yLabel: "Users",
+            series: [
+              {
+                name: "Mobile",
+                data: [
+                  { label: "Tue", value: 60 },
+                  { label: "Mon", value: 50 },
+                ],
+              },
+            ],
+          },
+        }),
+      ],
+    });
+
+    const blocks = cardToBlockKit(card);
+    expect(blocks[0]).toEqual({
+      type: "data_visualization",
+      title: "DAU",
+      chart: {
+        type: "bar",
+        series: [
+          {
+            name: "Mobile",
+            data: [
+              { label: "Mon", value: 50 },
+              { label: "Tue", value: 60 },
+            ],
+          },
+        ],
+        axis_config: {
+          categories: ["Mon", "Tue"],
+          x_label: "Day",
+          y_label: "Users",
+        },
+      },
+    });
+  });
+
+  it("omits axis labels that are not provided", () => {
+    const card = Card({
+      children: [
+        Chart({
+          title: "Sales",
+          chart: {
+            type: "line",
+            categories: ["W1"],
+            series: [{ name: "A", data: [{ label: "W1", value: 1 }] }],
+          },
+        }),
+      ],
+    });
+
+    const blocks = cardToBlockKit(card);
+    expect(blocks[0].chart).toEqual({
+      type: "line",
+      series: [{ name: "A", data: [{ label: "W1", value: 1 }] }],
+      axis_config: { categories: ["W1"] },
+    });
+  });
+
+  it("falls back to text when a pie segment value is not positive", () => {
+    const card = Card({
+      children: [
+        Chart({
+          title: "Bad Pie",
+          chart: {
+            type: "pie",
+            segments: [{ label: "Zero", value: 0 }],
+          },
+        }),
+      ],
+    });
+
+    const blocks = cardToBlockKit(card);
+    expect(blocks[0].type).toBe("section");
+    expect(blocks[0].text.text).toContain("Bad Pie");
+    expect(blocks[0].text.text).toContain("```");
+  });
+
+  it("falls back to text when a series misses a category", () => {
+    const card = Card({
+      children: [
+        Chart({
+          title: "Gaps",
+          chart: {
+            type: "area",
+            categories: ["Mon", "Tue"],
+            series: [{ name: "A", data: [{ label: "Mon", value: 1 }] }],
+          },
+        }),
+      ],
+    });
+
+    const blocks = cardToBlockKit(card);
+    expect(blocks[0].type).toBe("section");
+    expect(blocks[0].text.text).toContain("```");
+  });
+
+  it("falls back to text when the title exceeds 50 characters", () => {
+    const card = Card({
+      children: [
+        Chart({
+          title: "t".repeat(51),
+          chart: {
+            type: "pie",
+            segments: [{ label: "A", value: 1 }],
+          },
+        }),
+      ],
+    });
+
+    const blocks = cardToBlockKit(card);
+    expect(blocks[0].type).toBe("section");
+  });
+
+  it("falls back to text when there are more than 12 segments", () => {
+    const card = Card({
+      children: [
+        Chart({
+          title: "Too Many",
+          chart: {
+            type: "pie",
+            segments: Array.from({ length: 13 }, (_, i) => ({
+              label: `S${i}`,
+              value: i + 1,
+            })),
+          },
+        }),
+      ],
+    });
+
+    const blocks = cardToBlockKit(card);
+    expect(blocks[0].type).toBe("section");
+  });
+
+  it("falls back to text from the third chart in one message", () => {
+    const pie = (title: string) =>
+      Chart({
+        title,
+        chart: { type: "pie", segments: [{ label: "A", value: 1 }] },
+      });
+    const card = Card({
+      children: [pie("One"), pie("Two"), pie("Three")],
+    });
+
+    const blocks = cardToBlockKit(card);
+    expect(blocks.map((b) => b.type)).toEqual([
+      "data_visualization",
+      "data_visualization",
+      "section",
+    ]);
+    expect(blocks[2].text.text).toContain("Three");
+  });
+
+  it("includes chart data in card fallback text", () => {
+    const card = Card({
+      title: "Report",
+      children: [
+        Chart({
+          title: "Candy Bars",
+          chart: {
+            type: "pie",
+            segments: [{ label: "Kit Kat", value: 45 }],
+          },
+        }),
+      ],
+    });
+
+    const text = cardToFallbackText(card);
+    expect(text).toContain("Candy Bars");
+    expect(text).toContain("Kit Kat");
   });
 });

--- a/packages/adapter-slack/src/cards.ts
+++ b/packages/adapter-slack/src/cards.ts
@@ -15,6 +15,7 @@ import type {
   ButtonElement,
   CardChild,
   CardElement,
+  ChartElement,
   DividerElement,
   FieldsElement,
   ImageElement,
@@ -26,7 +27,11 @@ import type {
   TableElement,
   TextElement,
 } from "chat";
-import { cardChildToFallbackText, tableElementToAscii } from "chat";
+import {
+  cardChildToFallbackText,
+  chartElementToFallbackText,
+  tableElementToAscii,
+} from "chat";
 import { markdownBoldToSlackMrkdwn } from "./format";
 
 /**
@@ -124,9 +129,9 @@ export function cardToBlockKit(card: CardElement): SlackBlock[] {
     });
   }
 
-  // Convert children — track whether native table block has been used
-  // (Slack allows at most one table block per message)
-  const state = { usedNativeTable: false };
+  // Convert children — track native table/chart block usage (Slack allows
+  // at most one table block and two data_visualization blocks per message)
+  const state = { usedNativeTable: false, chartCount: 0 };
   for (const child of card.children) {
     const childBlocks = convertChildToBlocks(child, state);
     blocks.push(...childBlocks);
@@ -135,12 +140,18 @@ export function cardToBlockKit(card: CardElement): SlackBlock[] {
   return blocks;
 }
 
+/** Per-message rendering state for Slack's native block usage limits. */
+interface CardRenderState {
+  chartCount: number;
+  usedNativeTable: boolean;
+}
+
 /**
  * Convert a card child element to Slack blocks.
  */
 function convertChildToBlocks(
   child: CardChild,
-  state: { usedNativeTable: boolean }
+  state: CardRenderState
 ): SlackBlock[] {
   switch (child.type) {
     case "text":
@@ -159,6 +170,8 @@ function convertChildToBlocks(
       return [convertLinkToBlock(child)];
     case "table":
       return convertTableToBlocks(child, state);
+    case "chart":
+      return [convertChartToBlock(child, state)];
     default: {
       const text = cardChildToFallbackText(child);
       if (text) {
@@ -354,29 +367,36 @@ function convertRadioSelectToElement(
   return element;
 }
 
+const DATA_TABLE_MAX_ROWS = 100;
+const DATA_TABLE_MAX_COLS = 20;
+// A single table (all cells combined) can't exceed 10,000 characters
+const DATA_TABLE_MAX_CHARS = 10_000;
+const DATA_TABLE_MIN_PAGE_SIZE = 1;
+const DATA_TABLE_MAX_PAGE_SIZE = 100;
+
 /**
  * Convert a table element to Slack Block Kit blocks.
- * Uses Block Kit Table block for tables within limits (100 rows, 20 columns),
- * falls back to code block for larger tables.
- */
-/**
- * Convert a table element to Slack Block Kit blocks.
- * Uses the native table block with first-row-as-headers schema.
- * Falls back to code block for tables exceeding Slack limits (100 rows, 20 columns)
- * or when a native table block has already been used in this message.
- * @see https://docs.slack.dev/reference/block-kit/blocks/table-block/
+ * Uses the data table block (paginated + sortable) with first-row-as-headers
+ * schema when the table has at least one data row.
+ * Falls back to the plain table block for header-only tables, and to an
+ * ASCII code block for tables exceeding Slack limits (100 data rows,
+ * 20 columns, 10,000 characters) or when a native table block has already
+ * been used in this message.
+ * @see https://docs.slack.dev/reference/block-kit/blocks/data-table-block/
  */
 function convertTableToBlocks(
   element: TableElement,
-  state: { usedNativeTable: boolean }
+  state: CardRenderState
 ): SlackBlock[] {
-  const MAX_ROWS = 100;
-  const MAX_COLS = 20;
+  const cellCharCount = [element.headers, ...element.rows]
+    .flat()
+    .reduce((total, cell) => total + cell.length, 0);
 
   if (
     state.usedNativeTable ||
-    element.rows.length > MAX_ROWS ||
-    element.headers.length > MAX_COLS
+    element.rows.length > DATA_TABLE_MAX_ROWS ||
+    element.headers.length > DATA_TABLE_MAX_COLS ||
+    cellCharCount > DATA_TABLE_MAX_CHARS
   ) {
     // Fall back to ASCII table in a code block
     return [
@@ -405,17 +425,166 @@ function convertTableToBlocks(
     }))
   );
 
-  return [
-    {
-      type: "table",
-      rows: [headerRow, ...dataRows],
+  // The data table block requires a header row plus at least one data row
+  if (dataRows.length === 0) {
+    return [
+      {
+        type: "table",
+        rows: [headerRow],
+      },
+    ];
+  }
+
+  const block: SlackBlock = {
+    type: "data_table",
+    caption: convertEmoji(element.caption || "Table"),
+    rows: [headerRow, ...dataRows],
+  };
+  if (element.pageSize !== undefined) {
+    block.page_size = Math.min(
+      DATA_TABLE_MAX_PAGE_SIZE,
+      Math.max(DATA_TABLE_MIN_PAGE_SIZE, Math.floor(element.pageSize))
+    );
+  }
+  return [block];
+}
+
+const CHART_MAX_TITLE_CHARS = 50;
+const CHART_MAX_LABEL_CHARS = 20;
+const CHART_MAX_SEGMENTS = 12;
+const CHART_MAX_SERIES = 12;
+const CHART_MAX_DATA_POINTS = 20;
+// Slack rejects messages with more than 2 data_visualization blocks
+// (undocumented; enforced by the API as of July 2026)
+const CHART_MAX_PER_MESSAGE = 2;
+
+/**
+ * Convert a chart element to a Slack data visualization block.
+ * Falls back to the chart's data rendered as an ASCII table in a code block
+ * when the chart violates Slack constraints (label lengths, series counts,
+ * category/data-point mismatches, more than 2 charts per message), since
+ * Slack rejects invalid charts outright rather than truncating them.
+ * @see https://docs.slack.dev/reference/block-kit/blocks/data-visualization-block/
+ */
+function convertChartToBlock(
+  element: ChartElement,
+  state: CardRenderState
+): SlackBlock {
+  const block =
+    state.chartCount < CHART_MAX_PER_MESSAGE
+      ? chartToDataVisualization(element)
+      : null;
+  if (block) {
+    state.chartCount += 1;
+    return block;
+  }
+  return {
+    type: "section",
+    text: {
+      type: "mrkdwn",
+      text: `\`\`\`\n${chartElementToFallbackText(element)}\n\`\`\``,
     },
-  ];
+  };
+}
+
+/**
+ * Build a data_visualization block, or return null if the chart violates
+ * Slack constraints.
+ */
+function chartToDataVisualization(element: ChartElement): SlackBlock | null {
+  const title = convertEmoji(element.title);
+  if (title.length === 0 || title.length > CHART_MAX_TITLE_CHARS) {
+    return null;
+  }
+
+  const { chart } = element;
+
+  if (chart.type === "pie") {
+    const validSegments =
+      chart.segments.length >= 1 &&
+      chart.segments.length <= CHART_MAX_SEGMENTS &&
+      chart.segments.every(
+        (segment) => isValidChartLabel(segment.label) && segment.value > 0
+      );
+    if (!validSegments) {
+      return null;
+    }
+    return {
+      type: "data_visualization",
+      title,
+      chart: {
+        type: "pie",
+        segments: chart.segments.map((segment) => ({
+          label: segment.label,
+          value: segment.value,
+        })),
+      },
+    };
+  }
+
+  const { categories, series } = chart;
+  const validShape =
+    categories.length >= 1 &&
+    categories.length <= CHART_MAX_DATA_POINTS &&
+    categories.every((category) => isValidChartLabel(category)) &&
+    new Set(categories).size === categories.length &&
+    series.length >= 1 &&
+    series.length <= CHART_MAX_SERIES &&
+    series.every((s) => isValidChartLabel(s.name)) &&
+    new Set(series.map((s) => s.name)).size === series.length &&
+    (chart.xLabel === undefined ||
+      chart.xLabel.length <= CHART_MAX_TITLE_CHARS) &&
+    (chart.yLabel === undefined ||
+      chart.yLabel.length <= CHART_MAX_TITLE_CHARS);
+  if (!validShape) {
+    return null;
+  }
+
+  // Each series needs exactly one data point per category; normalize
+  // point order to the category order Slack expects.
+  const normalizedSeries: { name: string; data: unknown[] }[] = [];
+  for (const s of series) {
+    if (s.data.length !== categories.length) {
+      return null;
+    }
+    const byLabel = new Map(s.data.map((point) => [point.label, point]));
+    const data: unknown[] = [];
+    for (const category of categories) {
+      const point = byLabel.get(category);
+      if (!point) {
+        return null;
+      }
+      data.push({ label: category, value: point.value });
+    }
+    normalizedSeries.push({ name: s.name, data });
+  }
+
+  const axisConfig: Record<string, unknown> = { categories };
+  if (chart.xLabel !== undefined) {
+    axisConfig.x_label = chart.xLabel;
+  }
+  if (chart.yLabel !== undefined) {
+    axisConfig.y_label = chart.yLabel;
+  }
+
+  return {
+    type: "data_visualization",
+    title,
+    chart: {
+      type: chart.type,
+      series: normalizedSeries,
+      axis_config: axisConfig,
+    },
+  };
+}
+
+function isValidChartLabel(label: string): boolean {
+  return label.length >= 1 && label.length <= CHART_MAX_LABEL_CHARS;
 }
 
 function convertSectionToBlocks(
   element: SectionElement,
-  state: { usedNativeTable: boolean }
+  state: CardRenderState
 ): SlackBlock[] {
   // Flatten section children into blocks
   const blocks: SlackBlock[] = [];

--- a/packages/adapter-slack/src/cards.ts
+++ b/packages/adapter-slack/src/cards.ts
@@ -367,6 +367,24 @@ function convertRadioSelectToElement(
   return element;
 }
 
+// Slack's section text object limit
+const SECTION_TEXT_MAX_CHARS = 3000;
+
+/**
+ * Wrap ASCII fallback content in a fenced code block inside a section,
+ * truncating the content so the section text stays within Slack's
+ * 3,000-character limit while keeping the closing fence intact.
+ */
+function asciiFallbackBlock(content: string): SlackBlock {
+  const fence = (body: string) => `\`\`\`\n${body}\n\`\`\``;
+  const budget = SECTION_TEXT_MAX_CHARS - fence("").length;
+  const text =
+    content.length > budget
+      ? fence(`${content.slice(0, budget - 1)}…`)
+      : fence(content);
+  return { type: "section", text: { type: "mrkdwn", text } };
+}
+
 const DATA_TABLE_MAX_ROWS = 100;
 const DATA_TABLE_MAX_COLS = 20;
 // A single table (all cells combined) can't exceed 10,000 characters
@@ -400,13 +418,7 @@ function convertTableToBlocks(
   ) {
     // Fall back to ASCII table in a code block
     return [
-      {
-        type: "section",
-        text: {
-          type: "mrkdwn",
-          text: `\`\`\`\n${tableElementToAscii(element.headers, element.rows)}\n\`\`\``,
-        },
-      },
+      asciiFallbackBlock(tableElementToAscii(element.headers, element.rows)),
     ];
   }
 
@@ -478,13 +490,7 @@ function convertChartToBlock(
     state.chartCount += 1;
     return block;
   }
-  return {
-    type: "section",
-    text: {
-      type: "mrkdwn",
-      text: `\`\`\`\n${chartElementToFallbackText(element)}\n\`\`\``,
-    },
-  };
+  return asciiFallbackBlock(chartElementToFallbackText(element));
 }
 
 /**

--- a/packages/adapter-slack/src/index.ts
+++ b/packages/adapter-slack/src/index.ts
@@ -103,6 +103,46 @@ function timingSafeStringEqual(a: string, b: string): boolean {
   return timingSafeEqual(aBuf, bBuf);
 }
 
+/**
+ * Surface Slack's per-block validation details on invalid_blocks errors.
+ * The @slack/web-api error message is just "An API error occurred:
+ * invalid_blocks"; the actionable details (which block, which field) live in
+ * `data.errors` and `data.response_metadata.messages`.
+ */
+function enrichInvalidBlocksError(
+  error: unknown,
+  blocks: unknown[],
+  logger: Logger
+): unknown {
+  const slackError = error as {
+    code?: string;
+    data?: {
+      error?: string;
+      errors?: unknown[];
+      response_metadata?: { messages?: string[] };
+    };
+  };
+  if (
+    slackError.code !== "slack_webapi_platform_error" ||
+    slackError.data?.error !== "invalid_blocks"
+  ) {
+    return error;
+  }
+  const details = [
+    ...(slackError.data.errors ?? []),
+    ...(slackError.data.response_metadata?.messages ?? []),
+  ];
+  logger.error("Slack rejected blocks (invalid_blocks)", {
+    details,
+    blocks: JSON.stringify(blocks),
+  });
+  const enriched = new Error(
+    `Slack rejected blocks (invalid_blocks): ${JSON.stringify(details)}`
+  );
+  (enriched as { cause?: unknown }).cause = error;
+  return enriched;
+}
+
 /** Find the next `<@` or `<#` mention in text. */
 function findNextMention(text: string): number {
   const atIdx = text.indexOf("<@");
@@ -3265,16 +3305,21 @@ export class SlackAdapter implements Adapter<SlackThreadId, unknown> {
           blockCount: blocks.length,
         });
 
-        const result = await this._client.chat.postMessage(
-          await this.withToken({
-            channel,
-            thread_ts: threadTs,
-            text: fallbackText, // Fallback for notifications
-            blocks,
-            unfurl_links: false,
-            unfurl_media: false,
-          })
-        );
+        let result: Awaited<ReturnType<typeof this._client.chat.postMessage>>;
+        try {
+          result = await this._client.chat.postMessage(
+            await this.withToken({
+              channel,
+              thread_ts: threadTs,
+              text: fallbackText, // Fallback for notifications
+              blocks,
+              unfurl_links: false,
+              unfurl_media: false,
+            })
+          );
+        } catch (error) {
+          throw enrichInvalidBlocksError(error, blocks, this.logger);
+        }
 
         this.logger.debug("Slack API: chat.postMessage response", {
           messageId: result.ts,

--- a/packages/chat/src/cards.test.ts
+++ b/packages/chat/src/cards.test.ts
@@ -4,6 +4,8 @@ import {
   Button,
   Card,
   CardLink,
+  Chart,
+  cardChildToFallbackText,
   Divider,
   Field,
   Fields,
@@ -11,6 +13,7 @@ import {
   isCardElement,
   LinkButton,
   Section,
+  Table,
   Text,
 } from "./cards";
 import { RadioSelect, Select, SelectOption } from "./modals";
@@ -202,6 +205,136 @@ describe("Card Builder Functions", () => {
       ]);
       expect(fields.type).toBe("fields");
       expect(fields.children).toHaveLength(2);
+    });
+  });
+
+  describe("Table", () => {
+    it("creates a table with caption and pageSize", () => {
+      const table = Table({
+        headers: ["Name", "Score"],
+        rows: [["Ada", "10"]],
+        caption: "Scores",
+        pageSize: 25,
+      });
+      expect(table.type).toBe("table");
+      expect(table.caption).toBe("Scores");
+      expect(table.pageSize).toBe(25);
+    });
+
+    it("leaves caption and pageSize undefined when omitted", () => {
+      const table = Table({ headers: ["A"], rows: [["1"]] });
+      expect(table.caption).toBeUndefined();
+      expect(table.pageSize).toBeUndefined();
+    });
+  });
+
+  describe("Chart", () => {
+    it("creates a pie chart", () => {
+      const chart = Chart({
+        title: "Candy Bars",
+        chart: {
+          type: "pie",
+          segments: [
+            { label: "Kit Kat", value: 45 },
+            { label: "Twix", value: 28 },
+          ],
+        },
+      });
+      expect(chart.type).toBe("chart");
+      expect(chart.title).toBe("Candy Bars");
+      expect(chart.chart.type).toBe("pie");
+    });
+
+    it("creates a line chart with series and categories", () => {
+      const chart = Chart({
+        title: "Weekly Sales",
+        chart: {
+          type: "line",
+          categories: ["Week 1", "Week 2"],
+          xLabel: "Week",
+          yLabel: "Sales",
+          series: [
+            {
+              name: "Scranton",
+              data: [
+                { label: "Week 1", value: 120 },
+                { label: "Week 2", value: 135 },
+              ],
+            },
+          ],
+        },
+      });
+      expect(chart.chart).toEqual({
+        type: "line",
+        categories: ["Week 1", "Week 2"],
+        xLabel: "Week",
+        yLabel: "Sales",
+        series: [
+          {
+            name: "Scranton",
+            data: [
+              { label: "Week 1", value: 120 },
+              { label: "Week 2", value: 135 },
+            ],
+          },
+        ],
+      });
+    });
+  });
+
+  describe("chart fallback text", () => {
+    it("renders pie chart data as a labelled ASCII table", () => {
+      const text = cardChildToFallbackText(
+        Chart({
+          title: "Candy Bars",
+          chart: {
+            type: "pie",
+            segments: [
+              { label: "Kit Kat", value: 45 },
+              { label: "Twix", value: 28 },
+            ],
+          },
+        })
+      );
+      expect(text).toContain("Candy Bars");
+      expect(text).toContain("Kit Kat | 45");
+      expect(text).toContain("Twix");
+    });
+
+    it("renders series chart data with one column per series", () => {
+      const text = cardChildToFallbackText(
+        Chart({
+          title: "DAU",
+          chart: {
+            type: "area",
+            categories: ["Mon", "Tue"],
+            xLabel: "Day",
+            series: [
+              {
+                name: "Web",
+                data: [
+                  { label: "Mon", value: 100 },
+                  { label: "Tue", value: 110 },
+                ],
+              },
+              {
+                name: "Mobile",
+                data: [
+                  { label: "Tue", value: 60 },
+                  { label: "Mon", value: 50 },
+                ],
+              },
+            ],
+          },
+        })
+      );
+      expect(text).toContain("DAU");
+      expect(text).toContain("Day");
+      expect(text).toContain("Web");
+      expect(text).toContain("Mobile");
+      // Values align to categories even when point order differs
+      expect(text).toContain("Mon | 100 | 50");
+      expect(text).toContain("Tue | 110 | 60");
     });
   });
 

--- a/packages/chat/src/cards.ts
+++ b/packages/chat/src/cards.ts
@@ -44,7 +44,7 @@
  * ```
  */
 
-import { tableElementToAscii } from "./markdown";
+import { chartElementToFallbackText, tableElementToAscii } from "./markdown";
 import type { RadioSelectElement, SelectElement } from "./modals";
 
 // ============================================================================
@@ -163,11 +163,71 @@ export type TableAlignment = "left" | "center" | "right";
 export interface TableElement {
   /** Column alignment */
   align?: TableAlignment[];
+  /** Accessible table caption (used by platforms with native table support) */
+  caption?: string;
   /** Column header labels */
   headers: string[];
+  /** Rows per page on platforms that paginate tables (Slack: 1-100, default 5) */
+  pageSize?: number;
   /** Data rows (each row is an array of cell strings) */
   rows: string[][];
   type: "table";
+}
+
+/** Chart segment for pie charts */
+export interface ChartSegment {
+  /** Legend label (Slack: max 20 characters) */
+  label: string;
+  /** Segment value; must be greater than 0. Rendered as a percentage of the total. */
+  value: number;
+}
+
+/** A single data point within a chart series */
+export interface ChartDataPoint {
+  /** Category label; must match an entry in the chart's `categories` */
+  label: string;
+  /** Y-axis value (negative values are permitted) */
+  value: number;
+}
+
+/** A named data series for bar, area, and line charts */
+export interface ChartSeries {
+  /** One data point per category */
+  data: ChartDataPoint[];
+  /** Legend label; must be unique within the chart (Slack: max 20 characters) */
+  name: string;
+}
+
+/** Pie chart definition */
+export interface PieChartDefinition {
+  /** Pie segments (Slack: 1-12) */
+  segments: ChartSegment[];
+  type: "pie";
+}
+
+/** Bar, area, or line chart definition */
+export interface SeriesChartDefinition {
+  /** X-axis category labels in display order (Slack: max 20 characters each) */
+  categories: string[];
+  /** Data series (Slack: 1-12); each series needs one point per category */
+  series: ChartSeries[];
+  type: "area" | "bar" | "line";
+  /** X-axis title (Slack: max 50 characters) */
+  xLabel?: string;
+  /** Y-axis title (Slack: max 50 characters) */
+  yLabel?: string;
+}
+
+/** Chart definition, discriminated by chart type */
+export type ChartDefinition = PieChartDefinition | SeriesChartDefinition;
+
+/** Chart element for data visualization */
+export interface ChartElement {
+  /** Chart definition */
+  chart: ChartDefinition;
+  /** Chart title (Slack: max 50 characters) */
+  title: string;
+  type: "chart";
 }
 
 /** Union of all card child element types */
@@ -179,7 +239,8 @@ export type CardChild =
   | SectionElement
   | FieldsElement
   | LinkElement
-  | TableElement;
+  | TableElement
+  | ChartElement;
 
 /** Union of all element types (including nested children) */
 type AnyCardElement =
@@ -463,8 +524,12 @@ export function Fields(children: FieldElement[]): FieldsElement {
 export interface TableOptions {
   /** Column alignment */
   align?: TableAlignment[];
+  /** Accessible table caption (used by platforms with native table support) */
+  caption?: string;
   /** Column header labels */
   headers: string[];
+  /** Rows per page on platforms that paginate tables (Slack: 1-100, default 5) */
+  pageSize?: number;
   /** Data rows */
   rows: string[][];
 }
@@ -489,6 +554,63 @@ export function Table(options: TableOptions): TableElement {
     headers: options.headers,
     rows: options.rows,
     align: options.align,
+    caption: options.caption,
+    pageSize: options.pageSize,
+  };
+}
+
+/** Options for Chart */
+export interface ChartOptions {
+  /** Chart definition (pie segments, or bar/area/line series with categories) */
+  chart: ChartDefinition;
+  /** Chart title (Slack: max 50 characters) */
+  title: string;
+}
+
+/**
+ * Create a Chart element for data visualization.
+ *
+ * @example Pie chart
+ * ```ts
+ * Chart({
+ *   title: "My Favorite Candy Bars",
+ *   chart: {
+ *     type: "pie",
+ *     segments: [
+ *       { label: "Kit Kat", value: 45 },
+ *       { label: "Twix", value: 28 },
+ *     ],
+ *   },
+ * })
+ * ```
+ *
+ * @example Line chart
+ * ```ts
+ * Chart({
+ *   title: "Weekly Sales",
+ *   chart: {
+ *     type: "line",
+ *     categories: ["Week 1", "Week 2"],
+ *     xLabel: "Week",
+ *     yLabel: "Sales",
+ *     series: [
+ *       {
+ *         name: "Scranton",
+ *         data: [
+ *           { label: "Week 1", value: 120 },
+ *           { label: "Week 2", value: 135 },
+ *         ],
+ *       },
+ *     ],
+ *   },
+ * })
+ * ```
+ */
+export function Chart(options: ChartOptions): ChartElement {
+  return {
+    type: "chart",
+    title: options.title,
+    chart: options.chart,
   };
 }
 
@@ -553,6 +675,7 @@ const componentMap = new Map<unknown, string>([
   [Field, "Field"],
   [Fields, "Fields"],
   [Table, "Table"],
+  [Chart, "Chart"],
 ]);
 
 /**
@@ -711,6 +834,14 @@ export function fromReactElement(element: unknown): AnyCardElement | null {
         headers: props.headers as string[],
         rows: props.rows as string[][],
         align: props.align as TableAlignment[] | undefined,
+        caption: props.caption as string | undefined,
+        pageSize: props.pageSize as number | undefined,
+      });
+
+    case "Chart":
+      return Chart({
+        title: props.title as string,
+        chart: props.chart as ChartDefinition,
       });
 
     default:
@@ -806,6 +937,8 @@ export function cardChildToFallbackText(child: CardChild): string | null {
       return null;
     case "table":
       return tableElementToAscii(child.headers, child.rows);
+    case "chart":
+      return chartElementToFallbackText(child);
     case "section":
       return child.children
         .map((c) => cardChildToFallbackText(c))

--- a/packages/chat/src/index.ts
+++ b/packages/chat/src/index.ts
@@ -80,6 +80,7 @@ import {
   Card as _Card,
   CardLink as _CardLink,
   CardText as _CardText,
+  Chart as _Chart,
   cardChildToFallbackText as _cardChildToFallbackText,
   Divider as _Divider,
   Field as _Field,
@@ -96,6 +97,7 @@ import type {
   ButtonComponent,
   CardComponent,
   CardLinkComponent,
+  ChartComponent,
   DividerComponent,
   ExternalSelectComponent,
   FieldComponent,
@@ -124,6 +126,7 @@ export const Card = _Card as unknown as CardComponent;
 export const cardChildToFallbackText = _cardChildToFallbackText;
 export const CardLink = _CardLink as unknown as CardLinkComponent;
 export const CardText = _CardText as unknown as TextComponent;
+export const Chart = _Chart as unknown as ChartComponent;
 export const Divider = _Divider as unknown as DividerComponent;
 export const Field = _Field as unknown as FieldComponent;
 export const Fields = _Fields as unknown as FieldsComponent;
@@ -167,6 +170,12 @@ export type {
   CardChild,
   CardElement,
   CardOptions,
+  ChartDataPoint,
+  ChartDefinition,
+  ChartElement,
+  ChartOptions,
+  ChartSegment,
+  ChartSeries,
   DividerElement,
   FieldElement,
   FieldsElement,
@@ -174,7 +183,9 @@ export type {
   LinkButtonElement,
   LinkButtonOptions,
   LinkElement,
+  PieChartDefinition,
   SectionElement,
+  SeriesChartDefinition,
   TableAlignment,
   TableElement,
   TableOptions,
@@ -254,6 +265,7 @@ export {
   // Format converter base class
   BaseFormatConverter,
   blockquote,
+  chartElementToFallbackText,
   codeBlock,
   emphasis,
   // Types

--- a/packages/chat/src/jsx-runtime.ts
+++ b/packages/chat/src/jsx-runtime.ts
@@ -41,6 +41,9 @@ import {
   type CardElement,
   CardLink,
   type CardOptions,
+  Chart,
+  type ChartDefinition,
+  type ChartElement,
   Divider,
   type DividerElement,
   Field,
@@ -206,8 +209,16 @@ export interface SelectOptionProps {
 
 /** Props for Table component in JSX */
 export interface TableProps {
+  caption?: string;
   headers: string[];
+  pageSize?: number;
   rows: string[][];
+}
+
+/** Props for Chart component in JSX */
+export interface ChartProps {
+  chart: ChartDefinition;
+  title: string;
 }
 
 /** Union of all valid JSX props */
@@ -226,7 +237,8 @@ export type CardJSXProps =
   | SelectProps
   | ExternalSelectProps
   | SelectOptionProps
-  | TableProps;
+  | TableProps
+  | ChartProps;
 
 /** Component function type with proper overloads */
 type CardComponentFunction =
@@ -247,7 +259,8 @@ type CardComponentFunction =
   | typeof ExternalSelect
   | typeof RadioSelect
   | typeof SelectOption
-  | typeof Table;
+  | typeof Table
+  | typeof Chart;
 
 /**
  * Represents a JSX element from the chat JSX runtime.
@@ -280,7 +293,8 @@ export type ChatElement =
   | ExternalSelectElement
   | SelectOptionElement
   | RadioSelectElement
-  | TableElement;
+  | TableElement
+  | ChartElement;
 
 // ============================================================================
 // JSX Component Function Types
@@ -383,8 +397,18 @@ export interface RadioSelectComponent {
 }
 
 export interface TableComponent {
-  (options: { headers: string[]; rows: string[][] }): TableElement;
+  (options: {
+    caption?: string;
+    headers: string[];
+    pageSize?: number;
+    rows: string[][];
+  }): TableElement;
   (props: TableProps): ChatElement;
+}
+
+export interface ChartComponent {
+  (options: { chart: ChartDefinition; title: string }): ChartElement;
+  (props: ChartProps): ChatElement;
 }
 
 // Internal alias for backwards compatibility
@@ -780,10 +804,20 @@ function resolveJSXElement(element: JSXElement): AnyCardElement {
   }
 
   if (type === Table) {
-    const tableProps = props as { headers: string[]; rows: string[][] };
+    const tableProps = props as TableProps;
     return Table({
       headers: tableProps.headers,
       rows: tableProps.rows,
+      caption: tableProps.caption,
+      pageSize: tableProps.pageSize,
+    });
+  }
+
+  if (type === Chart) {
+    const chartProps = props as ChartProps;
+    return Chart({
+      title: chartProps.title,
+      chart: chartProps.chart,
     });
   }
 

--- a/packages/chat/src/markdown.ts
+++ b/packages/chat/src/markdown.ts
@@ -26,7 +26,7 @@ import remarkGfm from "remark-gfm";
 import remarkParse from "remark-parse";
 import remarkStringify from "remark-stringify";
 import { unified } from "unified";
-import type { CardChild, CardElement } from "./cards";
+import type { CardChild, CardElement, ChartElement } from "./cards";
 import type { AdapterPostableMessage } from "./types";
 
 // Alias for use within this file
@@ -226,6 +226,34 @@ export function tableElementToAscii(
     lines.push(formatRow(row));
   }
   return lines.join("\n");
+}
+
+/**
+ * Render a chart element as text: the title followed by the underlying
+ * data as a padded ASCII table.
+ * Used for card ChartElement fallback rendering on platforms without
+ * native chart support.
+ */
+export function chartElementToFallbackText(element: ChartElement): string {
+  const { chart, title } = element;
+
+  if (chart.type === "pie") {
+    const table = tableElementToAscii(
+      ["Label", "Value"],
+      chart.segments.map((s) => [s.label, String(s.value)])
+    );
+    return `${title}\n${table}`;
+  }
+
+  const headers = [chart.xLabel ?? "", ...chart.series.map((s) => s.name)];
+  const rows = chart.categories.map((category) => [
+    category,
+    ...chart.series.map((s) => {
+      const point = s.data.find((p) => p.label === category);
+      return point ? String(point.value) : "";
+    }),
+  ]);
+  return `${title}\n${tableElementToAscii(headers, rows)}`;
 }
 
 // ============================================================================
@@ -605,6 +633,8 @@ export abstract class BaseFormatConverter implements FormatConverter {
         return null;
       case "table":
         return tableElementToAscii(child.headers, child.rows);
+      case "chart":
+        return chartElementToFallbackText(child);
       case "section":
         return child.children
           .map((c) => this.cardChildToFallbackText(c))

--- a/packages/integration-tests/src/replay-native-table.test.ts
+++ b/packages/integration-tests/src/replay-native-table.test.ts
@@ -1,8 +1,9 @@
 /**
  * Replay test for native Slack table block rendering.
  *
- * Verifies that a card with a Table element produces a native Slack table block
- * (using raw_text cells and first-row-as-headers schema) instead of ASCII fallback.
+ * Verifies that a card with a Table element produces a native Slack data table
+ * block (using raw_text cells and first-row-as-headers schema) instead of
+ * ASCII fallback.
  */
 
 import { Card, CardText, Table } from "chat";
@@ -77,14 +78,15 @@ describe("Replay Tests - Native Table Block", () => {
 
       const blocks = postCall.blocks;
 
-      // Should have: header, section (text), table
+      // Should have: header, section (text), data table
       expect(blocks).toHaveLength(3);
       expect(blocks[0].type).toBe("header");
       expect(blocks[1].type).toBe("section");
-      expect(blocks[2].type).toBe("table");
+      expect(blocks[2].type).toBe("data_table");
 
       // Verify table block uses native schema
       const tableBlock = blocks[2];
+      expect(tableBlock.caption).toBe("Table");
       expect(tableBlock.rows).toBeDefined();
       expect(tableBlock.rows).toHaveLength(4); // 1 header row + 3 data rows
 


### PR DESCRIPTION
Adds support for Slack's [data table](https://docs.slack.dev/reference/block-kit/blocks/data-table-block) and [data visualization](https://docs.slack.dev/reference/block-kit/blocks/data-visualization-block) Block Kit blocks.

- **`chat`**: new cross-platform `ChartElement` + `Chart()` builder (JSX supported) mirroring Slack's model — pie `segments`, or bar/area/line `series` against shared `categories`. `Table()` gains optional `caption` and `pageSize`. Charts degrade to a text table on other platforms via the shared card fallback (`chartElementToFallbackText`).
- **`@chat-adapter/slack`**: card tables now render as paginated, sortable `data_table` blocks by default (header-only tables keep the plain `table` block; oversized tables still fall back to ASCII). Charts render as `data_visualization` blocks; charts violating Slack constraints — including the undocumented **max 2 charts per message** — fall back to a text rendering instead of an API rejection. Same treatment in the `@chat-adapter/slack/blocks` subpath.
- **`postMessage`** now surfaces Slack's per-block validation messages on `invalid_blocks` errors (this is how the 2-chart limit was found).
- Example app gets a **Show Charts** button and table pagination on **Show Table**; docs, feature matrices, and changeset updated.

Verified live against Slack: data table pagination/sorting and both chart types render natively.

<table>
  <tr>
    <th>Data Table</th>
    <th>Data Charts</th>
  </tr>
  <tr>
    <td><img width="979" height="896" alt="CleanShot 2026-07-12 at 23 28 32" src="https://github.com/user-attachments/assets/3307bd90-9322-452f-86fb-07d46446822d" /></td>
    <td><img width="955" height="879" alt="CleanShot 2026-07-12 at 23 29 02" src="https://github.com/user-attachments/assets/ddb31a1b-e3fd-457c-a2e6-bde4934afebe" /></td>
  </tr>
</table>
