### PR TITLE
fix(examples): forward X CRC challenge in the catch-all webhook route

### DIFF
--- a/examples/nextjs-chat/src/app/api/webhooks/[platform]/route.ts
+++ b/examples/nextjs-chat/src/app/api/webhooks/[platform]/route.ts
@@ -29,7 +29,8 @@ export async function POST(
 }
 
 // GET handler — serves as health check, but also forwards to webhook handler
-// for platforms that need GET verification (e.g. WhatsApp/Facebook challenge-response)
+// for platforms that need GET verification (e.g. WhatsApp/Facebook hub
+// challenge, X CRC challenge)
 export async function GET(
   request: Request,
   { params }: { params: Promise<{ platform: string }> }
@@ -45,7 +46,8 @@ export async function GET(
   const url = new URL(request.url);
   if (
     url.searchParams.has("hub.mode") ||
-    url.searchParams.has("hub.verify_token")
+    url.searchParams.has("hub.verify_token") ||
+    url.searchParams.has("crc_token")
   ) {
     return webhookHandler(request);
   }


### PR DESCRIPTION
## summary

the shared `[platform]` webhook route only forwarded a GET to the adapter when the query carried Meta's `hub.mode`/`hub.verify_token` challenge params, so X's Account Activity CRC challenge (a GET with `crc_token`) fell through to the plain health-check response and never reached the adapter. `@chat-adapter/x` already answers CRC inside `handleWebhook`, but the catch-all route never handed it the request, so X webhook registration would fail when wired through this shared multi-platform route. added `crc_token` to the forward condition

the dedicated `app/api/webhooks/x/route.ts` shown in the X adapter docs forwards GET unconditionally and was never affected; this only fixes the shared catch-all example

<details>
<summary>before / after</summary>

```ts
// before
if (
  url.searchParams.has("hub.mode") ||
  url.searchParams.has("hub.verify_token")
) {
  return webhookHandler(request)
}

// after
if (
  url.searchParams.has("hub.mode") ||
  url.searchParams.has("hub.verify_token") ||
  url.searchParams.has("crc_token")
) {
  return webhookHandler(request)
}
```

</details>

## test plan

- the X adapter's `handleWebhook` already answers the `crc_token` GET (covered by its `CRC challenge` unit tests); this change routes that GET to it through the shared example
- confirmed the WhatsApp/Messenger `hub.*` challenge forwarding is unchanged
- POST event delivery path untouched
