### PR TITLE
fix(discord): angle-wrapped markdown autolinks

### DIFF
--- a/.changeset/discord-angle-autolinks.md
+++ b/.changeset/discord-angle-autolinks.md
@@ -1,0 +1,5 @@
+---
+"@chat-adapter/discord": patch
+---
+
+Preserve Discord angle-wrapped markdown autolinks so link previews can be suppressed.

--- a/packages/adapter-discord/src/index.test.ts
+++ b/packages/adapter-discord/src/index.test.ts
@@ -1535,6 +1535,31 @@ describe("postMessage", () => {
     spy.mockRestore();
   });
 
+  it("preserves angle-wrapped autolinks in markdown message payloads", async () => {
+    const mockResponse = new Response(
+      JSON.stringify({
+        id: "msg-autolink",
+        channel_id: "channel456",
+        content: "<https://google.com>",
+        timestamp: "2021-01-01T00:00:00.000Z",
+        author: { id: "test-app-id", username: "bot" },
+      }),
+      { status: 200, headers: { "Content-Type": "application/json" } }
+    );
+    const spy = vi
+      .spyOn(adapter as any, "discordFetch")
+      .mockResolvedValue(mockResponse);
+
+    await adapter.postMessage("discord:guild1:channel456", {
+      markdown: "<https://google.com>",
+    });
+
+    const calledPayload = spy.mock.calls[0]?.[2] as { content?: string };
+    expect(calledPayload.content).toBe("<https://google.com>");
+
+    spy.mockRestore();
+  });
+
   it("posts to thread channel when threadId is present", async () => {
     const mockResponse = new Response(
       JSON.stringify({

--- a/packages/adapter-discord/src/markdown.test.ts
+++ b/packages/adapter-discord/src/markdown.test.ts
@@ -34,16 +34,16 @@ describe("DiscordFormatConverter", () => {
       // a bare URL as `[url](url)` shows up as literal text in a normal message.
       const ast = converter.toAst("https://example.com");
       const result = converter.fromAst(ast);
-      expect(result).toContain("https://example.com");
+      expect(result).toBe("https://example.com");
       expect(result).not.toContain(
         "[https://example.com](https://example.com)"
       );
     });
 
-    it("should render an autolink as a bare URL, not a masked link", () => {
+    it("should preserve an angle-wrapped autolink", () => {
       const ast = converter.toAst("<https://example.com>");
       const result = converter.fromAst(ast);
-      expect(result).toContain("https://example.com");
+      expect(result).toBe("<https://example.com>");
       expect(result).not.toContain(
         "[https://example.com](https://example.com)"
       );
@@ -256,6 +256,13 @@ describe("DiscordFormatConverter", () => {
       });
       expect(result).toContain("**world**");
       expect(result).toContain("<@user>");
+    });
+
+    it("should preserve angle-wrapped autolinks in markdown messages", () => {
+      const result = converter.renderPostable({
+        markdown: "<https://example.com>",
+      });
+      expect(result).toBe("<https://example.com>");
     });
 
     it("should handle empty message", () => {

--- a/packages/adapter-discord/src/markdown.ts
+++ b/packages/adapter-discord/src/markdown.ts
@@ -30,6 +30,7 @@ import {
   isStrongNode,
   isTableNode,
   isTextNode,
+  type Link,
   parseMarkdown,
   type Root,
   tableToAscii,
@@ -147,9 +148,14 @@ export class DiscordFormatConverter extends BaseFormatConverter {
       const linkText = getNodeChildren(node)
         .map((child) => this.nodeToDiscordMarkdown(child))
         .join("");
-      // Bare URLs / autolinks (label === url) must stay bare: Discord only
-      // renders masked links `[text](url)` inside embeds, so `[url](url)` in a
-      // normal message shows up as literal text instead of a clickable link.
+
+      if (isAngleWrappedAutolink(node, linkText)) {
+        return `<${node.url}>`;
+      }
+
+      // Bare URLs (label === url) must stay bare: Discord only renders masked
+      // links `[text](url)` inside embeds, so `[url](url)` in a normal message
+      // shows up as literal text instead of a clickable link.
       if (linkText === node.url) {
         return node.url;
       }
@@ -185,4 +191,31 @@ export class DiscordFormatConverter extends BaseFormatConverter {
       this.nodeToDiscordMarkdown(child)
     );
   }
+}
+
+// Check if a link is an angle-wrapped URL autolink.
+// Angle-wrapped autolinks are <http://example.com> or <https://example.com>.
+function isAngleWrappedAutolink(node: Link, linkText: string): boolean {
+  const isWebUrl =
+    node.url.startsWith("http://") || node.url.startsWith("https://");
+  if (linkText !== node.url || !isWebUrl) {
+    return false;
+  }
+
+  const child = node.children[0];
+  if (node.children.length !== 1 || child?.type !== "text") {
+    return false;
+  }
+
+  const linkStart = node.position?.start.offset;
+  const linkEnd = node.position?.end.offset;
+  const textStart = child.position?.start.offset;
+  const textEnd = child.position?.end.offset;
+
+  return (
+    linkStart !== undefined &&
+    linkEnd !== undefined &&
+    textStart === linkStart + 1 &&
+    textEnd === linkEnd - 1
+  );
 }


### PR DESCRIPTION
Fixes #692

## Summary

Fixes Discord markdown rendering for angle-wrapped autolinks so link previews can be suppressed.

Previously:

```ts
 await thread.post({ markdown: "<https://google.com>" });
```

was sent to Discord as:

```txt
 https://google.com
```
<img width="585" height="122" alt="image" src="https://github.com/user-attachments/assets/cd96691b-ff1e-48e7-8550-3669257d1699" />

Now it is preserved as:

```txt
 <https://google.com>
```
<img width="250" height="39" alt="image" src="https://github.com/user-attachments/assets/7dd66ff3-7b43-4996-8559-6255b8722aa5" />


## Test plan
- pnpm validate
- Tested locally against a real Discord bot

## Checklist

- [x] All commits are signed and verified
- [x] All commits are signed off for the DCO (`git commit -s`)
- [x] `pnpm validate` passes
- [x] Changeset added (or N/A — see [CONTRIBUTING.md](./CONTRIBUTING.md))
- [ ] Documentation updated (or N/A)
