### PR TITLE
fix(adapter-slack): establish per-team token context in Socket Mode (multi-workspace)

### DIFF
--- a/.changeset/slack-socket-multiworkspace-token.md
+++ b/.changeset/slack-socket-multiworkspace-token.md
@@ -1,0 +1,5 @@
+---
+"@chat-adapter/slack": patch
+---
+
+Establish the per-team bot token context in Socket Mode for multi-workspace apps. `routeSocketEvent` now resolves the installation token via `installationProvider` and runs the dispatch inside `requestContext` for `events_api`, `slash_commands`, and `interactive` events — matching the webhook path. Previously, Socket Mode dispatched events with no token in multi-workspace mode (no `botToken`, only an `installationProvider`), so every downstream Web API call threw `AuthenticationError: No bot token available. In multi-workspace mode, ensure the webhook is being processed.`

--- a/packages/adapter-slack/src/index.test.ts
+++ b/packages/adapter-slack/src/index.test.ts
@@ -7971,6 +7971,115 @@ describe("socket mode - routeSocketEvent", () => {
     expect(chatInstance).toHaveDispatched("processAction");
   });
 
+  describe("multi-workspace token context (installationProvider)", () => {
+    async function createMultiWorkspaceSocketAdapter(
+      getInstallation: (
+        installationId: string,
+        isEnterpriseInstall: boolean
+      ) => Promise<{ botToken: string; botUserId?: string } | null>
+    ) {
+      mockSocketStart.mockClear();
+      mockSocketOn.mockClear();
+      mockSocketDisconnect.mockClear();
+
+      const state = createMockState();
+      const chatInstance = createMockChatInstance({ state });
+      const adapter = createSlackAdapter({
+        mode: "socket",
+        appToken: "xapp-test-token",
+        // No botToken → multi-workspace mode (defaultBotTokenProvider undefined).
+        installationProvider: { getInstallation },
+        logger: mockLogger,
+      });
+      await adapter.initialize(chatInstance);
+
+      const slackEventHandler = mockSocketOn.mock.calls.find(
+        (call: unknown[]) => call[0] === "slack_event"
+      )?.[1] as (args: {
+        ack: (response?: Record<string, unknown>) => Promise<void>;
+        body: Record<string, unknown>;
+        type: string;
+      }) => Promise<void>;
+
+      return { adapter, chatInstance, slackEventHandler };
+    }
+
+    it("events_api resolves the per-team token via installationProvider", async () => {
+      const getInstallation = vi
+        .fn()
+        .mockResolvedValue({ botToken: "xoxb-team-A", botUserId: "U_BOT_A" });
+      const { chatInstance, slackEventHandler } =
+        await createMultiWorkspaceSocketAdapter(getInstallation);
+
+      await slackEventHandler({
+        ack: vi.fn().mockResolvedValue(undefined),
+        type: "events_api",
+        body: {
+          team_id: "T_TEAM_A",
+          event: {
+            type: "message",
+            channel: "C123",
+            ts: "1234567890.123456",
+            text: "hello",
+            user: "U_USER",
+          },
+        },
+      });
+
+      expect(getInstallation).toHaveBeenCalledWith("T_TEAM_A", false);
+      expect(chatInstance).toHaveDispatched("processMessage");
+    });
+
+    it("slash_commands resolves the per-team token via installationProvider", async () => {
+      const getInstallation = vi
+        .fn()
+        .mockResolvedValue({ botToken: "xoxb-team-B", botUserId: "U_BOT_B" });
+      const { slackEventHandler } =
+        await createMultiWorkspaceSocketAdapter(getInstallation);
+
+      await slackEventHandler({
+        ack: vi.fn().mockResolvedValue(undefined),
+        type: "slash_commands",
+        body: {
+          team_id: "T_TEAM_B",
+          command: "/test",
+          text: "arg",
+          user_id: "U_USER",
+          channel_id: "C123",
+        },
+      });
+
+      await vi.waitFor(() => {
+        expect(getInstallation).toHaveBeenCalledWith("T_TEAM_B", false);
+      });
+    });
+
+    it("interactive resolves the per-team token from payload.team.id", async () => {
+      const getInstallation = vi
+        .fn()
+        .mockResolvedValue({ botToken: "xoxb-team-C", botUserId: "U_BOT_C" });
+      const { slackEventHandler } =
+        await createMultiWorkspaceSocketAdapter(getInstallation);
+
+      await slackEventHandler({
+        ack: vi.fn().mockResolvedValue(undefined),
+        type: "interactive",
+        body: {
+          type: "block_actions",
+          team: { id: "T_TEAM_C" },
+          actions: [{ type: "button", action_id: "a", value: "v" }],
+          channel: { id: "C123", name: "test" },
+          container: { type: "message", message_ts: "1.1", channel_id: "C123" },
+          message: { ts: "1.1" },
+          trigger_id: "t123",
+          user: { id: "U_USER", username: "u" },
+        },
+      });
+
+      expect(getInstallation).toHaveBeenCalledWith("T_TEAM_C", false);
+    });
+  });
+
   it("acks interactive with response payload for view_submission", async () => {
     const { slackEventHandler } = await createSocketAdapter();
     const ack = vi.fn().mockResolvedValue(undefined);

--- a/packages/adapter-slack/src/index.ts
+++ b/packages/adapter-slack/src/index.ts
@@ -1974,6 +1974,45 @@ export class SlackAdapter implements Adapter<SlackThreadId, unknown> {
           event_time: body.event_time as number | undefined,
         };
         try {
+          // Multi-workspace: establish the per-team token context before
+          // dispatch, mirroring the webhook `event_callback` path. Without this,
+          // Socket Mode dispatched with no token in multi-workspace mode, so
+          // every downstream API call threw AuthenticationError ("No bot token
+          // available. In multi-workspace mode, ensure the webhook is being
+          // processed.").
+          if (!this.defaultBotTokenProvider) {
+            const isEnterpriseInstall = Boolean(
+              body.is_enterprise_install ?? body.enterprise_id
+            );
+            const installationId = (
+              isEnterpriseInstall ? body.enterprise_id : body.team_id
+            ) as string | undefined;
+            if (installationId) {
+              const ctx = await this.resolveTokenForTeam(
+                installationId,
+                isEnterpriseInstall
+              );
+              if (ctx) {
+                this.requestContext.run(
+                  {
+                    ...ctx,
+                    enterpriseId: body.enterprise_id as string | undefined,
+                    isEnterpriseInstall,
+                  },
+                  () => this.processEventPayload(payload, options)
+                );
+                return;
+              }
+              this.logger.warn(
+                "Could not resolve token for socket events_api",
+                {
+                  installationId,
+                  isEnterpriseInstall,
+                }
+              );
+              return;
+            }
+          }
           this.processEventPayload(payload, options);
         } catch (error) {
           this.logger.error("Error processing socket mode events_api", {
@@ -1991,13 +2030,88 @@ export class SlackAdapter implements Adapter<SlackThreadId, unknown> {
             params.set(key, value);
           }
         }
+        // Multi-workspace: establish the per-team token context before dispatch
+        // (webhook slash-command parity).
+        if (!this.defaultBotTokenProvider) {
+          const isEnterpriseInstall =
+            params.get("is_enterprise_install") === "true";
+          const installationId = isEnterpriseInstall
+            ? params.get("enterprise_id")
+            : params.get("team_id");
+          if (installationId) {
+            const ctx = await this.resolveTokenForTeam(
+              installationId,
+              isEnterpriseInstall
+            );
+            if (ctx) {
+              this.requestContext.run(
+                {
+                  ...ctx,
+                  enterpriseId: params.get("enterprise_id") ?? undefined,
+                  isEnterpriseInstall,
+                },
+                () => wrapAsync(this.handleSlashCommand(params, options))
+              );
+              return;
+            }
+            this.logger.warn(
+              "Could not resolve token for socket slash command",
+              {
+                installationId,
+                isEnterpriseInstall,
+              }
+            );
+            return;
+          }
+        }
         wrapAsync(this.handleSlashCommand(params, options));
         break;
       }
 
       case "interactive": {
         const payload = body as unknown as SlackInteractivePayload;
-        const result = this.dispatchInteractivePayload(payload, options);
+        const runDispatch = (): Response | Promise<Response> =>
+          this.dispatchInteractivePayload(payload, options);
+        // Multi-workspace: establish the per-team token context around dispatch
+        // (webhook interactive parity) so block_actions / view handlers can post.
+        let result: Response | Promise<Response>;
+        if (this.defaultBotTokenProvider) {
+          result = runDispatch();
+        } else {
+          const install = payload as {
+            team?: { id?: string };
+            enterprise?: { id?: string };
+            is_enterprise_install?: boolean;
+          };
+          const isEnterpriseInstall = Boolean(install.is_enterprise_install);
+          const installationId = isEnterpriseInstall
+            ? install.enterprise?.id
+            : install.team?.id;
+          const ctx = installationId
+            ? await this.resolveTokenForTeam(
+                installationId,
+                isEnterpriseInstall
+              )
+            : null;
+          if (ctx) {
+            result = this.requestContext.run(
+              {
+                ...ctx,
+                enterpriseId: install.enterprise?.id,
+                isEnterpriseInstall,
+              },
+              runDispatch
+            );
+          } else {
+            if (installationId) {
+              this.logger.warn(
+                "Could not resolve token for socket interactive",
+                { installationId, isEnterpriseInstall }
+              );
+            }
+            result = runDispatch();
+          }
+        }
         const response = result instanceof Promise ? await result : result;
         const responseBody = response.headers
           .get("content-type")


### PR DESCRIPTION
## Summary

In **multi-workspace mode** (an `installationProvider` is configured and there is no default `botToken`), the Slack adapter's **Socket Mode** dispatcher never resolves a per-team bot token. Every downstream Web API call made while handling a socket event then throws:

```
AuthenticationError: No bot token available. In multi-workspace mode, ensure the webhook is being processed.
```

This makes multi-workspace apps that use Socket Mode (no public ingress) unable to handle **any** inbound event — messages, mentions, slash commands, or interactive/button payloads all fail.

## Root cause

`getToken()` reads the token from the `requestContext` `AsyncLocalStorage`. The **webhook** path (`handleWebhook`) populates it per request: for `event_callback`, slash commands, and interactive payloads it calls `resolveTokenForTeam(installationId)` (which consults `installationProvider`) and runs the dispatch inside `this.requestContext.run({ ...ctx }, …)`.

`routeSocketEvent` (Socket Mode) does not — all three cases dispatch directly:

```ts
case "events_api":     this.processEventPayload(payload, options);            // no token ctx
case "slash_commands": wrapAsync(this.handleSlashCommand(params, options));   // no token ctx
case "interactive":    this.dispatchInteractivePayload(payload, options);     // no token ctx
```

So with no default token, `getToken()` has nothing to return and throws. (The error text — "ensure the webhook is being processed" — points right at this: only the webhook path sets the context.)

## Fix

Mirror the webhook token-context handling in `routeSocketEvent` for all three socket event types. When there is no default token, resolve the installation token via `resolveTokenForTeam` and run the dispatch inside `requestContext.run`. Team id comes from `body.team_id` (events_api / slash) or `payload.team.id` (interactive); enterprise installs use `enterprise_id` + `is_enterprise_install`.

Single-workspace (default token) behaviour is unchanged — the new path is guarded by `!this.defaultBotTokenProvider`, and everything falls through to the existing direct dispatch otherwise.

## Testing

- New tests under `socket mode - routeSocketEvent › multi-workspace token context (installationProvider)` assert each socket event type (`events_api`, `slash_commands`, `interactive`) resolves the per-team token via `installationProvider` before dispatch.
- `pnpm --filter @chat-adapter/slack typecheck` ✅
- `pnpm --filter @chat-adapter/slack test` ✅ (587 passed)
- `pnpm --filter @chat-adapter/slack build` ✅
- `biome check` ✅
- Changeset included (`@chat-adapter/slack` patch).

Happy to adjust naming/structure to fit your conventions.
