### PR TITLE
docs(dial): update feature table for adapter v0.2.0 — reactions, typing, history, channel info

### DIFF
--- a/apps/docs/content/adapters/vendor-official/dial.mdx
+++ b/apps/docs/content/adapters/vendor-official/dial.mdx
@@ -39,7 +39,9 @@ features:
     status: yes
     label: Native Tapbacks on iMessage, both directions; emoji delivered as text on SMS
   removeReactions: no
-  typingIndicator: no
+  typingIndicator:
+    status: partial
+    label: iMessage numbers only; silently ignored on SMS
   directMessages: yes
   ephemeralMessages: no
   userLookup: no

--- a/apps/docs/content/adapters/vendor-official/dial.mdx
+++ b/apps/docs/content/adapters/vendor-official/dial.mdx
@@ -11,6 +11,9 @@ author: Dial
 mdxBody: true
 features:
   postMessage: yes
+  threadedReplies:
+    status: yes
+    label: Native quoted replies on iMessage; regular message on SMS; inbound replies carry the target message ID
   editMessage: no
   deleteMessage: no
   fileUploads:
@@ -170,8 +173,6 @@ The adapter recomputes the HMAC with Node's `crypto.createHmac` + `timingSafeEqu
 | Outbound  | SMS / MMS / iMessage   | ✅   | ✅ (via attachment URLs) |
 
 Voice calls surface as their transcript via the `call.transcribed` event — the adapter fetches the transcript through `@getdial/sdk.getCall()` and forwards it as a message on the caller's thread.
-
-**Threaded replies and reactions** ride the same channels. Replies are delivered as native quoted replies on iMessage (regular messages on SMS), reactions as native Tapbacks (`love`, `like`, `dislike`, `laugh`, `emphasize`, `question`, or any single emoji) — and inbound replies and Tapbacks arrive carrying the ID of the message they target.
 
 ## Threads
 

--- a/apps/docs/content/adapters/vendor-official/dial.mdx
+++ b/apps/docs/content/adapters/vendor-official/dial.mdx
@@ -12,8 +12,8 @@ mdxBody: true
 features:
   postMessage: yes
   threadedReplies:
-    status: yes
-    label: Native quoted replies on iMessage; regular message on SMS
+    status: partial
+    label: Inbound replies carry their target message; no outbound quote primitive in Chat SDK
   editMessage: no
   deleteMessage: no
   fileUploads:
@@ -48,12 +48,14 @@ features:
   customApiEndpoint:
     status: yes
     label: apiBaseUrl override
-  fetchMessages: no
+  fetchMessages:
+    status: partial
+    label: Backfills from the account's 100 most recent messages; no pagination
   fetchSingleMessage: no
   fetchThreadInfo: yes
   fetchChannelMessages: no
   listThreads: no
-  fetchChannelInfo: no
+  fetchChannelInfo: yes
   postChannelMessage: no
 ---
 

--- a/apps/docs/content/adapters/vendor-official/dial.mdx
+++ b/apps/docs/content/adapters/vendor-official/dial.mdx
@@ -18,7 +18,7 @@ features:
   deleteMessage: no
   fileUploads:
     status: yes
-    label: MMS & iMessage media via public URLs; a single audio file on iMessage is delivered as a native voice message
+    label: MMS & iMessage media
   streaming: no
   scheduledMessages: no
   cardFormat: no

--- a/apps/docs/content/adapters/vendor-official/dial.mdx
+++ b/apps/docs/content/adapters/vendor-official/dial.mdx
@@ -15,7 +15,7 @@ features:
   deleteMessage: no
   fileUploads:
     status: yes
-    label: MMS via public URLs
+    label: MMS & iMessage media via public URLs; a single audio file on iMessage is delivered as a native voice message
   streaming: no
   scheduledMessages: no
   cardFormat: no
@@ -32,7 +32,9 @@ features:
   mentions:
     status: partial
     label: DMs only — every phone pair is 1:1
-  addReactions: no
+  addReactions:
+    status: yes
+    label: Native Tapbacks on iMessage, both directions; emoji delivered as text on SMS
   removeReactions: no
   typingIndicator: no
   directMessages: yes
@@ -168,6 +170,8 @@ The adapter recomputes the HMAC with Node's `crypto.createHmac` + `timingSafeEqu
 | Outbound  | SMS / MMS / iMessage   | ✅   | ✅ (via attachment URLs) |
 
 Voice calls surface as their transcript via the `call.transcribed` event — the adapter fetches the transcript through `@getdial/sdk.getCall()` and forwards it as a message on the caller's thread.
+
+**Threaded replies and reactions** ride the same channels. Replies are delivered as native quoted replies on iMessage (regular messages on SMS), reactions as native Tapbacks (`love`, `like`, `dislike`, `laugh`, `emphasize`, `question`, or any single emoji) — and inbound replies and Tapbacks arrive carrying the ID of the message they target.
 
 ## Threads
 

--- a/apps/docs/content/adapters/vendor-official/dial.mdx
+++ b/apps/docs/content/adapters/vendor-official/dial.mdx
@@ -11,9 +11,6 @@ author: Dial
 mdxBody: true
 features:
   postMessage: yes
-  threadedReplies:
-    status: partial
-    label: Inbound replies carry their target message; no outbound quote primitive in Chat SDK
   editMessage: no
   deleteMessage: no
   fileUploads:
@@ -177,6 +174,8 @@ The adapter recomputes the HMAC with Node's `crypto.createHmac` + `timingSafeEqu
 | Outbound  | SMS / MMS / iMessage   | ✅   | ✅ (via attachment URLs) |
 
 Voice calls surface as their transcript via the `call.transcribed` event — the adapter fetches the transcript through `@getdial/sdk.getCall()` and forwards it as a message on the caller's thread.
+
+**Threaded replies** flow inbound: when the peer quotes one of your messages on an iMessage number, the parsed message's `raw.replyToId` carries the targeted message's ID. Chat SDK has no primitive for *sending* a quoted reply, so outbound posts are always regular messages.
 
 ## Threads
 

--- a/apps/docs/content/adapters/vendor-official/dial.mdx
+++ b/apps/docs/content/adapters/vendor-official/dial.mdx
@@ -175,8 +175,6 @@ The adapter recomputes the HMAC with Node's `crypto.createHmac` + `timingSafeEqu
 
 Voice calls surface as their transcript via the `call.transcribed` event — the adapter fetches the transcript through `@getdial/sdk.getCall()` and forwards it as a message on the caller's thread.
 
-**Threaded replies** flow inbound: when the peer quotes one of your messages on an iMessage number, the parsed message's `raw.replyToId` carries the targeted message's ID. Chat SDK has no primitive for *sending* a quoted reply, so outbound posts are always regular messages.
-
 ## Threads
 
 A Chat SDK thread here is a **pair of phone numbers** — your Dial-owned number and the peer's — encoded as:

--- a/apps/docs/content/adapters/vendor-official/dial.mdx
+++ b/apps/docs/content/adapters/vendor-official/dial.mdx
@@ -13,7 +13,7 @@ features:
   postMessage: yes
   threadedReplies:
     status: yes
-    label: Native quoted replies on iMessage; regular message on SMS; inbound replies carry the target message ID
+    label: Native quoted replies on iMessage; regular message on SMS
   editMessage: no
   deleteMessage: no
   fileUploads:

--- a/apps/docs/lib/adapter-features.ts
+++ b/apps/docs/lib/adapter-features.ts
@@ -24,6 +24,7 @@ export const PLATFORM_FEATURE_CATEGORIES: AdapterFeatureCategory[] = [
     label: "Messaging",
     features: [
       { key: "postMessage", label: "Post message" },
+      { key: "threadedReplies", label: "Threaded replies" },
       { key: "editMessage", label: "Edit message" },
       { key: "deleteMessage", label: "Delete message" },
       { key: "fileUploads", label: "File uploads" },

--- a/apps/docs/lib/adapter-features.ts
+++ b/apps/docs/lib/adapter-features.ts
@@ -24,7 +24,6 @@ export const PLATFORM_FEATURE_CATEGORIES: AdapterFeatureCategory[] = [
     label: "Messaging",
     features: [
       { key: "postMessage", label: "Post message" },
-      { key: "threadedReplies", label: "Threaded replies" },
       { key: "editMessage", label: "Edit message" },
       { key: "deleteMessage", label: "Delete message" },
       { key: "fileUploads", label: "File uploads" },


### PR DESCRIPTION
Updates the Dial vendor-official adapter page to match [`@getdial/chat-sdk-adapter@0.2.0`](https://www.npmjs.com/package/@getdial/chat-sdk-adapter), released today ([adapter PR](https://github.com/GetDial-AI/chat-sdk-adapter/pull/1)).

## Vendor page changes (`dial.mdx`)

- **Add reactions** ❌ → ✅ — `addReaction` now delivers native Tapbacks on iMessage numbers (emoji-as-text on SMS), and inbound Tapbacks fire `onReaction`.
- **Typing indicator** ❌ → ⚠️ — wired to Dial's typing endpoint; iMessage numbers display it, SMS numbers ignore it.
- **Fetch messages** ❌ → ⚠️ — history backfill from the account's 100 most recent messages (no pagination on the underlying endpoint yet).
- **Fetch channel info** ❌ → ✅.
- **File uploads** note corrected — media flows over iMessage as well as MMS.
- **Threaded replies** — new row: inbound replies carry their target message; Chat SDK has no outbound quote primitive.

## Shared catalog change (`adapter-features.ts`)

Adds a `threadedReplies` row to the Messaging category. Missing keys default to unsupported, so other adapter pages render ❌ for it — happy to drop this part and keep threaded replies as page prose instead if you'd rather not grow the shared catalog.

All claims verified against a live bot on `chat@4.33.0` before release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
