### PR TITLE
fix(discord): Suppress link previews in markdown

### DIFF
--- a/.changeset/discord-suppress-link-previews.md
+++ b/.changeset/discord-suppress-link-previews.md
@@ -1,0 +1,5 @@
+---
+"@chat-adapter/discord": patch
+---
+
+Preserve Discord's angle-bracket syntax for suppressing link previews when rendering markdown.

--- a/packages/adapter-discord/src/index.test.ts
+++ b/packages/adapter-discord/src/index.test.ts
@@ -1535,6 +1535,33 @@ describe("postMessage", () => {
     spy.mockRestore();
   });
 
+  it("preserves suppressed links in the Discord API payload", async () => {
+    const markdown = "<https://google.com> [Google](<https://google.com>)";
+    const mockResponse = new Response(
+      JSON.stringify({
+        id: "msg-suppressed-links",
+        channel_id: "channel456",
+        content: markdown,
+        timestamp: "2021-01-01T00:00:00.000Z",
+        author: { id: "test-app-id", username: "bot" },
+      }),
+      { status: 200, headers: { "Content-Type": "application/json" } }
+    );
+    const spy = vi
+      .spyOn(adapter as any, "discordFetch")
+      .mockResolvedValue(mockResponse);
+
+    await adapter.postMessage("discord:guild1:channel456", { markdown });
+
+    expect(spy).toHaveBeenCalledWith(
+      "/channels/channel456/messages",
+      "POST",
+      expect.objectContaining({ content: markdown })
+    );
+
+    spy.mockRestore();
+  });
+
   it("posts to thread channel when threadId is present", async () => {
     const mockResponse = new Response(
       JSON.stringify({

--- a/packages/adapter-discord/src/markdown.test.ts
+++ b/packages/adapter-discord/src/markdown.test.ts
@@ -40,13 +40,21 @@ describe("DiscordFormatConverter", () => {
       );
     });
 
-    it("should render an autolink as a bare URL, not a masked link", () => {
+    it("should preserve angle brackets on an autolink to suppress its embed", () => {
       const ast = converter.toAst("<https://example.com>");
       const result = converter.fromAst(ast);
-      expect(result).toContain("https://example.com");
-      expect(result).not.toContain(
-        "[https://example.com](https://example.com)"
-      );
+      expect(result).toBe("<https://example.com>");
+    });
+
+    it("should preserve angle brackets in a masked link destination", () => {
+      const ast = converter.toAst("[link text](<https://example.com>)");
+      const result = converter.fromAst(ast);
+      expect(result).toBe("[link text](<https://example.com>)");
+    });
+
+    it("should preserve a masked link whose label matches its URL", () => {
+      const input = "[https://example.com](<https://example.com>)";
+      expect(converter.fromAst(converter.toAst(input))).toBe(input);
     });
 
     it("should preserve inline code", () => {
@@ -107,6 +115,20 @@ describe("DiscordFormatConverter", () => {
   });
 
   describe("renderPostable (mentions)", () => {
+    it("should preserve a preview-suppressed link in markdown", () => {
+      expect(
+        converter.renderPostable({ markdown: "<https://example.com>" })
+      ).toBe("<https://example.com>");
+    });
+
+    it("should preserve a preview-suppressed masked link in markdown", () => {
+      expect(
+        converter.renderPostable({
+          markdown: "[link text](<https://example.com>)",
+        })
+      ).toBe("[link text](<https://example.com>)");
+    });
+
     it("should convert a bare mention in raw text", () => {
       expect(converter.renderPostable({ raw: "hey @alice" })).toContain(
         "<@alice>"

--- a/packages/adapter-discord/src/markdown.ts
+++ b/packages/adapter-discord/src/markdown.ts
@@ -201,7 +201,8 @@ export class DiscordFormatConverter extends BaseFormatConverter {
       const linkText = children
         .map((child) => this.nodeToDiscordMarkdown(child))
         .join("");
-      const discordLinkStyle = (node.data as DiscordLinkData | undefined)?.discordLinkStyle;
+      const discordLinkStyle = (node.data as DiscordLinkData | undefined)
+        ?.discordLinkStyle;
       if (discordLinkStyle === DiscordLinkStyle.SuppressedAutolink) {
         return `<${node.url}>`;
       }

--- a/packages/adapter-discord/src/markdown.ts
+++ b/packages/adapter-discord/src/markdown.ts
@@ -35,6 +35,29 @@ import {
   tableToAscii,
 } from "chat";
 
+const SUPPRESSED_AUTOLINK_REGEX = /^<https?:\/\/[^<>\s]+>$/i;
+const SUPPRESSED_MASKED_LINK_REGEX = /\]\(<https?:\/\/[^<>\s]+>\)$/i;
+
+// biome-ignore lint/style/noEnum: Link styles must use an enum.
+enum DiscordLinkStyle {
+  SuppressedAutolink = "suppressed-autolink",
+  SuppressedMaskedLink = "suppressed-masked-link",
+}
+
+interface DiscordLinkData {
+  discordLinkStyle?: DiscordLinkStyle;
+}
+
+function getDiscordLinkStyle(source: string): DiscordLinkStyle | undefined {
+  if (SUPPRESSED_AUTOLINK_REGEX.test(source)) {
+    return DiscordLinkStyle.SuppressedAutolink;
+  }
+  if (SUPPRESSED_MASKED_LINK_REGEX.test(source)) {
+    return DiscordLinkStyle.SuppressedMaskedLink;
+  }
+  return undefined;
+}
+
 export class DiscordFormatConverter extends BaseFormatConverter {
   /**
    * Convert bare `@mentions` to Discord format (`@name` → `<@name>`), leaving
@@ -55,7 +78,7 @@ export class DiscordFormatConverter extends BaseFormatConverter {
       return this.convertMentionsToDiscord(message.raw);
     }
     if ("markdown" in message) {
-      return this.fromAst(parseMarkdown(message.markdown));
+      return this.fromAst(this.parseDiscordMarkdown(message.markdown));
     }
     if ("ast" in message) {
       return this.fromAst(message.ast);
@@ -95,7 +118,37 @@ export class DiscordFormatConverter extends BaseFormatConverter {
     // (no direct markdown equivalent, convert to placeholder)
     markdown = markdown.replace(/\|\|([^|]+)\|\|/g, "[spoiler: $1]");
 
-    return parseMarkdown(markdown);
+    return this.parseDiscordMarkdown(markdown);
+  }
+
+  /**
+   * mdast normalizes Discord's two angle-bracketed link forms, so retain their
+   * source style in the node's adapter-specific data before rendering.
+   */
+  private parseDiscordMarkdown(markdown: string): Root {
+    const ast = parseMarkdown(markdown);
+    this.markDiscordLinkStyles(ast.children, markdown);
+    return ast;
+  }
+
+  private markDiscordLinkStyles(nodes: Content[], markdown: string): void {
+    for (const node of nodes) {
+      if (isLinkNode(node)) {
+        const start = node.position?.start.offset;
+        const end = node.position?.end.offset;
+
+        if (start !== undefined && end !== undefined) {
+          const source = markdown.slice(start, end);
+          const discordLinkStyle = getDiscordLinkStyle(source);
+
+          if (discordLinkStyle !== undefined) {
+            node.data = { ...node.data, discordLinkStyle };
+          }
+        }
+      }
+
+      this.markDiscordLinkStyles(getNodeChildren(node), markdown);
+    }
   }
 
   private nodeToDiscordMarkdown(node: Content): string {
@@ -144,12 +197,21 @@ export class DiscordFormatConverter extends BaseFormatConverter {
     }
 
     if (isLinkNode(node)) {
-      const linkText = getNodeChildren(node)
+      const children = getNodeChildren(node);
+      const linkText = children
         .map((child) => this.nodeToDiscordMarkdown(child))
         .join("");
-      // Bare URLs / autolinks (label === url) must stay bare: Discord only
-      // renders masked links `[text](url)` inside embeds, so `[url](url)` in a
-      // normal message shows up as literal text instead of a clickable link.
+      const discordLinkStyle = (node.data as DiscordLinkData | undefined)?.discordLinkStyle;
+      if (discordLinkStyle === DiscordLinkStyle.SuppressedAutolink) {
+        return `<${node.url}>`;
+      }
+      if (discordLinkStyle === DiscordLinkStyle.SuppressedMaskedLink) {
+        return `[${linkText}](<${node.url}>)`;
+      }
+
+      // Bare URLs (label === url) must stay bare: Discord only renders masked
+      // links `[text](url)` inside embeds, so `[url](url)` in a normal message
+      // shows up as literal text instead of a clickable link.
       if (linkText === node.url) {
         return node.url;
       }


### PR DESCRIPTION
## Summary

Fixes #692 

When bracketed `<link>` or `[text](<link>)` notations are used in Discord markdown, embedded link previews should be suppressed.

We have to identify this notation in the markdown parser and decorate the resulting AST so the `[text](<link>)` notation can be handled as well. Otherwise, this information gets lost along the way.

## Test plan

```
await event.channel.post({ markdown: '<https://google.com>'});
```

<img width="172" height="27" alt="image" src="https://github.com/user-attachments/assets/386ea82d-d00c-4ebd-a29b-b2cd495e973e" />


```
await event.channel.post({ markdown: '[Google](<https://google.com>)'});
```

<img width="199" height="29" alt="image" src="https://github.com/user-attachments/assets/0faea900-1742-482e-b477-0b5e5ac87316" />


## Checklist

- [x] All commits are signed and verified
- [x] All commits are signed off for the DCO (`git commit -s`)
- [x] `pnpm validate` passes
- [x] Changeset added (or N/A — see [CONTRIBUTING.md](./CONTRIBUTING.md))
- [x] Documentation updated (or N/A)
