### PR TITLE
feat(teams): support outbound reactions

### DIFF
--- a/.changeset/calm-teams-react.md
+++ b/.changeset/calm-teams-react.md
@@ -1,0 +1,5 @@
+---
+"@chat-adapter/teams": minor
+---
+
+Add support for adding and removing reactions from Microsoft Teams messages.

--- a/apps/docs/content/adapters/official/teams.mdx
+++ b/apps/docs/content/adapters/official/teams.mdx
@@ -30,8 +30,8 @@ features:
   modals: yes
   slashCommands: no
   mentions: yes
-  addReactions: no
-  removeReactions: no
+  addReactions: yes
+  removeReactions: yes
   typingIndicator: yes
   directMessages: yes
   ephemeralMessages: no

--- a/packages/adapter-teams/README.md
+++ b/packages/adapter-teams/README.md
@@ -185,8 +185,8 @@ TEAMS_API_URL=...        # Optional, for GCC-High or sovereign-cloud deployments
 |---------|-----------|
 | Slash commands | No |
 | Mentions | Yes |
-| Add reactions | No |
-| Remove reactions | No |
+| Add reactions | Yes |
+| Remove reactions | Yes |
 | Receive reactions | Yes |
 | Typing indicator | Yes |
 | DMs | Yes |

--- a/packages/adapter-teams/package.json
+++ b/packages/adapter-teams/package.json
@@ -52,15 +52,15 @@
   },
   "dependencies": {
     "@chat-adapter/shared": "workspace:*",
-    "@microsoft/teams.api": "^2.0.8",
-    "@microsoft/teams.apps": "^2.0.8",
-    "@microsoft/teams.cards": "^2.0.8",
-    "@microsoft/teams.graph-endpoints": "^2.0.8",
+    "@microsoft/teams.api": "^2.0.14",
+    "@microsoft/teams.apps": "^2.0.14",
+    "@microsoft/teams.cards": "^2.0.14",
+    "@microsoft/teams.graph-endpoints": "^2.0.14",
     "chat": "workspace:*"
   },
   "devDependencies": {
-    "@microsoft/teams.graph": "^2.0.8",
     "@chat-adapter/tests": "workspace:*",
+    "@microsoft/teams.graph": "^2.0.14",
     "@types/node": "^25.3.2",
     "tsup": "^8.3.5",
     "typescript": "^5.7.2",

--- a/packages/adapter-teams/src/index.test.ts
+++ b/packages/adapter-teams/src/index.test.ts
@@ -8,7 +8,7 @@ import {
   threadIdContract,
 } from "@chat-adapter/tests";
 import type { IStreamer } from "@microsoft/teams.apps";
-import { ConsoleLogger } from "chat";
+import { ConsoleLogger, getEmoji } from "chat";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { createTeamsAdapter, TeamsAdapter, type TeamsThreadId } from "./index";
 
@@ -1049,6 +1049,88 @@ describe("TeamsAdapter", () => {
         adapter.deleteMessage(threadId, "del-msg-1")
       ).resolves.not.toThrow();
       expect(mockDelete).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("reactions", () => {
+    function createReactionTestAdapter() {
+      const adapter = createTeamsAdapter({
+        appId: "test-app-id",
+        appPassword: "test",
+        logger,
+      });
+      const addReaction = vi.fn(async () => undefined);
+      const deleteReaction = vi.fn(async () => undefined);
+      const mockApp = (adapter as unknown as { app: { api: unknown } }).app;
+      mockApp.api = {
+        conversations: {
+          addReaction,
+          deleteReaction,
+        },
+        serviceUrl: "https://smba.trafficmanager.net/teams/",
+      };
+
+      const threadId = adapter.encodeThreadId({
+        conversationId: "19:abc@thread.tacv2",
+        serviceUrl: "https://smba.trafficmanager.net/teams/",
+      });
+
+      return { adapter, addReaction, deleteReaction, threadId };
+    }
+
+    it("should add a raw Teams reaction ID", async () => {
+      const { adapter, addReaction, threadId } = createReactionTestAdapter();
+
+      await adapter.addReaction(threadId, "message-1", "think");
+
+      expect(addReaction).toHaveBeenCalledWith(
+        "19:abc@thread.tacv2",
+        "message-1",
+        "think"
+      );
+    });
+
+    it.each([
+      ["check", "2705_whiteheavycheckmark"],
+      ["eyes", "1f440_eyes"],
+      ["pin", "1f4cc_pushpin"],
+      ["rocket", "launch"],
+      ["thinking", "think"],
+      ["thumbs_up", "like"],
+      ["x", "274c_crossmark"],
+    ])("should map %s to the Teams reaction ID %s", async (name, teamsId) => {
+      const { adapter, addReaction, threadId } = createReactionTestAdapter();
+
+      await adapter.addReaction(threadId, "message-1", getEmoji(name));
+
+      expect(addReaction).toHaveBeenCalledWith(
+        "19:abc@thread.tacv2",
+        "message-1",
+        teamsId
+      );
+    });
+
+    it("should remove a reaction with the Teams conversation API", async () => {
+      const { adapter, deleteReaction, threadId } = createReactionTestAdapter();
+
+      await adapter.removeReaction(threadId, "message-1", getEmoji("check"));
+
+      expect(deleteReaction).toHaveBeenCalledWith(
+        "19:abc@thread.tacv2",
+        "message-1",
+        "2705_whiteheavycheckmark"
+      );
+    });
+
+    it("should translate Teams API failures", async () => {
+      const { adapter, addReaction, threadId } = createReactionTestAdapter();
+      addReaction.mockRejectedValueOnce(
+        new MockTeamsError({ statusCode: 401, message: "Unauthorized" })
+      );
+
+      await expect(
+        adapter.addReaction(threadId, "message-1", "like")
+      ).rejects.toThrow(AuthenticationError);
     });
   });
 

--- a/packages/adapter-teams/src/index.ts
+++ b/packages/adapter-teams/src/index.ts
@@ -86,6 +86,8 @@ const USER_INFO_NEGATIVE_CACHE_TTL_MS = 5 * 60 * 1000; // 5 minutes
 // consent don't pay a failing network call on every message.
 const USER_INFO_NEGATIVE_SENTINEL = "unresolvable";
 const DEFAULT_DIALOG_OPEN_TIMEOUT_MS = 5000; // Max wait for handler to call openModal()
+// Keep this list to common Chat SDK names that differ from Teams IDs.
+// Other strings are treated as native Teams reaction IDs and pass through.
 const TEAMS_REACTION_ALIASES: Readonly<Record<string, MessageReactionType>> = {
   check: "2705_whiteheavycheckmark",
   eyes: "1f440_eyes",

--- a/packages/adapter-teams/src/index.ts
+++ b/packages/adapter-teams/src/index.ts
@@ -13,6 +13,7 @@ import type {
   IMessageReactionActivity,
   ITaskFetchInvokeActivity,
   ITaskSubmitInvokeActivity,
+  MessageReactionType,
   SentActivity,
   TaskModuleResponse,
 } from "@microsoft/teams.api";
@@ -49,7 +50,6 @@ import {
   convertEmojiPlaceholders,
   defaultEmojiResolver,
   Message,
-  NotImplementedError,
 } from "chat";
 import { BridgeHttpAdapter } from "./bridge-adapter";
 import { AUTO_SUBMIT_ACTION_ID, cardToAdaptiveCard } from "./cards";
@@ -86,6 +86,22 @@ const USER_INFO_NEGATIVE_CACHE_TTL_MS = 5 * 60 * 1000; // 5 minutes
 // consent don't pay a failing network call on every message.
 const USER_INFO_NEGATIVE_SENTINEL = "unresolvable";
 const DEFAULT_DIALOG_OPEN_TIMEOUT_MS = 5000; // Max wait for handler to call openModal()
+const TEAMS_REACTION_ALIASES: Readonly<Record<string, MessageReactionType>> = {
+  check: "2705_whiteheavycheckmark",
+  eyes: "1f440_eyes",
+  pin: "1f4cc_pushpin",
+  rocket: "launch",
+  thinking: "think",
+  thumbs_up: "like",
+  x: "274c_crossmark",
+};
+
+function resolveTeamsReactionType(
+  emoji: EmojiValue | string
+): MessageReactionType {
+  const name = typeof emoji === "string" ? emoji : emoji.name;
+  return TEAMS_REACTION_ALIASES[name] ?? name;
+}
 
 export class TeamsAdapter implements Adapter<TeamsThreadId, unknown> {
   readonly name = "teams";
@@ -741,7 +757,7 @@ export class TeamsAdapter implements Adapter<TeamsThreadId, unknown> {
     const user = {
       userId: activity.from?.id || "unknown",
       userName: activity.from?.name || "unknown",
-      fullName: activity.from?.name,
+      fullName: activity.from?.name || "unknown",
       isBot: false,
       isMe: this.isMessageFromSelf(activity),
     };
@@ -1202,25 +1218,69 @@ export class TeamsAdapter implements Adapter<TeamsThreadId, unknown> {
   }
 
   async addReaction(
-    _threadId: string,
-    _messageId: string,
-    _emoji: EmojiValue | string
+    threadId: string,
+    messageId: string,
+    emoji: EmojiValue | string
   ): Promise<void> {
-    throw new NotImplementedError(
-      "addReaction is not yet supported by the Teams SDK",
-      "addReaction"
-    );
+    const { conversationId } = this.decodeThreadId(threadId);
+    const reactionType = resolveTeamsReactionType(emoji);
+
+    this.logger.debug("Teams API: addReaction", {
+      conversationId,
+      messageId,
+      reactionType,
+    });
+
+    try {
+      await this.app.api.conversations.addReaction(
+        conversationId,
+        messageId,
+        reactionType
+      );
+    } catch (error) {
+      this.logger.error("Teams API: addReaction failed", {
+        conversationId,
+        messageId,
+        reactionType,
+        error,
+      });
+      handleTeamsError(error, "addReaction");
+    }
+
+    this.logger.debug("Teams API: addReaction response", { ok: true });
   }
 
   async removeReaction(
-    _threadId: string,
-    _messageId: string,
-    _emoji: EmojiValue | string
+    threadId: string,
+    messageId: string,
+    emoji: EmojiValue | string
   ): Promise<void> {
-    throw new NotImplementedError(
-      "removeReaction is not yet supported by the Teams SDK",
-      "removeReaction"
-    );
+    const { conversationId } = this.decodeThreadId(threadId);
+    const reactionType = resolveTeamsReactionType(emoji);
+
+    this.logger.debug("Teams API: deleteReaction", {
+      conversationId,
+      messageId,
+      reactionType,
+    });
+
+    try {
+      await this.app.api.conversations.deleteReaction(
+        conversationId,
+        messageId,
+        reactionType
+      );
+    } catch (error) {
+      this.logger.error("Teams API: deleteReaction failed", {
+        conversationId,
+        messageId,
+        reactionType,
+        error,
+      });
+      handleTeamsError(error, "removeReaction");
+    }
+
+    this.logger.debug("Teams API: deleteReaction response", { ok: true });
   }
 
   async startTyping(threadId: string, _status?: string): Promise<void> {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6473,8 +6473,8 @@ packages:
     resolution: {integrity: sha512-Y/b0YJoCDda6DCFj8ikks06GrEWDsz/3vdgGLeectV9p+YJc76YugRjtqFdd2KTf2rnEPjalL2hcXP+x2KcSLQ==}
     engines: {node: '>=20'}
 
-  '@xhmikosr/bin-wrapper@14.4.0':
-    resolution: {integrity: sha512-Qp4YGNOIBnNEXoyM8nc0L92frBtrerzRpE/zZ4EMU9i37tGGfiuKyQTdHdVUcj7z1ZMfg2hAk+i5gMbWGc5cdw==}
+  '@xhmikosr/bin-wrapper@14.5.0':
+    resolution: {integrity: sha512-qzNWA0+YUbN3lVz79b2WK+X3QbR8+hmd6nMTAko1F/1jAeK7VbpK7TcfkYU4dL8iaLNNGYL94WsTewwH17jMTQ==}
     engines: {node: '>=20'}
 
   '@xhmikosr/decompress-tar@9.0.1':
@@ -7798,8 +7798,8 @@ packages:
     resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
     engines: {node: '>=12.0.0'}
 
-  express@4.22.2:
-    resolution: {integrity: sha512-IuL+Elrou2ZvCFHs18/CIzy2Nzvo25nZ1/D2eIZlz7c+QUayAcYoiM2BthCjs+EBHVpjYjcuLDAiCWgeIX3X1Q==}
+  express@4.22.1:
+    resolution: {integrity: sha512-F2X8g9P1X7uCPZMA3MVf9wcTqlyNp7IhH5qPCI0izhaOIYXaW9L535tGA3qmjRzpH+bZczqq7hVKxTR4NWnu+g==}
     engines: {node: '>= 0.10.0'}
 
   express@5.2.1:
@@ -10096,6 +10096,10 @@ packages:
   proxy-from-env@2.1.0:
     resolution: {integrity: sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==}
     engines: {node: '>=10'}
+
+  qs@6.14.2:
+    resolution: {integrity: sha512-V/yCWTTF7VJ9hIh18Ugr2zhJMP01MY7c5kh4J870L7imm6/DIzBsNLTXzMwUA3yZ5b/KBqLx8Kp3uRvd7xSe3Q==}
+    engines: {node: '>=0.6'}
 
   qs@6.15.1:
     resolution: {integrity: sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==}
@@ -16336,7 +16340,7 @@ snapshots:
     dependencies:
       '@swc/core': 1.15.3
       '@swc/counter': 0.1.3
-      '@xhmikosr/bin-wrapper': 14.4.0
+      '@xhmikosr/bin-wrapper': 14.5.0
       commander: 8.3.0
       minimatch: 9.0.9
       piscina: 4.9.3
@@ -16692,7 +16696,7 @@ snapshots:
   '@types/jsonwebtoken@9.0.10':
     dependencies:
       '@types/ms': 2.1.0
-      '@types/node': 25.3.2
+      '@types/node': 25.9.2
 
   '@types/mdast@4.0.4':
     dependencies:
@@ -17720,7 +17724,7 @@ snapshots:
 
   '@workflow/web@4.1.5':
     dependencies:
-      express: 4.22.2
+      express: 4.22.1
     transitivePeerDependencies:
       - supports-color
 
@@ -17806,7 +17810,7 @@ snapshots:
       execa: 9.6.1
       isexe: 4.0.0
 
-  '@xhmikosr/bin-wrapper@14.4.0':
+  '@xhmikosr/bin-wrapper@14.5.0':
     dependencies:
       '@xhmikosr/bin-check': 8.2.2
       '@xhmikosr/downloader': 16.3.0
@@ -18179,7 +18183,7 @@ snapshots:
       http-errors: 2.0.1
       iconv-lite: 0.4.24
       on-finished: 2.4.1
-      qs: 6.15.3
+      qs: 6.15.1
       raw-body: 2.5.3
       type-is: 1.6.18
       unpipe: 1.0.0
@@ -19291,7 +19295,7 @@ snapshots:
 
   expect-type@1.3.0: {}
 
-  express@4.22.2:
+  express@4.22.1:
     dependencies:
       accepts: 1.3.8
       array-flatten: 1.1.1
@@ -19314,7 +19318,7 @@ snapshots:
       parseurl: 1.3.3
       path-to-regexp: 0.1.13
       proxy-addr: 2.0.7
-      qs: 6.15.3
+      qs: 6.14.2
       range-parser: 1.2.1
       safe-buffer: 5.2.1
       send: 0.19.2
@@ -22249,6 +22253,10 @@ snapshots:
       ipaddr.js: 1.9.1
 
   proxy-from-env@2.1.0: {}
+
+  qs@6.14.2:
+    dependencies:
+      side-channel: 1.1.0
 
   qs@6.15.1:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -534,17 +534,17 @@ importers:
         specifier: workspace:*
         version: link:../adapter-shared
       '@microsoft/teams.api':
-        specifier: ^2.0.8
-        version: 2.0.8
+        specifier: ^2.0.14
+        version: 2.0.14
       '@microsoft/teams.apps':
-        specifier: ^2.0.8
-        version: 2.0.8
+        specifier: ^2.0.14
+        version: 2.0.14
       '@microsoft/teams.cards':
-        specifier: ^2.0.8
-        version: 2.0.8
+        specifier: ^2.0.14
+        version: 2.0.14
       '@microsoft/teams.graph-endpoints':
-        specifier: ^2.0.8
-        version: 2.0.8
+        specifier: ^2.0.14
+        version: 2.0.14
       chat:
         specifier: workspace:*
         version: link:../chat
@@ -553,8 +553,8 @@ importers:
         specifier: workspace:*
         version: link:../tests
       '@microsoft/teams.graph':
-        specifier: ^2.0.8
-        version: 2.0.8
+        specifier: ^2.0.14
+        version: 2.0.14
       '@types/node':
         specifier: ^25.3.2
         version: 25.3.2
@@ -1167,13 +1167,13 @@ packages:
     resolution: {integrity: sha512-sl4Bm6yiMNYrZKkqqDFWN0UfnWhlS8ivKxrYl+6t0gCLrqr8y3B2IqZZbFRkfaVVp7C/baApyh71P+LeE1A2sQ==}
     engines: {node: '>=18.0.0'}
 
-  '@azure/msal-common@15.17.0':
-    resolution: {integrity: sha512-VQ5/gTLFADkwue+FohVuCqlzFPUq4xSrX8jeZe+iwZuY6moliNC8xt86qPVNYdtbQfELDf2Nu6LI+demFPHGgw==}
+  '@azure/msal-common@16.11.2':
+    resolution: {integrity: sha512-yDhtBOGDCdK9ipQ9g3+wmlMEPnZx2pXaDicDd9jYyR1L+7lEbvEohTDmF5qejZDutZY3m9pWPxeYxzNC701A2w==}
     engines: {node: '>=0.8.0'}
 
-  '@azure/msal-node@3.8.10':
-    resolution: {integrity: sha512-0Hz7Kx4hs70KZWep/Rd7aw/qOLUF92wUOhn7ZsOuB5xNR/06NL1E2RAI9+UKH1FtvN8nD6mFjH7UKSjv6vOWvQ==}
-    engines: {node: '>=16'}
+  '@azure/msal-node@5.4.1':
+    resolution: {integrity: sha512-yqgoyOIMCH7TNaSLMBTP+4LUlbMMf1zgC8nzOFG95lmW82CmsAEtUT0J93e4BdqDcnX5qle/9X+yb7A8Mw9M0g==}
+    engines: {node: '>=20'}
 
   '@babel/code-frame@7.29.7':
     resolution: {integrity: sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==}
@@ -2526,28 +2526,28 @@ packages:
   '@mermaid-js/parser@1.1.1':
     resolution: {integrity: sha512-VuHdsYMK1bT6X2JbcAaWAhugTRvRBRyuZgd+c22swUeI9g/ntaxF7CY7dYarhZovofCbUNO0G7JesfmNtjYOCw==}
 
-  '@microsoft/teams.api@2.0.8':
-    resolution: {integrity: sha512-N13idaRZNnfL7aefzsn2rhPtujqke1QVM81bNWq1XeK+5yeXod3aLTmBY701DEKkZUXiSG0AogvzkNwVnBw4+g==}
+  '@microsoft/teams.api@2.0.14':
+    resolution: {integrity: sha512-mEHBgs7yklydQWTlfGFok5i7np2WxOKS3j6aMgRH0HVfiLqenPjGm0NAWKR/Hg29n9ODtGZZeuIXNCwIYQ8syA==}
     engines: {node: '>=20'}
 
-  '@microsoft/teams.apps@2.0.8':
-    resolution: {integrity: sha512-6YBOxnQSoEPu841zMa1SDBdwH3gsuzrz0LCONuaGOHJ3Kmv2S+7ih1DqEx4Ak3iAYHeCvxnWGqjcYSBhgeiuMQ==}
+  '@microsoft/teams.apps@2.0.14':
+    resolution: {integrity: sha512-7re8a3pnAUSD5rAGlWbKQd07XtQJwyuZ4rI7EWyqBQT2iLhqUU1r4jtq3jQFpfov7xhADVV+oExCc7IbNyYuGw==}
     engines: {node: '>=20'}
 
-  '@microsoft/teams.cards@2.0.8':
-    resolution: {integrity: sha512-WrGAgkDKqhvFhnsKPwFeKTkhAXu/fbySxq5+uIOqY1ffdgiEdEoj6c0cjyQJy0HJ9B5u/0SQ4hO2KUc6jlZSZw==}
+  '@microsoft/teams.cards@2.0.14':
+    resolution: {integrity: sha512-qrWnjJVgMPO8vvbLEiTeBLrrRLsr4rletQnuP9fPMXTTcrNx+Dh0gYWtQAOBvpoAuFo5tTXR/waNFNUm8IZtBw==}
     engines: {node: '>=20'}
 
-  '@microsoft/teams.common@2.0.8':
-    resolution: {integrity: sha512-nkolOYX9qCpfK2uitiuAYm3EvMleHer5P3OCx3IBOp2gxkkFvNNOcOIDXuPZ6BtiENt47FPn4fYMMgJrawCHcA==}
+  '@microsoft/teams.common@2.0.14':
+    resolution: {integrity: sha512-cjf3b/2sr5RqqiOaDuogJQ9fUNRZjDSh9eBEAv6NqkigNNLLjDgEgEl5lLoJsPp4usvc3drwFkx6HayuEbT7vA==}
     engines: {node: '>=20'}
 
-  '@microsoft/teams.graph-endpoints@2.0.8':
-    resolution: {integrity: sha512-KjDhMWn8ZcwTjDOw1hL0By/HvHEXe5+Bzy8tmEOsqPGUc/1HfwtBZAYsr8FUVBSBe0CObLYs2Pkh0wiHqWNNPw==}
+  '@microsoft/teams.graph-endpoints@2.0.14':
+    resolution: {integrity: sha512-UNP8aCeA8ZVKxH0nMKHT3UMRkA575PVu4HHhZhV8biZvNTfXzQELO8VtOsBON+5eGFo0qqrTWL+gC7CB7sRMNw==}
     engines: {node: '>=20'}
 
-  '@microsoft/teams.graph@2.0.8':
-    resolution: {integrity: sha512-M/skUNJFD+lIVNa+ng0iy8t3sFmki6NOiWpGwnWOBAKFgTYBTJVtPfWm6SNdGFTCUsV9rjep4s9S5zTKUg2HJg==}
+  '@microsoft/teams.graph@2.0.14':
+    resolution: {integrity: sha512-PufhROXKhsC/h6ZKuquPzvNBB1Q9lHHu//vZGfRj3yD+hgtQkEz2YzXZDYC3h0bDN4ej2KtvkDGrsovqrnU0cQ==}
     engines: {node: '>=20'}
 
   '@mux/mux-data-google-ima@0.3.4':
@@ -6473,8 +6473,8 @@ packages:
     resolution: {integrity: sha512-Y/b0YJoCDda6DCFj8ikks06GrEWDsz/3vdgGLeectV9p+YJc76YugRjtqFdd2KTf2rnEPjalL2hcXP+x2KcSLQ==}
     engines: {node: '>=20'}
 
-  '@xhmikosr/bin-wrapper@14.5.0':
-    resolution: {integrity: sha512-qzNWA0+YUbN3lVz79b2WK+X3QbR8+hmd6nMTAko1F/1jAeK7VbpK7TcfkYU4dL8iaLNNGYL94WsTewwH17jMTQ==}
+  '@xhmikosr/bin-wrapper@14.4.0':
+    resolution: {integrity: sha512-Qp4YGNOIBnNEXoyM8nc0L92frBtrerzRpE/zZ4EMU9i37tGGfiuKyQTdHdVUcj7z1ZMfg2hAk+i5gMbWGc5cdw==}
     engines: {node: '>=20'}
 
   '@xhmikosr/decompress-tar@9.0.1':
@@ -6683,6 +6683,9 @@ packages:
 
   axios@1.16.1:
     resolution: {integrity: sha512-caYkukvroVPO8KrzuJEb50Hm07KwfBZPEC3VeFHTsqWHvKTsy54hjJz9BS/cdaypROE2rH6xvm9mHX4fgWkr3A==}
+
+  axios@1.18.1:
+    resolution: {integrity: sha512-3nTvFlvpn9Zu/RkHUqtc7/+al4UpRW5az71ap5zccp6e8RAYEzhMTecX8Dz1wWDYrPpUoB1HAQEGEAEvUr7S9g==}
 
   axobject-query@4.1.0:
     resolution: {integrity: sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ==}
@@ -7795,8 +7798,8 @@ packages:
     resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
     engines: {node: '>=12.0.0'}
 
-  express@4.22.1:
-    resolution: {integrity: sha512-F2X8g9P1X7uCPZMA3MVf9wcTqlyNp7IhH5qPCI0izhaOIYXaW9L535tGA3qmjRzpH+bZczqq7hVKxTR4NWnu+g==}
+  express@4.22.2:
+    resolution: {integrity: sha512-IuL+Elrou2ZvCFHs18/CIzy2Nzvo25nZ1/D2eIZlz7c+QUayAcYoiM2BthCjs+EBHVpjYjcuLDAiCWgeIX3X1Q==}
     engines: {node: '>= 0.10.0'}
 
   express@5.2.1:
@@ -7953,6 +7956,10 @@ packages:
 
   form-data@4.0.5:
     resolution: {integrity: sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==}
+    engines: {node: '>= 6'}
+
+  form-data@4.0.6:
+    resolution: {integrity: sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==}
     engines: {node: '>= 6'}
 
   formatly@0.3.0:
@@ -10090,16 +10097,12 @@ packages:
     resolution: {integrity: sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==}
     engines: {node: '>=10'}
 
-  qs@6.14.2:
-    resolution: {integrity: sha512-V/yCWTTF7VJ9hIh18Ugr2zhJMP01MY7c5kh4J870L7imm6/DIzBsNLTXzMwUA3yZ5b/KBqLx8Kp3uRvd7xSe3Q==}
-    engines: {node: '>=0.6'}
-
-  qs@6.15.0:
-    resolution: {integrity: sha512-mAZTtNCeetKMH+pSjrb76NAM8V9a05I9aBZOHztWy/UqcJdQYNsf59vrRKWnojAT9Y+GbIvoTBC++CPHqpDBhQ==}
-    engines: {node: '>=0.6'}
-
   qs@6.15.1:
     resolution: {integrity: sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==}
+    engines: {node: '>=0.6'}
+
+  qs@6.15.3:
+    resolution: {integrity: sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==}
     engines: {node: '>=0.6'}
 
   quansync@0.2.11:
@@ -10523,6 +10526,10 @@ packages:
     resolution: {integrity: sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==}
     engines: {node: '>= 0.4'}
 
+  side-channel-list@1.0.1:
+    resolution: {integrity: sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==}
+    engines: {node: '>= 0.4'}
+
   side-channel-map@1.0.1:
     resolution: {integrity: sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==}
     engines: {node: '>= 0.4'}
@@ -10533,6 +10540,10 @@ packages:
 
   side-channel@1.1.0:
     resolution: {integrity: sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==}
+    engines: {node: '>= 0.4'}
+
+  side-channel@1.1.1:
+    resolution: {integrity: sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==}
     engines: {node: '>= 0.4'}
 
   siginfo@2.0.0:
@@ -11332,11 +11343,6 @@ packages:
 
   uuid@14.0.0:
     resolution: {integrity: sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==}
-    hasBin: true
-
-  uuid@8.3.2:
-    resolution: {integrity: sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==}
-    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
     hasBin: true
 
   vary@1.1.2:
@@ -12196,13 +12202,12 @@ snapshots:
 
   '@aws/lambda-invoke-store@0.3.0': {}
 
-  '@azure/msal-common@15.17.0': {}
+  '@azure/msal-common@16.11.2': {}
 
-  '@azure/msal-node@3.8.10':
+  '@azure/msal-node@5.4.1':
     dependencies:
-      '@azure/msal-common': 15.17.0
+      '@azure/msal-common': 16.11.2
       jsonwebtoken: 9.0.3
-      uuid: 8.3.2
 
   '@babel/code-frame@7.29.7':
     dependencies:
@@ -13380,23 +13385,23 @@ snapshots:
     dependencies:
       '@chevrotain/types': 11.1.2
 
-  '@microsoft/teams.api@2.0.8':
+  '@microsoft/teams.api@2.0.14':
     dependencies:
-      '@microsoft/teams.cards': 2.0.8
-      '@microsoft/teams.common': 2.0.8
+      '@microsoft/teams.cards': 2.0.14
+      '@microsoft/teams.common': 2.0.14
       jwt-decode: 4.0.0
-      qs: 6.15.0
+      qs: 6.15.3
     transitivePeerDependencies:
       - debug
       - supports-color
 
-  '@microsoft/teams.apps@2.0.8':
+  '@microsoft/teams.apps@2.0.14':
     dependencies:
-      '@azure/msal-node': 3.8.10
-      '@microsoft/teams.api': 2.0.8
-      '@microsoft/teams.common': 2.0.8
-      '@microsoft/teams.graph': 2.0.8
-      axios: 1.16.1
+      '@azure/msal-node': 5.4.1
+      '@microsoft/teams.api': 2.0.14
+      '@microsoft/teams.common': 2.0.14
+      '@microsoft/teams.graph': 2.0.14
+      axios: 1.18.1
       cors: 2.8.6
       express: 5.2.1
       jsonwebtoken: 9.0.3
@@ -13406,21 +13411,21 @@ snapshots:
       - debug
       - supports-color
 
-  '@microsoft/teams.cards@2.0.8': {}
+  '@microsoft/teams.cards@2.0.14': {}
 
-  '@microsoft/teams.common@2.0.8':
+  '@microsoft/teams.common@2.0.14':
     dependencies:
-      axios: 1.16.1
+      axios: 1.18.1
     transitivePeerDependencies:
       - debug
       - supports-color
 
-  '@microsoft/teams.graph-endpoints@2.0.8': {}
+  '@microsoft/teams.graph-endpoints@2.0.14': {}
 
-  '@microsoft/teams.graph@2.0.8':
+  '@microsoft/teams.graph@2.0.14':
     dependencies:
-      '@microsoft/teams.common': 2.0.8
-      qs: 6.15.0
+      '@microsoft/teams.common': 2.0.14
+      qs: 6.15.3
     transitivePeerDependencies:
       - debug
       - supports-color
@@ -16331,7 +16336,7 @@ snapshots:
     dependencies:
       '@swc/core': 1.15.3
       '@swc/counter': 0.1.3
-      '@xhmikosr/bin-wrapper': 14.5.0
+      '@xhmikosr/bin-wrapper': 14.4.0
       commander: 8.3.0
       minimatch: 9.0.9
       piscina: 4.9.3
@@ -16687,7 +16692,7 @@ snapshots:
   '@types/jsonwebtoken@9.0.10':
     dependencies:
       '@types/ms': 2.1.0
-      '@types/node': 25.9.2
+      '@types/node': 25.3.2
 
   '@types/mdast@4.0.4':
     dependencies:
@@ -17715,7 +17720,7 @@ snapshots:
 
   '@workflow/web@4.1.5':
     dependencies:
-      express: 4.22.1
+      express: 4.22.2
     transitivePeerDependencies:
       - supports-color
 
@@ -17801,7 +17806,7 @@ snapshots:
       execa: 9.6.1
       isexe: 4.0.0
 
-  '@xhmikosr/bin-wrapper@14.5.0':
+  '@xhmikosr/bin-wrapper@14.4.0':
     dependencies:
       '@xhmikosr/bin-check': 8.2.2
       '@xhmikosr/downloader': 16.3.0
@@ -18069,6 +18074,16 @@ snapshots:
       - debug
       - supports-color
 
+  axios@1.18.1:
+    dependencies:
+      follow-redirects: 1.16.0
+      form-data: 4.0.6
+      https-proxy-agent: 5.0.1
+      proxy-from-env: 2.1.0
+    transitivePeerDependencies:
+      - debug
+      - supports-color
+
   axobject-query@4.1.0: {}
 
   b4a@1.8.1: {}
@@ -18164,7 +18179,7 @@ snapshots:
       http-errors: 2.0.1
       iconv-lite: 0.4.24
       on-finished: 2.4.1
-      qs: 6.15.1
+      qs: 6.15.3
       raw-body: 2.5.3
       type-is: 1.6.18
       unpipe: 1.0.0
@@ -19276,7 +19291,7 @@ snapshots:
 
   expect-type@1.3.0: {}
 
-  express@4.22.1:
+  express@4.22.2:
     dependencies:
       accepts: 1.3.8
       array-flatten: 1.1.1
@@ -19299,7 +19314,7 @@ snapshots:
       parseurl: 1.3.3
       path-to-regexp: 0.1.13
       proxy-addr: 2.0.7
-      qs: 6.14.2
+      qs: 6.15.3
       range-parser: 1.2.1
       safe-buffer: 5.2.1
       send: 0.19.2
@@ -19513,6 +19528,14 @@ snapshots:
       combined-stream: 1.0.8
       es-set-tostringtag: 2.1.0
       hasown: 2.0.2
+      mime-types: 2.1.35
+
+  form-data@4.0.6:
+    dependencies:
+      asynckit: 0.4.0
+      combined-stream: 1.0.8
+      es-set-tostringtag: 2.1.0
+      hasown: 2.0.4
       mime-types: 2.1.35
 
   formatly@0.3.0:
@@ -22227,17 +22250,14 @@ snapshots:
 
   proxy-from-env@2.1.0: {}
 
-  qs@6.14.2:
-    dependencies:
-      side-channel: 1.1.0
-
-  qs@6.15.0:
-    dependencies:
-      side-channel: 1.1.0
-
   qs@6.15.1:
     dependencies:
       side-channel: 1.1.0
+
+  qs@6.15.3:
+    dependencies:
+      es-define-property: 1.0.1
+      side-channel: 1.1.1
 
   quansync@0.2.11: {}
 
@@ -22876,6 +22896,11 @@ snapshots:
       es-errors: 1.3.0
       object-inspect: 1.13.4
 
+  side-channel-list@1.0.1:
+    dependencies:
+      es-errors: 1.3.0
+      object-inspect: 1.13.4
+
   side-channel-map@1.0.1:
     dependencies:
       call-bound: 1.0.4
@@ -22896,6 +22921,14 @@ snapshots:
       es-errors: 1.3.0
       object-inspect: 1.13.4
       side-channel-list: 1.0.0
+      side-channel-map: 1.0.1
+      side-channel-weakmap: 1.0.2
+
+  side-channel@1.1.1:
+    dependencies:
+      es-errors: 1.3.0
+      object-inspect: 1.13.4
+      side-channel-list: 1.0.1
       side-channel-map: 1.0.1
       side-channel-weakmap: 1.0.2
 
@@ -23699,8 +23732,6 @@ snapshots:
   utils-merge@1.0.1: {}
 
   uuid@14.0.0: {}
-
-  uuid@8.3.2: {}
 
   vary@1.1.2: {}
 


### PR DESCRIPTION
## Summary

Outbound Teams reactions were originally implemented as part of #302, then removed because the Teams feature was not fully rolled out. In [the follow-up discussion](https://github.com/vercel/chat/pull/302#issuecomment-4147056867), the Teams SDK maintainer said they were happy to add the support back once the rollout was ready. Microsoft now documents agent reaction support without a preview caveat.

This PR restores that support against the current Teams SDK API:

- implement `addReaction` and `removeReaction` with `conversations.addReaction` / `conversations.deleteReaction`
- pass native Teams reaction IDs through unchanged and map common normalized Chat SDK emoji names to their Teams IDs
- upgrade the aligned `@microsoft/teams.*` dependencies to 2.0.14
- update the Teams feature matrices and add a minor changeset

The implementation stays within the existing adapter methods and does not add another abstraction or affect streaming behavior.

## Test plan

- [x] `pnpm --filter @chat-adapter/teams test` — 243 tests passed
- [x] `pnpm build --filter=@chat-adapter/teams`
- [x] `pnpm check`
- [x] `pnpm konsistent`
- [x] GitHub Actions on Node 22 and 24
- [ ] Live Teams tenant verification

## Checklist

- [x] All commits are signed and verified
- [x] All commits are signed off for the DCO (`git commit -s` equivalent trailer)
- [ ] `pnpm validate` passes locally (the unrelated Discord replay test is flaky; it passes in isolation, and the full GitHub Actions suite passes)
- [x] Changeset added
- [x] Documentation updated



