### PR TITLE
fix: Enhance mention regex and sleep method with abort support

### DIFF
--- a/.changeset/telegram-mention-regex-abortable-sleep.md
+++ b/.changeset/telegram-mention-regex-abortable-sleep.md
@@ -1,0 +1,5 @@
+---
+"@chat-adapter/telegram": patch
+---
+
+Cache the compiled bot-mention regex in `isBotMentioned` instead of recompiling it per message, and make the protected `sleep` helper accept an optional `AbortSignal` so `stopPolling()` interrupts the polling backoff delay immediately.

--- a/packages/adapter-telegram/src/index.test.ts
+++ b/packages/adapter-telegram/src/index.test.ts
@@ -4511,3 +4511,97 @@ describe("subclass extensibility", () => {
     expect(TestSubclass.prototype.checkAccess).toBeInstanceOf(Function);
   });
 });
+
+describe("sleep abort support", () => {
+  class SleepTestAdapter extends TelegramAdapter {
+    sleepFor(delayMs: number, signal?: AbortSignal): Promise<void> {
+      return this.sleep(delayMs, signal);
+    }
+  }
+
+  const makeAdapter = () =>
+    new SleepTestAdapter({
+      botToken: "token",
+      mode: "webhook",
+      logger: mockLogger,
+    });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("resolves immediately when the signal is already aborted", async () => {
+    vi.useFakeTimers();
+    const controller = new AbortController();
+    controller.abort();
+
+    await makeAdapter().sleepFor(10_000, controller.signal);
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it("resolves early and clears the timeout when aborted mid-sleep", async () => {
+    vi.useFakeTimers();
+    const controller = new AbortController();
+    let resolved = false;
+    const promise = makeAdapter()
+      .sleepFor(10_000, controller.signal)
+      .then(() => {
+        resolved = true;
+      });
+
+    await Promise.resolve();
+    expect(resolved).toBe(false);
+
+    controller.abort();
+    await promise;
+    expect(resolved).toBe(true);
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it("sleeps the full delay when no signal is provided", async () => {
+    vi.useFakeTimers();
+    let resolved = false;
+    const promise = makeAdapter()
+      .sleepFor(1000)
+      .then(() => {
+        resolved = true;
+      });
+
+    await vi.advanceTimersByTimeAsync(999);
+    expect(resolved).toBe(false);
+
+    await vi.advanceTimersByTimeAsync(1);
+    await promise;
+    expect(resolved).toBe(true);
+  });
+});
+
+describe("mention regex caching", () => {
+  class MentionTestAdapter extends TelegramAdapter {
+    checkMention(text: string): boolean {
+      return this.isBotMentioned({} as TelegramMessage, text);
+    }
+
+    setUserName(name: string): void {
+      this._userName = name;
+    }
+  }
+
+  it("matches with the cached regex and recompiles when the username changes", () => {
+    const adapter = new MentionTestAdapter({
+      botToken: "token",
+      mode: "webhook",
+      userName: "first_bot",
+      logger: mockLogger,
+    });
+
+    expect(adapter.checkMention("hi @first_bot")).toBe(true);
+    // Second call exercises the cached-regex path.
+    expect(adapter.checkMention("hi @first_bot, again")).toBe(true);
+    expect(adapter.checkMention("hi @second_bot")).toBe(false);
+
+    adapter.setUserName("second_bot");
+    expect(adapter.checkMention("hi @second_bot")).toBe(true);
+    expect(adapter.checkMention("hi @first_bot")).toBe(false);
+  });
+});

--- a/packages/adapter-telegram/src/index.ts
+++ b/packages/adapter-telegram/src/index.ts
@@ -2514,7 +2514,10 @@ export class TelegramAdapter
   protected getMentionRegex(username: string): RegExp {
     if (!this._mentionRegex || this._mentionRegexUsername !== username) {
       this._mentionRegexUsername = username;
-      this._mentionRegex = new RegExp(`@${this.escapeRegex(username)}\\b`, "i");
+      this._mentionRegex = new RegExp(
+        `@${this.escapeRegex(username)}(?![\\w-])`,
+        "i"
+      );
     }
 
     return this._mentionRegex;

--- a/packages/adapter-telegram/src/index.ts
+++ b/packages/adapter-telegram/src/index.ts
@@ -2471,6 +2471,9 @@ export class TelegramAdapter
     return chat.username;
   }
 
+  private _mentionRegexUsername?: string;
+  private _mentionRegex?: RegExp;
+
   protected isBotMentioned(message: TelegramMessage, text: string): boolean {
     if (!text) {
       return false;
@@ -2504,11 +2507,17 @@ export class TelegramAdapter
       }
     }
 
-    const mentionRegex = new RegExp(
-      `@${this.escapeRegex(username)}(?![\\w-])`,
-      "i"
-    );
+    const mentionRegex = this.getMentionRegex(username);
     return mentionRegex.test(text);
+  }
+
+  protected getMentionRegex(username: string): RegExp {
+    if (!this._mentionRegex || this._mentionRegexUsername !== username) {
+      this._mentionRegexUsername = username;
+      this._mentionRegex = new RegExp(`@${this.escapeRegex(username)}\\b`, "i");
+    }
+
+    return this._mentionRegex;
   }
 
   protected entityText(text: string, entity: TelegramMessageEntity): string {
@@ -2861,13 +2870,24 @@ export class TelegramAdapter
     return error instanceof Error && error.name === "AbortError";
   }
 
-  protected async sleep(delayMs: number): Promise<void> {
-    if (delayMs <= 0) {
+  protected async sleep(delayMs: number, signal?: AbortSignal): Promise<void> {
+    if (delayMs <= 0 || signal?.aborted) {
       return;
     }
 
     await new Promise<void>((resolve) => {
-      setTimeout(resolve, delayMs);
+      const timeoutId = setTimeout(() => {
+        signal?.removeEventListener("abort", onAbort);
+        resolve();
+      }, delayMs);
+
+      const onAbort = () => {
+        clearTimeout(timeoutId);
+        signal?.removeEventListener("abort", onAbort);
+        resolve();
+      };
+
+      signal?.addEventListener("abort", onAbort, { once: true });
     });
   }
 

--- a/packages/adapter-telegram/src/index.ts
+++ b/packages/adapter-telegram/src/index.ts
@@ -266,6 +266,8 @@ export class TelegramAdapter
   protected chat: ChatInstance | null = null;
   protected _botUserId?: string;
   protected _userName: string;
+  private _mentionRegexUsername?: string;
+  private _mentionRegex?: RegExp;
   protected readonly hasExplicitUserName: boolean;
   protected readonly mode: TelegramAdapterMode;
   protected readonly longPolling?: TelegramLongPollingConfig;
@@ -2471,9 +2473,6 @@ export class TelegramAdapter
     return chat.username;
   }
 
-  private _mentionRegexUsername?: string;
-  private _mentionRegex?: RegExp;
-
   protected isBotMentioned(message: TelegramMessage, text: string): boolean {
     if (!text) {
       return false;
@@ -2511,7 +2510,7 @@ export class TelegramAdapter
     return mentionRegex.test(text);
   }
 
-  protected getMentionRegex(username: string): RegExp {
+  private getMentionRegex(username: string): RegExp {
     if (!this._mentionRegex || this._mentionRegexUsername !== username) {
       this._mentionRegexUsername = username;
       this._mentionRegex = new RegExp(
@@ -2811,7 +2810,7 @@ export class TelegramAdapter
           return;
         }
 
-        await this.sleep(backoffMs);
+        await this.sleep(backoffMs, this.pollingAbortController?.signal);
       } finally {
         this.pollingAbortController = null;
       }


### PR DESCRIPTION
Refactor mention regex handling and sleep method to support abort signal. a new `RegExp` is compiled on every call to `isBotMentioned`, which is invoked for every incoming message. Since `username` is stable after initialization, this regex can be compiled once (e.g. cached in a private field and updated when `_userName` changes) and reused across calls.


## Checklist

- [x] All commits are signed and verified
- [x] All commits are signed off for the DCO (`git commit -s`)
- [x] `pnpm validate` passes
- [x] reported through [H101-3864642](https://hackerone.com/reports/3864642)
- [ ] Changeset added (or N/A — see [CONTRIBUTING.md](./CONTRIBUTING.md))
- [ ] Documentation updated (or N/A)
