### PR TITLE
fix(teams): hydrate incoming author email

### DIFF
--- a/.changeset/teams-author-email.md
+++ b/.changeset/teams-author-email.md
@@ -1,6 +1,6 @@
 ---
-"@chat-adapter/teams": patch
-"chat": patch
+"@chat-adapter/teams": minor
+"chat": minor
 ---
 
 Expose Microsoft Graph email addresses on normalized incoming Teams message authors.

--- a/.changeset/teams-author-email.md
+++ b/.changeset/teams-author-email.md
@@ -3,4 +3,4 @@
 "chat": minor
 ---
 
-Expose Microsoft Graph email addresses on normalized incoming Teams message authors.
+Expose Microsoft Graph email addresses on normalized incoming Teams message authors. Resolved user profiles are cached in the state adapter (1 hour, failed lookups 5 minutes) so the lookup doesn't add a Graph call per message.

--- a/.changeset/teams-author-email.md
+++ b/.changeset/teams-author-email.md
@@ -1,0 +1,6 @@
+---
+"@chat-adapter/teams": patch
+"chat": patch
+---
+
+Expose Microsoft Graph email addresses on normalized incoming Teams message authors.

--- a/apps/docs/content/docs/api/message.mdx
+++ b/apps/docs/content/docs/api/message.mdx
@@ -77,6 +77,10 @@ import { Message } from "chat";
       description: 'Display name.',
       type: 'string',
     },
+    email: {
+      description: 'Email address when provided by the platform. Availability may require additional permissions.',
+      type: 'string | undefined',
+    },
     isBot: {
       description: 'Whether the author is a bot.',
       type: 'boolean | "unknown"',

--- a/packages/adapter-teams/README.md
+++ b/packages/adapter-teams/README.md
@@ -218,7 +218,7 @@ console.log(user?.email);    // "alice@contoso.com"
 console.log(user?.fullName); // "Alice Smith"
 ```
 
-Incoming message authors also include `email` when Graph resolves the sender. The adapter uses the activity's Azure AD object ID first and falls back to its cached ID, so missing permissions or lookup failures leave `message.author.email` undefined without preventing message delivery.
+Incoming message authors also include `email` when Graph resolves the sender. The adapter uses the activity's Azure AD object ID first and falls back to its cached ID, so missing permissions or lookup failures leave `message.author.email` undefined without preventing message delivery. This applies to live incoming messages only — authors on edited-message events and messages returned by `fetchMessages` are not hydrated with an email.
 
 The adapter caches each user's Azure AD object ID from incoming activities for later `getUser` calls. `getUser` returns `null` if the user hasn't been seen or the Graph call fails.
 

--- a/packages/adapter-teams/README.md
+++ b/packages/adapter-teams/README.md
@@ -218,7 +218,7 @@ console.log(user?.email);    // "alice@contoso.com"
 console.log(user?.fullName); // "Alice Smith"
 ```
 
-Incoming message authors also include `email` when Graph resolves the sender. The adapter uses the activity's Azure AD object ID first and falls back to its cached ID, so missing permissions or lookup failures leave `message.author.email` undefined without blocking message delivery.
+Incoming message authors also include `email` when Graph resolves the sender. The adapter uses the activity's Azure AD object ID first and falls back to its cached ID, so missing permissions or lookup failures leave `message.author.email` undefined without preventing message delivery.
 
 The adapter caches each user's Azure AD object ID from incoming activities for later `getUser` calls. `getUser` returns `null` if the user hasn't been seen or the Graph call fails.
 

--- a/packages/adapter-teams/README.md
+++ b/packages/adapter-teams/README.md
@@ -218,7 +218,7 @@ console.log(user?.email);    // "alice@contoso.com"
 console.log(user?.fullName); // "Alice Smith"
 ```
 
-Incoming message authors also include `email` when Graph resolves the sender. The adapter uses the activity's Azure AD object ID first and falls back to its cached ID, so missing permissions or lookup failures leave `message.author.email` undefined without preventing message delivery. This applies to live incoming messages only — authors on edited-message events and messages returned by `fetchMessages` are not hydrated with an email.
+Incoming message authors also include `email` when Graph resolves the sender. The adapter uses the activity's Azure AD object ID first and falls back to its cached ID, so missing permissions or lookup failures leave `message.author.email` undefined without preventing message delivery. This applies to live incoming messages only — authors on edited-message events and messages returned by `fetchMessages` are not hydrated with an email. Resolved profiles are cached in the state adapter for 1 hour (failed lookups for 5 minutes), so busy conversations don't trigger a Graph call per message.
 
 The adapter caches each user's Azure AD object ID from incoming activities for later `getUser` calls. `getUser` returns `null` if the user hasn't been seen or the Graph call fails.
 

--- a/packages/adapter-teams/README.md
+++ b/packages/adapter-teams/README.md
@@ -218,7 +218,9 @@ console.log(user?.email);    // "alice@contoso.com"
 console.log(user?.fullName); // "Alice Smith"
 ```
 
-The adapter caches each user's Azure AD object ID from incoming activities, so `getUser` only works for users who have previously interacted with the bot. Returns `null` if the user hasn't been seen or the Graph call fails.
+Incoming message authors also include `email` when Graph resolves the sender. The adapter uses the activity's Azure AD object ID first and falls back to its cached ID, so missing permissions or lookup failures leave `message.author.email` undefined without blocking message delivery.
+
+The adapter caches each user's Azure AD object ID from incoming activities for later `getUser` calls. `getUser` returns `null` if the user hasn't been seen or the Graph call fails.
 
 ## Message history (`fetchMessages`)
 

--- a/packages/adapter-teams/src/index.test.ts
+++ b/packages/adapter-teams/src/index.test.ts
@@ -1161,7 +1161,9 @@ describe("TeamsAdapter", () => {
 
       await adapter.handleIncoming(activity("activity-aad-id"));
 
-      expect(state.get).not.toHaveBeenCalled();
+      expect(state.get).not.toHaveBeenCalledWith(
+        "teams:aadObjectId:29:user-123"
+      );
       expect(mockApp.graph.call).toHaveBeenCalledWith(expect.anything(), {
         "user-id": "activity-aad-id",
       });
@@ -1195,6 +1197,33 @@ describe("TeamsAdapter", () => {
 
       expect(chat.processMessage).toHaveBeenCalledOnce();
       const message = vi.mocked(chat.processMessage).mock.calls[0]?.[2];
+      expect(message?.author.email).toBeUndefined();
+    });
+
+    it("caches the Graph lookup across messages", async () => {
+      const { adapter, chat, mockApp } = await setup({
+        displayName: "Alice",
+        mail: "alice@example.com",
+        userPrincipalName: "alice@contoso.com",
+      });
+
+      await adapter.handleIncoming(activity("activity-aad-id"));
+      await adapter.handleIncoming(activity("activity-aad-id"));
+
+      expect(mockApp.graph.call).toHaveBeenCalledOnce();
+      const message = vi.mocked(chat.processMessage).mock.calls[1]?.[2];
+      expect(message?.author.email).toBe("alice@example.com");
+    });
+
+    it("caches failed Graph lookups without retrying", async () => {
+      const { adapter, chat, mockApp } = await setup(new Error("Forbidden"));
+
+      await adapter.handleIncoming(activity("activity-aad-id"));
+      await adapter.handleIncoming(activity("activity-aad-id"));
+
+      expect(mockApp.graph.call).toHaveBeenCalledOnce();
+      expect(chat.processMessage).toHaveBeenCalledTimes(2);
+      const message = vi.mocked(chat.processMessage).mock.calls[1]?.[2];
       expect(message?.author.email).toBeUndefined();
     });
 

--- a/packages/adapter-teams/src/index.test.ts
+++ b/packages/adapter-teams/src/index.test.ts
@@ -1097,6 +1097,108 @@ describe("TeamsAdapter", () => {
   // getUser Tests
   // ==========================================================================
 
+  describe("incoming sender email", () => {
+    class IncomingMessageTestAdapter extends TeamsAdapter {
+      handleIncoming(activity: Record<string, unknown>) {
+        return this.handleMessageActivity({ activity } as never);
+      }
+    }
+
+    const activity = (aadObjectId?: string) => ({
+      type: "message",
+      id: "msg-100",
+      text: "Hello world",
+      from: {
+        id: "29:user-123",
+        name: "Alice",
+        aadObjectId,
+      },
+      conversation: { id: "19:abc@thread.tacv2" },
+      serviceUrl: "https://smba.trafficmanager.net/teams/",
+    });
+
+    const setup = async (
+      graphResult: Record<string, unknown> | Error,
+      cachedAadObjectId?: string
+    ) => {
+      const adapter = new IncomingMessageTestAdapter({
+        appId: "test",
+        appPassword: "test",
+        logger,
+      });
+      const state = createMockState();
+      if (cachedAadObjectId) {
+        state.cache.set("teams:aadObjectId:29:user-123", cachedAadObjectId);
+      }
+      const chat = createMockChatInstance({ state });
+      const mockApp = (
+        adapter as unknown as {
+          app: {
+            initialize: ReturnType<typeof vi.fn>;
+            graph: { call: ReturnType<typeof vi.fn> };
+          };
+        }
+      ).app;
+      mockApp.initialize = vi.fn(async () => undefined);
+      mockApp.graph = {
+        call: vi.fn(async () => {
+          if (graphResult instanceof Error) {
+            throw graphResult;
+          }
+          return graphResult;
+        }),
+      };
+      await adapter.initialize(chat);
+      return { adapter, chat, mockApp, state };
+    };
+
+    it("hydrates email from the activity AAD object ID without cached state", async () => {
+      const { adapter, chat, mockApp, state } = await setup({
+        displayName: "Alice",
+        mail: "alice@example.com",
+        userPrincipalName: "alice@contoso.com",
+      });
+
+      await adapter.handleIncoming(activity("activity-aad-id"));
+
+      expect(state.get).not.toHaveBeenCalled();
+      expect(mockApp.graph.call).toHaveBeenCalledWith(expect.anything(), {
+        "user-id": "activity-aad-id",
+      });
+      const message = vi.mocked(chat.processMessage).mock.calls[0]?.[2];
+      expect(message?.author.email).toBe("alice@example.com");
+    });
+
+    it("falls back to the cached AAD object ID", async () => {
+      const { adapter, chat, mockApp } = await setup(
+        {
+          displayName: "Alice",
+          mail: null,
+          userPrincipalName: "alice@contoso.com",
+        },
+        "cached-aad-id"
+      );
+
+      await adapter.handleIncoming(activity());
+
+      expect(mockApp.graph.call).toHaveBeenCalledWith(expect.anything(), {
+        "user-id": "cached-aad-id",
+      });
+      const message = vi.mocked(chat.processMessage).mock.calls[0]?.[2];
+      expect(message?.author.email).toBe("alice@contoso.com");
+    });
+
+    it("dispatches the message when Graph lookup fails", async () => {
+      const { adapter, chat } = await setup(new Error("Forbidden"));
+
+      await adapter.handleIncoming(activity("activity-aad-id"));
+
+      expect(chat.processMessage).toHaveBeenCalledOnce();
+      const message = vi.mocked(chat.processMessage).mock.calls[0]?.[2];
+      expect(message?.author.email).toBeUndefined();
+    });
+  });
+
   describe("getUser", () => {
     it("should return user info when aadObjectId is cached and Graph call succeeds", async () => {
       const adapter = new TeamsAdapter({

--- a/packages/adapter-teams/src/index.test.ts
+++ b/packages/adapter-teams/src/index.test.ts
@@ -1197,6 +1197,33 @@ describe("TeamsAdapter", () => {
       const message = vi.mocked(chat.processMessage).mock.calls[0]?.[2];
       expect(message?.author.email).toBeUndefined();
     });
+
+    it("hydrates email on the DM path and completes processing", async () => {
+      const { adapter, chat } = await setup({
+        displayName: "Alice",
+        mail: "alice@example.com",
+        userPrincipalName: "alice@contoso.com",
+      });
+      // DM handling blocks on a waitUntil-driven promise for native
+      // streaming, so the mock must invoke waitUntil for the handler
+      // to resolve.
+      vi.mocked(chat.processMessage).mockImplementation(
+        (_adapter, _threadId, _message, options) => {
+          (
+            options as { waitUntil?: (task: Promise<unknown>) => void }
+          )?.waitUntil?.(Promise.resolve());
+        }
+      );
+
+      await adapter.handleIncoming({
+        ...activity("activity-aad-id"),
+        conversation: { id: "a:1dm-conversation" },
+      });
+
+      expect(chat.processMessage).toHaveBeenCalledOnce();
+      const message = vi.mocked(chat.processMessage).mock.calls[0]?.[2];
+      expect(message?.author.email).toBe("alice@example.com");
+    });
   });
 
   describe("getUser", () => {

--- a/packages/adapter-teams/src/index.ts
+++ b/packages/adapter-teams/src/index.ts
@@ -334,6 +334,15 @@ export class TeamsAdapter implements Adapter<TeamsThreadId, unknown> {
     });
 
     const message = this.parseTeamsMessage(activity, threadId);
+    const user = activity.from?.aadObjectId
+      ? await this.getUserByAadObjectId(
+          message.author.userId,
+          activity.from.aadObjectId
+        )
+      : await this.getUser(message.author.userId);
+    if (user?.email) {
+      message.author.email = user.email;
+    }
 
     // Detect @mention by checking if any mentioned entity matches our app ID
     const entities = activity.entities || [];
@@ -905,6 +914,21 @@ export class TeamsAdapter implements Adapter<TeamsThreadId, unknown> {
         return null;
       }
 
+      return await this.getUserByAadObjectId(userId, aadObjectId);
+    } catch (error) {
+      this.logger.warn("Failed to fetch user info from Graph API", {
+        userId,
+        error,
+      });
+      return null;
+    }
+  }
+
+  private async getUserByAadObjectId(
+    userId: string,
+    aadObjectId: string
+  ): Promise<UserInfo | null> {
+    try {
       const graphUser = await this.app.graph.call(users.get, {
         "user-id": aadObjectId,
       });

--- a/packages/adapter-teams/src/index.ts
+++ b/packages/adapter-teams/src/index.ts
@@ -916,7 +916,7 @@ export class TeamsAdapter implements Adapter<TeamsThreadId, unknown> {
 
       return await this.getUserByAadObjectId(userId, aadObjectId);
     } catch (error) {
-      this.logger.warn("Failed to fetch user info from Graph API", {
+      this.logger.warn("Failed to read cached aadObjectId from state", {
         userId,
         error,
       });

--- a/packages/adapter-teams/src/index.ts
+++ b/packages/adapter-teams/src/index.ts
@@ -80,6 +80,11 @@ interface ActionSubmitData {
 const MESSAGEID_CAPTURE_PATTERN = /messageid=(\d+)/;
 const MESSAGEID_STRIP_PATTERN = /;messageid=\d+/;
 const CACHE_TTL_MS = 30 * 24 * 60 * 60 * 1000; // 30 days
+const USER_INFO_CACHE_TTL_MS = 60 * 60 * 1000; // 1 hour
+const USER_INFO_NEGATIVE_CACHE_TTL_MS = 5 * 60 * 1000; // 5 minutes
+// Sentinel cached when a Graph lookup fails, so tenants without Graph
+// consent don't pay a failing network call on every message.
+const USER_INFO_NEGATIVE_SENTINEL = "unresolvable";
 const DEFAULT_DIALOG_OPEN_TIMEOUT_MS = 5000; // Max wait for handler to call openModal()
 
 export class TeamsAdapter implements Adapter<TeamsThreadId, unknown> {
@@ -928,12 +933,21 @@ export class TeamsAdapter implements Adapter<TeamsThreadId, unknown> {
     userId: string,
     aadObjectId: string
   ): Promise<UserInfo | null> {
+    const cacheKey = `teams:userInfo:${aadObjectId}`;
+    const cached = await this.readCachedUserInfo(cacheKey);
+    if (cached === USER_INFO_NEGATIVE_SENTINEL) {
+      return null;
+    }
+    if (cached) {
+      return { ...cached, userId };
+    }
+
     try {
       const graphUser = await this.app.graph.call(users.get, {
         "user-id": aadObjectId,
       });
 
-      return {
+      const userInfo: UserInfo = {
         avatarUrl: undefined,
         email: graphUser.mail ?? graphUser.userPrincipalName ?? undefined,
         fullName: graphUser.displayName ?? aadObjectId,
@@ -942,11 +956,44 @@ export class TeamsAdapter implements Adapter<TeamsThreadId, unknown> {
         userName:
           graphUser.userPrincipalName ?? graphUser.displayName ?? userId,
       };
+      this.chat
+        ?.getState()
+        .set(cacheKey, JSON.stringify(userInfo), USER_INFO_CACHE_TTL_MS)
+        .catch(() => {});
+      return userInfo;
     } catch (error) {
       this.logger.warn("Failed to fetch user info from Graph API", {
         userId,
         error,
       });
+      this.chat
+        ?.getState()
+        .set(
+          cacheKey,
+          USER_INFO_NEGATIVE_SENTINEL,
+          USER_INFO_NEGATIVE_CACHE_TTL_MS
+        )
+        .catch(() => {});
+      return null;
+    }
+  }
+
+  private async readCachedUserInfo(
+    cacheKey: string
+  ): Promise<UserInfo | typeof USER_INFO_NEGATIVE_SENTINEL | null> {
+    if (!this.chat) {
+      return null;
+    }
+    try {
+      const cached = await this.chat.getState().get<string>(cacheKey);
+      if (!cached) {
+        return null;
+      }
+      if (cached === USER_INFO_NEGATIVE_SENTINEL) {
+        return USER_INFO_NEGATIVE_SENTINEL;
+      }
+      return JSON.parse(cached) as UserInfo;
+    } catch {
       return null;
     }
   }

--- a/packages/chat/src/message.test.ts
+++ b/packages/chat/src/message.test.ts
@@ -145,6 +145,23 @@ describe("Message", () => {
       const json = makeMessage({ isMention: true }).toJSON();
       expect(json.isMention).toBe(true);
     });
+
+    it("should preserve author email through serialization", () => {
+      const original = makeMessage({
+        author: {
+          userId: "U123",
+          userName: "testuser",
+          fullName: "Test User",
+          email: "test@example.com",
+          isBot: false,
+          isMe: false,
+        },
+      });
+
+      const json = original.toJSON();
+      expect(json.author.email).toBe("test@example.com");
+      expect(Message.fromJSON(json).author.email).toBe("test@example.com");
+    });
   });
 
   describe("fromJSON()", () => {

--- a/packages/chat/src/message.ts
+++ b/packages/chat/src/message.ts
@@ -67,6 +67,7 @@ export interface SerializedMessage {
     userId: string;
     userName: string;
     fullName: string;
+    email?: string;
     isBot: boolean | "unknown";
     isMe: boolean;
   };
@@ -214,6 +215,9 @@ export class Message<TRawMessage = unknown> {
         userId: this.author.userId,
         userName: this.author.userName,
         fullName: this.author.fullName,
+        ...(this.author.email === undefined
+          ? {}
+          : { email: this.author.email }),
         isBot: this.author.isBot,
         isMe: this.author.isMe,
       },

--- a/packages/chat/src/types.ts
+++ b/packages/chat/src/types.ts
@@ -1430,6 +1430,8 @@ export interface RawMessage<TRawMessage = unknown> {
 }
 
 export interface Author {
+  /** Email address when provided by the platform */
+  email?: string;
   /** Display name */
   fullName: string;
   /** Whether the author is a bot */


### PR DESCRIPTION
## Summary

Adds optional email to normalized message authors and preserves it through message serialization.

For incoming Teams messages, resolves the sender with the activity's Entra object ID before dispatch, falling back to the cached ID when the activity omits it. The lookup reuses the existing `mail ?? userPrincipalName` mapping from #708, and missing permissions or Graph failures leave email undefined without blocking message delivery.

This deliberately revisits the author-profile boundary discussed in #239: the core field is optional, and Teams populates it only when Microsoft Graph can resolve the sender.

## Test plan

- [x] `pnpm --filter chat exec vitest run src/message.test.ts`
- [x] `pnpm --filter @chat-adapter/teams exec vitest run src/index.test.ts`
- [x] Chat and Teams package typechecks and builds
- [x] `TURBO_CONCURRENCY=2 pnpm validate`

## Checklist

- [x] All commits are signed and verified
- [x] All commits are signed off for the DCO (`git commit -s`)
- [x] `pnpm validate` passes
- [x] Changeset added (or N/A — see [CONTRIBUTING.md](./CONTRIBUTING.md))
- [x] Documentation updated (or N/A)
