### PR TITLE
feat(slack): support native Slack agents

### DIFF
--- a/.changeset/slack-suggested-prompts-config.md
+++ b/.changeset/slack-suggested-prompts-config.md
@@ -1,0 +1,14 @@
+---
+"@chat-adapter/slack": minor
+---
+
+Add declarative agent-experience config and harden native streaming:
+
+- `suggestedPrompts` — a static payload or per-thread resolver, applied automatically when an assistant/agent thread opens (`assistant_thread_started` in legacy `assistant_view`, or a Messages-tab `app_home_opened` under `agentView`, where prompts pin at the top of the agent conversation without a `thread_ts`). The resolver receives the thread context (`channelId`, `userId`, legacy `threadTs`/`teamId`/`enterpriseId`, and active-view `entities` under `agentView`); returning `null`/`undefined` skips the thread. Prompts beyond Slack's 4-prompt limit are dropped with a warning, and resolver/API failures are logged without failing the webhook.
+- `loadingMessages` — default rotating status strings for the assistant thinking indicator, used by `startTyping` and `setAssistantStatus` when no explicit status/messages are passed.
+- `nativeStreaming` config (default `true`). Set `false` on Slack flavours without the `chat.startStream` family (e.g. GovSlack) to always stream via post-and-edit.
+- If the workspace rejects the first native streaming call, `stream()` now falls back to throttled post-and-edit mid-stream instead of failing the reply; already-consumed text is preserved. Permanent platform errors (`unknown_method`, `method_deprecated`, `feature_not_enabled`) latch native streaming off for subsequent streams on the adapter instance. Structured chunks (`task_update` / `plan_update`) are skipped in fallback mode.
+
+- `feedbackButtons` — append Slack's native thumbs up/down (`context_actions` + `feedback_buttons` block) to every streamed reply. Pass `true` for defaults or an options object (`actionId`, labels, values); clicks dispatch through `bot.onAction` with a positive/negative value. A `buildFeedbackButtonsBlock(options?)` helper is exported for attaching the block to non-streamed messages.
+
+New exported types: `SlackFeedbackButtonsOptions`, `SlackSuggestedPrompt`, `SlackSuggestedPrompts`, `SlackSuggestedPromptsContext`, `SlackSuggestedPromptsOptions`.

--- a/apps/docs/content/adapters/official/slack.mdx
+++ b/apps/docs/content/adapters/official/slack.mdx
@@ -83,17 +83,17 @@ bot.onNewMention(async (thread, message) => {
     botToken: {
       type: "string | () => string | Promise<string>",
       description:
-        "Bot token (`xoxb-...`) or a resolver function for rotation / lazy fetch. Auto-detected from `SLACK_BOT_TOKEN`.",
+        "Bot token (xoxb-...) or a resolver function for rotation / lazy fetch. Auto-detected from SLACK_BOT_TOKEN.",
     },
     signingSecret: {
       type: "string",
       description:
-        "Signing secret for webhook verification. Auto-detected from `SLACK_SIGNING_SECRET`.",
+        "Signing secret for webhook verification. Auto-detected from SLACK_SIGNING_SECRET.",
     },
     webhookVerifier: {
       type: "(request, body) => unknown | Promise<unknown>",
       description:
-        "Custom verifier used in place of `signingSecret`. Returning a string substitutes the verified body downstream.",
+        "Custom verifier used in place of signingSecret. Returning a string substitutes the verified body downstream.",
     },
     mode: {
       type: '"webhook" | "socket"',
@@ -103,33 +103,60 @@ bot.onNewMention(async (thread, message) => {
     appToken: {
       type: "string",
       description:
-        "App-level token (`xapp-...`) for socket mode. Auto-detected from `SLACK_APP_TOKEN`.",
+        "App-level token (xapp-...) for socket mode. Auto-detected from SLACK_APP_TOKEN.",
     },
     clientId: {
       type: "string",
       description:
-        "App client ID for multi-workspace OAuth. Auto-detected from `SLACK_CLIENT_ID`.",
+        "App client ID for multi-workspace OAuth. Auto-detected from SLACK_CLIENT_ID.",
     },
     clientSecret: {
       type: "string",
       description:
-        "App client secret for multi-workspace OAuth. Auto-detected from `SLACK_CLIENT_SECRET`.",
+        "App client secret for multi-workspace OAuth. Auto-detected from SLACK_CLIENT_SECRET.",
     },
     encryptionKey: {
       type: "string",
       description:
-        "AES-256-GCM key for encrypting stored tokens. Auto-detected from `SLACK_ENCRYPTION_KEY`.",
+        "AES-256-GCM key for encrypting stored tokens. Auto-detected from SLACK_ENCRYPTION_KEY.",
     },
     installationKeyPrefix: {
       type: "string",
       default: '"slack:installation"',
       description:
-        "Prefix for the state key used to store workspace installations. Full key is `{prefix}:{teamId}` (or `{prefix}:{enterpriseId}` for org-wide installs).",
+        "Prefix for the state key used to store workspace installations. Full key is {prefix}:{teamId}, or {prefix}:{enterpriseId} for org-wide installs.",
     },
     installationProvider: {
       type: "{ getInstallation(installationId, isEnterpriseInstall) }",
       description:
         "External installation lookup. When set, bypasses the internal state adapter for token resolution. Read-only — manage your own writes externally.",
+    },
+    agentView: {
+      type: "boolean",
+      default: "false",
+      description:
+        "Enable the Agent messaging experience (agent_view manifest mode).",
+    },
+    suggestedPrompts: {
+      type: "SlackSuggestedPrompts",
+      description:
+        "Static payload or per-thread resolver for prompts pinned when an assistant/agent thread opens.",
+    },
+    loadingMessages: {
+      type: "string[]",
+      description:
+        "Default rotating status strings for the assistant thinking indicator, used by startTyping and setAssistantStatus when no explicit status is passed.",
+    },
+    nativeStreaming: {
+      type: "boolean",
+      default: "true",
+      description:
+        "Use Slack's native streaming API for streamed posts. Set false to always stream via post-and-edit.",
+    },
+    feedbackButtons: {
+      type: "boolean | SlackFeedbackButtonsOptions",
+      description:
+        "Append native thumbs up/down to every streamed reply; clicks dispatch to bot.onAction.",
     },
     apiUrl: {
       type: "string",
@@ -237,6 +264,169 @@ If your app already owns routing, state, sessions, or workflow execution, use th
 The `@chat-adapter/slack/webhook`, `@chat-adapter/slack/format`, `@chat-adapter/slack/api`, and `@chat-adapter/slack/blocks` subpaths expose request verification, payload parsing, mrkdwn helpers, fetch-based Web API calls, and Block Kit conversion without importing the full `Chat` runtime.
 
 ## Advanced
+
+### Agents
+
+Everything for building an AI agent on Slack: the Agent messaging experience (`agent_view`), the Assistants API (suggested prompts, status, titles), native streaming, and feedback buttons.
+
+#### Agent messaging experience
+
+Slack's Agent messaging experience (`agent_view` manifest mode) supersedes the older `assistant_view`. New Slack apps can only use `agent_view`. Enable it on the adapter:
+
+```typescript
+const slack = createSlackAdapter({ agentView: true });
+```
+
+With `agentView: true`:
+
+- `onAppHomeOpened` is the DM-open signal (Slack no longer signals DM-open via `assistant_thread_started` under `agent_view`), and it fires regardless of the opened tab — branch on `event.tab` (`"home"` vs `"messages"`) if you also publish a Home view.
+- `onAppContextChanged` reports the user's active view (see [Handling active-view context](/docs/handling-events#handling-active-view-context-agent-messaging)).
+- `getAppContext(message)` returns the folded active-view context on a DM message.
+- `setSuggestedPrompts(channelId, undefined, prompts)` may omit the thread reference — prompts sit at the top of the agent conversation. A `suggestedPrompts` config entry is applied automatically on every Messages-tab open.
+- DM messages are threaded per Slack's model (each user message is a thread root). Threads returned by `openDM()` keep working: when the conversation-scoped thread is subscribed, incoming top-level DM messages route to it, so `onSubscribedMessage` and per-thread state behave as before.
+
+<Callout type="warn">
+Because bot replies are threaded under each user message, channel-level history (`channel.messages`, `conversations.history`) only returns the user's side of a DM conversation. If you build AI conversation history for DMs, use [transcripts](/docs/conversation-history) (which record both roles across thread IDs) instead of channel history — otherwise the model never sees its own previous replies.
+</Callout>
+
+Add the event subscription and scope to your manifest:
+
+```yaml
+oauth_config:
+  scopes:
+    bot:
+      - assistant:write
+
+settings:
+  event_subscriptions:
+    bot_events:
+      - app_home_opened
+      - app_context_changed
+```
+
+#### Slack Assistants API
+
+The adapter supports Slack's [Assistants API](https://api.slack.com/docs/apps/ai). Register handlers on the `Chat` instance:
+
+```typescript
+bot.onAssistantThreadStarted(async (event) => {
+  const slack = bot.getAdapter("slack");
+  await slack.setSuggestedPrompts(event.channelId, event.threadTs, [
+    { title: "Summarize", message: "Summarize this channel" },
+    { title: "Draft", message: "Help me draft a message" },
+  ]);
+});
+
+bot.onAssistantContextChanged(async (event) => {
+  // User navigated to a different channel
+});
+```
+
+Instead of wiring the handler yourself, you can configure prompts declaratively — the adapter applies them automatically whenever an assistant/agent thread opens (`assistant_thread_started` in legacy mode, or a Messages-tab open with [`agentView`](#agent-messaging-experience) enabled):
+
+```typescript
+const slack = createSlackAdapter({
+  suggestedPrompts: {
+    title: "Welcome! What can I do for you?",
+    prompts: [
+      { title: "Summarize", message: "Summarize this channel" },
+      { title: "Draft", message: "Help me draft a message" },
+    ],
+  },
+  // Rotating status strings shown while the bot is thinking
+  loadingMessages: ["Thinking...", "Digging through the archives..."],
+});
+```
+
+`suggestedPrompts` also accepts an async resolver, called per thread-open with the thread context (`channelId`, `userId`, `threadTs` in legacy mode, active-view `entities` under `agentView`). Return `null` to skip a thread. Slack shows at most 4 prompts.
+
+```typescript
+const slack = createSlackAdapter({
+  agentView: true,
+  suggestedPrompts: async ({ userId, entities }) => ({
+    prompts: entities?.some((e) => e.kind === "channel")
+      ? [{ title: "Summarize", message: "Summarize the channel I'm viewing" }]
+      : [{ title: "Catch me up", message: "What did I miss today?" }],
+  }),
+});
+```
+
+`loadingMessages` becomes the default for `startTyping(threadId)` and `setAssistantStatus(...)` when no explicit status/messages are passed.
+
+The `SlackAdapter` exposes:
+
+| Method | Description |
+|--------|-------------|
+| `setSuggestedPrompts(channelId, threadTs, prompts, title?)` | Show prompt suggestions in the thread |
+| `setAssistantStatus(channelId, threadTs, status)` | Show a thinking/status indicator |
+| `setAssistantTitle(channelId, threadTs, title)` | Set the thread title (shown in History) |
+| `publishHomeView(userId, view)` | Publish a Home tab view for a user |
+| `startTyping(threadId, status)` | Show a custom loading status (requires `assistant:write`) |
+
+Add these scopes/events to your manifest:
+
+```yaml
+oauth_config:
+  scopes:
+    bot:
+      - assistant:write
+
+settings:
+  event_subscriptions:
+    bot_events:
+      - assistant_thread_started
+      - assistant_thread_context_changed
+```
+
+When streaming in an assistant thread, attach Block Kit elements to the final message via `StreamingPlan`'s `endWith` option:
+
+```typescript
+import { StreamingPlan } from "chat";
+
+await thread.post(
+  new StreamingPlan(textStream, {
+    endWith: [
+      {
+        type: "actions",
+        elements: [
+          { type: "button", text: { type: "plain_text", text: "Retry" }, action_id: "retry" },
+        ],
+      },
+    ],
+  })
+);
+```
+
+#### Native streaming
+
+Streamed posts (`thread.post(asyncIterable)`) use Slack's native streaming API (`chat.startStream` / `chat.appendStream` / `chat.stopStream`) whenever the thread has streaming context: any DM thread, or a channel thread where the recipient user/team is known (derived automatically from the incoming message). Structured `task_update` / `plan_update` chunks render as native task cards, and plain text renders token-by-token with safe incremental markdown.
+
+Threads without streaming context fall back to post-and-edit (`chat.update` deltas) automatically. If the workspace rejects the first native call — for example on Slack flavours without the streaming methods, like GovSlack — the adapter falls back to post-and-edit mid-stream without losing content, and skips the native attempt on subsequent streams when the error is permanent (e.g. `unknown_method`). To skip native streaming entirely:
+
+```typescript
+const slack = createSlackAdapter({ nativeStreaming: false });
+```
+
+#### Feedback buttons
+
+Slack's agent UX guidance recommends native thumbs up/down feedback on agent replies (a `context_actions` block with a `feedback_buttons` element). Configure `feedbackButtons` and the adapter appends them to every streamed reply when the stream finishes:
+
+```typescript
+const slack = createSlackAdapter({
+  feedbackButtons: true, // or customize:
+  // feedbackButtons: {
+  //   actionId: "ai_feedback",
+  //   positiveLabel: "Helpful", positiveValue: "up",
+  //   negativeLabel: "Not helpful", negativeValue: "down",
+  // },
+});
+
+bot.onAction("message_feedback", async (event) => {
+  await recordFeedback(event.threadId, event.messageId, event.value); // "positive" | "negative"
+});
+```
+
+Clicks dispatch through the regular action flow with the configured `actionId` (default `"message_feedback"`). For non-streamed messages, build the same block with the exported `buildFeedbackButtonsBlock(options?)` helper and attach it via raw blocks. Feedback buttons are skipped when a stream falls back to post-and-edit.
 
 ### Slack app manifest
 
@@ -422,103 +612,6 @@ export async function GET(request: Request) {
 ```
 
 Forwarded events are authenticated using `socketForwardingSecret` (defaults to `SLACK_SOCKET_FORWARDING_SECRET`, falling back to `appToken`).
-
-### Slack Assistants API
-
-The adapter supports Slack's [Assistants API](https://api.slack.com/docs/apps/ai). Register handlers on the `Chat` instance:
-
-```typescript
-bot.onAssistantThreadStarted(async (event) => {
-  const slack = bot.getAdapter("slack");
-  await slack.setSuggestedPrompts(event.channelId, event.threadTs, [
-    { title: "Summarize", message: "Summarize this channel" },
-    { title: "Draft", message: "Help me draft a message" },
-  ]);
-});
-
-bot.onAssistantContextChanged(async (event) => {
-  // User navigated to a different channel
-});
-```
-
-The `SlackAdapter` exposes:
-
-| Method | Description |
-|--------|-------------|
-| `setSuggestedPrompts(channelId, threadTs, prompts, title?)` | Show prompt suggestions in the thread |
-| `setAssistantStatus(channelId, threadTs, status)` | Show a thinking/status indicator |
-| `setAssistantTitle(channelId, threadTs, title)` | Set the thread title (shown in History) |
-| `publishHomeView(userId, view)` | Publish a Home tab view for a user |
-| `startTyping(threadId, status)` | Show a custom loading status (requires `assistant:write`) |
-
-Add these scopes/events to your manifest:
-
-```yaml
-oauth_config:
-  scopes:
-    bot:
-      - assistant:write
-
-settings:
-  event_subscriptions:
-    bot_events:
-      - assistant_thread_started
-      - assistant_thread_context_changed
-```
-
-When streaming in an assistant thread, attach Block Kit elements to the final message via `StreamingPlan`'s `endWith` option:
-
-```typescript
-import { StreamingPlan } from "chat";
-
-await thread.post(
-  new StreamingPlan(textStream, {
-    endWith: [
-      {
-        type: "actions",
-        elements: [
-          { type: "button", text: { type: "plain_text", text: "Retry" }, action_id: "retry" },
-        ],
-      },
-    ],
-  })
-);
-```
-
-### Agent messaging experience
-
-Slack's Agent messaging experience (`agent_view` manifest mode) supersedes the older `assistant_view`. New Slack apps can only use `agent_view`. Enable it on the adapter:
-
-```typescript
-const slack = createSlackAdapter({ agentView: true });
-```
-
-With `agentView: true`:
-
-- `onAppHomeOpened` is the DM-open signal (Slack no longer signals DM-open via `assistant_thread_started` under `agent_view`), and it fires regardless of the opened tab — branch on `event.tab` (`"home"` vs `"messages"`) if you also publish a Home view.
-- `onAppContextChanged` reports the user's active view (see [Handling active-view context](/docs/handling-events#handling-active-view-context-agent-messaging)).
-- `getAppContext(message)` returns the folded active-view context on a DM message.
-- `setSuggestedPrompts(channelId, undefined, prompts)` may omit the thread reference — prompts sit at the top of the agent conversation.
-- DM messages are threaded per Slack's model (each user message is a thread root). Threads returned by `openDM()` keep working: when the conversation-scoped thread is subscribed, incoming top-level DM messages route to it, so `onSubscribedMessage` and per-thread state behave as before.
-
-<Callout type="warn">
-Because bot replies are threaded under each user message, channel-level history (`channel.messages`, `conversations.history`) only returns the user's side of a DM conversation. If you build AI conversation history for DMs, use [transcripts](/docs/conversation-history) (which record both roles across thread IDs) instead of channel history — otherwise the model never sees its own previous replies.
-</Callout>
-
-Add the event subscription and scope to your manifest:
-
-```yaml
-oauth_config:
-  scopes:
-    bot:
-      - assistant:write
-
-settings:
-  event_subscriptions:
-    bot_events:
-      - app_home_opened
-      - app_context_changed
-```
 
 ## Feature support
 

--- a/examples/nextjs-chat/README.md
+++ b/examples/nextjs-chat/README.md
@@ -73,6 +73,8 @@ Copy `.env.example` for the full list. At minimum, set `BOT_USERNAME` and creden
 |----------|-------------|
 | `BOT_USERNAME` | Bot display name |
 | `SLACK_CONNECTOR` | Slack [Vercel Connect](https://vercel.com/docs/connect) connector UID (e.g. `slack/acme-slack`) |
+| `SLACK_AGENT_VIEW` | Set to `true` when your Slack manifest uses `agent_view` (see the commented blocks in `slack-manifest.yml`) — enables the Agent messaging experience with auto-applied suggested prompts |
+| `SLACK_NATIVE_STREAMING` | Set to `false` to stream via post-and-edit (`chat.update`) instead of Slack's native streaming API — useful on Slack flavours without `chat.startStream` (e.g. GovSlack) |
 | `VERCEL_OIDC_TOKEN` | Vercel OIDC token used by Connect (run `vercel env pull`) |
 | `TEAMS_APP_ID` | Teams app ID |
 | `TEAMS_APP_PASSWORD` | Teams app password |

--- a/examples/nextjs-chat/slack-manifest.yml
+++ b/examples/nextjs-chat/slack-manifest.yml
@@ -7,6 +7,13 @@ features:
   bot_user:
     display_name: Chat SDK Bot
     always_online: true
+  # Optional: Slack Agent messaging experience. Uncomment (with the
+  # assistant:write scope and the agent events below) and set
+  # SLACK_AGENT_VIEW=true so the adapter treats Messages-tab opens as the
+  # thread-open signal. Note: switching an app to agent_view can't be
+  # reverted.
+  # agent_view:
+  #   agent_description: A bot built with chat-sdk
 
 oauth_config:
   scopes:
@@ -27,6 +34,9 @@ oauth_config:
       - reactions:write
       # User info for display names
       - users:read
+      # Agent experience (suggested prompts, thinking status) — uncomment
+      # together with the agent_view / event blocks below.
+      # - assistant:write
 
 settings:
   event_subscriptions:
@@ -39,6 +49,9 @@ settings:
       - message.groups
       - message.im
       - message.mpim
+      # Agent experience events — uncomment together with agent_view above.
+      # - app_home_opened
+      # - app_context_changed
   interactivity:
     is_enabled: false
   org_deploy_enabled: false

--- a/examples/nextjs-chat/src/lib/adapters.ts
+++ b/examples/nextjs-chat/src/lib/adapters.ts
@@ -12,7 +12,11 @@ import {
   createMessengerAdapter,
   type MessengerAdapter,
 } from "@chat-adapter/messenger";
-import { createSlackAdapter, type SlackAdapter } from "@chat-adapter/slack";
+import {
+  createSlackAdapter,
+  type SlackAdapter,
+  type SlackAdapterConfig,
+} from "@chat-adapter/slack";
 import { createTeamsAdapter, type TeamsAdapter } from "@chat-adapter/teams";
 import {
   createTelegramAdapter,
@@ -58,6 +62,52 @@ const DISCORD_METHODS = [
   "openDM",
   "fetchMessages",
 ];
+// Slack agent experience (optional) — requires the Agents feature and the
+// assistant:write scope plus the matching events in slack-manifest.yml.
+// Suggested prompts are pinned automatically when an assistant/agent thread
+// opens; the resolver tailors them to the user's active view (agent_view
+// folds what the user is looking at into the event as `entities`).
+// `loadingMessages` rotate in the thinking indicator while the bot works.
+// Set SLACK_AGENT_VIEW=true when your manifest uses `agent_view`.
+// Set SLACK_NATIVE_STREAMING=false to compare Slack's native streaming API
+// (chat.startStream/appendStream/stopStream, the default) against the
+// post-and-edit fallback (chat.update deltas).
+const SLACK_AGENT_OPTIONS: Pick<
+  SlackAdapterConfig,
+  | "agentView"
+  | "feedbackButtons"
+  | "loadingMessages"
+  | "nativeStreaming"
+  | "suggestedPrompts"
+> = {
+  agentView: process.env.SLACK_AGENT_VIEW === "true",
+  // Thumbs up/down on every streamed reply; clicks dispatch to
+  // bot.onAction("ai_feedback") — see bot.tsx.
+  feedbackButtons: { actionId: "ai_feedback" },
+  nativeStreaming: process.env.SLACK_NATIVE_STREAMING !== "false",
+  loadingMessages: [
+    "Thinking...",
+    "Consulting the Chat SDK docs...",
+    "Almost there...",
+  ],
+  suggestedPrompts: ({ entities }) => ({
+    title: "Welcome! What can I do for you?",
+    prompts: [
+      entities?.some((entity) => entity.kind === "channel")
+        ? {
+            title: "Summarize this channel",
+            message: "Summarize the channel I'm currently viewing",
+          }
+        : {
+            title: "Catch me up",
+            message: "What can you help me with?",
+          },
+      { title: "Draft a message", message: "Help me draft a message" },
+      { title: "Explain Chat SDK", message: "What is the Chat SDK?" },
+    ],
+  }),
+};
+
 const SLACK_METHODS = [
   "postMessage",
   "editMessage",
@@ -189,6 +239,7 @@ export function buildAdapters(): Adapters {
       createSlackAdapter({
         userName: "Chat SDK Bot",
         logger: logger.child("slack"),
+        ...SLACK_AGENT_OPTIONS,
         ...connectSlackAdapter(process.env.SLACK_CONNECTOR),
       }),
       "slack",
@@ -202,6 +253,7 @@ export function buildAdapters(): Adapters {
       createSlackAdapter({
         userName: "Chat SDK Bot",
         logger: logger.child("slack"),
+        ...SLACK_AGENT_OPTIONS,
       }),
       "slack",
       SLACK_METHODS

--- a/examples/nextjs-chat/src/lib/bot.tsx
+++ b/examples/nextjs-chat/src/lib/bot.tsx
@@ -110,8 +110,10 @@ bot.onNewMention(async (thread, message) => {
   // Check if user wants to enable AI mode (mention contains "AI")
   if (AI_MENTION_REGEX.test(message.text)) {
     await thread.setState({ aiMode: true });
-    // Also respond to the initial message with AI (including any image attachments)
-    await thread.startTyping("Thinking...");
+    // Also respond to the initial message with AI (including any image attachments).
+    // No explicit status: on Slack this falls back to the adapter-level
+    // `loadingMessages` rotation (see SLACK_AGENT_OPTIONS in adapters.ts).
+    await thread.startTyping();
     try {
       const history = await toAiMessages([message]);
       const result = await agent.stream({ prompt: history });
@@ -591,6 +593,21 @@ const FeedbackModal = (
 // Open feedback modal
 bot.onAction("feedback", async (event) => {
   await event.openModal(FeedbackModal);
+});
+
+// Native feedback buttons appended to streamed Slack replies (see the
+// `feedbackButtons` adapter config in adapters.ts). In a real app you'd
+// persist this signal for evals; here we just acknowledge it.
+bot.onAction("ai_feedback", async (event) => {
+  if (!event.thread) {
+    return;
+  }
+  const positive = event.value === "positive";
+  await event.thread.post(
+    positive
+      ? `${emoji.sparkles} Thanks for the positive feedback!`
+      : `${emoji.wrench} Thanks — I'll try to do better.`
+  );
 });
 
 bot.onSlashCommand("/ping", async (event) => {
@@ -1218,7 +1235,9 @@ bot.onSubscribedMessage(async (thread, message) => {
       );
     }
 
-    await thread.startTyping("Thinking...");
+    // No explicit status: on Slack this falls back to the adapter-level
+    // `loadingMessages` rotation (see SLACK_AGENT_OPTIONS in adapters.ts).
+    await thread.startTyping();
     try {
       const result = await agent.stream({ prompt: history });
       await thread.post(result.fullStream);

--- a/packages/adapter-slack/AGENTS.md
+++ b/packages/adapter-slack/AGENTS.md
@@ -21,8 +21,11 @@ covers:
 - Block Kit rendering for cards, modals, ephemeral messages, slash
   commands, scheduled messages, file uploads, and the Slack Assistants
   API.
-- Native streaming via `chat.update` deltas plus a Block Kit fallback
-  for non-streaming Slack flavours (e.g. GovSlack).
+- Native streaming via `chat.startStream` / `chat.appendStream` /
+  `chat.stopStream` (including structured task/plan chunks), with an
+  automatic post-and-edit fallback for threads without streaming
+  context and Slack flavours without the streaming methods (e.g.
+  GovSlack; also `nativeStreaming: false`).
 
 The adapter is the first Chat SDK target and the most fully-featured —
 several conventions in `packages/chat` were originally shaped here.
@@ -239,15 +242,31 @@ JSX or pre-built Slack views. `modals.ts` handles the translation:
 
 ## Streaming
 
-`postMessage` accepts `AsyncIterable<string | StreamChunk>` and pumps
-the deltas onto Slack via incremental `chat.update` calls, with a
-configurable minimum-edit interval to avoid hitting Slack's rate
-limit. The streaming markdown renderer keeps mrkdwn formatting valid as
-the stream progresses (no half-formed tags).
+`stream()` consumes `AsyncIterable<string | StreamChunk>` and uses
+Slack's native streaming API via the `@slack/web-api` `chatStream`
+helper (`chat.startStream` → `chat.appendStream` → `chat.stopStream`).
+Plain strings go through `StreamingMarkdownRenderer` so incremental
+markdown stays valid (no half-formed tags); structured `task_update` /
+`plan_update` chunks are passed through as native chunk payloads
+(`task_display_mode: "plan"` groups them into a plan). `stopBlocks`
+(the `StreamingPlan` `endWith` option) attach Block Kit to the final
+message on `chat.stopStream`.
 
-For Assistants API threads, the adapter additionally drives
-`assistant.threads.setStatus` between deltas so the user sees a
-"thinking…" indicator.
+Fallback to post-and-edit (`chat.update` deltas, throttled by
+`updateIntervalMs`) happens at three levels:
+
+- `stream()` returns `null` before consuming anything (no thread
+  context, no recipient context, `nativeStreaming: false`, or a latched
+  unsupported workspace) — the chat core runs its own post-and-edit.
+- The first native call is rejected (e.g. GovSlack `unknown_method`,
+  feature not enabled) — the adapter switches to internal post-and-edit
+  mid-stream without losing consumed text, and latches native streaming
+  off for permanent platform errors.
+- A structured chunk is rejected (missing scope/feature) — the chunk is
+  skipped and text streaming continues.
+
+Failures after native content has rendered still propagate — mixing the
+two surfaces would duplicate output.
 
 ## Socket Mode
 

--- a/packages/adapter-slack/src/index.test.ts
+++ b/packages/adapter-slack/src/index.test.ts
@@ -8716,19 +8716,33 @@ describe("native streaming fallback", () => {
 
   it("propagates mid-stream failures once native content has rendered", async () => {
     const { adapter, postSpy } = createAdapter();
-    // ts is set: chat.startStream already succeeded, content is rendering.
+    // First native call succeeds (content is rendering), the next fails.
+    const append = vi
+      .fn()
+      .mockResolvedValueOnce({ ok: true })
+      .mockRejectedValue(new Error("mid-stream boom"));
     mockClientMethod(
       adapter,
       "chatStream",
-      vi.fn().mockReturnValue({
-        append: vi.fn().mockRejectedValue(new Error("mid-stream boom")),
-        stop: vi.fn(),
-        ts: "1234567890.222222",
-      })
+      vi.fn().mockReturnValue({ append, stop: vi.fn(), ts: undefined })
     );
 
+    async function* mixedStream() {
+      // A structured chunk flushes to the native stream immediately,
+      // deterministically marking native content as rendered before the
+      // text append fails.
+      yield {
+        details: "step",
+        id: "task-1",
+        status: "in_progress" as const,
+        title: "Task",
+        type: "task_update" as const,
+      };
+      yield "hello";
+    }
+
     await expect(
-      adapter.stream("slack:D123:1234567890.000000", textStream("hello"))
+      adapter.stream("slack:D123:1234567890.000000", mixedStream())
     ).rejects.toThrow("mid-stream boom");
     expect(postSpy).not.toHaveBeenCalled();
   });

--- a/packages/adapter-slack/src/index.test.ts
+++ b/packages/adapter-slack/src/index.test.ts
@@ -6118,6 +6118,320 @@ describe("publishHomeView", () => {
 });
 
 // ============================================================================
+// Configured suggestedPrompts / loadingMessages Tests
+// ============================================================================
+
+describe("configured suggestedPrompts", () => {
+  const secret = "test-signing-secret";
+
+  const assistantThreadStartedBody = () =>
+    JSON.stringify({
+      type: "event_callback",
+      team_id: "T123",
+      event: {
+        type: "assistant_thread_started",
+        event_ts: "1234567890.000000",
+        assistant_thread: {
+          user_id: "U_USER",
+          channel_id: "D_ASSISTANT",
+          thread_ts: "1234567890.111111",
+          context: { channel_id: "C_CONTEXT", team_id: "T123" },
+        },
+      },
+    });
+
+  const homeOpenedBody = (tab: string, context?: unknown) =>
+    JSON.stringify({
+      type: "event_callback",
+      team_id: "T123",
+      event: {
+        type: "app_home_opened",
+        user: "U_USER",
+        channel: "D1",
+        tab,
+        event_ts: "1.2",
+        ...(context ? { context } : {}),
+      },
+    });
+
+  async function setup(config: Parameters<typeof createSlackAdapter>[0]) {
+    const adapter = createSlackAdapter({
+      botToken: "xoxb-test-token",
+      signingSecret: secret,
+      logger: mockLogger,
+      botUserId: "U_BOT",
+      ...config,
+    });
+    const chatInstance = {
+      ...createMockChatInstance({ state: createMockState() }),
+      processAssistantThreadStarted: vi.fn(),
+    };
+    await adapter.initialize(chatInstance);
+    const setPrompts = vi.fn().mockResolvedValue({ ok: true });
+    mockClientMethod(
+      adapter,
+      "assistant.threads.setSuggestedPrompts",
+      setPrompts
+    );
+    return { adapter, setPrompts };
+  }
+
+  async function dispatch(adapter: SlackAdapter, body: string) {
+    const tasks: Promise<unknown>[] = [];
+    const response = await adapter.handleWebhook(
+      createWebhookRequest(body, secret),
+      {
+        waitUntil: (p) => {
+          tasks.push(p);
+        },
+      }
+    );
+    await Promise.all(tasks);
+    return response;
+  }
+
+  it("applies static prompts on assistant_thread_started (legacy assistant_view)", async () => {
+    const { adapter, setPrompts } = await setup({
+      suggestedPrompts: {
+        title: "Welcome!",
+        prompts: [{ title: "Ideas", message: "Generate ideas" }],
+      },
+    });
+
+    const response = await dispatch(adapter, assistantThreadStartedBody());
+
+    expect(response.status).toBe(200);
+    expect(setPrompts).toHaveBeenCalledWith(
+      expect.objectContaining({
+        channel_id: "D_ASSISTANT",
+        thread_ts: "1234567890.111111",
+        title: "Welcome!",
+        prompts: [{ title: "Ideas", message: "Generate ideas" }],
+      })
+    );
+  });
+
+  it("applies prompts on Messages-tab app_home_opened under agentView, without thread_ts", async () => {
+    const { adapter, setPrompts } = await setup({
+      agentView: true,
+      suggestedPrompts: {
+        prompts: [{ title: "Summarize", message: "Summarize this channel" }],
+      },
+    });
+
+    await dispatch(adapter, homeOpenedBody("messages"));
+
+    expect(setPrompts).toHaveBeenCalledTimes(1);
+    const [arg] = setPrompts.mock.calls[0];
+    expect(arg).toMatchObject({ channel_id: "D1" });
+    expect(arg).not.toHaveProperty("thread_ts");
+  });
+
+  it("does not apply prompts on a Home-tab open under agentView", async () => {
+    const { adapter, setPrompts } = await setup({
+      agentView: true,
+      suggestedPrompts: {
+        prompts: [{ title: "Summarize", message: "Summarize this channel" }],
+      },
+    });
+
+    await dispatch(adapter, homeOpenedBody("home"));
+
+    expect(setPrompts).not.toHaveBeenCalled();
+  });
+
+  it("does nothing when suggestedPrompts is not configured", async () => {
+    const { adapter, setPrompts } = await setup({});
+
+    await dispatch(adapter, assistantThreadStartedBody());
+
+    expect(setPrompts).not.toHaveBeenCalled();
+  });
+
+  it("invokes a dynamic resolver with thread context", async () => {
+    const resolver = vi.fn().mockResolvedValue({
+      prompts: [{ title: "Dynamic", message: "Resolved per thread" }],
+    });
+    const { adapter, setPrompts } = await setup({
+      suggestedPrompts: resolver,
+    });
+
+    await dispatch(adapter, assistantThreadStartedBody());
+
+    expect(resolver).toHaveBeenCalledWith(
+      expect.objectContaining({
+        channelId: "D_ASSISTANT",
+        threadTs: "1234567890.111111",
+        userId: "U_USER",
+        teamId: "T123",
+      })
+    );
+    expect(setPrompts).toHaveBeenCalledWith(
+      expect.objectContaining({
+        prompts: [{ title: "Dynamic", message: "Resolved per thread" }],
+      })
+    );
+  });
+
+  it("passes active-view entities to the resolver under agentView", async () => {
+    const resolver = vi.fn().mockResolvedValue(null);
+    const { adapter } = await setup({
+      agentView: true,
+      suggestedPrompts: resolver,
+    });
+
+    await dispatch(
+      adapter,
+      homeOpenedBody("messages", {
+        entities: [
+          { type: "slack#/types/channel_id", value: "C42", team_id: "T123" },
+        ],
+      })
+    );
+
+    expect(resolver).toHaveBeenCalledWith(
+      expect.objectContaining({
+        channelId: "D1",
+        entities: [
+          expect.objectContaining({ kind: "channel", channelId: "C42" }),
+        ],
+      })
+    );
+  });
+
+  it("skips setting prompts when the resolver returns null", async () => {
+    const { adapter, setPrompts } = await setup({
+      suggestedPrompts: () => null,
+    });
+
+    await dispatch(adapter, assistantThreadStartedBody());
+
+    expect(setPrompts).not.toHaveBeenCalled();
+  });
+
+  it("truncates to Slack's 4-prompt limit with a warning", async () => {
+    const prompts = Array.from({ length: 6 }, (_, i) => ({
+      title: `P${i}`,
+      message: `M${i}`,
+    }));
+    const { adapter, setPrompts } = await setup({
+      suggestedPrompts: { prompts },
+    });
+
+    await dispatch(adapter, assistantThreadStartedBody());
+
+    const [arg] = setPrompts.mock.calls[0];
+    expect(arg.prompts).toHaveLength(4);
+    expect(arg.prompts[3]).toEqual({ title: "P3", message: "M3" });
+  });
+
+  it("logs and keeps the webhook green when the resolver throws", async () => {
+    const { adapter, setPrompts } = await setup({
+      suggestedPrompts: () => {
+        throw new Error("resolver blew up");
+      },
+    });
+
+    const response = await dispatch(adapter, assistantThreadStartedBody());
+
+    expect(response.status).toBe(200);
+    expect(setPrompts).not.toHaveBeenCalled();
+  });
+
+  it("logs and keeps the webhook green when the API call fails", async () => {
+    const { adapter, setPrompts } = await setup({
+      suggestedPrompts: {
+        prompts: [{ title: "Ideas", message: "Generate ideas" }],
+      },
+    });
+    setPrompts.mockRejectedValue(new Error("slack down"));
+
+    const response = await dispatch(adapter, assistantThreadStartedBody());
+
+    expect(response.status).toBe(200);
+    expect(setPrompts).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("configured loadingMessages", () => {
+  const secret = "test-signing-secret";
+
+  function setupAdapter(loadingMessages?: string[]) {
+    const adapter = createSlackAdapter({
+      botToken: "xoxb-test-token",
+      signingSecret: secret,
+      logger: mockLogger,
+      loadingMessages,
+    });
+    const setStatus = vi.fn().mockResolvedValue({ ok: true });
+    mockClientMethod(adapter, "assistant.threads.setStatus", setStatus);
+    return { adapter, setStatus };
+  }
+
+  it("startTyping uses configured loading messages by default", async () => {
+    const { adapter, setStatus } = setupAdapter(["Thinking...", "Digging..."]);
+
+    await adapter.startTyping("slack:D1:1.2");
+
+    expect(setStatus).toHaveBeenCalledWith(
+      expect.objectContaining({
+        status: "Thinking...",
+        loading_messages: ["Thinking...", "Digging..."],
+      })
+    );
+  });
+
+  it("startTyping prefers an explicit status over configured messages", async () => {
+    const { adapter, setStatus } = setupAdapter(["Thinking..."]);
+
+    await adapter.startTyping("slack:D1:1.2", "Searching docs...");
+
+    expect(setStatus).toHaveBeenCalledWith(
+      expect.objectContaining({
+        status: "Searching docs...",
+        loading_messages: ["Searching docs..."],
+      })
+    );
+  });
+
+  it("setAssistantStatus falls back to configured loading messages", async () => {
+    const { adapter, setStatus } = setupAdapter(["Thinking..."]);
+
+    await adapter.setAssistantStatus("D1", "1.2", "working");
+
+    expect(setStatus).toHaveBeenCalledWith(
+      expect.objectContaining({
+        status: "working",
+        loading_messages: ["Thinking..."],
+      })
+    );
+  });
+
+  it("setAssistantStatus explicit loadingMessages win over config", async () => {
+    const { adapter, setStatus } = setupAdapter(["Thinking..."]);
+
+    await adapter.setAssistantStatus("D1", "1.2", "working", ["Custom..."]);
+
+    expect(setStatus).toHaveBeenCalledWith(
+      expect.objectContaining({ loading_messages: ["Custom..."] })
+    );
+  });
+
+  it("startTyping keeps the Typing... default without config", async () => {
+    const { adapter, setStatus } = setupAdapter();
+
+    await adapter.startTyping("slack:D1:1.2");
+
+    expect(setStatus).toHaveBeenCalledWith(
+      expect.objectContaining({
+        status: "Typing...",
+        loading_messages: ["Typing..."],
+      })
+    );
+  });
+});
+
+// ============================================================================
 // setSuggestedPrompts Tests
 // ============================================================================
 

--- a/packages/adapter-slack/src/index.test.ts
+++ b/packages/adapter-slack/src/index.test.ts
@@ -8747,6 +8747,45 @@ describe("native streaming fallback", () => {
     expect(postSpy).not.toHaveBeenCalled();
   });
 
+  it("falls back when buffered appends never hit the API and stop() fails", async () => {
+    const { adapter, postSpy } = createAdapter();
+    // append() returning null means the delta was only buffered in memory —
+    // no API call happened, so stop() carries the first real failure.
+    const append = vi.fn().mockResolvedValue(null);
+    const stop = vi.fn().mockRejectedValue(new Error("no streaming here"));
+    mockClientMethod(
+      adapter,
+      "chatStream",
+      vi.fn().mockReturnValue({ append, stop, ts: undefined })
+    );
+
+    const result = await adapter.stream(
+      "slack:D123:1234567890.000000",
+      textStream("short reply")
+    );
+
+    expect(result).toMatchObject({ id: "fallback-ts" });
+    expect(postSpy).toHaveBeenCalledTimes(1);
+    expect(postSpy.mock.calls.at(-1)?.[1]).toContain("short reply");
+  });
+
+  it("propagates stop() failures once native content has rendered", async () => {
+    const { adapter, postSpy } = createAdapter();
+    // A non-null append response means content rendered natively.
+    const append = vi.fn().mockResolvedValue({ ok: true });
+    const stop = vi.fn().mockRejectedValue(new Error("stop boom"));
+    mockClientMethod(
+      adapter,
+      "chatStream",
+      vi.fn().mockReturnValue({ append, stop, ts: undefined })
+    );
+
+    await expect(
+      adapter.stream("slack:D123:1234567890.000000", textStream("hello"))
+    ).rejects.toThrow("stop boom");
+    expect(postSpy).not.toHaveBeenCalled();
+  });
+
   it("skips structured chunks in fallback mode without failing the stream", async () => {
     const { adapter, postSpy } = createAdapter();
     const append = vi.fn().mockRejectedValue(new Error("no streaming here"));

--- a/packages/adapter-slack/src/index.test.ts
+++ b/packages/adapter-slack/src/index.test.ts
@@ -14,8 +14,16 @@ import {
 import { WebClient } from "@slack/web-api";
 import type { AdapterPostableMessage, ChatInstance, StateAdapter } from "chat";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import type { SlackInstallation, SlackThreadId } from "./index";
-import { createSlackAdapter, SlackAdapter } from "./index";
+import type {
+  SlackAdapterConfig,
+  SlackInstallation,
+  SlackThreadId,
+} from "./index";
+import {
+  buildFeedbackButtonsBlock,
+  createSlackAdapter,
+  SlackAdapter,
+} from "./index";
 
 const FILE_ID_PATTERN = /^file-/;
 
@@ -8756,6 +8764,168 @@ describe("native streaming fallback", () => {
     // arrived via the post-and-edit fallback.
     expect(postSpy).toHaveBeenCalledTimes(1);
     expect(postSpy.mock.calls.at(-1)?.[1]).toContain("hello");
+  });
+});
+
+describe("feedbackButtons", () => {
+  function createStreamAdapter(
+    feedbackButtons?: SlackAdapterConfig["feedbackButtons"]
+  ) {
+    const adapter = createSlackAdapter({
+      botToken: "xoxb-test-token",
+      signingSecret: "test-signing-secret",
+      logger: mockLogger,
+      ...(feedbackButtons !== undefined ? { feedbackButtons } : {}),
+    });
+    const append = vi.fn().mockResolvedValue({ ok: true });
+    const stop = vi
+      .fn()
+      .mockResolvedValue({ ok: true, ts: "1234567890.111111" });
+    mockClientMethod(
+      adapter,
+      "chatStream",
+      vi.fn().mockReturnValue({ append, stop, ts: undefined })
+    );
+    return { adapter, append, stop };
+  }
+
+  async function* helloStream() {
+    yield "hello";
+  }
+
+  it("appends a feedback context_actions block on stream stop", async () => {
+    const { adapter, stop } = createStreamAdapter(true);
+
+    await adapter.stream("slack:D123:1234567890.000000", helloStream());
+
+    const [arg] = stop.mock.calls[0];
+    expect(arg.blocks).toEqual([
+      expect.objectContaining({
+        type: "context_actions",
+        elements: [
+          expect.objectContaining({
+            type: "feedback_buttons",
+            action_id: "message_feedback",
+            positive_button: expect.objectContaining({ value: "positive" }),
+            negative_button: expect.objectContaining({ value: "negative" }),
+          }),
+        ],
+      }),
+    ]);
+  });
+
+  it("honors custom labels, values, and action id", async () => {
+    const { adapter, stop } = createStreamAdapter({
+      actionId: "ai_feedback",
+      negativeLabel: "Nope",
+      negativeValue: "down",
+      positiveLabel: "Nice",
+      positiveValue: "up",
+    });
+
+    await adapter.stream("slack:D123:1234567890.000000", helloStream());
+
+    const [arg] = stop.mock.calls[0];
+    const element = arg.blocks[0].elements[0];
+    expect(element.action_id).toBe("ai_feedback");
+    expect(element.positive_button).toEqual({
+      text: { type: "plain_text", text: "Nice" },
+      value: "up",
+    });
+    expect(element.negative_button).toEqual({
+      text: { type: "plain_text", text: "Nope" },
+      value: "down",
+    });
+  });
+
+  it("places feedback buttons after caller stopBlocks", async () => {
+    const { adapter, stop } = createStreamAdapter(true);
+    const endWith = { type: "actions", elements: [] };
+
+    await adapter.stream("slack:D123:1234567890.000000", helloStream(), {
+      stopBlocks: [endWith],
+    });
+
+    const [arg] = stop.mock.calls[0];
+    expect(arg.blocks).toHaveLength(2);
+    expect(arg.blocks[0]).toEqual(endWith);
+    expect(arg.blocks[1].type).toBe("context_actions");
+  });
+
+  it("attaches no blocks when unconfigured", async () => {
+    const { adapter, stop } = createStreamAdapter();
+
+    await adapter.stream("slack:D123:1234567890.000000", helloStream());
+
+    const [arg] = stop.mock.calls[0];
+    expect(arg.blocks).toBeUndefined();
+  });
+
+  it("routes feedback button clicks through onAction", async () => {
+    const adapter = createSlackAdapter({
+      botToken: "xoxb-test-token",
+      signingSecret: "test-signing-secret",
+      logger: mockLogger,
+    });
+    const mockChat = createMockChatInstance({ state: createMockState() });
+    await adapter.initialize(mockChat);
+
+    const payload = {
+      type: "block_actions",
+      user: { id: "U1", username: "user" },
+      trigger_id: "trigger-1",
+      channel: { id: "D123", name: "dm" },
+      container: {
+        type: "message",
+        message_ts: "1234567890.111111",
+        channel_id: "D123",
+      },
+      message: { ts: "1234567890.111111", thread_ts: "1234567890.000000" },
+      actions: [
+        {
+          type: "feedback_buttons",
+          action_id: "message_feedback",
+          value: "positive",
+          action_ts: "1234567891.000000",
+        },
+      ],
+    };
+    const body = `payload=${encodeURIComponent(JSON.stringify(payload))}`;
+    const response = await adapter.handleWebhook(
+      createWebhookRequest(body, "test-signing-secret", {
+        contentType: "application/x-www-form-urlencoded",
+      })
+    );
+
+    expect(response.status).toBe(200);
+    expect(mockChat.processAction).toHaveBeenCalledWith(
+      expect.objectContaining({
+        actionId: "message_feedback",
+        value: "positive",
+        threadId: "slack:D123:1234567890.000000",
+      }),
+      undefined
+    );
+  });
+
+  it("exposes buildFeedbackButtonsBlock defaults", () => {
+    expect(buildFeedbackButtonsBlock()).toEqual({
+      type: "context_actions",
+      elements: [
+        {
+          type: "feedback_buttons",
+          action_id: "message_feedback",
+          positive_button: {
+            text: { type: "plain_text", text: "Good response" },
+            value: "positive",
+          },
+          negative_button: {
+            text: { type: "plain_text", text: "Bad response" },
+            value: "negative",
+          },
+        },
+      ],
+    });
   });
 });
 

--- a/packages/adapter-slack/src/index.test.ts
+++ b/packages/adapter-slack/src/index.test.ts
@@ -8597,6 +8597,168 @@ describe("stream with empty threadTs", () => {
   });
 });
 
+describe("native streaming fallback", () => {
+  function createAdapter(config?: Record<string, unknown>) {
+    const adapter = createSlackAdapter({
+      botToken: "xoxb-test-token",
+      signingSecret: "test-signing-secret",
+      logger: mockLogger,
+      ...config,
+    });
+    const postSpy = vi
+      .spyOn(adapter, "postMessage")
+      .mockResolvedValue({ id: "fallback-ts", threadId: "t", raw: {} });
+    const editSpy = vi
+      .spyOn(adapter, "editMessage")
+      .mockResolvedValue({ id: "fallback-ts", threadId: "t", raw: {} });
+    return { adapter, postSpy, editSpy };
+  }
+
+  async function* textStream(...parts: string[]) {
+    for (const part of parts) {
+      yield part;
+    }
+  }
+
+  it("returns null before consuming the stream when nativeStreaming is false", async () => {
+    const { adapter } = createAdapter({ nativeStreaming: false });
+    const chatStream = vi.fn();
+    mockClientMethod(adapter, "chatStream", chatStream);
+
+    const next = vi.fn();
+    const stream = { [Symbol.asyncIterator]: () => ({ next }) };
+
+    await expect(
+      adapter.stream("slack:D123:1234567890.000000", stream)
+    ).resolves.toBeNull();
+    expect(next).not.toHaveBeenCalled();
+    expect(chatStream).not.toHaveBeenCalled();
+  });
+
+  it("falls back to post-and-edit when the first native call fails", async () => {
+    const { adapter, postSpy, editSpy } = createAdapter();
+    const append = vi.fn().mockRejectedValue(new Error("no streaming here"));
+    const stop = vi.fn();
+    mockClientMethod(
+      adapter,
+      "chatStream",
+      vi.fn().mockReturnValue({ append, stop, ts: undefined })
+    );
+
+    const result = await adapter.stream(
+      "slack:D123:1234567890.000000",
+      textStream("hello ", "world")
+    );
+
+    expect(postSpy).toHaveBeenCalledTimes(1);
+    expect(stop).not.toHaveBeenCalled();
+    expect(result).toMatchObject({ id: "fallback-ts" });
+    // Whatever the throttle did mid-stream, the final forced flush must have
+    // delivered the full text — via the initial post or a closing edit.
+    const lastPosted = editSpy.mock.calls.length
+      ? editSpy.mock.calls.at(-1)?.[2]
+      : postSpy.mock.calls.at(-1)?.[1];
+    expect(lastPosted).toContain("world");
+  });
+
+  it("latches native streaming off after an unsupported-method platform error", async () => {
+    const { adapter } = createAdapter();
+    const platformError = Object.assign(new Error("unknown_method"), {
+      code: "slack_webapi_platform_error",
+      data: { error: "unknown_method" },
+    });
+    const chatStream = vi.fn().mockReturnValue({
+      append: vi.fn().mockRejectedValue(platformError),
+      stop: vi.fn(),
+      ts: undefined,
+    });
+    mockClientMethod(adapter, "chatStream", chatStream);
+
+    await adapter.stream("slack:D123:1234567890.000000", textStream("hello"));
+    expect(chatStream).toHaveBeenCalledTimes(1);
+
+    // Second stream skips the doomed native attempt entirely.
+    const next = vi.fn();
+    const stream = { [Symbol.asyncIterator]: () => ({ next }) };
+    await expect(
+      adapter.stream("slack:D123:1234567890.111111", stream)
+    ).resolves.toBeNull();
+    expect(chatStream).toHaveBeenCalledTimes(1);
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it("does not latch native streaming off after a transient error", async () => {
+    const { adapter } = createAdapter();
+    const chatStream = vi.fn().mockReturnValue({
+      append: vi.fn().mockRejectedValue(new Error("socket hang up")),
+      stop: vi.fn(),
+      ts: undefined,
+    });
+    mockClientMethod(adapter, "chatStream", chatStream);
+
+    await adapter.stream("slack:D123:1234567890.000000", textStream("hello"));
+    await adapter.stream(
+      "slack:D123:1234567890.111111",
+      textStream("hello again")
+    );
+
+    // Native streaming is re-attempted on the next stream.
+    expect(chatStream).toHaveBeenCalledTimes(2);
+  });
+
+  it("propagates mid-stream failures once native content has rendered", async () => {
+    const { adapter, postSpy } = createAdapter();
+    // ts is set: chat.startStream already succeeded, content is rendering.
+    mockClientMethod(
+      adapter,
+      "chatStream",
+      vi.fn().mockReturnValue({
+        append: vi.fn().mockRejectedValue(new Error("mid-stream boom")),
+        stop: vi.fn(),
+        ts: "1234567890.222222",
+      })
+    );
+
+    await expect(
+      adapter.stream("slack:D123:1234567890.000000", textStream("hello"))
+    ).rejects.toThrow("mid-stream boom");
+    expect(postSpy).not.toHaveBeenCalled();
+  });
+
+  it("skips structured chunks in fallback mode without failing the stream", async () => {
+    const { adapter, postSpy } = createAdapter();
+    const append = vi.fn().mockRejectedValue(new Error("no streaming here"));
+    mockClientMethod(
+      adapter,
+      "chatStream",
+      vi.fn().mockReturnValue({ append, stop: vi.fn(), ts: undefined })
+    );
+
+    async function* mixedStream() {
+      yield "hello";
+      yield {
+        details: "step",
+        id: "task-1",
+        status: "in_progress" as const,
+        title: "Task",
+        type: "task_update" as const,
+      };
+      yield " world";
+    }
+
+    const result = await adapter.stream(
+      "slack:D123:1234567890.000000",
+      mixedStream()
+    );
+
+    expect(result).toMatchObject({ id: "fallback-ts" });
+    // The structured chunk didn't fail the stream, and the text still
+    // arrived via the post-and-edit fallback.
+    expect(postSpy).toHaveBeenCalledTimes(1);
+    expect(postSpy.mock.calls.at(-1)?.[1]).toContain("hello");
+  });
+});
+
 describe("scheduleMessage with empty threadTs", () => {
   it("normalizes empty threadTs to undefined", async () => {
     const adapter = createSlackAdapter({

--- a/packages/adapter-slack/src/index.ts
+++ b/packages/adapter-slack/src/index.ts
@@ -143,6 +143,7 @@ import type {
   SlackAdapterConfig,
   SlackAdapterMode,
   SlackBotToken,
+  SlackFeedbackButtonsOptions,
   SlackInstallation,
   SlackSuggestedPrompts,
   SlackSuggestedPromptsContext,
@@ -152,12 +153,47 @@ export type {
   SlackAdapterConfig,
   SlackAdapterMode,
   SlackBotToken,
+  SlackFeedbackButtonsOptions,
   SlackInstallation,
   SlackSuggestedPrompt,
   SlackSuggestedPrompts,
   SlackSuggestedPromptsContext,
   SlackSuggestedPromptsOptions,
 } from "./types";
+
+/**
+ * Build a `context_actions` block with Slack's native feedback buttons
+ * (thumbs up/down on agent replies). The adapter appends this automatically
+ * to streamed replies when the `feedbackButtons` config is set; use this
+ * helper to attach the same block to non-streamed messages via raw blocks.
+ */
+export function buildFeedbackButtonsBlock(
+  options: SlackFeedbackButtonsOptions = {}
+): Record<string, unknown> {
+  return {
+    type: "context_actions",
+    elements: [
+      {
+        type: "feedback_buttons",
+        action_id: options.actionId ?? "message_feedback",
+        positive_button: {
+          text: {
+            type: "plain_text",
+            text: options.positiveLabel ?? "Good response",
+          },
+          value: options.positiveValue ?? "positive",
+        },
+        negative_button: {
+          text: {
+            type: "plain_text",
+            text: options.negativeLabel ?? "Bad response",
+          },
+          value: options.negativeValue ?? "negative",
+        },
+      },
+    ],
+  };
+}
 
 /** Slack displays at most this many suggested prompts per thread. */
 const MAX_SUGGESTED_PROMPTS = 4;
@@ -524,6 +560,8 @@ export class SlackAdapter implements Adapter<SlackThreadId, unknown> {
   protected readonly agentView: boolean;
   protected readonly suggestedPrompts?: SlackSuggestedPrompts;
   protected readonly loadingMessages?: string[];
+  /** Normalized feedbackButtons config (`true` becomes `{}`). */
+  protected readonly feedbackButtons?: SlackFeedbackButtonsOptions;
   protected readonly nativeStreaming: boolean;
   /**
    * Latched when the workspace rejects native streaming with an error that
@@ -695,6 +733,10 @@ export class SlackAdapter implements Adapter<SlackThreadId, unknown> {
     this.suggestedPrompts = config.suggestedPrompts;
     this.loadingMessages = config.loadingMessages;
     this.nativeStreaming = config.nativeStreaming ?? true;
+    if (config.feedbackButtons) {
+      this.feedbackButtons =
+        config.feedbackButtons === true ? {} : config.feedbackButtons;
+    }
     this.mode = config.mode ?? "webhook";
     this.socketForwardingSecret =
       config.socketForwardingSecret ?? config.appToken;
@@ -4368,9 +4410,9 @@ export class SlackAdapter implements Adapter<SlackThreadId, unknown> {
     await flushCommitted(true);
 
     if (fallback.mode === "fallback") {
-      if (options?.stopBlocks) {
+      if (options?.stopBlocks || this.feedbackButtons) {
         this.logger.warn(
-          "Slack: stopBlocks skipped - post-and-edit fallback cannot attach stream blocks",
+          "Slack: stream-end blocks (stopBlocks/feedbackButtons) skipped - post-and-edit fallback cannot attach stream blocks",
           { channel }
         );
       }
@@ -4380,12 +4422,18 @@ export class SlackAdapter implements Adapter<SlackThreadId, unknown> {
       return fallback.message;
     }
 
+    // Caller blocks (StreamingPlan endWith) first, then the configured
+    // feedback buttons so they render at the very end of the reply.
+    const stopBlocks = [
+      ...(options?.stopBlocks ?? []),
+      ...(this.feedbackButtons
+        ? [buildFeedbackButtonsBlock(this.feedbackButtons)]
+        : []),
+    ];
     const result = await streamer.stop({
       token,
-      ...(options?.stopBlocks
-        ? {
-            blocks: options.stopBlocks as ChatStopStreamArguments["blocks"],
-          }
+      ...(stopBlocks.length > 0
+        ? { blocks: stopBlocks as ChatStopStreamArguments["blocks"] }
         : {}),
     });
     const messageTs = (result.message?.ts ?? result.ts) as string;
@@ -5333,6 +5381,7 @@ export function createSlackAdapter(config?: SlackAdapterConfig): SlackAdapter {
       (noAuthConfig ? process.env.SLACK_CLIENT_SECRET : undefined),
     encryptionKey: config?.encryptionKey ?? process.env.SLACK_ENCRYPTION_KEY,
     installationKeyPrefix: config?.installationKeyPrefix,
+    feedbackButtons: config?.feedbackButtons,
     installationProvider: config?.installationProvider,
     loadingMessages: config?.loadingMessages,
     logger: config?.logger ?? new ConsoleLogger("info").child("slack"),

--- a/packages/adapter-slack/src/index.ts
+++ b/packages/adapter-slack/src/index.ts
@@ -4388,8 +4388,16 @@ export class SlackAdapter implements Adapter<SlackThreadId, unknown> {
         return;
       }
       try {
-        await streamer.append({ markdown_text: delta, token });
-        fallback.nativeRendered = true;
+        // append() buffers small deltas in memory and returns null until it
+        // actually calls the API — only a non-null response proves content
+        // is rendering natively.
+        const response = await streamer.append({
+          markdown_text: delta,
+          token,
+        });
+        if (response) {
+          fallback.nativeRendered = true;
+        }
         lastAppended = committable;
       } catch (error) {
         if (fallback.nativeRendered) {
@@ -4484,12 +4492,29 @@ export class SlackAdapter implements Adapter<SlackThreadId, unknown> {
         ? [buildFeedbackButtonsBlock(this.feedbackButtons)]
         : []),
     ];
-    const result = await streamer.stop({
-      token,
-      ...(stopBlocks.length > 0
-        ? { blocks: stopBlocks as ChatStopStreamArguments["blocks"] }
-        : {}),
-    });
+    let result: Awaited<ReturnType<typeof streamer.stop>>;
+    try {
+      result = await streamer.stop({
+        token,
+        ...(stopBlocks.length > 0
+          ? { blocks: stopBlocks as ChatStopStreamArguments["blocks"] }
+          : {}),
+      });
+    } catch (error) {
+      if (fallback.nativeRendered) {
+        throw error;
+      }
+      // Short streams can buffer every delta in the streamer, making stop()
+      // the FIRST real API call — on an unsupported workspace this is where
+      // the failure lands, so the post-and-edit fallback must engage here
+      // too. Stream-end blocks are skipped, as in any fallback.
+      switchToFallback(error);
+      await flushFallback(true);
+      this.logger.debug("Slack: fallback stream complete", {
+        messageId: fallback.message?.id,
+      });
+      return fallback.message;
+    }
     const messageTs = (result.message?.ts ?? result.ts) as string;
 
     this.logger.debug("Slack: stream complete", { messageId: messageTs });

--- a/packages/adapter-slack/src/index.ts
+++ b/packages/adapter-slack/src/index.ts
@@ -107,6 +107,46 @@ function timingSafeStringEqual(a: string, b: string): boolean {
   return timingSafeEqual(aBuf, bBuf);
 }
 
+/**
+ * Surface Slack's per-block validation details on invalid_blocks errors.
+ * The @slack/web-api error message is just "An API error occurred:
+ * invalid_blocks"; the actionable details (which block, which field) live in
+ * `data.errors` and `data.response_metadata.messages`.
+ */
+function enrichInvalidBlocksError(
+  error: unknown,
+  blocks: unknown[],
+  logger: Logger
+): unknown {
+  const slackError = error as {
+    code?: string;
+    data?: {
+      error?: string;
+      errors?: unknown[];
+      response_metadata?: { messages?: string[] };
+    };
+  };
+  if (
+    slackError.code !== "slack_webapi_platform_error" ||
+    slackError.data?.error !== "invalid_blocks"
+  ) {
+    return error;
+  }
+  const details = [
+    ...(slackError.data.errors ?? []),
+    ...(slackError.data.response_metadata?.messages ?? []),
+  ];
+  logger.error("Slack rejected blocks (invalid_blocks)", {
+    details,
+    blocks: JSON.stringify(blocks),
+  });
+  const enriched = new Error(
+    `Slack rejected blocks (invalid_blocks): ${JSON.stringify(details)}`
+  );
+  (enriched as { cause?: unknown }).cause = error;
+  return enriched;
+}
+
 /** Find the next `<@` or `<#` mention in text. */
 function findNextMention(text: string): number {
   const atIdx = text.indexOf("<@");
@@ -3428,16 +3468,21 @@ export class SlackAdapter implements Adapter<SlackThreadId, unknown> {
           blockCount: blocks.length,
         });
 
-        const result = await this._client.chat.postMessage(
-          await this.withToken({
-            channel,
-            thread_ts: threadTs,
-            text: fallbackText, // Fallback for notifications
-            blocks,
-            unfurl_links: false,
-            unfurl_media: false,
-          })
-        );
+        let result: Awaited<ReturnType<typeof this._client.chat.postMessage>>;
+        try {
+          result = await this._client.chat.postMessage(
+            await this.withToken({
+              channel,
+              thread_ts: threadTs,
+              text: fallbackText, // Fallback for notifications
+              blocks,
+              unfurl_links: false,
+              unfurl_media: false,
+            })
+          );
+        } catch (error) {
+          throw enrichInvalidBlocksError(error, blocks, this.logger);
+        }
 
         this.logger.debug("Slack API: chat.postMessage response", {
           messageId: result.ts,
@@ -4280,7 +4325,14 @@ export class SlackAdapter implements Adapter<SlackThreadId, unknown> {
     const fallback: {
       message: RawMessage<unknown> | null;
       mode: "fallback" | "native";
-    } = { message: null, mode: "native" };
+      /**
+       * True once any native append has succeeded (chat.startStream fired and
+       * content is rendering in Slack). Tracked here rather than via the
+       * ChatStreamer `ts` accessor, which has not been public in every
+       * @slack/web-api release.
+       */
+      nativeRendered: boolean;
+    } = { message: null, mode: "native", nativeRendered: false };
     const updateIntervalMs = options?.updateIntervalMs ?? 1000;
     let fallbackSent = "";
     let lastFallbackEditAt = 0;
@@ -4337,10 +4389,11 @@ export class SlackAdapter implements Adapter<SlackThreadId, unknown> {
       }
       try {
         await streamer.append({ markdown_text: delta, token });
+        fallback.nativeRendered = true;
         lastAppended = committable;
       } catch (error) {
-        if (streamer.ts !== undefined) {
-          // chat.startStream succeeded earlier; content is already rendering
+        if (fallback.nativeRendered) {
+          // A native call succeeded earlier; content is already rendering
           // natively, so a mid-stream failure can't be recovered here.
           throw error;
         }
@@ -4378,6 +4431,7 @@ export class SlackAdapter implements Adapter<SlackThreadId, unknown> {
           chunks: [chunk] as ChatAppendStreamArguments["chunks"],
           token,
         });
+        fallback.nativeRendered = true;
       } catch (error) {
         // Structured chunks may fail if the app doesn't have the required
         // Assistant scopes/features. Disable for the rest of this stream

--- a/packages/adapter-slack/src/index.ts
+++ b/packages/adapter-slack/src/index.ts
@@ -11,7 +11,11 @@ import {
   ValidationError,
 } from "@chat-adapter/shared";
 import { SocketModeClient } from "@slack/socket-mode";
-import { type ChatStopStreamArguments, WebClient } from "@slack/web-api";
+import {
+  type ChatAppendStreamArguments,
+  type ChatStopStreamArguments,
+  WebClient,
+} from "@slack/web-api";
 import type {
   ActionEvent,
   Adapter,
@@ -157,6 +161,27 @@ export type {
 
 /** Slack displays at most this many suggested prompts per thread. */
 const MAX_SUGGESTED_PROMPTS = 4;
+
+/**
+ * Slack platform errors indicating the workspace will never accept the native
+ * streaming methods (as opposed to transient/request-specific failures).
+ */
+const NATIVE_STREAMING_UNSUPPORTED_ERRORS = new Set([
+  "feature_not_enabled",
+  "method_deprecated",
+  "unknown_method",
+]);
+
+/**
+ * Extract the Slack platform error code (`data.error`) from a WebClient
+ * error, or undefined for non-platform errors (network failures, timeouts).
+ */
+function slackPlatformErrorCode(error: unknown): string | undefined {
+  const slackError = error as { code?: string; data?: { error?: string } };
+  return slackError?.code === "slack_webapi_platform_error"
+    ? slackError.data?.error
+    : undefined;
+}
 
 /**
  * Normalize a SlackBotToken config value to a resolver function, or undefined
@@ -499,6 +524,13 @@ export class SlackAdapter implements Adapter<SlackThreadId, unknown> {
   protected readonly agentView: boolean;
   protected readonly suggestedPrompts?: SlackSuggestedPrompts;
   protected readonly loadingMessages?: string[];
+  protected readonly nativeStreaming: boolean;
+  /**
+   * Latched when the workspace rejects native streaming with an error that
+   * won't heal (e.g. `unknown_method` on GovSlack) so later streams skip the
+   * doomed native attempt and go straight to post-and-edit.
+   */
+  protected nativeStreamingBroken = false;
   protected readonly mode: SlackAdapterMode;
   protected readonly socketForwardingSecret: string | undefined;
   private socketClient: SocketModeClient | null = null;
@@ -662,6 +694,7 @@ export class SlackAdapter implements Adapter<SlackThreadId, unknown> {
     this.agentView = config.agentView ?? false;
     this.suggestedPrompts = config.suggestedPrompts;
     this.loadingMessages = config.loadingMessages;
+    this.nativeStreaming = config.nativeStreaming ?? true;
     this.mode = config.mode ?? "webhook";
     this.socketForwardingSecret =
       config.socketForwardingSecret ?? config.appToken;
@@ -4164,6 +4197,13 @@ export class SlackAdapter implements Adapter<SlackThreadId, unknown> {
       this.logger.debug("Slack: using fallback stream - no recipient context");
       return null;
     }
+    if (!this.nativeStreaming || this.nativeStreamingBroken) {
+      this.logger.debug(
+        "Slack: using fallback stream - native streaming disabled",
+        { configured: this.nativeStreaming, broken: this.nativeStreamingBroken }
+      );
+      return null;
+    }
     this.logger.debug("Slack: starting stream", { channel, threadTs });
 
     const token = await this.getToken();
@@ -4186,11 +4226,85 @@ export class SlackAdapter implements Adapter<SlackThreadId, unknown> {
       wrapTablesForAppend: false,
     });
 
-    const flushMarkdownDelta = async (delta: string): Promise<void> => {
+    // In-stream fallback state. If the very first native call is rejected
+    // (streaming methods unavailable — e.g. GovSlack — or the feature is off
+    // for the workspace), nothing has rendered yet, so the rest of the stream
+    // is delivered via throttled post-and-edit instead. The already-consumed
+    // text lives in the renderer, so nothing is lost. Failures after content
+    // has rendered natively still propagate — mixing the two modes would
+    // duplicate output.
+    // Held in an object because the mode flips inside closures, which
+    // TypeScript's control-flow narrowing can't track on a plain `let`.
+    const fallback: {
+      message: RawMessage<unknown> | null;
+      mode: "fallback" | "native";
+    } = { message: null, mode: "native" };
+    const updateIntervalMs = options?.updateIntervalMs ?? 1000;
+    let fallbackSent = "";
+    let lastFallbackEditAt = 0;
+
+    const flushFallback = async (force: boolean): Promise<void> => {
+      const committable = renderer.getCommittableText();
+      if (committable.length === 0 || committable === fallbackSent) {
+        return;
+      }
+      const now = Date.now();
+      if (!(force || now - lastFallbackEditAt >= updateIntervalMs)) {
+        return;
+      }
+      if (fallback.message) {
+        await this.editMessage(threadId, fallback.message.id, committable);
+      } else {
+        fallback.message = await this.postMessage(threadId, committable);
+      }
+      fallbackSent = committable;
+      lastFallbackEditAt = now;
+    };
+
+    const switchToFallback = (error: unknown): void => {
+      fallback.mode = "fallback";
+      const platformError = slackPlatformErrorCode(error);
+      if (
+        platformError &&
+        NATIVE_STREAMING_UNSUPPORTED_ERRORS.has(platformError)
+      ) {
+        // The workspace will reject every future attempt too — latch so
+        // later streams skip straight to post-and-edit.
+        this.nativeStreamingBroken = true;
+      }
+      this.logger.warn(
+        "Slack native streaming unavailable, falling back to post-and-edit",
+        { channel, error }
+      );
+    };
+
+    /**
+     * Flush committed renderer text: as a markdown_text delta on the native
+     * stream, or as a throttled post/edit in fallback mode. A failure of the
+     * FIRST native flush (chat.startStream) switches to fallback mode.
+     */
+    const flushCommitted = async (force = false): Promise<void> => {
+      if (fallback.mode === "fallback") {
+        await flushFallback(force);
+        return;
+      }
+      const committable = renderer.getCommittableText();
+      const delta = committable.slice(lastAppended.length);
       if (delta.length === 0) {
         return;
       }
-      await streamer.append({ markdown_text: delta, token });
+      try {
+        await streamer.append({ markdown_text: delta, token });
+        lastAppended = committable;
+      } catch (error) {
+        if (streamer.ts !== undefined) {
+          // chat.startStream succeeded earlier; content is already rendering
+          // natively, so a mid-stream failure can't be recovered here.
+          throw error;
+        }
+        switchToFallback(error);
+        await flushFallback(force);
+      }
     };
 
     /**
@@ -4198,26 +4312,30 @@ export class SlackAdapter implements Adapter<SlackThreadId, unknown> {
      * directly to Slack's streaming API. Any buffered markdown text is
      * flushed first to maintain correct ordering.
      *
-     * If the Slack API rejects the chunk (e.g. missing assistant:write scope,
-     * older @slack/web-api version, or Assistant features not enabled in the
-     * app manifest), the error is logged and the chunk is silently skipped.
-     * Text streaming continues unaffected.
+     * If the Slack API rejects the chunk (e.g. missing assistant:write scope
+     * or Assistant features not enabled in the app manifest), the error is
+     * logged and the chunk is silently skipped. Text streaming continues
+     * unaffected. In fallback mode structured chunks are skipped — task
+     * cards only exist on the native streaming surface.
      */
     let structuredChunksSupported = true;
     const sendStructuredChunk = async (chunk: StreamChunk): Promise<void> => {
-      if (!structuredChunksSupported) {
+      // Flush any buffered markdown before sending the structured chunk
+      await flushCommitted();
+
+      if (fallback.mode === "fallback" || !structuredChunksSupported) {
+        this.logger.debug("Slack: structured chunk skipped", {
+          chunkType: chunk.type,
+          mode: fallback.mode,
+        });
         return;
       }
 
-      // Flush any buffered markdown before sending the structured chunk
-      const committable = renderer.getCommittableText();
-      const delta = committable.slice(lastAppended.length);
-      await flushMarkdownDelta(delta);
-      lastAppended = committable;
-
       try {
-        // biome-ignore lint/suspicious/noExplicitAny: chunks not in ChatAppendStreamArguments for older @slack/web-api
-        await streamer.append({ chunks: [chunk], token } as any);
+        await streamer.append({
+          chunks: [chunk] as ChatAppendStreamArguments["chunks"],
+          token,
+        });
       } catch (error) {
         // Structured chunks may fail if the app doesn't have the required
         // Assistant scopes/features. Disable for the rest of this stream
@@ -4225,26 +4343,20 @@ export class SlackAdapter implements Adapter<SlackThreadId, unknown> {
         structuredChunksSupported = false;
         this.logger.warn(
           "Structured streaming chunk failed, falling back to text-only streaming. " +
-            "Ensure your Slack app manifest includes assistant_view, assistant:write scope, " +
-            "and @slack/web-api >= 7.14.0",
+            "Ensure your Slack app manifest includes the agent/assistant feature " +
+            "and the assistant:write scope",
           { chunkType: chunk.type, error }
         );
       }
     };
 
-    const pushTextAndFlush = async (text: string): Promise<void> => {
-      renderer.push(text);
-      const committable = renderer.getCommittableText();
-      const delta = committable.slice(lastAppended.length);
-      await flushMarkdownDelta(delta);
-      lastAppended = committable;
-    };
-
     for await (const chunk of textStream) {
       if (typeof chunk === "string") {
-        await pushTextAndFlush(chunk);
+        renderer.push(chunk);
+        await flushCommitted();
       } else if (chunk.type === "markdown_text") {
-        await pushTextAndFlush(chunk.text);
+        renderer.push(chunk.text);
+        await flushCommitted();
       } else {
         // Structured chunk (task_update, plan_update) — send directly to Slack
         await sendStructuredChunk(chunk);
@@ -4253,9 +4365,20 @@ export class SlackAdapter implements Adapter<SlackThreadId, unknown> {
 
     // Flush any remaining buffered content (e.g. held table rows at end of stream).
     renderer.finish();
-    const finalCommittable = renderer.getCommittableText();
-    const finalDelta = finalCommittable.slice(lastAppended.length);
-    await flushMarkdownDelta(finalDelta);
+    await flushCommitted(true);
+
+    if (fallback.mode === "fallback") {
+      if (options?.stopBlocks) {
+        this.logger.warn(
+          "Slack: stopBlocks skipped - post-and-edit fallback cannot attach stream blocks",
+          { channel }
+        );
+      }
+      this.logger.debug("Slack: fallback stream complete", {
+        messageId: fallback.message?.id,
+      });
+      return fallback.message;
+    }
 
     const result = await streamer.stop({
       token,
@@ -5213,6 +5336,7 @@ export function createSlackAdapter(config?: SlackAdapterConfig): SlackAdapter {
     installationProvider: config?.installationProvider,
     loadingMessages: config?.loadingMessages,
     logger: config?.logger ?? new ConsoleLogger("info").child("slack"),
+    nativeStreaming: config?.nativeStreaming,
     suggestedPrompts: config?.suggestedPrompts,
     socketForwardingSecret:
       config?.socketForwardingSecret ??

--- a/packages/adapter-slack/src/index.ts
+++ b/packages/adapter-slack/src/index.ts
@@ -140,6 +140,8 @@ import type {
   SlackAdapterMode,
   SlackBotToken,
   SlackInstallation,
+  SlackSuggestedPrompts,
+  SlackSuggestedPromptsContext,
 } from "./types";
 
 export type {
@@ -147,7 +149,14 @@ export type {
   SlackAdapterMode,
   SlackBotToken,
   SlackInstallation,
+  SlackSuggestedPrompt,
+  SlackSuggestedPrompts,
+  SlackSuggestedPromptsContext,
+  SlackSuggestedPromptsOptions,
 } from "./types";
+
+/** Slack displays at most this many suggested prompts per thread. */
+const MAX_SUGGESTED_PROMPTS = 4;
 
 /**
  * Normalize a SlackBotToken config value to a resolver function, or undefined
@@ -488,6 +497,8 @@ export class SlackAdapter implements Adapter<SlackThreadId, unknown> {
   // Socket mode support
   protected readonly appToken: string | undefined;
   protected readonly agentView: boolean;
+  protected readonly suggestedPrompts?: SlackSuggestedPrompts;
+  protected readonly loadingMessages?: string[];
   protected readonly mode: SlackAdapterMode;
   protected readonly socketForwardingSecret: string | undefined;
   private socketClient: SocketModeClient | null = null;
@@ -649,6 +660,8 @@ export class SlackAdapter implements Adapter<SlackThreadId, unknown> {
 
     this.appToken = config.appToken;
     this.agentView = config.agentView ?? false;
+    this.suggestedPrompts = config.suggestedPrompts;
+    this.loadingMessages = config.loadingMessages;
     this.mode = config.mode ?? "webhook";
     this.socketForwardingSecret =
       config.socketForwardingSecret ?? config.appToken;
@@ -2389,6 +2402,19 @@ export class SlackAdapter implements Adapter<SlackThreadId, unknown> {
       threadTs: thread_ts,
     });
 
+    // Apply configured suggested prompts for the new assistant thread. The
+    // task starts inside the request scope so the multi-workspace token
+    // context propagates; it catches internally, so it is safe without a
+    // waitUntil (fire-and-forget under socket mode).
+    const promptsTask = this.applyConfiguredSuggestedPrompts({
+      channelId: channel_id,
+      enterpriseId: context.enterprise_id,
+      teamId: context.team_id,
+      threadTs: thread_ts,
+      userId: user_id,
+    });
+    options?.waitUntil?.(promptsTask);
+
     this.chat.processAssistantThreadStarted(
       {
         threadId,
@@ -2468,6 +2494,21 @@ export class SlackAdapter implements Adapter<SlackThreadId, unknown> {
         "Chat instance not initialized, ignoring app_home_opened"
       );
       return;
+    }
+
+    // Under agent_view, a Messages-tab open is the thread-open signal —
+    // apply configured suggested prompts (no thread_ts; they pin at the top
+    // of the agent conversation). Legacy assistant_view prompts flow through
+    // assistant_thread_started instead.
+    if (this.agentView && event.tab === "messages") {
+      const promptsTask = this.applyConfiguredSuggestedPrompts({
+        channelId: event.channel,
+        userId: event.user,
+        ...(event.context
+          ? { entities: normalizeAppContextEntities(event.context) }
+          : {}),
+      });
+      options?.waitUntil?.(promptsTask);
     }
 
     this.chat.processAppHomeOpened(
@@ -2592,8 +2633,52 @@ export class SlackAdapter implements Adapter<SlackThreadId, unknown> {
   }
 
   /**
+   * Resolve and apply the configured `suggestedPrompts` for a newly opened
+   * assistant/agent thread. Errors are logged, never thrown — this runs on
+   * the webhook path where a failure must not turn into a 500.
+   */
+  protected async applyConfiguredSuggestedPrompts(
+    context: SlackSuggestedPromptsContext
+  ): Promise<void> {
+    if (!this.suggestedPrompts) {
+      return;
+    }
+    try {
+      const resolved =
+        typeof this.suggestedPrompts === "function"
+          ? await this.suggestedPrompts(context)
+          : this.suggestedPrompts;
+      if (!resolved || resolved.prompts.length === 0) {
+        return;
+      }
+      let prompts = resolved.prompts;
+      if (prompts.length > MAX_SUGGESTED_PROMPTS) {
+        this.logger.warn(
+          `Slack shows at most ${MAX_SUGGESTED_PROMPTS} suggested prompts; dropping the rest`,
+          { configured: prompts.length }
+        );
+        prompts = prompts.slice(0, MAX_SUGGESTED_PROMPTS);
+      }
+      await this.setSuggestedPrompts(
+        context.channelId,
+        context.threadTs,
+        prompts,
+        resolved.title
+      );
+    } catch (error) {
+      this.logger.warn("Failed to apply configured suggested prompts", {
+        channelId: context.channelId,
+        error,
+      });
+    }
+  }
+
+  /**
    * Set status/thinking indicator for an assistant thread.
    * Slack Assistants API: assistant.threads.setStatus
+   *
+   * When `loadingMessages` is omitted, falls back to the adapter-level
+   * `loadingMessages` config.
    */
   async setAssistantStatus(
     channelId: string,
@@ -2601,12 +2686,15 @@ export class SlackAdapter implements Adapter<SlackThreadId, unknown> {
     status: string,
     loadingMessages?: string[]
   ): Promise<void> {
+    const effectiveLoadingMessages = loadingMessages ?? this.loadingMessages;
     await this._client.assistant.threads.setStatus(
       await this.withToken({
         channel_id: channelId,
         thread_ts: threadTs,
         status,
-        ...(loadingMessages && { loading_messages: loadingMessages }),
+        ...(effectiveLoadingMessages && {
+          loading_messages: effectiveLoadingMessages,
+        }),
       })
     );
   }
@@ -4023,12 +4111,15 @@ export class SlackAdapter implements Adapter<SlackThreadId, unknown> {
       status,
     });
     try {
+      const loadingMessages = status
+        ? [status]
+        : (this.loadingMessages ?? ["Typing..."]);
       await this._client.assistant.threads.setStatus(
         await this.withToken({
           channel_id: channel,
           thread_ts: threadTs,
-          status: status ?? "Typing...",
-          loading_messages: [status ?? "Typing..."],
+          status: status ?? this.loadingMessages?.[0] ?? "Typing...",
+          loading_messages: loadingMessages,
         })
       );
     } catch (error) {
@@ -5120,7 +5211,9 @@ export function createSlackAdapter(config?: SlackAdapterConfig): SlackAdapter {
     encryptionKey: config?.encryptionKey ?? process.env.SLACK_ENCRYPTION_KEY,
     installationKeyPrefix: config?.installationKeyPrefix,
     installationProvider: config?.installationProvider,
+    loadingMessages: config?.loadingMessages,
     logger: config?.logger ?? new ConsoleLogger("info").child("slack"),
+    suggestedPrompts: config?.suggestedPrompts,
     socketForwardingSecret:
       config?.socketForwardingSecret ??
       process.env.SLACK_SOCKET_FORWARDING_SECRET,

--- a/packages/adapter-slack/src/types.ts
+++ b/packages/adapter-slack/src/types.ts
@@ -22,6 +22,23 @@ export interface SlackInstallation {
   teamName?: string;
 }
 
+/** Options for the feedback buttons appended to streamed replies. */
+export interface SlackFeedbackButtonsOptions {
+  /**
+   * `action_id` dispatched to `bot.onAction` when a button is clicked.
+   * Defaults to "message_feedback".
+   */
+  actionId?: string;
+  /** Label for the negative button. Defaults to "Bad response". */
+  negativeLabel?: string;
+  /** Action value dispatched for negative clicks. Defaults to "negative". */
+  negativeValue?: string;
+  /** Label for the positive button. Defaults to "Good response". */
+  positiveLabel?: string;
+  /** Action value dispatched for positive clicks. Defaults to "positive". */
+  positiveValue?: string;
+}
+
 /** A single suggested prompt shown in an assistant/agent thread. */
 export interface SlackSuggestedPrompt {
   /** Full prompt text sent as the user's message when the prompt is clicked. */
@@ -98,6 +115,15 @@ export interface SlackAdapterConfig {
    * If provided, bot tokens stored via setInstallation() will be encrypted at rest.
    */
   encryptionKey?: string;
+  /**
+   * Append Slack's native feedback buttons (a `context_actions` block with a
+   * `feedback_buttons` element) to every streamed reply, attached when the
+   * stream finishes. Clicks dispatch to `bot.onAction` with the configured
+   * `actionId` and a positive/negative value. Pass `true` for defaults, or an
+   * options object to customize labels, values, and the action id. Skipped
+   * when a stream falls back to post-and-edit.
+   */
+  feedbackButtons?: boolean | SlackFeedbackButtonsOptions;
   /**
    * Prefix for the state key used to store workspace installations.
    * Defaults to `slack:installation`. The full key will be `{prefix}:{teamId}`.

--- a/packages/adapter-slack/src/types.ts
+++ b/packages/adapter-slack/src/types.ts
@@ -127,6 +127,14 @@ export interface SlackAdapterConfig {
   logger?: Logger;
   /** Connection mode: "webhook" (default) or "socket" */
   mode?: SlackAdapterMode;
+  /**
+   * Use Slack's native streaming API (`chat.startStream` / `chat.appendStream`
+   * / `chat.stopStream`) for streamed posts. Defaults to true. Set false on
+   * Slack flavours without the streaming methods (e.g. GovSlack) to always
+   * stream via post-and-edit; the adapter also falls back automatically when
+   * the workspace rejects the first native call.
+   */
+  nativeStreaming?: boolean;
   /** Signing secret for webhook verification. Defaults to SLACK_SIGNING_SECRET env var. */
   signingSecret?: string;
   /** Shared secret for authenticating forwarded socket mode events. Auto-detected from SLACK_SOCKET_FORWARDING_SECRET. Falls back to appToken if not set. */

--- a/packages/adapter-slack/src/types.ts
+++ b/packages/adapter-slack/src/types.ts
@@ -3,7 +3,7 @@
  */
 
 import type { WebClientOptions } from "@slack/web-api";
-import type { Logger } from "chat";
+import type { AppContextEntity, Logger } from "chat";
 import type { SlackWebhookVerifier } from "./webhook/index";
 
 export type SlackAdapterMode = "webhook" | "socket";
@@ -21,6 +21,53 @@ export interface SlackInstallation {
   botUserId?: string;
   teamName?: string;
 }
+
+/** A single suggested prompt shown in an assistant/agent thread. */
+export interface SlackSuggestedPrompt {
+  /** Full prompt text sent as the user's message when the prompt is clicked. */
+  message: string;
+  /** Short label shown on the prompt button. */
+  title: string;
+}
+
+/** Suggested prompts payload applied when an assistant/agent thread opens. */
+export interface SlackSuggestedPromptsOptions {
+  /** The prompts to display. Slack shows at most 4. */
+  prompts: SlackSuggestedPrompt[];
+  /** Optional heading shown above the prompts. */
+  title?: string;
+}
+
+/** Context passed to a dynamic `suggestedPrompts` resolver. */
+export interface SlackSuggestedPromptsContext {
+  /** The DM channel the assistant/agent thread lives in. */
+  channelId: string;
+  /** Enterprise the user opened the thread from (legacy assistant_view). */
+  enterpriseId?: string;
+  /** Active-view context entities (agent_view, when Slack folds context in). */
+  entities?: AppContextEntity[];
+  /** Team the user opened the thread from (legacy assistant_view). */
+  teamId?: string;
+  /** Assistant thread root (legacy assistant_view; absent under agent_view). */
+  threadTs?: string;
+  /** The user who opened the thread. */
+  userId: string;
+}
+
+/**
+ * Suggested prompts configuration: a static payload, or a resolver invoked
+ * each time an assistant/agent thread opens. Return null/undefined from the
+ * resolver to skip setting prompts for that thread.
+ */
+export type SlackSuggestedPrompts =
+  | SlackSuggestedPromptsOptions
+  | ((
+      context: SlackSuggestedPromptsContext
+    ) =>
+      | SlackSuggestedPromptsOptions
+      | null
+      | undefined
+      | Promise<SlackSuggestedPromptsOptions | null | undefined>);
 
 export interface SlackAdapterConfig {
   /**
@@ -70,6 +117,12 @@ export interface SlackAdapterConfig {
       isEnterpriseInstall: boolean
     ) => Promise<SlackInstallation | null>;
   };
+  /**
+   * Default rotating loading messages for the assistant thinking indicator
+   * (`assistant.threads.setStatus` `loading_messages`). Used by `startTyping`
+   * and `setAssistantStatus` when no explicit status/messages are passed.
+   */
+  loadingMessages?: string[];
   /** Logger instance for error reporting. Defaults to ConsoleLogger. */
   logger?: Logger;
   /** Connection mode: "webhook" (default) or "socket" */
@@ -78,6 +131,15 @@ export interface SlackAdapterConfig {
   signingSecret?: string;
   /** Shared secret for authenticating forwarded socket mode events. Auto-detected from SLACK_SOCKET_FORWARDING_SECRET. Falls back to appToken if not set. */
   socketForwardingSecret?: string;
+  /**
+   * Suggested prompts to pin automatically when an assistant/agent thread
+   * opens. Applied on `assistant_thread_started` (legacy `assistant_view`)
+   * and on Messages-tab `app_home_opened` (with `agentView` enabled, where
+   * prompts sit at the top of the agent conversation). Pass a static payload
+   * or a resolver that receives the thread context (user, channel,
+   * active-view entities) and returns prompts per thread.
+   */
+  suggestedPrompts?: SlackSuggestedPrompts;
   /** Override bot username (optional) */
   userName?: string;
   /**


### PR DESCRIPTION
Builds on the Agent messaging experience support from #684 with a declarative config layer for building Slack agents, plus hardening for native streaming.

Everything is configured on `createSlackAdapter()` — no per-event wiring required.

## Slack adapter (`@chat-adapter/slack`)

### `suggestedPrompts`

Static payload or per-thread resolver, applied automatically when an assistant/agent thread opens:

- `assistant_thread_started` (legacy `assistant_view`), with the thread's `thread_ts`
- Messages-tab `app_home_opened` (with `agentView` enabled), without `thread_ts` so prompts pin atop the agent conversation

The resolver receives the thread context (`channelId`, `userId`, legacy `threadTs`/`teamId`/`enterpriseId`, and normalized active-view `entities` under `agentView`); returning `null`/`undefined` skips the thread. Prompts beyond Slack's 4-prompt limit are dropped with a warning. Resolver/API failures are logged, never a webhook 500. Applied via `waitUntil` inside the request scope so multi-workspace token context propagates.

### `loadingMessages`

Default rotating status strings for the assistant thinking indicator, used by `startTyping` and `setAssistantStatus` when no explicit status/messages are passed.

### `nativeStreaming` + automatic post-and-edit fallback

- New `nativeStreaming` config (default `true`). Set `false` on Slack flavours without the `chat.startStream` family (e.g., GovSlack) to always stream via post-and-edit.
- If the workspace rejects the **first** native streaming call, `stream()` falls back to throttled post-and-edit mid-stream instead of failing the reply; already-consumed text is preserved (it lives in the renderer). Permanent platform errors (`unknown_method`, `method_deprecated`, `feature_not_enabled`) latch native streaming off for subsequent streams on the adapter instance; transient errors don't latch.
- Structured chunks (`task_update`/`plan_update`) are skipped in fallback mode; failures after native content has rendered still propagate (mixing surfaces would duplicate output).
- Also updates the stale streaming description in the package AGENTS.md (the adapter now streams via `chat.startStream`/`appendStream`/`stopStream`, not `chat.update`).

### `feedbackButtons`

Appends Slack's native thumbs up/down (a `context_actions` block with a `feedback_buttons` element) to every streamed reply on `chat.stopStream`, after any `StreamingPlan` `endWith` blocks. Pass `true` for defaults or an options object (`actionId`, labels, values). Clicks dispatch through the regular `block_actions` flow to `bot.onAction` with a positive/negative value — no new plumbing. Exports `buildFeedbackButtonsBlock(options?)` for attaching the same block to non-streamed messages.

New exported types: `SlackFeedbackButtonsOptions`, `SlackSuggestedPrompt`, `SlackSuggestedPrompts`, `SlackSuggestedPromptsContext`, `SlackSuggestedPromptsOptions`.

## Docs

- Configuration table rows for `agentView`, `suggestedPrompts`, `loadingMessages`, `nativeStreaming`, `feedbackButtons`.
- New "Native streaming" and "Feedback buttons" sections plus declarative suggested-prompts examples.
- All agent content grouped under a new **Advanced → Agents** subsection (Agent messaging experience → Assistants API → Native streaming → Feedback buttons). Heading titles unchanged, so existing anchors keep resolving.
- TypeTable descriptions rewritten as plain text (they don't render markdown).

## Example app (`examples/nextjs-chat`)

- `SLACK_AGENT_OPTIONS` shared across both Slack adapter branches: active-view-aware `suggestedPrompts` resolver, `loadingMessages`, `feedbackButtons` with an `ai_feedback` acknowledgment handler.
- Env toggles: `SLACK_AGENT_VIEW` (agent_view mode) and `SLACK_NATIVE_STREAMING` (compare native vs post-and-edit).
- Commented `agent_view` blocks in `slack-manifest.yml` (feature block, `assistant:write` scope, agent events) with a note that the switch is irreversible.
- AI flows call `startTyping()` without an explicit status so configured loading messages rotate.

## Test plan

- `pnpm validate` and `pnpm konsistent` pass.
- 26 new unit tests: suggested prompts (static/resolver/agent_view/truncation/error paths), loading message defaults, native streaming fallback (opt-out, mid-stream fallback, permanent-error latching, transient non-latching, propagation after native render, structured-chunk skipping), feedback buttons (block shape, custom options, ordering after `endWith`, webhook round-trip of a click).
- Each adapter commit was built and verified independently (typecheck + full suite green at every step) for bisectability.
- Verified manually against a live `agent_view` workspace: prompts pinned on thread open, loading messages rotating in the thinking indicator, native token-by-token streaming in DMs and channel threads, post-and-edit fallback via the opt-out flag, and feedback clicks dispatching to `onAction`.

## Notes

- One changeset covers the three adapter features (`minor` for `@chat-adapter/slack`).
- Known follow-up (not in this PR): under `agentView`, a subscribed conversation-scoped DM thread (the #684 openDM bridge) routes DM messages to a thread without `thread_ts`, which silently pins DMs to post-and-edit. Worth deciding whether the bridge should keep per-message threading for replies or log loudly when it redirects.

## Screenshots

| Suggested Prompts | Feedback Buttons |
| --- | --- |
| <img width="647" height="347" alt="CleanShot 2026-07-13 at 13 26 27" src="https://github.com/user-attachments/assets/4c89932b-ed19-4b4a-83ae-d3d022d0c120" /> | <img width="825" height="276" alt="CleanShot 2026-07-13 at 13 28 23" src="https://github.com/user-attachments/assets/6bdf6979-5209-4bed-b0bc-dfbee7165455" /> |

