### PR TITLE
fix(teams): preserve native streaming with placeholders

### DIFF
--- a/.changeset/teams-streaming-placeholder.md
+++ b/.changeset/teams-streaming-placeholder.md
@@ -1,0 +1,6 @@
+---
+"@chat-adapter/teams": patch
+"chat": patch
+---
+
+Show explicitly configured progress as a native Teams DM status while preserving native streaming.

--- a/apps/docs/content/docs/streaming.mdx
+++ b/apps/docs/content/docs/streaming.mdx
@@ -97,6 +97,8 @@ const bot = new Chat({
 });
 ```
 
+On Teams, a custom placeholder becomes an informative status during native direct-message streaming, while group chats edit the placeholder into the final answer. Leave the option unset to preserve native DM and buffered group-chat behavior, or set it to `null` to disable the status.
+
 ## Markdown healing
 
 During streaming, chunks often arrive mid-word or mid-syntax — for example, `**bold` before the closing `**` arrives. The SDK automatically heals incomplete markdown in intermediate renders using [remend](https://www.npmjs.com/package/remend), so messages always display with correct formatting while streaming.

--- a/packages/adapter-teams/src/index.test.ts
+++ b/packages/adapter-teams/src/index.test.ts
@@ -7,6 +7,7 @@ import {
   createMockState,
   threadIdContract,
 } from "@chat-adapter/tests";
+import type { IStreamer } from "@microsoft/teams.apps";
 import { ConsoleLogger } from "chat";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { createTeamsAdapter, TeamsAdapter, type TeamsThreadId } from "./index";
@@ -242,6 +243,111 @@ describe("TeamsAdapter", () => {
         logger,
       });
       expect(adapter.name).toBe("teams");
+    });
+  });
+
+  describe("streaming", () => {
+    class StreamingTestAdapter extends TeamsAdapter {
+      streamNatively(
+        textStream: AsyncIterable<string>,
+        stream: IStreamer,
+        placeholderText?: string | null
+      ) {
+        return this.streamViaEmit(
+          "teams:dm",
+          textStream,
+          stream,
+          placeholderText
+        );
+      }
+    }
+
+    let adapter: StreamingTestAdapter;
+
+    beforeEach(() => {
+      adapter = new StreamingTestAdapter({
+        appId: "test",
+        appPassword: "test",
+        logger,
+      });
+    });
+
+    const textStream = async function* (chunks: string[]) {
+      yield* chunks;
+    };
+
+    const createStreamer = () => {
+      let onChunk: ((activity: { id: string }) => void) | undefined;
+      return {
+        canceled: false,
+        close: vi.fn(),
+        emit: vi.fn(() => onChunk?.({ id: "answer-id" })),
+        events: {
+          once: vi.fn((_event, listener) => {
+            onChunk = listener;
+          }),
+        },
+        update: vi.fn(),
+      } as unknown as IStreamer;
+    };
+
+    it("uses core fallback for an explicit group-chat placeholder", async () => {
+      let consumed = false;
+      const source = {
+        async *[Symbol.asyncIterator]() {
+          consumed = true;
+          yield "Done";
+        },
+      };
+
+      const result = await adapter.stream("teams:group", source, {
+        fallbackStreamingPlaceholderText: "Working...",
+      });
+
+      expect(result).toBeNull();
+      expect(consumed).toBe(false);
+    });
+
+    it.each([
+      undefined,
+      null,
+    ])("preserves buffered group-chat streaming for placeholder %s", async (placeholderText) => {
+      const postMessage = vi.spyOn(adapter, "postMessage").mockResolvedValue({
+        id: "answer-id",
+        threadId: "teams:group",
+        raw: {},
+      });
+
+      const result = await adapter.stream(
+        "teams:group",
+        textStream(["Do", "ne"]),
+        placeholderText === undefined
+          ? undefined
+          : { fallbackStreamingPlaceholderText: placeholderText }
+      );
+
+      expect(postMessage).toHaveBeenCalledOnce();
+      expect(postMessage).toHaveBeenCalledWith("teams:group", {
+        markdown: "Done",
+      });
+      expect(result?.id).toBe("answer-id");
+    });
+
+    it("sends an explicit placeholder as native status before the first chunk", async () => {
+      const stream = createStreamer();
+
+      const result = await adapter.streamNatively(
+        textStream(["Do", "ne"]),
+        stream,
+        "Working..."
+      );
+
+      expect(stream.update).toHaveBeenCalledWith("Working...");
+      expect(vi.mocked(stream.update).mock.invocationCallOrder[0]).toBeLessThan(
+        vi.mocked(stream.emit).mock.invocationCallOrder[0] ?? 0
+      );
+      expect(stream.emit).toHaveBeenCalledTimes(2);
+      expect(result).toMatchObject({ id: "answer-id", threadId: "teams:dm" });
     });
   });
 

--- a/packages/adapter-teams/src/index.ts
+++ b/packages/adapter-teams/src/index.ts
@@ -1177,12 +1177,24 @@ export class TeamsAdapter implements Adapter<TeamsThreadId, unknown> {
   async stream(
     threadId: string,
     textStream: AsyncIterable<string | StreamChunk>,
-    _options?: StreamOptions
-  ): Promise<RawMessage<unknown>> {
+    options?: StreamOptions
+  ): Promise<RawMessage<unknown> | null> {
     const activeStream = this.activeStreams.get(threadId);
 
     if (activeStream && !activeStream.canceled) {
-      return this.streamViaEmit(threadId, textStream, activeStream);
+      return this.streamViaEmit(
+        threadId,
+        textStream,
+        activeStream,
+        options?.fallbackStreamingPlaceholderText
+      );
+    }
+
+    if (
+      !activeStream &&
+      typeof options?.fallbackStreamingPlaceholderText === "string"
+    ) {
+      return null;
     }
 
     // No native streamer available (group chats, proactive messages) —
@@ -1212,7 +1224,8 @@ export class TeamsAdapter implements Adapter<TeamsThreadId, unknown> {
   protected async streamViaEmit(
     threadId: string,
     textStream: AsyncIterable<string | StreamChunk>,
-    stream: IStreamer
+    stream: IStreamer,
+    placeholderText?: string | null
   ): Promise<RawMessage<unknown>> {
     let accumulated = "";
     let messageId = "";
@@ -1224,6 +1237,10 @@ export class TeamsAdapter implements Adapter<TeamsThreadId, unknown> {
     });
 
     try {
+      if (typeof placeholderText === "string") {
+        stream.update(placeholderText);
+      }
+
       for await (const chunk of textStream) {
         if (stream.canceled) {
           this.logger.debug("Teams stream canceled by user", { threadId });

--- a/packages/chat/src/chat.test.ts
+++ b/packages/chat/src/chat.test.ts
@@ -1993,6 +1993,38 @@ describe("Chat", () => {
       expect(mockAdapter.editMessage).toHaveBeenCalled();
     });
 
+    it.each([
+      [{}, undefined],
+      [{ fallbackStreamingPlaceholderText: "Working..." }, "Working..."],
+      [{ fallbackStreamingPlaceholderText: null }, null],
+    ] as const)("passes only explicit placeholder config to adapter streaming", async (placeholderConfig, expected) => {
+      const adapter = createMockAdapter("teams");
+      const stream = vi.fn().mockResolvedValue({
+        id: "answer-id",
+        threadId: "teams:C123:1234.5678",
+        raw: {},
+      });
+      adapter.stream = stream;
+      const customChat = new Chat({
+        userName: "testbot",
+        adapters: { teams: adapter },
+        state: createMockState(),
+        ...placeholderConfig,
+      });
+
+      await customChat.thread("teams:C123:1234.5678").post(chunks());
+
+      const options = stream.mock.calls[0]?.[2];
+      if (expected !== undefined) {
+        expect(options).toHaveProperty(
+          "fallbackStreamingPlaceholderText",
+          expected
+        );
+      } else {
+        expect(options).not.toHaveProperty("fallbackStreamingPlaceholderText");
+      }
+    });
+
     it("should throw for an invalid thread ID", () => {
       expect(() => chat.thread("")).toThrow("Invalid thread ID");
     });

--- a/packages/chat/src/chat.ts
+++ b/packages/chat/src/chat.ts
@@ -243,7 +243,7 @@ export class Chat<
   private readonly userName: string;
   private readonly logger: Logger;
   private readonly _streamingUpdateIntervalMs: number;
-  private readonly _fallbackStreamingPlaceholderText: string | null;
+  private readonly _fallbackStreamingPlaceholderText: string | null | undefined;
   private readonly _dedupeTtlMs: number;
   private readonly _onLockConflict: ChatConfig["onLockConflict"];
   private readonly _threadHistory: ThreadHistoryCache;
@@ -296,9 +296,7 @@ export class Chat<
     this.adapters = new Map();
     this._streamingUpdateIntervalMs = config.streamingUpdateIntervalMs ?? 500;
     this._fallbackStreamingPlaceholderText =
-      config.fallbackStreamingPlaceholderText !== undefined
-        ? config.fallbackStreamingPlaceholderText
-        : "...";
+      config.fallbackStreamingPlaceholderText;
     this._dedupeTtlMs = config.dedupeTtlMs ?? DEDUPE_TTL_MS;
     this._onLockConflict = config.onLockConflict;
     this._lockScope = config.lockScope;

--- a/packages/chat/src/thread.ts
+++ b/packages/chat/src/thread.ts
@@ -132,7 +132,7 @@ export class ThreadImpl<TState = Record<string, unknown>>
   /** Update interval for fallback streaming */
   private readonly _streamingUpdateIntervalMs: number;
   /** Placeholder text for fallback streaming (post + edit) */
-  private readonly _fallbackStreamingPlaceholderText: string | null;
+  private readonly _fallbackStreamingPlaceholderText: string | null | undefined;
   /** Cached channel instance */
   private _channel?: Channel<TState>;
   /** Thread history cache (set only for adapters with persistThreadHistory) */
@@ -149,9 +149,7 @@ export class ThreadImpl<TState = Record<string, unknown>>
     this._logger = config.logger;
     this._streamingUpdateIntervalMs = config.streamingUpdateIntervalMs ?? 500;
     this._fallbackStreamingPlaceholderText =
-      config.fallbackStreamingPlaceholderText !== undefined
-        ? config.fallbackStreamingPlaceholderText
-        : "...";
+      config.fallbackStreamingPlaceholderText;
 
     if (isLazyConfig(config)) {
       // Lazy resolution mode - store adapter name for later lookup
@@ -607,6 +605,12 @@ export class ThreadImpl<TState = Record<string, unknown>>
     const options: StreamOptions = {
       updateIntervalMs: this._streamingUpdateIntervalMs,
       ...callerOptions,
+      ...(this._fallbackStreamingPlaceholderText !== undefined
+        ? {
+            fallbackStreamingPlaceholderText:
+              this._fallbackStreamingPlaceholderText,
+          }
+        : {}),
     };
     if (this._currentMessage) {
       options.recipientUserId = this._currentMessage.author.userId;
@@ -745,7 +749,10 @@ export class ThreadImpl<TState = Record<string, unknown>>
   ): Promise<SentMessage> {
     const intervalMs =
       options?.updateIntervalMs ?? this._streamingUpdateIntervalMs;
-    const placeholderText = this._fallbackStreamingPlaceholderText;
+    const placeholderText =
+      this._fallbackStreamingPlaceholderText === undefined
+        ? "..."
+        : this._fallbackStreamingPlaceholderText;
     let msg: { id: string; threadId: string; raw: unknown } | null =
       placeholderText === null
         ? null

--- a/packages/chat/src/types.ts
+++ b/packages/chat/src/types.ts
@@ -587,6 +587,8 @@ export interface PlanUpdateChunk {
  * Platform-specific options are passed through to the adapter.
  */
 export interface StreamOptions {
+  /** Placeholder text when explicitly configured for fallback streaming. */
+  fallbackStreamingPlaceholderText?: string | null;
   /** Slack: The team/workspace ID */
   recipientTeamId?: string;
   /** Slack: The user ID to stream to (for AI assistant context) */


### PR DESCRIPTION
## Summary

Preserves Teams native DM streaming when `fallbackStreamingPlaceholderText` is explicitly configured. Direct messages show the text through the Teams SDK native informative status before streaming the answer, group chats use the core post-and-edit fallback, `null` disables progress, and omitted configuration keeps the existing native-DM/buffered-group behavior.

## Test plan

- [x] `pnpm --filter @chat-adapter/teams exec vitest run src/index.test.ts`
- [x] `pnpm --filter chat exec vitest run src/chat.test.ts src/thread.test.ts`
- [x] Teams and Chat package typechecks and builds
- [x] `TURBO_CONCURRENCY=2 pnpm validate`

## Checklist

- [x] All commits are signed and verified
- [x] All commits are signed off for the DCO (`git commit -s`)
- [x] `pnpm validate` passes
- [x] Changeset added (or N/A — see [CONTRIBUTING.md](./CONTRIBUTING.md))
- [x] Documentation updated (or N/A)