### PR TITLE
test(telegram): raise rich-truncate test timeout to 15s

### DIFF
--- a/packages/adapter-telegram/src/index.test.ts
+++ b/packages/adapter-telegram/src/index.test.ts
@@ -3637,7 +3637,7 @@ describe("message length limits", () => {
     const markdown = readSentBody(1).rich_message?.markdown ?? "";
     expect(Array.from(markdown).length).toBeLessThanOrEqual(32_768);
     expect(markdown.endsWith("...")).toBe(true);
-  });
+  }, 15_000);
 
   it("MarkdownV2 truncation does not leave an orphan trailing backslash before the ellipsis", async () => {
     const adapter = await createInitializedAdapter();


### PR DESCRIPTION
## summary

the `rich markdown messages truncate at the rich message limit` test runs ~5.5s in CI (coverage + shared runner) and intermittently exceeds the 5s default, failing unrelated PRs. raise its timeout to 15s

## test plan

- `pnpm --filter @chat-adapter/telegram test`
