### PR TITLE
fix(teams): fall back to user principal name for email

### DIFF
--- a/.changeset/calm-users-email.md
+++ b/.changeset/calm-users-email.md
@@ -1,0 +1,5 @@
+---
+"@chat-adapter/teams": patch
+---
+
+Fall back to Microsoft Graph's user principal name when a Teams user has no mail address.

--- a/packages/adapter-teams/src/index.test.ts
+++ b/packages/adapter-teams/src/index.test.ts
@@ -1015,7 +1015,7 @@ describe("TeamsAdapter", () => {
       mockApp.graph = {
         call: vi.fn(async () => ({
           displayName: "Alice Smith",
-          mail: "alice@contoso.com",
+          mail: "alice.smith@contoso.com",
           userPrincipalName: "alice@contoso.com",
           id: "aad-object-id-456",
         })),
@@ -1026,7 +1026,7 @@ describe("TeamsAdapter", () => {
       const user = await adapter.getUser("29:user-123");
       expect(user).not.toBeNull();
       expect(user?.fullName).toBe("Alice Smith");
-      expect(user?.email).toBe("alice@contoso.com");
+      expect(user?.email).toBe("alice.smith@contoso.com");
       expect(user?.userName).toBe("alice@contoso.com");
       expect(user?.userId).toBe("29:user-123");
       expect(user?.isBot).toBe(false);
@@ -1086,7 +1086,7 @@ describe("TeamsAdapter", () => {
       expect(user).toBeNull();
     });
 
-    it("should handle missing mail gracefully", async () => {
+    it("should fall back to userPrincipalName when mail is missing", async () => {
       const adapter = new TeamsAdapter({
         appId: "test",
         appPassword: "test",
@@ -1120,7 +1120,7 @@ describe("TeamsAdapter", () => {
       const user = await adapter.getUser("29:user-123");
       expect(user).not.toBeNull();
       expect(user?.fullName).toBe("Bob Jones");
-      expect(user?.email).toBeUndefined();
+      expect(user?.email).toBe("bob@contoso.com");
       expect(user?.userName).toBe("bob@contoso.com");
     });
 

--- a/packages/adapter-teams/src/index.ts
+++ b/packages/adapter-teams/src/index.ts
@@ -911,7 +911,7 @@ export class TeamsAdapter implements Adapter<TeamsThreadId, unknown> {
 
       return {
         avatarUrl: undefined,
-        email: graphUser.mail ?? undefined,
+        email: graphUser.mail ?? graphUser.userPrincipalName ?? undefined,
         fullName: graphUser.displayName ?? aadObjectId,
         isBot: false,
         userId,


### PR DESCRIPTION
## Summary

Use Microsoft Graph's `userPrincipalName` as the Teams user's email when `mail` is missing, while preserving `mail` precedence when both fields are present.

## Test plan

- [x] `pnpm --filter @chat-adapter/teams test`
- [x] `pnpm --filter @chat-adapter/teams typecheck`
- [x] `pnpm --filter @chat-adapter/teams build`
- [x] `TURBO_CONCURRENCY=2 pnpm validate`

## Checklist

- [x] All commits are signed and verified
- [x] All commits are signed off for the DCO (`git commit -s`)
- [x] `pnpm validate` passes
- [x] Changeset added (or N/A — see [CONTRIBUTING.md](./CONTRIBUTING.md))
- [x] Documentation updated (N/A — no public API change)
