### PR TITLE
feat(discord): add channel response allowlist

### DIFF
--- a/.changeset/discord-channel-allowlist.md
+++ b/.changeset/discord-channel-allowlist.md
@@ -2,4 +2,4 @@
 "@chat-adapter/discord": minor
 ---
 
-Add an opt-in channel allowlist for treating non-bot Discord messages as directed to the bot without requiring a mention.
+Add an opt-in channel allowlist for treating non-bot Discord messages as directed to the bot without requiring a mention. Configure via `respondToChannelIds` or the `DISCORD_RESPOND_TO_CHANNEL_IDS` env var (comma-separated).

--- a/.changeset/discord-channel-allowlist.md
+++ b/.changeset/discord-channel-allowlist.md
@@ -1,0 +1,5 @@
+---
+"@chat-adapter/discord": minor
+---
+
+Add an opt-in channel allowlist for treating non-bot Discord messages as directed to the bot without requiring a mention.

--- a/apps/docs/content/adapters/official/discord.mdx
+++ b/apps/docs/content/adapters/official/discord.mdx
@@ -103,6 +103,11 @@ bot.onNewMention(async (thread, message) => {
       description:
         "Role IDs that should trigger mention handlers. Auto-detected from `DISCORD_MENTION_ROLE_IDS` (comma-separated).",
     },
+    respondToChannelIds: {
+      type: "string[]",
+      description:
+        "Parent channel IDs whose non-bot messages, including messages in child threads, trigger mention handlers without an @mention. Top-level messages use the adapter's normal per-message Discord thread. Defaults to `[]`.",
+    },
     respondToGlobalMentions: {
       type: "boolean",
       description:

--- a/apps/docs/content/adapters/official/discord.mdx
+++ b/apps/docs/content/adapters/official/discord.mdx
@@ -106,7 +106,7 @@ bot.onNewMention(async (thread, message) => {
     respondToChannelIds: {
       type: "string[]",
       description:
-        "Parent channel IDs whose non-bot messages, including messages in child threads, trigger mention handlers without an @mention. Top-level messages use the adapter's normal per-message Discord thread. Defaults to `[]`.",
+        "Parent channel IDs whose non-bot messages, including messages in child threads, trigger mention handlers without an @mention. Top-level messages use the adapter's normal per-message Discord thread. Auto-detected from `DISCORD_RESPOND_TO_CHANNEL_IDS` (comma-separated). Defaults to `[]`.",
     },
     respondToGlobalMentions: {
       type: "boolean",

--- a/packages/adapter-discord/README.md
+++ b/packages/adapter-discord/README.md
@@ -226,7 +226,7 @@ All options are auto-detected from environment variables when not provided.
 | `applicationId` | No* | Discord application ID. Auto-detected from `DISCORD_APPLICATION_ID` |
 | `contentFormat` | No | Render Chat SDK cards as `DiscordContentFormat.Embeds` or `DiscordContentFormat.ComponentsV2`. Defaults to `DiscordContentFormat.Embeds` |
 | `mentionRoleIds` | No | Array of role IDs that trigger mention handlers. Auto-detected from `DISCORD_MENTION_ROLE_IDS` (comma-separated) |
-| `respondToChannelIds` | No | Parent channel IDs whose non-bot messages, including messages in child threads, trigger mention handlers without an @mention. Top-level messages use the adapter's normal per-message Discord thread. Defaults to `[]` |
+| `respondToChannelIds` | No | Parent channel IDs whose non-bot messages, including messages in child threads, trigger mention handlers without an @mention. Top-level messages use the adapter's normal per-message Discord thread. Auto-detected from `DISCORD_RESPOND_TO_CHANNEL_IDS` (comma-separated). Defaults to `[]` |
 | `respondToGlobalMentions` | No | Treat `@everyone`/`@here` pings as mentions of the bot. Defaults to `false` |
 | `interactionFlags` | No | Function returning Discord interaction flags for the initial deferred slash command response |
 | `apiUrl` | No | Override the Discord API base URL. Auto-detected from `DISCORD_API_URL` |

--- a/packages/adapter-discord/README.md
+++ b/packages/adapter-discord/README.md
@@ -226,6 +226,7 @@ All options are auto-detected from environment variables when not provided.
 | `applicationId` | No* | Discord application ID. Auto-detected from `DISCORD_APPLICATION_ID` |
 | `contentFormat` | No | Render Chat SDK cards as `DiscordContentFormat.Embeds` or `DiscordContentFormat.ComponentsV2`. Defaults to `DiscordContentFormat.Embeds` |
 | `mentionRoleIds` | No | Array of role IDs that trigger mention handlers. Auto-detected from `DISCORD_MENTION_ROLE_IDS` (comma-separated) |
+| `respondToChannelIds` | No | Parent channel IDs whose non-bot messages, including messages in child threads, trigger mention handlers without an @mention. Top-level messages use the adapter's normal per-message Discord thread. Defaults to `[]` |
 | `respondToGlobalMentions` | No | Treat `@everyone`/`@here` pings as mentions of the bot. Defaults to `false` |
 | `interactionFlags` | No | Function returning Discord interaction flags for the initial deferred slash command response |
 | `apiUrl` | No | Override the Discord API base URL. Auto-detected from `DISCORD_API_URL` |

--- a/packages/adapter-discord/src/gateway.test.ts
+++ b/packages/adapter-discord/src/gateway.test.ts
@@ -86,7 +86,7 @@ describe("Gateway client configuration", () => {
     expect(clientOptions.intents).toContain(GatewayIntentBits.DirectMessages);
   });
 
-  it("forwards the parent channel for thread messages", async () => {
+  it("forwards the parent channel only for allowlisted thread messages", async () => {
     mockClientInstance.on.mockClear();
     mockClientInstance.channels.fetch.mockResolvedValue({
       id: "thread789",
@@ -136,6 +136,21 @@ describe("Gateway client configuration", () => {
         author: { bot: false },
         thread: { id: "thread789", parent_id: "channel456" },
       },
+    });
+
+    mockClientInstance.channels.fetch.mockResolvedValue({
+      id: "thread000",
+      parentId: "other-channel",
+      isThread: () => true,
+    });
+    await rawHandler({
+      t: "MESSAGE_CREATE",
+      d: { channel_id: "thread000", author: { bot: false } },
+    });
+    const otherRequest = fetchMock.mock.calls[1]?.[1] as RequestInit;
+    expect(JSON.parse(otherRequest.body as string).data).toEqual({
+      channel_id: "thread000",
+      author: { bot: false },
     });
 
     controller.abort();

--- a/packages/adapter-discord/src/gateway.test.ts
+++ b/packages/adapter-discord/src/gateway.test.ts
@@ -7,11 +7,12 @@
 
 import { createMockChatInstance, mockLogger } from "@chat-adapter/tests";
 import { GatewayIntentBits, Partials } from "discord.js";
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { createDiscordAdapter } from "./index";
 
 const { MockClient, mockClientInstance } = vi.hoisted(() => {
   const mockClientInstance = {
+    channels: { fetch: vi.fn() },
     on: vi.fn(),
     login: vi.fn().mockResolvedValue("token"),
     destroy: vi.fn(),
@@ -32,6 +33,10 @@ vi.mock("discord.js", async () => {
     ...actual,
     Client: MockClient,
   };
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
 });
 
 describe("Gateway client configuration", () => {
@@ -79,5 +84,61 @@ describe("Gateway client configuration", () => {
 
     expect(clientOptions.partials).toContain(Partials.Channel);
     expect(clientOptions.intents).toContain(GatewayIntentBits.DirectMessages);
+  });
+
+  it("forwards the parent channel for thread messages", async () => {
+    mockClientInstance.on.mockClear();
+    mockClientInstance.channels.fetch.mockResolvedValue({
+      id: "thread789",
+      parentId: "channel456",
+      isThread: () => true,
+    });
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(new Response(null, { status: 200 }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const adapter = createDiscordAdapter({
+      botToken: "test-token",
+      publicKey: "a".repeat(64),
+      applicationId: "test-app-id",
+      logger: mockLogger,
+      respondToChannelIds: ["channel456"],
+    });
+    await adapter.initialize(createMockChatInstance());
+
+    const controller = new AbortController();
+    let listenerPromise: Promise<unknown> | undefined;
+    await adapter.startGatewayListener(
+      {
+        waitUntil: (promise) => {
+          listenerPromise = promise as Promise<unknown>;
+        },
+      },
+      1000,
+      controller.signal,
+      "https://example.com/webhook"
+    );
+
+    const rawHandler = mockClientInstance.on.mock.calls.find(
+      ([event]) => event === "raw"
+    )?.[1] as (packet: { t: string; d: unknown }) => Promise<void>;
+    await rawHandler({
+      t: "MESSAGE_CREATE",
+      d: { channel_id: "thread789", author: { bot: false } },
+    });
+
+    expect(mockClientInstance.channels.fetch).toHaveBeenCalledWith("thread789");
+    const request = fetchMock.mock.calls[0]?.[1] as RequestInit;
+    expect(JSON.parse(request.body as string)).toMatchObject({
+      data: {
+        channel_id: "thread789",
+        author: { bot: false },
+        thread: { id: "thread789", parent_id: "channel456" },
+      },
+    });
+
+    controller.abort();
+    await listenerPromise;
   });
 });

--- a/packages/adapter-discord/src/index.test.ts
+++ b/packages/adapter-discord/src/index.test.ts
@@ -3634,6 +3634,56 @@ describe("legacy gateway interactions", () => {
     );
   });
 
+  it("creates a thread for messages in an allowlisted channel", async () => {
+    const adapter = new TestGatewayDiscordAdapter({
+      botToken: "test-token",
+      publicKey: testPublicKey,
+      applicationId: "test-app-id",
+      logger: mockLogger,
+      respondToChannelIds: ["channel456"],
+    });
+    const fetchSpy = vi.spyOn(adapter as any, "discordFetch").mockResolvedValue(
+      new Response(JSON.stringify({ id: "thread789", name: "Thread" }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      })
+    );
+    const chat = createMockChatInstance();
+    await adapter.initialize(chat);
+
+    const client = createGatewayClient();
+    adapter.listen(client);
+    client.emit(Events.MessageCreate, {
+      id: "msg123",
+      channelId: "channel456",
+      guildId: "guild1",
+      content: "No mention needed",
+      author: {
+        id: "user789",
+        username: "testuser",
+        displayName: "Test User",
+        bot: false,
+      },
+      mentions: { everyone: false, roles: [], has: () => false },
+      channel: { isThread: () => false },
+      createdAt: new Date("2021-01-01T00:00:00.000Z"),
+      editedAt: null,
+      attachments: [],
+    });
+    await waitForGatewayHandlers();
+
+    expect(fetchSpy).toHaveBeenCalledWith(
+      "/channels/channel456/messages/msg123/threads",
+      "POST",
+      expect.anything()
+    );
+    expect(chat.handleIncomingMessage).toHaveBeenCalledWith(
+      adapter,
+      "discord:guild1:channel456:thread789",
+      expect.objectContaining({ isMention: true })
+    );
+  });
+
   it("handles component interactions from the gateway", async () => {
     const adapter = new TestGatewayDiscordAdapter({
       botToken: "test-token",
@@ -4054,6 +4104,83 @@ describe("handleForwardedMessage - thread handling", () => {
     );
 
     fetchSpy.mockRestore();
+  });
+
+  it("keeps allowlisted forwarded messages in their Discord thread", async () => {
+    const adapter = createDiscordAdapter({
+      botToken: "test-token",
+      publicKey: testPublicKey,
+      applicationId: "test-app-id",
+      logger: mockLogger,
+      respondToChannelIds: ["channel456"],
+    });
+    const fetchSpy = vi.spyOn(adapter as any, "discordFetch").mockResolvedValue(
+      new Response(JSON.stringify({ id: "thread789", name: "Thread" }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      })
+    );
+    const chat = createMockChatInstance();
+    await adapter.initialize(chat);
+
+    const forward = (data: Record<string, unknown>) =>
+      adapter.handleWebhook(
+        new Request("https://example.com/webhook", {
+          method: "POST",
+          headers: {
+            "x-discord-gateway-token": "test-token",
+            "content-type": "application/json",
+          },
+          body: JSON.stringify({
+            type: "GATEWAY_MESSAGE_CREATE",
+            timestamp: Date.now(),
+            data,
+          }),
+        })
+      );
+    const message = {
+      guild_id: "guild1",
+      content: "No mention needed",
+      timestamp: "2021-01-01T00:00:00.000Z",
+      author: { id: "user789", username: "testuser", bot: false },
+      mentions: [],
+      attachments: [],
+    };
+
+    await forward({ ...message, id: "msg123", channel_id: "channel456" });
+    await forward({
+      ...message,
+      id: "msg456",
+      channel_id: "thread789",
+      thread: { id: "thread789", parent_id: "channel456" },
+    });
+    await forward({
+      ...message,
+      id: "msg789",
+      channel_id: "thread789",
+      author: { id: "other-bot", username: "other-bot", bot: true },
+      thread: { id: "thread789", parent_id: "channel456" },
+    });
+
+    expect(fetchSpy).toHaveBeenCalledOnce();
+    expect(chat.handleIncomingMessage).toHaveBeenNthCalledWith(
+      1,
+      adapter,
+      "discord:guild1:channel456:thread789",
+      expect.objectContaining({ isMention: true })
+    );
+    expect(chat.handleIncomingMessage).toHaveBeenNthCalledWith(
+      2,
+      adapter,
+      "discord:guild1:channel456:thread789",
+      expect.objectContaining({ isMention: true })
+    );
+    expect(chat.handleIncomingMessage).toHaveBeenNthCalledWith(
+      3,
+      adapter,
+      "discord:guild1:channel456:thread789",
+      expect.objectContaining({ isMention: false })
+    );
   });
 });
 

--- a/packages/adapter-discord/src/index.test.ts
+++ b/packages/adapter-discord/src/index.test.ts
@@ -171,6 +171,18 @@ describe("constructor env var resolution", () => {
     expect(adapter).toBeInstanceOf(DiscordAdapter);
   });
 
+  it("should resolve respondToChannelIds from DISCORD_RESPOND_TO_CHANNEL_IDS env var", () => {
+    process.env.DISCORD_BOT_TOKEN = "env-token";
+    process.env.DISCORD_PUBLIC_KEY = testPublicKey;
+    process.env.DISCORD_APPLICATION_ID = "env-app-id";
+    process.env.DISCORD_RESPOND_TO_CHANNEL_IDS = "channel1, channel2";
+    const adapter = new DiscordAdapter();
+    expect(
+      (adapter as unknown as { respondToChannelIds: string[] })
+        .respondToChannelIds
+    ).toEqual(["channel1", "channel2"]);
+  });
+
   it("should default logger when not provided", () => {
     process.env.DISCORD_BOT_TOKEN = "env-token";
     process.env.DISCORD_PUBLIC_KEY = testPublicKey;
@@ -3681,6 +3693,92 @@ describe("legacy gateway interactions", () => {
       adapter,
       "discord:guild1:channel456:thread789",
       expect.objectContaining({ isMention: true })
+    );
+  });
+
+  it("reuses the existing thread for messages in a thread of an allowlisted channel", async () => {
+    const adapter = new TestGatewayDiscordAdapter({
+      botToken: "test-token",
+      publicKey: testPublicKey,
+      applicationId: "test-app-id",
+      logger: mockLogger,
+      respondToChannelIds: ["channel456"],
+    });
+    const fetchSpy = vi
+      .spyOn(adapter as any, "discordFetch")
+      .mockResolvedValue(new Response(null, { status: 200 }));
+    const chat = createMockChatInstance();
+    await adapter.initialize(chat);
+
+    const client = createGatewayClient();
+    adapter.listen(client);
+    client.emit(Events.MessageCreate, {
+      id: "msg456",
+      channelId: "thread789",
+      guildId: "guild1",
+      content: "Thread reply without mention",
+      author: {
+        id: "user789",
+        username: "testuser",
+        displayName: "Test User",
+        bot: false,
+      },
+      mentions: { everyone: false, roles: [], has: () => false },
+      channel: { isThread: () => true, parentId: "channel456" },
+      createdAt: new Date("2021-01-01T00:00:00.000Z"),
+      editedAt: null,
+      attachments: [],
+    });
+    await waitForGatewayHandlers();
+
+    expect(fetchSpy).not.toHaveBeenCalled();
+    expect(chat.handleIncomingMessage).toHaveBeenCalledWith(
+      adapter,
+      "discord:guild1:channel456:thread789",
+      expect.objectContaining({ isMention: true })
+    );
+  });
+
+  it("does not treat a parentless thread message as allowlisted", async () => {
+    const adapter = new TestGatewayDiscordAdapter({
+      botToken: "test-token",
+      publicKey: testPublicKey,
+      applicationId: "test-app-id",
+      logger: mockLogger,
+      respondToChannelIds: ["channel456"],
+    });
+    const fetchSpy = vi
+      .spyOn(adapter as any, "discordFetch")
+      .mockResolvedValue(new Response(null, { status: 200 }));
+    const chat = createMockChatInstance();
+    await adapter.initialize(chat);
+
+    const client = createGatewayClient();
+    adapter.listen(client);
+    client.emit(Events.MessageCreate, {
+      id: "msg000",
+      channelId: "thread000",
+      guildId: "guild1",
+      content: "Orphan thread message",
+      author: {
+        id: "user789",
+        username: "testuser",
+        displayName: "Test User",
+        bot: false,
+      },
+      mentions: { everyone: false, roles: [], has: () => false },
+      channel: { isThread: () => true, parentId: null },
+      createdAt: new Date("2021-01-01T00:00:00.000Z"),
+      editedAt: null,
+      attachments: [],
+    });
+    await waitForGatewayHandlers();
+
+    expect(fetchSpy).not.toHaveBeenCalled();
+    expect(chat.handleIncomingMessage).toHaveBeenCalledWith(
+      adapter,
+      "discord:guild1:thread000",
+      expect.objectContaining({ isMention: false })
     );
   });
 

--- a/packages/adapter-discord/src/index.ts
+++ b/packages/adapter-discord/src/index.ts
@@ -181,7 +181,13 @@ export class DiscordAdapter implements Adapter<DiscordThreadId, unknown> {
       );
     }
 
-    this.respondToChannelIds = config.respondToChannelIds ?? [];
+    this.respondToChannelIds =
+      config.respondToChannelIds ??
+      (process.env.DISCORD_RESPOND_TO_CHANNEL_IDS
+        ? process.env.DISCORD_RESPOND_TO_CHANNEL_IDS.split(",").map((id) =>
+            id.trim()
+          )
+        : []);
     this.respondToGlobalMentions = config.respondToGlobalMentions ?? false;
     this.botUserId = applicationId; // Discord app ID is the bot's user ID
     this.contentFormat = contentFormat;
@@ -2181,15 +2187,16 @@ export class DiscordAdapter implements Adapter<DiscordThreadId, unknown> {
         );
       const isEveryoneMentioned =
         this.respondToGlobalMentions && message.mentions.everyone;
+      const isChannelAllowlisted = this.respondToChannelIds.includes(
+        message.channel.isThread()
+          ? (message.channel.parentId ?? message.channelId)
+          : message.channelId
+      );
       const isMentioned =
         isUserMentioned ||
         isRoleMentioned ||
         isEveryoneMentioned ||
-        this.respondToChannelIds.includes(
-          message.channel.isThread()
-            ? (message.channel.parentId ?? message.channelId)
-            : message.channelId
-        );
+        isChannelAllowlisted;
 
       this.logger.info("Discord Gateway message received", {
         channelId: message.channelId,
@@ -2199,6 +2206,7 @@ export class DiscordAdapter implements Adapter<DiscordThreadId, unknown> {
         isUserMentioned,
         isRoleMentioned,
         isEveryoneMentioned,
+        isChannelAllowlisted,
         content: message.content.slice(0, 100),
       });
 

--- a/packages/adapter-discord/src/index.ts
+++ b/packages/adapter-discord/src/index.ts
@@ -122,6 +122,7 @@ export class DiscordAdapter implements Adapter<DiscordThreadId, unknown> {
   protected readonly applicationId: string;
   protected readonly mentionRoleIds: string[];
   protected readonly contentFormat: DiscordContentFormat;
+  protected readonly respondToChannelIds: string[];
   protected readonly respondToGlobalMentions: boolean;
   protected readonly interactionFlags?: DiscordAdapterConfig["interactionFlags"];
   protected chat: ChatInstance | null = null;
@@ -180,6 +181,7 @@ export class DiscordAdapter implements Adapter<DiscordThreadId, unknown> {
       );
     }
 
+    this.respondToChannelIds = config.respondToChannelIds ?? [];
     this.respondToGlobalMentions = config.respondToGlobalMentions ?? false;
     this.botUserId = applicationId; // Discord app ID is the bot's user ID
     this.contentFormat = contentFormat;
@@ -854,7 +856,10 @@ export class DiscordAdapter implements Adapter<DiscordThreadId, unknown> {
     const isEveryoneMentioned =
       this.respondToGlobalMentions && data.mention_everyone === true;
     const isMentioned =
-      isUserMentioned || isRoleMentioned || isEveryoneMentioned;
+      isUserMentioned ||
+      isRoleMentioned ||
+      isEveryoneMentioned ||
+      (!data.author.bot && this.respondToChannelIds.includes(parentChannelId));
 
     // If mentioned and not in a thread, create one
     if (!discordThreadId && isMentioned) {
@@ -2037,11 +2042,44 @@ export class DiscordAdapter implements Adapter<DiscordThreadId, unknown> {
           type: packet.t,
         });
 
+        let data = packet.d;
+        if (
+          packet.t === "MESSAGE_CREATE" &&
+          this.respondToChannelIds.length > 0
+        ) {
+          const message = packet.d as DiscordGatewayMessageData;
+          if (
+            !(
+              message.author.bot ||
+              this.respondToChannelIds.includes(message.channel_id)
+            )
+          ) {
+            const channel = await client.channels
+              .fetch(message.channel_id)
+              .catch((error) => {
+                this.logger.warn(
+                  "Failed to resolve forwarded message channel",
+                  {
+                    channelId: message.channel_id,
+                    error: String(error),
+                  }
+                );
+                return null;
+              });
+            if (channel?.isThread() && channel.parentId) {
+              data = {
+                ...message,
+                thread: { id: channel.id, parent_id: channel.parentId },
+              };
+            }
+          }
+        }
+
         // Forward to webhook
         await this.forwardGatewayEvent(webhookUrl, {
           type: `GATEWAY_${packet.t}` as DiscordGatewayEventType,
           timestamp: Date.now(),
-          data: packet.d,
+          data,
         });
       });
     } else {
@@ -2140,7 +2178,14 @@ export class DiscordAdapter implements Adapter<DiscordThreadId, unknown> {
       const isEveryoneMentioned =
         this.respondToGlobalMentions && message.mentions.everyone;
       const isMentioned =
-        isUserMentioned || isRoleMentioned || isEveryoneMentioned;
+        isUserMentioned ||
+        isRoleMentioned ||
+        isEveryoneMentioned ||
+        this.respondToChannelIds.includes(
+          message.channel.isThread()
+            ? (message.channel.parentId ?? message.channelId)
+            : message.channelId
+        );
 
       this.logger.info("Discord Gateway message received", {
         channelId: message.channelId,

--- a/packages/adapter-discord/src/index.ts
+++ b/packages/adapter-discord/src/index.ts
@@ -2066,7 +2066,11 @@ export class DiscordAdapter implements Adapter<DiscordThreadId, unknown> {
                 );
                 return null;
               });
-            if (channel?.isThread() && channel.parentId) {
+            if (
+              channel?.isThread() &&
+              channel.parentId &&
+              this.respondToChannelIds.includes(channel.parentId)
+            ) {
               data = {
                 ...message,
                 thread: { id: channel.id, parent_id: channel.parentId },

--- a/packages/adapter-discord/src/types.ts
+++ b/packages/adapter-discord/src/types.ts
@@ -39,7 +39,7 @@ export interface DiscordAdapterConfig {
   mentionRoleIds?: string[];
   /** Discord application public key for webhook signature verification. Defaults to DISCORD_PUBLIC_KEY env var. */
   publicKey?: string;
-  /** Parent channel IDs whose non-bot messages, including messages in child threads, should trigger mention handlers without a mention. Defaults to an empty array. */
+  /** Parent channel IDs whose non-bot messages, including messages in child threads, should trigger mention handlers without a mention. Defaults to DISCORD_RESPOND_TO_CHANNEL_IDS env var (comma-separated), or an empty array. */
   respondToChannelIds?: string[];
   /** Treat @everyone/@here pings as mentions of the bot. Defaults to false. */
   respondToGlobalMentions?: boolean;

--- a/packages/adapter-discord/src/types.ts
+++ b/packages/adapter-discord/src/types.ts
@@ -39,6 +39,8 @@ export interface DiscordAdapterConfig {
   mentionRoleIds?: string[];
   /** Discord application public key for webhook signature verification. Defaults to DISCORD_PUBLIC_KEY env var. */
   publicKey?: string;
+  /** Parent channel IDs whose non-bot messages, including messages in child threads, should trigger mention handlers without a mention. Defaults to an empty array. */
+  respondToChannelIds?: string[];
   /** Treat @everyone/@here pings as mentions of the bot. Defaults to false. */
   respondToGlobalMentions?: boolean;
   /** Override bot username (optional) */

--- a/packages/chat/src/adapters/index.ts
+++ b/packages/chat/src/adapters/index.ts
@@ -258,6 +258,10 @@ export const ADAPTERS = {
           "DISCORD_MENTION_ROLE_IDS",
           "Comma-separated role IDs that should trigger mention handlers."
         ),
+        env(
+          "DISCORD_RESPOND_TO_CHANNEL_IDS",
+          "Comma-separated parent channel IDs whose non-bot messages trigger mention handlers without an @mention."
+        ),
         urlEnv("DISCORD_API_URL", "Override the Discord API base URL."),
       ],
       required: [


### PR DESCRIPTION
## Summary

Adds an opt-in `respondToChannelIds` Discord adapter option. Non-bot messages in configured parent channels and their child threads are routed through mention handlers without requiring an @mention; top-level messages keep the adapter's existing automatic thread creation, and forwarded Gateway packets preserve the parent channel for thread replies.

I understand this might be something you want to keep out but I find it very useful for my own "Hermes-like" agent :)

## Test plan

- `pnpm --filter @chat-adapter/discord test`
- `pnpm --filter @chat-adapter/discord typecheck`
- `pnpm check`
- `pnpm konsistent`
- `pnpm typecheck`
- `pnpm validate`

## Checklist

- [x] All commits are signed and verified
- [x] All commits are signed off for the DCO (`git commit -s`)
- [x] `pnpm validate` passes
- [x] Changeset added (or N/A — see [CONTRIBUTING.md](./CONTRIBUTING.md))
- [x] Documentation updated (or N/A)
