### PR TITLE
fix(docs): include adapter pages in the search index

### DIFF
--- a/apps/docs/app/api/search/route.ts
+++ b/apps/docs/app/api/search/route.ts
@@ -1,5 +1,9 @@
 import { createSearchRoute } from "@vercel/geistdocs/routes/search";
+import { adaptersSource } from "@/lib/geistdocs/adapters-source";
 import { config } from "@/lib/geistdocs/config";
 import { geistdocsSource } from "@/lib/geistdocs/source";
 
-export const GET = createSearchRoute({ config, sources: [geistdocsSource] });
+export const GET = createSearchRoute({
+  config,
+  sources: [geistdocsSource, adaptersSource],
+});


### PR DESCRIPTION
## Summary

Site search on chat-sdk.dev never returned adapter pages — e.g. searching `imessage` found nothing even though several `content/adapters/vendor-official/` pages (Sendblue, Linq, Photon, Dial) mention iMessage prominently.

The cause: the search route only passed the `content/docs` collection (`geistdocsSource`) to `createSearchRoute`, so the separate `content/adapters` collection (`adaptersSource`) was never indexed by Orama.

This adds `adaptersSource` to the route's sources. The adapters loader already shares the same `i18n` config, and `createSearchRoute` supports plain fumadocs loaders, so no other changes are needed.

## Testing

Ran the docs dev server and queried `/api/search` directly:

- `?query=imessage` → 46 results across 6 adapter pages (sendblue, linq, photon, dial, agentphone, blooio), with content-level matches and highlights
- `?query=sendblue` → returns the Sendblue page
- `?query=webhook` → core `/docs` pages still returned alongside adapters (existing search unaffected)
- No duplicate result IDs (no per-locale double indexing)

`pnpm check` and `tsc --noEmit` in `apps/docs` are clean. Docs-only change — no changeset.