### PR TITLE
feat(slack): expose author email on incoming messages

### DIFF
--- a/.changeset/slack-author-email.md
+++ b/.changeset/slack-author-email.md
@@ -1,0 +1,5 @@
+---
+"@chat-adapter/slack": minor
+---
+
+Expose sender email addresses on normalized incoming Slack message authors. `message.author.email` is populated from the same cached `users.info` lookup used for display names and requires the `users:read.email` scope; without it the field stays undefined.

--- a/apps/docs/content/adapters/official/slack.mdx
+++ b/apps/docs/content/adapters/official/slack.mdx
@@ -479,6 +479,8 @@ settings:
     request_url: https://your-domain.com/api/webhooks/slack
 ```
 
+To expose sender email addresses on incoming messages (`message.author.email`), also add the `users:read.email` scope. Without it the field is `undefined`.
+
 After creating the app, copy:
 
 - **Signing Secret** → `SLACK_SIGNING_SECRET`

--- a/packages/adapter-slack/README.md
+++ b/packages/adapter-slack/README.md
@@ -428,6 +428,10 @@ SLACK_API_URL=...                    # Optional, for GovSlack or a self-hosted g
 | Fetch channel info | Yes |
 | Post channel message | Yes |
 
+### Author emails
+
+Incoming message authors include `message.author.email` when your app has the `users:read.email` scope (add it to the manifest alongside `users:read`). Without the scope, or when Slack omits the profile email, the field is `undefined`. The email comes from the same cached `users.info` lookup the adapter already performs for display names, so no extra API call is made per message.
+
 ### Platform-specific
 
 | Feature | Supported |

--- a/packages/adapter-slack/src/index.test.ts
+++ b/packages/adapter-slack/src/index.test.ts
@@ -7647,6 +7647,118 @@ describe("reverse user lookup", () => {
     });
   });
 
+  describe("incoming author email", () => {
+    interface ParsingAdapter {
+      parseSlackMessage(
+        event: Record<string, unknown>,
+        threadId: string
+      ): Promise<{ author: Record<string, unknown> }>;
+    }
+
+    const humanEvent = {
+      type: "message",
+      user: "U_HUMAN_1",
+      text: "Hello",
+      ts: "1234567890.123456",
+      channel: "C123",
+    };
+
+    it("hydrates author email from users.info", async () => {
+      const { adapter } = createAdapterWithState();
+      const mockClient = (
+        adapter as unknown as { _client: { users: { info: unknown } } }
+      )._client;
+      mockClient.users.info = vi.fn().mockResolvedValue({
+        user: {
+          profile: {
+            display_name: "Alice",
+            real_name: "Alice Example",
+            email: "alice@example.com",
+          },
+          real_name: "Alice Example",
+          name: "alice",
+        },
+      });
+
+      const message = await (
+        adapter as unknown as ParsingAdapter
+      ).parseSlackMessage(humanEvent, "slack:C123:1234567890.123456");
+
+      expect(message.author.email).toBe("alice@example.com");
+    });
+
+    it("leaves email undefined when the profile has none", async () => {
+      const { adapter } = createAdapterWithState();
+      const mockClient = (
+        adapter as unknown as { _client: { users: { info: unknown } } }
+      )._client;
+      mockClient.users.info = vi.fn().mockResolvedValue({
+        user: {
+          profile: { display_name: "Alice", real_name: "Alice Example" },
+          real_name: "Alice Example",
+          name: "alice",
+        },
+      });
+
+      const message = await (
+        adapter as unknown as ParsingAdapter
+      ).parseSlackMessage(humanEvent, "slack:C123:1234567890.123456");
+
+      expect(message.author.email).toBeUndefined();
+    });
+
+    it("leaves email undefined when the user lookup is skipped", async () => {
+      const { adapter } = createAdapterWithState();
+      const mockClient = (
+        adapter as unknown as { _client: { users: { info: unknown } } }
+      )._client;
+      const usersInfoMock = vi.fn();
+      mockClient.users.info = usersInfoMock;
+
+      const message = await (
+        adapter as unknown as ParsingAdapter
+      ).parseSlackMessage(
+        { ...humanEvent, username: "webhook-bot", user: undefined },
+        "slack:C123:1234567890.123456"
+      );
+
+      expect(usersInfoMock).not.toHaveBeenCalled();
+      expect(message.author.email).toBeUndefined();
+    });
+
+    it("serves email from the user cache without a second users.info call", async () => {
+      const { adapter } = createAdapterWithState();
+      const mockClient = (
+        adapter as unknown as { _client: { users: { info: unknown } } }
+      )._client;
+      const usersInfoMock = vi.fn().mockResolvedValue({
+        user: {
+          profile: {
+            display_name: "Alice",
+            real_name: "Alice Example",
+            email: "alice@example.com",
+          },
+          real_name: "Alice Example",
+          name: "alice",
+        },
+      });
+      mockClient.users.info = usersInfoMock;
+
+      const parsingAdapter = adapter as unknown as ParsingAdapter;
+      await parsingAdapter.parseSlackMessage(
+        humanEvent,
+        "slack:C123:1234567890.123456"
+      );
+      const second = await parsingAdapter.parseSlackMessage(
+        humanEvent,
+        "slack:C123:1234567890.123456"
+      );
+
+      expect(usersInfoMock).toHaveBeenCalledOnce();
+      expect(second.author.email).toBe("alice@example.com");
+    });
+  });
+
   describe("user_change event", () => {
     it("invalidates user cache on profile change", async () => {
       const state = createMockState();

--- a/packages/adapter-slack/src/index.ts
+++ b/packages/adapter-slack/src/index.ts
@@ -3066,12 +3066,14 @@ export class SlackAdapter implements Adapter<SlackThreadId, unknown> {
     // since Slack events only include the user ID, not the username
     let userName = event.username || "unknown";
     let fullName = event.username || "unknown";
+    let email: string | undefined;
 
     // If we have a user ID but no username, look up the user info
     if (event.user && !event.username) {
       const userInfo = await this.lookupUser(event.user);
       userName = userInfo?.displayName ?? event.user;
       fullName = userInfo?.realName ?? userName;
+      email = userInfo?.email;
     }
 
     // Track thread participants for outgoing mention resolution (skip dupes)
@@ -3109,6 +3111,7 @@ export class SlackAdapter implements Adapter<SlackThreadId, unknown> {
         userId: event.user || event.bot_id || "unknown",
         userName,
         fullName,
+        email,
         isBot: !!event.bot_id,
         isSystem: event.user === SLACK_SYSTEM_USER_ID,
         isMe,


### PR DESCRIPTION
## Summary

Slack counterpart to #711: populates `message.author.email` on normalized incoming Slack messages.

Unlike Teams, no new lookup was needed — `parseSlackMessage` already resolves the sender via the state-cached `users.info` call (`lookupUser`), and the cached profile already carried `email`. This change threads that value onto the author, so there is no additional API call per message. The email is only present when the app has the `users:read.email` scope; otherwise (or when the lookup is skipped, e.g. webhook posts with a `username`) the field stays `undefined`.

Also documents the optional scope in the adapter README and the docs site manifest section. The core `Author.email` field and serialization already landed in #711, so this is a Slack-only changeset.

## Test plan

- [x] New unit tests: hydration from `users.info`, missing profile email, skipped lookup, and cache reuse across messages
- [x] `pnpm --filter @chat-adapter/slack test` (358 tests)
- [x] `pnpm --filter @chat-adapter/slack typecheck`
- [x] `pnpm validate`

## Checklist

- [x] All commits are signed and verified
- [x] All commits are signed off for the DCO (`git commit -s`)
- [x] `pnpm validate` passes
- [x] Changeset added
- [x] Documentation updated