### PR TITLE
fix(chat): keep attachment/link-only messages in toAiMessages

### DIFF
--- a/.changeset/to-ai-messages-keep-attachment-only.md
+++ b/.changeset/to-ai-messages-keep-attachment-only.md
@@ -2,4 +2,6 @@
 "chat": patch
 ---
 
-`toAiMessages` no longer drops messages that have no text. Messages with image/file attachments or links but an empty text body (e.g. an image uploaded without a caption) are now included; only messages with no text, attachments, or links are skipped.
+`toAiMessages` no longer drops messages that have no text. A message with an empty text body is now kept when it has links or attachments the converter can include: images and text files (`text/*`, JSON, XML, YAML, etc.) with a working `fetchData()`. Messages whose only attachments are unsupported (video, audio, other file types, or attachments without `fetchData()`) are still skipped, and `onUnsupportedAttachment` now fires for video/audio attachments on these previously filtered messages.
+
+Note: multipart `content` no longer always starts with a text part. When a kept message had no text, its `content` array contains only attachment parts.

--- a/.changeset/to-ai-messages-keep-attachment-only.md
+++ b/.changeset/to-ai-messages-keep-attachment-only.md
@@ -1,0 +1,5 @@
+---
+"chat": patch
+---
+
+`toAiMessages` no longer drops messages that have no text. Messages with image/file attachments or links but an empty text body (e.g. an image uploaded without a caption) are now included; only messages with no text, attachments, or links are skipped.

--- a/apps/docs/content/docs/ai/to-ai-messages.mdx
+++ b/apps/docs/content/docs/ai/to-ai-messages.mdx
@@ -89,10 +89,10 @@ function toAiMessages(
 ## Behavior
 
 - **Role mapping** — `author.isMe === true` maps to `"assistant"`, all others to `"user"`
-- **Filtering** — Messages are kept as long as they carry content. A message with no text is still included when it has image/file attachments or links (e.g. an image uploaded with no caption). Only messages with no text, attachments, or links are removed
+- **Filtering** — A message with no text is kept when it has links or attachments the converter can include: images and text files with a working `fetchData()`. Messages with no text whose only attachments are unsupported (video, audio, other file types, or missing `fetchData()`) are removed. Attachment-only messages produce multipart `content` with no leading text part
 - **Sorting** — Messages are sorted chronologically (oldest first) by `metadata.dateSent`
 - **Links** — Link metadata (URL, title, description, site name) is appended to message content. Embedded message links are labeled as `[Embedded message: ...]`
-- **Attachments** — Images and text files (JSON, XML, YAML, etc.) are included as multipart content using `fetchData()`. Video and audio attachments trigger `onUnsupportedAttachment`
+- **Attachments** — Images and text files (JSON, XML, YAML, etc.) are included as multipart content using `fetchData()`. When the message has no text, the `content` array contains only attachment parts, with no leading text part. Video and audio attachments trigger `onUnsupportedAttachment`
 
 ## Return types
 

--- a/apps/docs/content/docs/ai/to-ai-messages.mdx
+++ b/apps/docs/content/docs/ai/to-ai-messages.mdx
@@ -89,7 +89,7 @@ function toAiMessages(
 ## Behavior
 
 - **Role mapping** — `author.isMe === true` maps to `"assistant"`, all others to `"user"`
-- **Filtering** — Messages with empty or whitespace-only text are removed
+- **Filtering** — Messages are kept as long as they carry content. A message with no text is still included when it has image/file attachments or links (e.g. an image uploaded with no caption). Only messages with no text, attachments, or links are removed
 - **Sorting** — Messages are sorted chronologically (oldest first) by `metadata.dateSent`
 - **Links** — Link metadata (URL, title, description, site name) is appended to message content. Embedded message links are labeled as `[Embedded message: ...]`
 - **Attachments** — Images and text files (JSON, XML, YAML, etc.) are included as multipart content using `fetchData()`. Video and audio attachments trigger `onUnsupportedAttachment`

--- a/packages/chat/src/ai/messages.test.ts
+++ b/packages/chat/src/ai/messages.test.ts
@@ -592,6 +592,71 @@ describe("toAiMessages", () => {
     );
   });
 
+  it("skips video-only messages with no text and reports the attachment", async () => {
+    const onUnsupported = vi.fn();
+    const messages = [
+      createTestMessage("1", "", {
+        attachments: [
+          {
+            type: "video",
+            url: "https://example.com/video.mp4",
+            mimeType: "video/mp4",
+          },
+        ],
+      }),
+    ];
+
+    const result = await toAiMessages(messages, {
+      onUnsupportedAttachment: onUnsupported,
+    });
+
+    expect(result).toEqual([]);
+    expect(onUnsupported).toHaveBeenCalledOnce();
+    expect(onUnsupported.mock.calls[0]?.[0].type).toBe("video");
+  });
+
+  it("skips image-only messages with no text when fetchData is unavailable", async () => {
+    const messages = [
+      createTestMessage("1", "", {
+        attachments: [
+          {
+            type: "image",
+            url: "https://example.com/photo.png",
+            mimeType: "image/png",
+          },
+        ],
+      }),
+    ];
+
+    const result = await toAiMessages(messages);
+
+    expect(result).toEqual([]);
+  });
+
+  it("keeps link-only assistant messages with no text", async () => {
+    const messages = [
+      createTestMessage("1", "", {
+        author: {
+          userId: "bot",
+          userName: "bot",
+          fullName: "Bot",
+          isBot: true,
+          isMe: true,
+        },
+        links: [{ url: "https://example.com", title: "Example" }],
+      }),
+    ];
+
+    const result = await toAiMessages(messages);
+
+    expect(result).toEqual([
+      {
+        role: "assistant",
+        content: "Links:\nhttps://example.com\nTitle: Example",
+      },
+    ]);
+  });
+
   it("does not add a text part when an image-only message has no text", async () => {
     const messages = [
       createTestMessage("1", "   ", {

--- a/packages/chat/src/ai/messages.test.ts
+++ b/packages/chat/src/ai/messages.test.ts
@@ -531,6 +531,99 @@ describe("toAiMessages", () => {
     expect(typeof result[0]?.content).toBe("string");
   });
 
+  it("keeps image-only messages that have no text", async () => {
+    const messages = [
+      createTestMessage("1", "", {
+        attachments: [
+          {
+            type: "image",
+            mimeType: "image/png",
+            name: "photo.png",
+            fetchData: async () => Buffer.from("png-data"),
+          },
+        ],
+      }),
+    ];
+
+    const result = await toAiMessages(messages);
+    const content = result[0]?.content as AiMessagePart[];
+
+    expect(result).toHaveLength(1);
+    expect(Array.isArray(content)).toBe(true);
+    expect(content).toHaveLength(1);
+    expect(content[0]?.type).toBe("file");
+  });
+
+  it("keeps interleaved text and image-only messages", async () => {
+    const messages = [
+      createTestMessage("1", "Here is some context"),
+      createTestMessage("2", "", {
+        attachments: [
+          {
+            type: "image",
+            mimeType: "image/png",
+            fetchData: async () => Buffer.from("png-data"),
+          },
+        ],
+      }),
+      createTestMessage("3", "What do you think?"),
+    ];
+
+    const result = await toAiMessages(messages);
+
+    expect(result).toHaveLength(3);
+    expect(result[0]?.content).toBe("Here is some context");
+    expect(Array.isArray(result[1]?.content)).toBe(true);
+    expect(result[2]?.content).toBe("What do you think?");
+  });
+
+  it("keeps link-only messages that have no text", async () => {
+    const messages = [
+      createTestMessage("1", "", {
+        links: [{ url: "https://example.com", title: "Example" }],
+      }),
+    ];
+
+    const result = await toAiMessages(messages);
+
+    expect(result).toHaveLength(1);
+    expect(result[0]?.content).toBe(
+      "Links:\nhttps://example.com\nTitle: Example"
+    );
+  });
+
+  it("does not add a text part when an image-only message has no text", async () => {
+    const messages = [
+      createTestMessage("1", "   ", {
+        attachments: [
+          {
+            type: "image",
+            mimeType: "image/png",
+            fetchData: async () => Buffer.from("png-data"),
+          },
+        ],
+      }),
+    ];
+
+    const result = await toAiMessages(messages);
+    const content = result[0]?.content as AiMessagePart[];
+
+    expect(content).toHaveLength(1);
+    expect(content[0]?.type).toBe("file");
+  });
+
+  it("skips messages with no text, attachments, or links", async () => {
+    const messages = [
+      createTestMessage("1", "Real message"),
+      createTestMessage("2", ""),
+      createTestMessage("3", "   "),
+    ];
+
+    const result = await toAiMessages(messages);
+
+    expect(result).toEqual([{ role: "user", content: "Real message" }]);
+  });
+
   it("includes links in text part when attachments are present", async () => {
     const messages = [
       createTestMessage("1", "Image with link", {

--- a/packages/chat/src/ai/messages.ts
+++ b/packages/chat/src/ai/messages.ts
@@ -144,7 +144,8 @@ async function attachmentToPart(
 /**
  * Convert chat SDK messages to AI SDK conversation format.
  *
- * - Filters out messages with empty/whitespace-only text
+ * - Keeps messages that have no text but carry content (images, files, links).
+ *   Only messages with no usable content at all are skipped.
  * - Maps `author.isMe === true` to `"assistant"`, otherwise `"user"`
  * - Uses `message.text` for content
  * - Appends link metadata when available
@@ -182,15 +183,17 @@ export async function toAiMessages(
       (b.metadata.dateSent?.getTime() ?? 0)
   );
 
-  const filtered = sorted.filter((msg) => msg.text.trim());
-
   const results = await Promise.all(
-    filtered.map(async (msg) => {
+    sorted.map(async (msg) => {
       const role: "user" | "assistant" = msg.author.isMe ? "assistant" : "user";
-      let textContent =
-        includeNames && role === "user"
-          ? `[${msg.author.userName}]: ${msg.text}`
-          : msg.text;
+      const hasText = msg.text.trim().length > 0;
+      let textContent = "";
+      if (hasText) {
+        textContent =
+          includeNames && role === "user"
+            ? `[${msg.author.userName}]: ${msg.text}`
+            : msg.text;
+      }
 
       // Append link metadata when available
       if (msg.links && msg.links.length > 0) {
@@ -211,7 +214,9 @@ export async function toAiMessages(
             return parts.join("\n");
           })
           .join("\n\n");
-        textContent += `\n\nLinks:\n${linkParts}`;
+        textContent = textContent
+          ? `${textContent}\n\nLinks:\n${linkParts}`
+          : `Links:\n${linkParts}`;
       }
 
       // Build attachment parts for images and text files (only for user messages)
@@ -228,18 +233,27 @@ export async function toAiMessages(
         }
 
         if (attachmentParts.length > 0) {
-          aiMessage = {
-            role,
-            content: [
-              { type: "text" as const, text: textContent },
-              ...attachmentParts,
-            ],
-          } satisfies AiUserMessage;
+          // Only prepend a text part when there is text — a message may have
+          // images (or other attachments) with no accompanying text.
+          const parts: AiMessagePart[] = textContent
+            ? [{ type: "text" as const, text: textContent }, ...attachmentParts]
+            : attachmentParts;
+          aiMessage = { role, content: parts } satisfies AiUserMessage;
         } else {
           aiMessage = { role, content: textContent } as AiMessage;
         }
       } else {
         aiMessage = { role, content: textContent } as AiMessage;
+      }
+
+      // Skip messages that carry no usable content (no text, no attachments,
+      // no links). Text-only or attachment-only messages are kept.
+      const isEmpty =
+        typeof aiMessage.content === "string"
+          ? aiMessage.content.trim().length === 0
+          : aiMessage.content.length === 0;
+      if (isEmpty) {
+        return { result: null, source: msg };
       }
 
       if (transformMessage) {


### PR DESCRIPTION
## Summary

- `toAiMessages` previously filtered out any message with empty or whitespace-only text (`sorted.filter((msg) => msg.text.trim())`). This discarded messages that carry meaningful content without text — e.g. an image uploaded with no caption, a file-only upload, or a link-only message.
- Now messages are kept as long as they have usable content (text, image/file attachments, or links). Only messages with *none* of those are skipped.
- When an attachment-only message is included, no empty `text` part is prepended (an empty text part would be rejected by the AI SDK). Link-only messages render a standalone `Links:\n...` block.

## Changes

- `packages/chat/src/ai/messages.ts` — drop the text-only pre-filter; build text conditionally; skip only truly empty messages.
- `packages/chat/src/ai/messages.test.ts` — add tests for image-only, link-only, interleaved, whitespace-with-attachment, and fully-empty cases.
- `apps/docs/content/docs/ai/to-ai-messages.mdx` — update the documented filtering behavior.
- Changeset added (`chat`: patch).

## Test plan

- [x] `pnpm --filter chat test -- messages.test.ts` (1063 passing, incl. 40 in `messages.test.ts`)
- [x] `pnpm check` on edited files

Made with [Cursor](https://cursor.com)