### PR TITLE
fix(whatsapp): model forwarded and product-inquiry context variants in WhatsAppInboundMessage

### DIFF
--- a/.changeset/whatsapp-context-variants.md
+++ b/.changeset/whatsapp-context-variants.md
@@ -1,0 +1,5 @@
+---
+"@chat-adapter/whatsapp": patch
+---
+
+Fix the `WhatsAppInboundMessage.context` type to model all documented webhook variants. The type previously declared `context?: { from: string; id: string }`, but Meta's Cloud API sends mutually exclusive context shapes: quoted replies carry `from`/`id`, forwarded messages carry only `forwarded` or `frequently_forwarded` (no `id`), and catalog product inquiries add `referred_product`. Code narrowed by the old type could dereference `context.id` and crash at runtime on forwarded messages. All context fields are now optional and the forwarded/product-inquiry fields are included.

--- a/.changeset/whatsapp-context-variants.md
+++ b/.changeset/whatsapp-context-variants.md
@@ -1,5 +1,5 @@
 ---
-"@chat-adapter/whatsapp": patch
+"@chat-adapter/whatsapp": minor
 ---
 
-Fix the `WhatsAppInboundMessage.context` type to model all documented webhook variants. The type previously declared `context?: { from: string; id: string }`, but Meta's Cloud API sends mutually exclusive context shapes: quoted replies carry `from`/`id`, forwarded messages carry only `forwarded` or `frequently_forwarded` (no `id`), and catalog product inquiries add `referred_product`. Code narrowed by the old type could dereference `context.id` and crash at runtime on forwarded messages. All context fields are now optional and the forwarded/product-inquiry fields are included.
+Fix the `WhatsAppInboundMessage.context` type to model all documented webhook variants. The type previously declared `context?: { from: string; id: string }`, but Meta's Cloud API sends mutually exclusive context shapes: quoted replies carry `from`/`id`, forwarded messages carry only `forwarded` or `frequently_forwarded` (no `id`), and catalog product inquiries add `referred_product`. Code narrowed by the old type could dereference `context.id` and crash at runtime on forwarded messages. All context fields are now optional and the forwarded/product-inquiry fields are included. Consumers that dereference `context.from` or `context.id` without a guard will now see a type error, surfacing what was already a latent crash on forwarded messages.

--- a/packages/adapter-whatsapp/src/types.ts
+++ b/packages/adapter-whatsapp/src/types.ts
@@ -127,10 +127,30 @@ export interface WhatsAppInboundMessage {
     payload: string;
     text: string;
   };
-  /** Context for quoted replies */
+  /**
+   * Context accompanying quoted replies, forwarded messages, and catalog
+   * product inquiries. The shape depends on the message origin: replies (and
+   * interactions with a business message) carry `from` and `id`, forwarded
+   * messages carry only `forwarded` or `frequently_forwarded`, and catalog
+   * product inquiries add `referred_product`. No field is present in every
+   * variant.
+   *
+   * @see https://developers.facebook.com/documentation/business-messaging/whatsapp/webhooks/reference/messages/text
+   */
   context?: {
-    from: string;
-    id: string;
+    /** True when the message was forwarded five or fewer times; forwards only */
+    forwarded?: boolean;
+    /** True when the message was forwarded more than five times; forwards only */
+    frequently_forwarded?: boolean;
+    /** WhatsApp ID of the sender of the quoted message; replies only */
+    from?: string;
+    /** ID of the quoted message; replies only */
+    id?: string;
+    /** Product the customer is asking about; catalog inquiries only */
+    referred_product?: {
+      catalog_id: string;
+      product_retailer_id: string;
+    };
   };
   /** Document message content */
   document?: {

--- a/packages/adapter-whatsapp/src/types.ts
+++ b/packages/adapter-whatsapp/src/types.ts
@@ -142,9 +142,16 @@ export interface WhatsAppInboundMessage {
     forwarded?: boolean;
     /** True when the message was forwarded more than five times; forwards only */
     frequently_forwarded?: boolean;
-    /** WhatsApp ID of the sender of the quoted message; replies only */
+    /**
+     * Sender of the quoted message on a reply, or the business display phone
+     * number when the message came from a "Message business" button. Absent on
+     * forwards.
+     */
     from?: string;
-    /** ID of the quoted message; replies only */
+    /**
+     * ID of the quoted message on a reply, or of the message the user tapped
+     * "Message business" from. Absent on forwards.
+     */
     id?: string;
     /** Product the customer is asking about; catalog inquiries only */
     referred_product?: {


### PR DESCRIPTION
## Problem

`WhatsAppInboundMessage.context` is typed as:

```ts
/** Context for quoted replies */
context?: {
  from: string;
  id: string;
};
```

But Meta's Cloud API webhook sends **mutually exclusive context shapes** depending on message origin ([text messages webhook reference](https://developers.facebook.com/documentation/business-messaging/whatsapp/webhooks/reference/messages/text)):

- **Quoted replies** (and interactions with a business message): `from` + `id`
- **Forwarded messages**: only `forwarded` ("only included if forwarded 5 times or less") or `frequently_forwarded` ("only included if forwarded more than 5 times") — **no `id`, no `from`**
- **Catalog product inquiries**: `from` + `id` + `referred_product`

Because the type declares `id` required whenever `context` is present, downstream code like `message.raw.message.context?.id.trim()` type-checks cleanly and then throws a `TypeError` at runtime the first time a user forwards a message to the bot — `context` exists, `id` doesn't. We hit exactly this in production code building reply-to handling on top of the adapter.

## Change

- All `context` fields are optional, and the forwarded/product-inquiry fields (`forwarded`, `frequently_forwarded`, `referred_product`) are added, with doc comments noting which variant each field belongs to.
- Changeset included (`@chat-adapter/whatsapp`: patch).

The adapter itself never reads `context` at runtime, so this is a type-only change. Consumers who currently dereference `context.id` unguarded will get a compile error after upgrading — intentionally, since that code is a latent runtime crash on forwarded messages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)