### PR TITLE
fix(docs): use Claude for Ask AI

### DIFF
--- a/apps/docs/app/api/chat/route.ts
+++ b/apps/docs/app/api/chat/route.ts
@@ -7,7 +7,7 @@ const chatProxyToken = process.env.GEISTDOCS_CHAT_PROXY_TOKEN;
 
 export const { POST, maxDuration } = createChatRoute({
   config,
-  model: "xai/grok-4.5",
+  model: "anthropic/claude-sonnet-5",
   proxy: chatProxyUrl
     ? {
         url: chatProxyUrl,


### PR DESCRIPTION
## Summary

- switch the docs Ask AI route from `xai/grok-4.5` to `anthropic/claude-sonnet-5`
- avoid the team-level xAI provider restriction that prevents chat responses

## Testing

- `pnpm --filter docs exec tsc --noEmit`
- `pnpm --filter docs build`