### PR TITLE
feat(discord): ignore @everyone/@here pings unless respondToGlobalMentions is set

### DIFF
--- a/.changeset/discord-ignore-global-mentions.md
+++ b/.changeset/discord-ignore-global-mentions.md
@@ -1,0 +1,5 @@
+---
+"@chat-adapter/discord": minor
+---
+
+Ignore `@everyone`/`@here` pings by default in gateway mode. Previously the legacy gateway listener treated global pings as bot mentions, so the bot responded to announcements. A new `respondToGlobalMentions` config option (default `false`) restores the old behavior when enabled, and also lets forwarded gateway messages opt in via the `mention_everyone` field.

--- a/apps/docs/content/adapters/official/discord.mdx
+++ b/apps/docs/content/adapters/official/discord.mdx
@@ -95,6 +95,11 @@ bot.onNewMention(async (thread, message) => {
       description:
         "Role IDs that should trigger mention handlers. Auto-detected from `DISCORD_MENTION_ROLE_IDS` (comma-separated).",
     },
+    respondToGlobalMentions: {
+      type: "boolean",
+      description:
+        "Treat `@everyone`/`@here` pings as mentions of the bot. Defaults to `false`, so the bot only responds when mentioned directly (or via `mentionRoleIds`).",
+    },
     interactionFlags: {
       type: "(context) => DiscordInteractionResponseFlag.Ephemeral | undefined",
       description:

--- a/packages/adapter-discord/README.md
+++ b/packages/adapter-discord/README.md
@@ -202,6 +202,7 @@ All options are auto-detected from environment variables when not provided.
 | `publicKey` | No* | Application public key. Auto-detected from `DISCORD_PUBLIC_KEY` |
 | `applicationId` | No* | Discord application ID. Auto-detected from `DISCORD_APPLICATION_ID` |
 | `mentionRoleIds` | No | Array of role IDs that trigger mention handlers. Auto-detected from `DISCORD_MENTION_ROLE_IDS` (comma-separated) |
+| `respondToGlobalMentions` | No | Treat `@everyone`/`@here` pings as mentions of the bot. Defaults to `false` |
 | `interactionFlags` | No | Function returning Discord interaction flags for the initial deferred slash command response |
 | `apiUrl` | No | Override the Discord API base URL. Auto-detected from `DISCORD_API_URL` |
 | `logger` | No | Logger instance (defaults to `ConsoleLogger("info")`) |

--- a/packages/adapter-discord/src/index.test.ts
+++ b/packages/adapter-discord/src/index.test.ts
@@ -4324,6 +4324,242 @@ describe("mentionRoleIds handling", () => {
 });
 
 // ============================================================================
+// Global Mention (@everyone/@here) Tests
+// ============================================================================
+
+describe("respondToGlobalMentions handling", () => {
+  function createForwardedEveryoneRequest() {
+    const body = JSON.stringify({
+      type: "GATEWAY_MESSAGE_CREATE",
+      timestamp: Date.now(),
+      data: {
+        id: "msg123",
+        channel_id: "channel456",
+        guild_id: "guild1",
+        content: "@everyone big announcement",
+        timestamp: "2021-01-01T00:00:00.000Z",
+        author: {
+          id: "user789",
+          username: "testuser",
+          bot: false,
+        },
+        mentions: [],
+        mention_roles: [],
+        mention_everyone: true,
+        attachments: [],
+      },
+    });
+
+    return new Request("https://example.com/webhook", {
+      method: "POST",
+      headers: {
+        "x-discord-gateway-token": "test-token",
+        "content-type": "application/json",
+      },
+      body,
+    });
+  }
+
+  function createAdapterWithThreadSpy(config?: {
+    respondToGlobalMentions?: boolean;
+  }) {
+    const adapter = createDiscordAdapter({
+      botToken: "test-token",
+      publicKey: testPublicKey,
+      applicationId: "test-app-id",
+      logger: mockLogger,
+      ...config,
+    });
+
+    const fetchSpy = vi.spyOn(adapter as any, "discordFetch").mockResolvedValue(
+      new Response(JSON.stringify({ id: "new-thread", name: "Thread" }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      })
+    );
+
+    return { adapter, fetchSpy };
+  }
+
+  it("ignores @everyone in forwarded gateway messages by default", async () => {
+    const { adapter, fetchSpy } = createAdapterWithThreadSpy();
+    const chat = createMockChatInstance();
+    await adapter.initialize(chat);
+
+    await adapter.handleWebhook(createForwardedEveryoneRequest());
+
+    // No thread created and message is not flagged as a mention
+    expect(fetchSpy).not.toHaveBeenCalled();
+    expect(chat.handleIncomingMessage).toHaveBeenCalledWith(
+      adapter,
+      expect.any(String),
+      expect.objectContaining({ isMention: false })
+    );
+
+    fetchSpy.mockRestore();
+  });
+
+  it("treats @everyone in forwarded gateway messages as a mention when respondToGlobalMentions is true", async () => {
+    const { adapter, fetchSpy } = createAdapterWithThreadSpy({
+      respondToGlobalMentions: true,
+    });
+    const chat = createMockChatInstance();
+    await adapter.initialize(chat);
+
+    await adapter.handleWebhook(createForwardedEveryoneRequest());
+
+    expect(fetchSpy).toHaveBeenCalledWith(
+      "/channels/channel456/messages/msg123/threads",
+      "POST",
+      expect.anything()
+    );
+    expect(chat.handleIncomingMessage).toHaveBeenCalledWith(
+      adapter,
+      expect.any(String),
+      expect.objectContaining({ isMention: true })
+    );
+
+    fetchSpy.mockRestore();
+  });
+
+  class TestGatewayDiscordAdapter extends DiscordAdapter {
+    listen(client: Client, isShuttingDown = () => false) {
+      this.setupLegacyGatewayHandlers(client, isShuttingDown);
+    }
+  }
+
+  function createEveryoneGatewayMessage() {
+    // Mirrors discord.js MessageMentions semantics: has() matches
+    // @everyone pings unless ignoreEveryone is set
+    const mentions = {
+      everyone: true,
+      roles: [] as Array<{ id: string }>,
+      has: (_id: string, options?: { ignoreEveryone?: boolean }) =>
+        !options?.ignoreEveryone,
+    };
+
+    return {
+      id: "msg123",
+      channelId: "channel456",
+      guildId: "guild1",
+      content: "@everyone big announcement",
+      author: {
+        id: "user789",
+        username: "testuser",
+        displayName: "Test User",
+        bot: false,
+      },
+      mentions,
+      channel: { isThread: () => false },
+      createdAt: new Date("2021-01-01T00:00:00.000Z"),
+      editedAt: null,
+      attachments: [],
+    };
+  }
+
+  it("ignores @everyone in legacy gateway mode by default", async () => {
+    const adapter = new TestGatewayDiscordAdapter({
+      botToken: "test-token",
+      publicKey: testPublicKey,
+      applicationId: "test-app-id",
+      logger: mockLogger,
+    });
+    const fetchSpy = vi.spyOn(adapter as any, "discordFetch").mockResolvedValue(
+      new Response(JSON.stringify({ id: "new-thread", name: "Thread" }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      })
+    );
+    const chat = createMockChatInstance();
+    await adapter.initialize(chat);
+
+    const client = new EventEmitter() as Client;
+    adapter.listen(client);
+    client.emit(Events.MessageCreate, createEveryoneGatewayMessage());
+    await waitForGatewayHandlers();
+
+    expect(fetchSpy).not.toHaveBeenCalled();
+    expect(chat.handleIncomingMessage).toHaveBeenCalledWith(
+      adapter,
+      expect.any(String),
+      expect.objectContaining({ isMention: false })
+    );
+
+    fetchSpy.mockRestore();
+  });
+
+  it("treats @everyone in legacy gateway mode as a mention when respondToGlobalMentions is true", async () => {
+    const adapter = new TestGatewayDiscordAdapter({
+      botToken: "test-token",
+      publicKey: testPublicKey,
+      applicationId: "test-app-id",
+      logger: mockLogger,
+      respondToGlobalMentions: true,
+    });
+    const fetchSpy = vi.spyOn(adapter as any, "discordFetch").mockResolvedValue(
+      new Response(JSON.stringify({ id: "new-thread", name: "Thread" }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      })
+    );
+    const chat = createMockChatInstance();
+    await adapter.initialize(chat);
+
+    const client = new EventEmitter() as Client;
+    adapter.listen(client);
+    client.emit(Events.MessageCreate, createEveryoneGatewayMessage());
+    await waitForGatewayHandlers();
+
+    expect(fetchSpy).toHaveBeenCalledWith(
+      "/channels/channel456/messages/msg123/threads",
+      "POST",
+      expect.anything()
+    );
+    expect(chat.handleIncomingMessage).toHaveBeenCalledWith(
+      adapter,
+      expect.any(String),
+      expect.objectContaining({ isMention: true })
+    );
+
+    fetchSpy.mockRestore();
+  });
+
+  it("still detects direct user mentions when @everyone is ignored", async () => {
+    const adapter = new TestGatewayDiscordAdapter({
+      botToken: "test-token",
+      publicKey: testPublicKey,
+      applicationId: "test-app-id",
+      logger: mockLogger,
+    });
+    const fetchSpy = vi.spyOn(adapter as any, "discordFetch").mockResolvedValue(
+      new Response(JSON.stringify({ id: "new-thread", name: "Thread" }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      })
+    );
+    const chat = createMockChatInstance();
+    await adapter.initialize(chat);
+
+    const message = createEveryoneGatewayMessage();
+    // Direct bot mention alongside @everyone
+    message.mentions.has = () => true;
+
+    const client = new EventEmitter() as Client;
+    adapter.listen(client);
+    client.emit(Events.MessageCreate, message);
+    await waitForGatewayHandlers();
+
+    expect(chat.handleIncomingMessage).toHaveBeenCalledWith(
+      adapter,
+      expect.any(String),
+      expect.objectContaining({ isMention: true })
+    );
+
+    fetchSpy.mockRestore();
+  });
+});
+
+// ============================================================================
 // createDiscordThread 160004 Recovery Tests
 // ============================================================================
 

--- a/packages/adapter-discord/src/index.ts
+++ b/packages/adapter-discord/src/index.ts
@@ -106,6 +106,7 @@ export class DiscordAdapter implements Adapter<DiscordThreadId, unknown> {
   protected readonly publicKey: string;
   protected readonly applicationId: string;
   protected readonly mentionRoleIds: string[];
+  protected readonly respondToGlobalMentions: boolean;
   protected readonly interactionFlags?: DiscordAdapterConfig["interactionFlags"];
   protected chat: ChatInstance | null = null;
   protected readonly logger: Logger;
@@ -152,6 +153,7 @@ export class DiscordAdapter implements Adapter<DiscordThreadId, unknown> {
       (process.env.DISCORD_MENTION_ROLE_IDS
         ? process.env.DISCORD_MENTION_ROLE_IDS.split(",").map((id) => id.trim())
         : []);
+    this.respondToGlobalMentions = config.respondToGlobalMentions ?? false;
     this.botUserId = applicationId; // Discord app ID is the bot's user ID
     this.interactionFlags = config.interactionFlags;
     this.logger = config.logger ?? new ConsoleLogger("info").child("discord");
@@ -818,7 +820,10 @@ export class DiscordAdapter implements Adapter<DiscordThreadId, unknown> {
       data.mention_roles?.some((roleId) =>
         this.mentionRoleIds.includes(roleId)
       );
-    const isMentioned = isUserMentioned || isRoleMentioned;
+    const isEveryoneMentioned =
+      this.respondToGlobalMentions && data.mention_everyone === true;
+    const isMentioned =
+      isUserMentioned || isRoleMentioned || isEveryoneMentioned;
 
     // If mentioned and not in a thread, create one
     if (!discordThreadId && isMentioned) {
@@ -2014,14 +2019,20 @@ export class DiscordAdapter implements Adapter<DiscordThreadId, unknown> {
         return;
       }
 
-      // Check if we're mentioned (by user ID or configured role IDs)
-      const isUserMentioned = message.mentions.has(client.user?.id ?? "");
+      // Check if we're mentioned (by user ID or configured role IDs).
+      // @everyone/@here only count when respondToGlobalMentions is enabled.
+      const isUserMentioned = message.mentions.has(client.user?.id ?? "", {
+        ignoreEveryone: true,
+      });
       const isRoleMentioned =
         this.mentionRoleIds.length > 0 &&
         message.mentions.roles.some((role) =>
           this.mentionRoleIds.includes(role.id)
         );
-      const isMentioned = isUserMentioned || isRoleMentioned;
+      const isEveryoneMentioned =
+        this.respondToGlobalMentions && message.mentions.everyone;
+      const isMentioned =
+        isUserMentioned || isRoleMentioned || isEveryoneMentioned;
 
       this.logger.info("Discord Gateway message received", {
         channelId: message.channelId,
@@ -2030,6 +2041,7 @@ export class DiscordAdapter implements Adapter<DiscordThreadId, unknown> {
         isMentioned,
         isUserMentioned,
         isRoleMentioned,
+        isEveryoneMentioned,
         content: message.content.slice(0, 100),
       });
 

--- a/packages/adapter-discord/src/types.ts
+++ b/packages/adapter-discord/src/types.ts
@@ -31,6 +31,8 @@ export interface DiscordAdapterConfig {
   mentionRoleIds?: string[];
   /** Discord application public key for webhook signature verification. Defaults to DISCORD_PUBLIC_KEY env var. */
   publicKey?: string;
+  /** Treat @everyone/@here pings as mentions of the bot. Defaults to false. */
+  respondToGlobalMentions?: boolean;
   /** Override bot username (optional) */
   userName?: string;
 }
@@ -287,6 +289,8 @@ export interface DiscordGatewayMessageData {
   id: string;
   /** Whether the bot was mentioned */
   is_mention?: boolean;
+  /** Whether the message pings @everyone or @here */
+  mention_everyone?: boolean;
   /** Role IDs mentioned in the message */
   mention_roles?: string[];
   /** Users mentioned in the message */


### PR DESCRIPTION
## Summary

Fixes #699.

In gateway mode, the bot responded to `@everyone`/`@here` announcements. The legacy gateway listener used discord.js `message.mentions.has(botId)`, which counts global pings as a mention of the bot by default.

Global pings are now ignored on both gateway paths by default, and a new `respondToGlobalMentions` config option (default `false`, per the issue's suggestion) lets users opt back in:

- **Legacy gateway mode**: mention detection passes `{ ignoreEveryone: true }` to `mentions.has()`; `@everyone`/`@here` only count via `message.mentions.everyone` when the option is enabled. Direct mentions, `mentionRoleIds` role mentions, and replies to the bot are unaffected.
- **Forwarded gateway mode**: added the `mention_everyone` field to `DiscordGatewayMessageData` and wired it into the same gate (this path previously ignored global pings silently, with no way to opt in).

## Changes

- `respondToGlobalMentions?: boolean` on `DiscordAdapterConfig` (default `false`)
- Mention detection updated in both `setupLegacyGatewayHandlers` and `handleForwardedMessage`
- 5 new tests covering both transports: global pings ignored by default, honored when opted in, and direct mentions still detected while global pings are ignored
- Docs: config tables in `apps/docs/content/adapters/official/discord.mdx` and the adapter README
- Changeset (minor, `@chat-adapter/discord`)

## Testing

- `pnpm validate` passes (knip + check + typecheck + test + build)
- All 249 `@chat-adapter/discord` tests pass, including the 5 new ones

🤖 Generated with [Claude Code](https://claude.com/claude-code)