### PR TITLE
feat(x): support image uploads on posts and DMs

### DIFF
--- a/.changeset/long-times-love.md
+++ b/.changeset/long-times-love.md
@@ -1,0 +1,5 @@
+---
+"@chat-adapter/x": minor
+---
+
+add image upload support to X posts and DMs via the chunked media upload endpoints

--- a/apps/docs/content/adapters/official/x.mdx
+++ b/apps/docs/content/adapters/official/x.mdx
@@ -13,7 +13,7 @@ features:
     status: partial
     label: Posts only
   deleteMessage: yes
-  fileUploads: no
+  fileUploads: yes
   streaming:
     status: partial
     label: Buffered
@@ -159,7 +159,7 @@ export async function POST(request: Request) {
 
 1. Go to the [X developer portal](https://developer.x.com) and create a Project and App.
 2. Under **Keys and tokens**, copy the **API Key Secret** to `X_CONSUMER_SECRET`.
-3. Enable **OAuth 2.0** user authentication with the scopes `tweet.read`, `tweet.write`, `users.read`, `dm.read`, `dm.write`, `like.write`, and `offline.access`.
+3. Enable **OAuth 2.0** user authentication with the scopes `tweet.read`, `tweet.write`, `users.read`, `dm.read`, `dm.write`, `like.write`, `media.write`, and `offline.access`.
 4. Complete the OAuth 2.0 flow for the bot account. Either store the access token as `X_USER_ACCESS_TOKEN`, or store `X_CLIENT_ID` plus `X_REFRESH_TOKEN` to let the adapter manage token refresh.
 
 <Callout type="warn">
@@ -195,6 +195,19 @@ Replies target the most recent mention received in the conversation, and consecu
 ### Reactions
 
 Likes are the only reaction X exposes. `addReaction` accepts `emoji.heart` or `"like"` and maps to `POST /2/users/:id/likes`; anything else throws a `ValidationError`.
+
+### Media uploads
+
+Attach images by passing `files` (or `attachments`) on the message. The adapter uploads each image (png, jpeg, webp) through X's chunked media endpoints (`initialize` then `append` then `finalize`) and attaches the returned `media_id`s. Posts and DMs accept up to four images, with or without text.
+
+```typescript
+await thread.post({
+  markdown: "France lead the title race",
+  files: [{ data: pngBuffer, filename: "odds.png", mimeType: "image/png" }],
+});
+```
+
+Media upload requires the `media.write` scope on the OAuth 2.0 token, alongside `tweet.write`; without it uploads fail with a 403.
 
 ### Thread ID format
 

--- a/packages/adapter-x/README.md
+++ b/packages/adapter-x/README.md
@@ -143,7 +143,18 @@ export async function POST(request: Request) {
 | Buttons | No (link buttons render as text) |
 | Tables | ASCII |
 | Modals | No |
-| File uploads | Not yet |
+| Image uploads | Yes (png, jpeg, webp; up to 4 per post; also DMs) |
+
+Attach images by passing `files` (or `attachments`) on the message; the adapter uploads each through X's chunked media endpoints (`initialize` then `append` then `finalize`) and attaches the returned `media_id`s to the post or DM. A post can carry media with or without text.
+
+```typescript
+await thread.post({
+  markdown: "France lead the title race",
+  files: [{ data: pngBuffer, filename: "odds.png", mimeType: "image/png" }],
+});
+```
+
+Media upload requires the `media.write` scope on your OAuth 2.0 token, in addition to `tweet.write`. Mint the token with `media.write` included or uploads fail with a 403.
 
 ### Conversations
 

--- a/packages/adapter-x/src/index.test.ts
+++ b/packages/adapter-x/src/index.test.ts
@@ -559,6 +559,143 @@ describe("XAdapter", () => {
       expect(JSON.parse(String(init?.body))).toEqual({ text: "hello!" });
     });
 
+    describe("media attachments", () => {
+      const image = () => ({
+        data: Buffer.from("PNGDATA"),
+        filename: "card.png",
+        mimeType: "image/png",
+      });
+
+      function queueMediaUpload(): void {
+        mockFetch
+          .mockResolvedValueOnce(apiOk({ data: { id: "MEDIA1" } })) // INIT
+          .mockResolvedValueOnce(apiOk({})) // APPEND
+          .mockResolvedValueOnce(apiOk({ data: { id: "MEDIA1" } })); // FINALIZE
+      }
+
+      it("uploads an image and attaches the media_id to the reply", async () => {
+        const { adapter } = await createInitializedAdapter();
+        queueMediaUpload();
+        mockFetch.mockResolvedValueOnce(apiOk({ data: { id: "600" } }));
+
+        await adapter.postMessage("x:post:500", {
+          files: [image()],
+          markdown: "here you go",
+        });
+
+        // initialize (JSON body)
+        expect(String(mockFetch.mock.calls[0][0])).toBe(
+          "https://api.x.com/2/media/upload/initialize"
+        );
+        expect(JSON.parse(String(mockFetch.mock.calls[0][1]?.body))).toEqual({
+          media_category: "tweet_image",
+          media_type: "image/png",
+          total_bytes: 7,
+        });
+        expect(mockFetch.mock.calls[0][1]?.headers).toMatchObject({
+          Authorization: `Bearer ${ACCESS_TOKEN}`,
+        });
+
+        // append (multipart to /{id}/append)
+        expect(String(mockFetch.mock.calls[1][0])).toBe(
+          "https://api.x.com/2/media/upload/MEDIA1/append"
+        );
+        const append = mockFetch.mock.calls[1][1]?.body as FormData;
+        expect(append.get("segment_index")).toBe("0");
+        expect(append.get("media")).toBeInstanceOf(Blob);
+
+        // finalize
+        expect(String(mockFetch.mock.calls[2][0])).toBe(
+          "https://api.x.com/2/media/upload/MEDIA1/finalize"
+        );
+
+        const tweetBody = JSON.parse(String(mockFetch.mock.calls[3][1]?.body));
+        expect(tweetBody).toEqual({
+          media: { media_ids: ["MEDIA1"] },
+          reply: { in_reply_to_tweet_id: "500" },
+          text: "here you go",
+        });
+      });
+
+      it("allows a media-only reply with no text", async () => {
+        const { adapter } = await createInitializedAdapter();
+        queueMediaUpload();
+        mockFetch.mockResolvedValueOnce(apiOk({ data: { id: "600" } }));
+
+        await adapter.postMessage("x:post:500", {
+          files: [image()],
+          markdown: "",
+        });
+
+        const tweetBody = JSON.parse(String(mockFetch.mock.calls[3][1]?.body));
+        expect(tweetBody.media).toEqual({ media_ids: ["MEDIA1"] });
+        expect(tweetBody.text).toBeUndefined();
+      });
+
+      it("infers the media type from the filename when mimeType is absent", async () => {
+        const { adapter } = await createInitializedAdapter();
+        queueMediaUpload();
+        mockFetch.mockResolvedValueOnce(apiOk({ data: { id: "600" } }));
+
+        await adapter.postMessage("x:post:500", {
+          files: [{ data: Buffer.from("x"), filename: "draw.png" }],
+          markdown: "",
+        });
+
+        const initBody = JSON.parse(String(mockFetch.mock.calls[0][1]?.body));
+        expect(initBody.media_type).toBe("image/png");
+        expect(initBody.media_category).toBe("tweet_image");
+      });
+
+      it("attaches uploaded media to a DM", async () => {
+        const { adapter } = await createInitializedAdapter();
+        queueMediaUpload();
+        mockFetch.mockResolvedValueOnce(
+          apiOk({
+            data: { dm_conversation_id: "111-999", dm_event_id: "9002" },
+          })
+        );
+
+        await adapter.postMessage("x:dm:111", {
+          files: [image()],
+          markdown: "pic",
+        });
+
+        const dmBody = JSON.parse(String(mockFetch.mock.calls[3][1]?.body));
+        expect(dmBody).toEqual({
+          attachments: [{ media_id: "MEDIA1" }],
+          text: "pic",
+        });
+      });
+
+      it("rejects more than four media attachments", async () => {
+        const { adapter } = await createInitializedAdapter();
+        await expect(
+          adapter.postMessage("x:post:500", {
+            files: Array.from({ length: 5 }, image),
+            markdown: "",
+          })
+        ).rejects.toThrow("at most 4 media");
+        expect(mockFetch).not.toHaveBeenCalled();
+      });
+
+      it("rejects an unsupported media type", async () => {
+        const { adapter } = await createInitializedAdapter();
+        await expect(
+          adapter.postMessage("x:post:500", {
+            files: [
+              {
+                data: Buffer.from("x"),
+                filename: "note.txt",
+                mimeType: "text/plain",
+              },
+            ],
+            markdown: "",
+          })
+        ).rejects.toThrow("supports image uploads");
+      });
+    });
+
     it("flattens markdown before posting", async () => {
       const { adapter } = await createInitializedAdapter();
       mockFetch.mockResolvedValueOnce(apiOk({ data: { id: "600" } }));
@@ -600,16 +737,6 @@ describe("XAdapter", () => {
       await expect(adapter.postMessage("x:post:500", "  ")).rejects.toThrow(
         ValidationError
       );
-    });
-
-    it("rejects messages with attachments", async () => {
-      const { adapter } = await createInitializedAdapter();
-      await expect(
-        adapter.postMessage("x:post:500", {
-          files: [{ data: Buffer.from("x"), filename: "a.png" }],
-          markdown: "with file",
-        })
-      ).rejects.toThrow(ValidationError);
     });
 
     it("resolves the access token from a provider function", async () => {

--- a/packages/adapter-x/src/index.test.ts
+++ b/packages/adapter-x/src/index.test.ts
@@ -661,6 +661,11 @@ describe("XAdapter", () => {
           markdown: "pic",
         });
 
+        // DM media must register as dm_image; X rejects a tweet_image media_id
+        // attached to a DM event.
+        const initBody = JSON.parse(String(mockFetch.mock.calls[0][1]?.body));
+        expect(initBody.media_category).toBe("dm_image");
+
         const dmBody = JSON.parse(String(mockFetch.mock.calls[3][1]?.body));
         expect(dmBody).toEqual({
           attachments: [{ media_id: "MEDIA1" }],

--- a/packages/adapter-x/src/index.ts
+++ b/packages/adapter-x/src/index.ts
@@ -387,7 +387,7 @@ export class XAdapter implements Adapter<XThreadId, XRawMessage> {
   ): Promise<RawMessage<XRawMessage>> {
     const decoded = this.decodeThreadId(threadId);
     const text = this.renderOutbound(message);
-    const mediaIds = await this.uploadAttachments(message);
+    const mediaIds = await this.uploadAttachments(message, decoded.kind);
 
     if (!(text.trim() || mediaIds.length > 0)) {
       throw new ValidationError("x", "Message must have text or media");
@@ -411,7 +411,7 @@ export class XAdapter implements Adapter<XThreadId, XRawMessage> {
     }
 
     const text = this.renderOutbound(message);
-    const mediaIds = await this.uploadAttachments(message);
+    const mediaIds = await this.uploadAttachments(message, "post");
     if (!(text.trim() || mediaIds.length > 0)) {
       throw new ValidationError("x", "Message must have text or media");
     }
@@ -521,7 +521,8 @@ export class XAdapter implements Adapter<XThreadId, XRawMessage> {
    * {@link MAX_MEDIA_PER_POST} media per post.
    */
   protected async uploadAttachments(
-    message: AdapterPostableMessage
+    message: AdapterPostableMessage,
+    surface: "dm" | "post"
   ): Promise<string[]> {
     const sources: { load: () => Promise<Buffer>; mimeType: string }[] = [];
     for (const file of extractFiles(message)) {
@@ -559,7 +560,7 @@ export class XAdapter implements Adapter<XThreadId, XRawMessage> {
     const mediaIds: string[] = [];
     for (const source of sources) {
       const bytes = await source.load();
-      mediaIds.push(await this.uploadMedia(bytes, source.mimeType));
+      mediaIds.push(await this.uploadMedia(bytes, source.mimeType, surface));
     }
     return mediaIds;
   }
@@ -571,7 +572,8 @@ export class XAdapter implements Adapter<XThreadId, XRawMessage> {
    */
   protected async uploadMedia(
     bytes: Buffer,
-    mimeType: string
+    mimeType: string,
+    surface: "dm" | "post"
   ): Promise<string> {
     // v2 chunked upload is path-based: initialize (JSON) then one or more
     // multipart appends, then finalize (JSON). Images finalize synchronously.
@@ -579,7 +581,7 @@ export class XAdapter implements Adapter<XThreadId, XRawMessage> {
       `${MEDIA_UPLOAD_PATH}/initialize`,
       "POST",
       {
-        media_category: mediaCategory(mimeType),
+        media_category: mediaCategory(mimeType, surface),
         media_type: mimeType,
         total_bytes: bytes.length,
       }
@@ -1417,13 +1419,15 @@ async function toBytes(data: Buffer | Blob | ArrayBuffer): Promise<Buffer> {
   throw new ValidationError("x", "Unsupported attachment data type");
 }
 
-function mediaCategory(mimeType: string): string {
+function mediaCategory(mimeType: string, surface: "dm" | "post"): string {
   if (
     mimeType === "image/png" ||
     mimeType === "image/jpeg" ||
     mimeType === "image/webp"
   ) {
-    return "tweet_image";
+    // DM attachments must be registered as dm_image; X rejects a tweet_image
+    // media_id attached to a DM event with "unsupported media category".
+    return surface === "dm" ? "dm_image" : "tweet_image";
   }
   throw new ValidationError(
     "x",

--- a/packages/adapter-x/src/index.ts
+++ b/packages/adapter-x/src/index.ts
@@ -50,6 +50,7 @@ import type {
   XDmEvent,
   XDmSendResult,
   XDmWireEvent,
+  XMediaUploadResult,
   XOauthTokenResult,
   XPost,
   XPostCreateResult,
@@ -71,6 +72,9 @@ const TOKEN_REFRESH_MARGIN_MS = 60_000;
 const DEFAULT_TOKEN_LIFETIME_S = 7200;
 /** Channel ID for public post threads. */
 const PUBLIC_CHANNEL_ID = "x:public";
+const MEDIA_UPLOAD_PATH = "/2/media/upload";
+const MEDIA_CHUNK_BYTES = 4 * 1024 * 1024;
+const MAX_MEDIA_PER_POST = 4;
 
 interface ManagedToken {
   accessToken: string;
@@ -374,8 +378,8 @@ export class XAdapter implements Adapter<XThreadId, XRawMessage> {
    * Post to a thread. `x:post:` threads become a reply to the latest mention
    * in the conversation (chaining under the bot's own prior replies);
    * `x:dm:` threads send a direct message to the participant. Cards and
-   * markdown are flattened to plain text; attachments are rejected (not yet
-   * supported).
+   * markdown are flattened to plain text; image, gif, and video attachments are
+   * uploaded via the chunked media endpoint and attached to the post.
    */
   async postMessage(
     threadId: string,
@@ -383,15 +387,16 @@ export class XAdapter implements Adapter<XThreadId, XRawMessage> {
   ): Promise<RawMessage<XRawMessage>> {
     const decoded = this.decodeThreadId(threadId);
     const text = this.renderOutbound(message);
+    const mediaIds = await this.uploadAttachments(message);
 
-    if (!text.trim()) {
-      throw new ValidationError("x", "Message text cannot be empty");
+    if (!(text.trim() || mediaIds.length > 0)) {
+      throw new ValidationError("x", "Message must have text or media");
     }
 
     if (decoded.kind === "post") {
-      return this.sendReply(threadId, decoded.conversationId, text);
+      return this.sendReply(threadId, decoded.conversationId, text, mediaIds);
     }
-    return this.sendDm(threadId, decoded.conversationId, text);
+    return this.sendDm(threadId, decoded.conversationId, text, mediaIds);
   }
 
   async postChannelMessage(
@@ -406,15 +411,17 @@ export class XAdapter implements Adapter<XThreadId, XRawMessage> {
     }
 
     const text = this.renderOutbound(message);
-    if (!text.trim()) {
-      throw new ValidationError("x", "Message text cannot be empty");
+    const mediaIds = await this.uploadAttachments(message);
+    if (!(text.trim() || mediaIds.length > 0)) {
+      throw new ValidationError("x", "Message must have text or media");
     }
 
     const result = await this.xApiFetch<XPostCreateResult>(
       "/2/tweets",
       "POST",
       {
-        text,
+        ...(text.trim() ? { text } : {}),
+        ...(mediaIds.length > 0 ? { media: { media_ids: mediaIds } } : {}),
       }
     );
     const post = this.requireData(result, "create post");
@@ -430,7 +437,8 @@ export class XAdapter implements Adapter<XThreadId, XRawMessage> {
   protected async sendReply(
     threadId: string,
     conversationId: string,
-    text: string
+    text: string,
+    mediaIds: string[] = []
   ): Promise<RawMessage<XRawMessage>> {
     const replyTarget = this.replyTargets.get(threadId) ?? conversationId;
     const result = await this.xApiFetch<XPostCreateResult>(
@@ -438,7 +446,8 @@ export class XAdapter implements Adapter<XThreadId, XRawMessage> {
       "POST",
       {
         reply: { in_reply_to_tweet_id: replyTarget },
-        text,
+        ...(text.trim() ? { text } : {}),
+        ...(mediaIds.length > 0 ? { media: { media_ids: mediaIds } } : {}),
       }
     );
     const post = this.requireData(result, "create reply");
@@ -471,7 +480,8 @@ export class XAdapter implements Adapter<XThreadId, XRawMessage> {
   protected async sendDm(
     threadId: string,
     participantId: string,
-    text: string
+    text: string,
+    mediaIds: string[] = []
   ): Promise<RawMessage<XRawMessage>> {
     // DM threads are keyed by the other participant, so send via the
     // documented by-participant endpoint. Inbound echoes for this
@@ -479,7 +489,12 @@ export class XAdapter implements Adapter<XThreadId, XRawMessage> {
     const result = await this.xApiFetch<XDmSendResult>(
       `/2/dm_conversations/with/${encodeURIComponent(participantId)}/messages`,
       "POST",
-      { text }
+      {
+        ...(text.trim() ? { text } : {}),
+        ...(mediaIds.length > 0
+          ? { attachments: mediaIds.map((id) => ({ media_id: id })) }
+          : {}),
+      }
     );
     const sent = this.requireData(result, "send DM");
     this.trackSentId(sent.dm_event_id);
@@ -497,6 +512,132 @@ export class XAdapter implements Adapter<XThreadId, XRawMessage> {
     };
     this.cacheMessage(this.buildDmMessage(raw, threadId));
     return { id: sent.dm_event_id, raw, threadId };
+  }
+
+  /**
+   * Upload every attachment on the message via the chunked media endpoint and
+   * return the resulting media IDs, ready to attach to a post or DM. Accepts
+   * both `files` (FileUpload) and `attachments` (Attachment). X allows at most
+   * {@link MAX_MEDIA_PER_POST} media per post.
+   */
+  protected async uploadAttachments(
+    message: AdapterPostableMessage
+  ): Promise<string[]> {
+    const sources: { load: () => Promise<Buffer>; mimeType: string }[] = [];
+    for (const file of extractFiles(message)) {
+      sources.push({
+        load: () => toBytes(file.data),
+        mimeType: inferMediaType(file.mimeType, file.filename),
+      });
+    }
+    for (const attachment of extractPostableAttachments(message)) {
+      const load = attachment.data
+        ? () => toBytes(attachment.data as Buffer | Blob)
+        : attachment.fetchData;
+      if (!load) {
+        throw new ValidationError(
+          "x",
+          "Attachment has no data to upload (provide data or fetchData)"
+        );
+      }
+      sources.push({
+        load,
+        mimeType: inferMediaType(attachment.mimeType, attachment.name),
+      });
+    }
+
+    if (sources.length === 0) {
+      return [];
+    }
+    if (sources.length > MAX_MEDIA_PER_POST) {
+      throw new ValidationError(
+        "x",
+        `X allows at most ${MAX_MEDIA_PER_POST} media per post, got ${sources.length}`
+      );
+    }
+
+    const mediaIds: string[] = [];
+    for (const source of sources) {
+      const bytes = await source.load();
+      mediaIds.push(await this.uploadMedia(bytes, source.mimeType));
+    }
+    return mediaIds;
+  }
+
+  /**
+   * Upload one media file through the v2 chunked flow (INIT, APPEND, FINALIZE)
+   * and return its media ID. Waits for server-side processing when X reports it
+   * (video/gif); images are ready immediately.
+   */
+  protected async uploadMedia(
+    bytes: Buffer,
+    mimeType: string
+  ): Promise<string> {
+    // v2 chunked upload is path-based: initialize (JSON) then one or more
+    // multipart appends, then finalize (JSON). Images finalize synchronously.
+    const init = await this.xApiFetch<XMediaUploadResult>(
+      `${MEDIA_UPLOAD_PATH}/initialize`,
+      "POST",
+      {
+        media_category: mediaCategory(mimeType),
+        media_type: mimeType,
+        total_bytes: bytes.length,
+      }
+    );
+    const mediaId = this.requireData(init, "media upload initialize").id;
+
+    let segment = 0;
+    for (let offset = 0; offset < bytes.length; offset += MEDIA_CHUNK_BYTES) {
+      const chunk = bytes.subarray(offset, offset + MEDIA_CHUNK_BYTES);
+      const form = new FormData();
+      form.append("segment_index", String(segment));
+      form.append(
+        "media",
+        new Blob([new Uint8Array(chunk)], { type: mimeType }),
+        "chunk"
+      );
+      await this.xMediaAppend(mediaId, form);
+      segment += 1;
+    }
+
+    const finalized = this.requireData(
+      await this.xApiFetch<XMediaUploadResult>(
+        `${MEDIA_UPLOAD_PATH}/${encodeURIComponent(mediaId)}/finalize`,
+        "POST"
+      ),
+      "media upload finalize"
+    );
+    const state = finalized.processing_info?.state;
+    if (state && state !== "succeeded") {
+      throw new ValidationError(
+        "x",
+        `X media ${mediaId} needs async processing (state: ${state}); the X adapter supports image uploads only`
+      );
+    }
+    return mediaId;
+  }
+
+  /** Upload one chunk to an initialized media id (multipart append). */
+  protected async xMediaAppend(mediaId: string, form: FormData): Promise<void> {
+    const token = await this.resolveAccessToken();
+    const path = `${MEDIA_UPLOAD_PATH}/${encodeURIComponent(mediaId)}/append`;
+    let response: Response;
+    try {
+      response = await fetch(`${this.apiBaseUrl}${path}`, {
+        body: form,
+        headers: { Authorization: `Bearer ${token}` },
+        method: "POST",
+      });
+    } catch (error) {
+      throw new NetworkError(
+        "x",
+        "Network error uploading X media chunk",
+        error instanceof Error ? error : undefined
+      );
+    }
+    if (!response.ok) {
+      this.throwApiError(path, response, await readMediaResponse(response));
+    }
   }
 
   /**
@@ -829,15 +970,6 @@ export class XAdapter implements Adapter<XThreadId, XRawMessage> {
   }
 
   protected renderOutbound(message: AdapterPostableMessage): string {
-    const attachmentCount =
-      extractPostableAttachments(message).length + extractFiles(message).length;
-    if (attachmentCount > 0) {
-      throw new ValidationError(
-        "x",
-        "File uploads are not supported by the X adapter yet"
-      );
-    }
-
     const card = extractCard(message);
     const text = card
       ? cardToXText(card)
@@ -1260,6 +1392,70 @@ export class XAdapter implements Adapter<XThreadId, XRawMessage> {
       throw new ValidationError("x", message);
     }
     throw new NetworkError("x", `${message} (status ${response.status})`);
+  }
+}
+
+const MIME_BY_EXTENSION: Record<string, string> = {
+  gif: "image/gif",
+  jpeg: "image/jpeg",
+  jpg: "image/jpeg",
+  mp4: "video/mp4",
+  png: "image/png",
+  webp: "image/webp",
+};
+
+async function toBytes(data: Buffer | Blob | ArrayBuffer): Promise<Buffer> {
+  if (Buffer.isBuffer(data)) {
+    return data;
+  }
+  if (data instanceof ArrayBuffer) {
+    return Buffer.from(data);
+  }
+  if (data instanceof Blob) {
+    return Buffer.from(await data.arrayBuffer());
+  }
+  throw new ValidationError("x", "Unsupported attachment data type");
+}
+
+function mediaCategory(mimeType: string): string {
+  if (
+    mimeType === "image/png" ||
+    mimeType === "image/jpeg" ||
+    mimeType === "image/webp"
+  ) {
+    return "tweet_image";
+  }
+  throw new ValidationError(
+    "x",
+    `X adapter supports image uploads (png, jpeg, webp); got ${mimeType}`
+  );
+}
+
+function inferMediaType(
+  mimeType: string | undefined,
+  name: string | undefined
+): string {
+  if (mimeType) {
+    return mimeType;
+  }
+  const extension = name?.split(".").pop()?.toLowerCase();
+  const inferred = extension ? MIME_BY_EXTENSION[extension] : undefined;
+  if (!inferred) {
+    throw new ValidationError(
+      "x",
+      `Cannot determine media type${name ? ` for "${name}"` : ""}; set mimeType`
+    );
+  }
+  return inferred;
+}
+
+async function readMediaResponse(
+  response: Response
+): Promise<XApiResponse<XMediaUploadResult> | undefined> {
+  try {
+    return (await response.json()) as XApiResponse<XMediaUploadResult>;
+  } catch {
+    return undefined;
   }
 }
 

--- a/packages/adapter-x/src/types.ts
+++ b/packages/adapter-x/src/types.ts
@@ -187,6 +187,19 @@ export interface XDmSendResult {
   dm_event_id: string;
 }
 
+/** Response body of the /2/media/upload INIT, FINALIZE, and STATUS commands. */
+export interface XMediaUploadResult {
+  expires_after_secs?: number;
+  id: string;
+  media_key?: string;
+  processing_info?: {
+    state: "pending" | "in_progress" | "succeeded" | "failed";
+    check_after_secs?: number;
+    progress_percent?: number;
+    error?: { code?: number; name?: string; message?: string };
+  };
+}
+
 /** Response body of POST /2/oauth2/token. */
 export interface XOauthTokenResult {
   access_token?: string;


### PR DESCRIPTION
## summary

the X adapter previously rejected every attachment (`File uploads are not supported by the X adapter yet`). this adds image upload support: images passed as `files` or `attachments` are uploaded through X's v2 chunked media endpoints and attached to the resulting post or DM

- uploads via X's current path-based flow: `POST /2/media/upload/initialize` (JSON) then `/{id}/append` (multipart) then `/{id}/finalize`, reusing the adapter's managed OAuth token
- attaches `media_ids` on `POST /2/tweets` for posts, and `attachments` for DMs
- supports png, jpeg, and webp, up to 4 per post, with or without text
- requires the `media.write` OAuth 2.0 scope on the user token

### before / after

- before: posting a message with `files`/`attachments` throws a `ValidationError`
- after: images upload and attach, and a post can be media-only or media plus text

<details>
<summary>usage</summary>

```typescript
await thread.post({
  markdown: "France lead the title race",
  files: [{ data: pngBuffer, filename: "odds.png", mimeType: "image/png" }],
});
```

</details>

## test plan

- added unit tests covering the initialize JSON body, the multipart append path, finalize, `media_ids` on the tweet, DM `attachments`, media-only posts, MIME inference from filename, the over-limit rejection, and unsupported-type rejection
- verified live against the X API end to end: uploaded an image and posted then deleted it through the adapter (the initial command-param implementation 400'd against the live API, which is what surfaced the path-based endpoints as required)
- `pnpm --filter @chat-adapter/x build`, tests, `pnpm exec biome check`, and `pnpm konsistent` all pass
