### PR TITLE
fix(slack): return replyable thread ID from channel posts

### DIFF
--- a/.changeset/slack-channel-post-thread-id.md
+++ b/.changeset/slack-channel-post-thread-id.md
@@ -1,0 +1,5 @@
+---
+"@chat-adapter/slack": patch
+---
+
+Return a replyable Slack thread ID from `channel.post()` by using the posted top-level message's timestamp as the thread root.

--- a/packages/adapter-slack/src/index.test.ts
+++ b/packages/adapter-slack/src/index.test.ts
@@ -5090,6 +5090,7 @@ describe("postChannelMessage", () => {
     );
 
     expect(result.id).toBe("2222222222.000000");
+    expect(result.threadId).toBe("slack:C123:2222222222.000000");
 
     const client = getClient(adapter);
     expect(client.chat.postMessage).toHaveBeenCalledWith(

--- a/packages/adapter-slack/src/index.ts
+++ b/packages/adapter-slack/src/index.ts
@@ -4834,7 +4834,21 @@ export class SlackAdapter implements Adapter<SlackThreadId, unknown> {
     // Use the existing postMessage logic but with no threadTs
     // Build a synthetic thread ID with empty threadTs
     const syntheticThreadId = `slack:${channel}:`;
-    return await this.postMessage(syntheticThreadId, message);
+    const result = await this.postMessage(syntheticThreadId, message);
+
+    if (
+      typeof result.raw !== "object" ||
+      result.raw === null ||
+      !("ts" in result.raw) ||
+      typeof result.raw.ts !== "string"
+    ) {
+      return result;
+    }
+
+    return {
+      ...result,
+      threadId: this.encodeThreadId({ channel, threadTs: result.raw.ts }),
+    };
   }
 
   renderFormatted(content: FormattedContent): string {


### PR DESCRIPTION
## summary

fixes #719

updates Slack channel posts to return a replyable thread ID rooted at the newly posted top-level message

`postChannelMessage` still omits `thread_ts` for the initial channel post, then uses Slack's returned message `ts` to construct `slack:<channel>:<ts>` for the `SentMessage`

this allows `chat.thread(sent.threadId).post(...)` to reply to a message returned by `channel.post(...)` instead of creating another top-level channel message

file-only uploads without a Slack message `ts` keep their existing channel-scoped thread ID

## test plan

- added a Slack adapter regression assertion that `postChannelMessage` returns `slack:C123:<message ts>`
- ran the `@chat-adapter/slack` test suite
- ran `pnpm validate`

## checklist

- [x] all commits are signed and verified
- [x] targeted builds and tests pass
- [x] changeset added or not applicable
- [x] documentation updated or not applicable
