### PR TITLE
fix(whatsapp): stop duplicating card title when posting Card with files

### DIFF
--- a/.changeset/wacky-fans-talk.md
+++ b/.changeset/wacky-fans-talk.md
@@ -1,5 +1,5 @@
 ---
-"@chat-adapter/whatsapp": minor
+"@chat-adapter/whatsapp": patch
 ---
 
 fix whatsapp card media duplication

--- a/.changeset/wacky-fans-talk.md
+++ b/.changeset/wacky-fans-talk.md
@@ -1,0 +1,9 @@
+---
+"@chat-adapter/whatsapp": minor
+---
+
+fix whatsapp card media duplication
+
+- Prevent card titles and body content from appearing twice when sending cards with files on WhatsApp.
+- Avoid adding the full card fallback text as an image caption when an interactive message follows.
+- Keep interactive WhatsApp messages responsible for rendering card titles, bodies, and actions.

--- a/apps/docs/content/adapters/official/whatsapp.mdx
+++ b/apps/docs/content/adapters/official/whatsapp.mdx
@@ -211,7 +211,7 @@ WhatsApp-specific behavior:
 - **One media per message** — multiple `files` or `attachments` in a single `post()` are sent as sequential messages (the last message ID is returned).
 - **Captions** — markdown (or card fallback text) is attached as a caption on the first media message when supported (max 1024 characters). Text is sent as a separate message first when the caption is too long or when the first media is audio (audio does not support captions).
 - **Binary vs link** — buffers are uploaded via the Cloud API `/media` endpoint; `attachments` with only an `url` use HTTPS link passthrough (no upload). URLs must use `https://`.
-- **Cards + files** — media is sent first (caption from card fallback text), then an interactive button message when the card has valid reply buttons. To send a photo with buttons, pass the image via `files` or `attachments` — card-embedded images (`imageUrl` or `<Image>` children) are not sent as native media.
+- **Cards + files** — when the card renders as an interactive message (reply buttons or a list), media is sent first without a caption and the interactive message that follows carries the title, body, and buttons. When the card falls back to plain text (e.g. only link buttons), the fallback text captions the first media. To send a photo with buttons, pass the image via `files` or `attachments` — card-embedded images (`imageUrl` or `<Image>` children) are not sent as native media.
 
 ```typescript title="lib/bot.ts" lineNumbers
 await thread.post({

--- a/packages/adapter-whatsapp/AGENTS.md
+++ b/packages/adapter-whatsapp/AGENTS.md
@@ -207,8 +207,13 @@ else maps to `document`. Pre-flight size checks throw
 `ValidationError` when binary size is known (image 5 MB, audio/video
 16 MB, document 100 MB).
 
-**Cards + files.** Media is sent first (caption from card fallback
-text), then an interactive card message when the card has buttons.
+**Cards + files.** When the card renders as an interactive message
+(reply buttons or a list), media is sent without a caption and the
+interactive message that follows carries the title, body, and
+buttons. Text-fallback cards (e.g. only link buttons) caption the
+first media with the fallback text. Card validation runs before
+media upload, so `ValidationError` is thrown before any media is
+sent.
 
 Media IDs expire after 30 days. For inbound media, the adapter
 exposes a lazy `fetchData()` that downloads the binary on demand.

--- a/packages/adapter-whatsapp/src/index.test.ts
+++ b/packages/adapter-whatsapp/src/index.test.ts
@@ -1158,7 +1158,7 @@ describe("postMessage - file uploads", () => {
     expect(header).toBe(title);
 
     const serialized = JSON.stringify([mediaMessage, interactiveMessage]);
-    expect(serialized.match(new RegExp(title, "g"))).toHaveLength(1);
+    expect(serialized.split(title).length - 1).toBe(1);
   });
 
   it("interactive card + file does not duplicate CardText/Fields in caption", async () => {
@@ -1430,8 +1430,8 @@ describe("postMessage - file uploads", () => {
 
     expect(caption).toContain(title);
     expect(caption).toContain(bodyLine);
-    expect(caption.match(new RegExp(title, "g"))).toHaveLength(1);
-    expect(caption.match(new RegExp(bodyLine, "g"))).toHaveLength(1);
+    expect(caption.split(title).length - 1).toBe(1);
+    expect(caption.split(bodyLine).length - 1).toBe(1);
   });
 
   it("oversize image throws ValidationError before upload", async () => {

--- a/packages/adapter-whatsapp/src/index.test.ts
+++ b/packages/adapter-whatsapp/src/index.test.ts
@@ -1107,7 +1107,9 @@ describe("postMessage - file uploads", () => {
     const interactiveMessage = parseMessageBody(1);
 
     expect(mediaMessage.type).toBe("image");
-    expect((mediaMessage.image as { caption?: string }).caption).toBeUndefined();
+    expect(
+      (mediaMessage.image as { caption?: string }).caption
+    ).toBeUndefined();
     expect(interactiveMessage.type).toBe("interactive");
 
     const interactive = interactiveMessage.interactive as {
@@ -1174,9 +1176,7 @@ describe("postMessage - file uploads", () => {
           { type: "text", content: bodyLine },
           {
             type: "fields",
-            children: [
-              { type: "field", label: fieldLabel, value: fieldValue },
-            ],
+            children: [{ type: "field", label: fieldLabel, value: fieldValue }],
           },
           {
             type: "actions",
@@ -1339,7 +1339,9 @@ describe("postMessage - file uploads", () => {
     const interactiveMessage = parseMessageBody(1);
 
     expect(mediaMessage.type).toBe("image");
-    expect((mediaMessage.image as { caption?: string }).caption).toBeUndefined();
+    expect(
+      (mediaMessage.image as { caption?: string }).caption
+    ).toBeUndefined();
     expect((mediaMessage.image as { link: string }).link).toBe(
       "https://example.com/photo.jpg"
     );

--- a/packages/adapter-whatsapp/src/index.test.ts
+++ b/packages/adapter-whatsapp/src/index.test.ts
@@ -1107,10 +1107,246 @@ describe("postMessage - file uploads", () => {
     const interactiveMessage = parseMessageBody(1);
 
     expect(mediaMessage.type).toBe("image");
-    expect((mediaMessage.image as { caption: string }).caption).toContain(
-      "Approve"
-    );
+    expect((mediaMessage.image as { caption?: string }).caption).toBeUndefined();
     expect(interactiveMessage.type).toBe("interactive");
+
+    const interactive = interactiveMessage.interactive as {
+      header?: { text: string };
+      body: { text: string };
+      action: { buttons: Array<{ reply: { title: string } }> };
+    };
+    expect(interactive.header?.text).toBe("Approve?");
+    expect(interactive.action.buttons).toHaveLength(2);
+  });
+
+  it("interactive card + file does not duplicate title across caption and header", async () => {
+    const adapter = createTestAdapter();
+    const title = "Demo image card";
+
+    await adapter.postMessage(THREAD_ID, {
+      card: {
+        type: "card",
+        title,
+        children: [
+          {
+            type: "actions",
+            children: [{ type: "button", id: "ok", label: "OK" }],
+          },
+        ],
+      },
+      files: [
+        {
+          data: Buffer.from("png"),
+          filename: "demo.png",
+          mimeType: "image/png",
+        },
+      ],
+    });
+
+    expect(getMessageCalls()).toHaveLength(2);
+
+    const mediaMessage = parseMessageBody(0);
+    const interactiveMessage = parseMessageBody(1);
+    const caption = (mediaMessage.image as { caption?: string }).caption;
+    const header = (
+      interactiveMessage.interactive as { header?: { text: string } }
+    ).header?.text;
+
+    expect(caption).toBeUndefined();
+    expect(header).toBe(title);
+
+    const serialized = JSON.stringify([mediaMessage, interactiveMessage]);
+    expect(serialized.match(new RegExp(title, "g"))).toHaveLength(1);
+  });
+
+  it("interactive card + file does not duplicate CardText/Fields in caption", async () => {
+    const adapter = createTestAdapter();
+    const bodyLine = "Your order has shipped";
+    const fieldLabel = "Tracking code";
+    const fieldValue = "SHIP-UNIQUE-VALUE";
+
+    await adapter.postMessage(THREAD_ID, {
+      card: {
+        type: "card",
+        title: "Shipment",
+        subtitle: "Status update",
+        children: [
+          { type: "text", content: bodyLine },
+          {
+            type: "fields",
+            children: [
+              { type: "field", label: fieldLabel, value: fieldValue },
+            ],
+          },
+          {
+            type: "actions",
+            children: [
+              { type: "button", id: "track", label: "Track" },
+              { type: "button", id: "help", label: "Help" },
+            ],
+          },
+        ],
+      },
+      files: [
+        {
+          data: Buffer.from("png"),
+          filename: "box.png",
+          mimeType: "image/png",
+        },
+      ],
+    });
+
+    expect(getMessageCalls()).toHaveLength(2);
+
+    const mediaMessage = parseMessageBody(0);
+    const interactiveMessage = parseMessageBody(1);
+    const caption = (mediaMessage.image as { caption?: string }).caption;
+    const interactive = interactiveMessage.interactive as {
+      header?: { text: string };
+      body: { text: string };
+    };
+
+    expect(caption).toBeUndefined();
+    expect(interactive.header?.text).toBe("Shipment");
+    expect(interactive.body.text).toContain("Status update");
+    expect(interactive.body.text).toContain(bodyLine);
+    expect(interactive.body.text).toContain(`${fieldLabel}: ${fieldValue}`);
+  });
+
+  it("interactive card + multiple files leaves all media uncaptioned", async () => {
+    const adapter = createTestAdapter();
+
+    await adapter.postMessage(THREAD_ID, {
+      card: {
+        type: "card",
+        title: "Review docs",
+        children: [
+          {
+            type: "actions",
+            children: [
+              { type: "button", id: "approve", label: "Approve" },
+              { type: "button", id: "reject", label: "Reject" },
+            ],
+          },
+        ],
+      },
+      files: [
+        {
+          data: Buffer.from("a"),
+          filename: "a.pdf",
+          mimeType: "application/pdf",
+        },
+        {
+          data: Buffer.from("b"),
+          filename: "b.pdf",
+          mimeType: "application/pdf",
+        },
+      ],
+    });
+
+    expect(getMediaCalls()).toHaveLength(2);
+    expect(getMessageCalls()).toHaveLength(3);
+
+    const first = parseMessageBody(0);
+    const second = parseMessageBody(1);
+    const interactiveMessage = parseMessageBody(2);
+
+    expect(first.type).toBe("document");
+    expect(second.type).toBe("document");
+    expect((first.document as { caption?: string }).caption).toBeUndefined();
+    expect((second.document as { caption?: string }).caption).toBeUndefined();
+    expect(interactiveMessage.type).toBe("interactive");
+    expect(
+      (interactiveMessage.interactive as { header?: { text: string } }).header
+        ?.text
+    ).toBe("Review docs");
+  });
+
+  it("interactive card + audio sends audio then interactive with no leading text", async () => {
+    const adapter = createTestAdapter();
+
+    await adapter.postMessage(THREAD_ID, {
+      card: {
+        type: "card",
+        title: "Voice note",
+        children: [
+          {
+            type: "actions",
+            children: [{ type: "button", id: "ack", label: "Got it" }],
+          },
+        ],
+      },
+      files: [
+        {
+          data: Buffer.from("audio"),
+          filename: "note.mp3",
+          mimeType: "audio/mpeg",
+        },
+      ],
+    });
+
+    // Audio cannot take a caption; interactive path also skips card fallback
+    // text, so there must be no leading text message with the title.
+    expect(getMessageCalls()).toHaveLength(2);
+
+    const audioMessage = parseMessageBody(0);
+    const interactiveMessage = parseMessageBody(1);
+
+    expect(audioMessage.type).toBe("audio");
+    expect(
+      (audioMessage.audio as { caption?: string }).caption
+    ).toBeUndefined();
+    expect(interactiveMessage.type).toBe("interactive");
+    expect(
+      (interactiveMessage.interactive as { header?: { text: string } }).header
+        ?.text
+    ).toBe("Voice note");
+
+    for (const message of [audioMessage, interactiveMessage]) {
+      if (message.type === "text") {
+        throw new Error("unexpected leading text message for interactive card");
+      }
+    }
+  });
+
+  it("interactive card + HTTPS attachment does not caption with card title", async () => {
+    const adapter = createTestAdapter();
+
+    await adapter.postMessage(THREAD_ID, {
+      card: {
+        type: "card",
+        title: "Remote image card",
+        children: [
+          {
+            type: "actions",
+            children: [{ type: "button", id: "open", label: "Open" }],
+          },
+        ],
+      },
+      attachments: [
+        {
+          type: "image",
+          url: "https://example.com/photo.jpg",
+          mimeType: "image/jpeg",
+        },
+      ],
+    });
+
+    expect(getMediaCalls()).toHaveLength(0);
+    expect(getMessageCalls()).toHaveLength(2);
+
+    const mediaMessage = parseMessageBody(0);
+    const interactiveMessage = parseMessageBody(1);
+
+    expect(mediaMessage.type).toBe("image");
+    expect((mediaMessage.image as { caption?: string }).caption).toBeUndefined();
+    expect((mediaMessage.image as { link: string }).link).toBe(
+      "https://example.com/photo.jpg"
+    );
+    expect(
+      (interactiveMessage.interactive as { header?: { text: string } }).header
+        ?.text
+    ).toBe("Remote image card");
   });
 
   it("card with text fallback and file does not send duplicate text", async () => {
@@ -1151,6 +1387,49 @@ describe("postMessage - file uploads", () => {
     expect((mediaMessage.image as { caption: string }).caption).toContain(
       "Order update"
     );
+  });
+
+  it("text-fallback card + file puts title and body only in the caption once", async () => {
+    const adapter = createTestAdapter();
+    const title = "Receipt details";
+    const bodyLine = "Thanks for your purchase";
+
+    await adapter.postMessage(THREAD_ID, {
+      card: {
+        type: "card",
+        title,
+        children: [
+          { type: "text", content: bodyLine },
+          {
+            type: "actions",
+            children: [
+              {
+                type: "link-button",
+                url: "https://example.com/receipt",
+                label: "View",
+              },
+            ],
+          },
+        ],
+      },
+      files: [
+        {
+          data: Buffer.from("png"),
+          filename: "receipt.png",
+          mimeType: "image/png",
+        },
+      ],
+    });
+
+    expect(getMessageCalls()).toHaveLength(1);
+
+    const mediaMessage = parseMessageBody(0);
+    const caption = (mediaMessage.image as { caption: string }).caption;
+
+    expect(caption).toContain(title);
+    expect(caption).toContain(bodyLine);
+    expect(caption.match(new RegExp(title, "g"))).toHaveLength(1);
+    expect(caption.match(new RegExp(bodyLine, "g"))).toHaveLength(1);
   });
 
   it("oversize image throws ValidationError before upload", async () => {

--- a/packages/adapter-whatsapp/src/index.ts
+++ b/packages/adapter-whatsapp/src/index.ts
@@ -952,12 +952,10 @@ export class WhatsAppAdapter
     const card = extractCard(message);
     const cardResult = card ? cardToWhatsApp(card) : null;
 
-    let text: string;
+    let text = "";
 
     if (card) {
-      if (cardResult?.type === "interactive") {
-        text = "";
-      } else {
+      if (cardResult && cardResult.type !== "interactive") {
         text = convertEmojiPlaceholders(cardToFallbackText(card), "whatsapp");
       }
     } else {
@@ -1003,7 +1001,7 @@ export class WhatsAppAdapter
       );
     }
 
-    if (card && cardResult) {
+    if (cardResult) {
       if (cardResult.type === "interactive") {
         const interactive = JSON.parse(
           convertEmojiPlaceholders(

--- a/packages/adapter-whatsapp/src/index.ts
+++ b/packages/adapter-whatsapp/src/index.ts
@@ -952,10 +952,20 @@ export class WhatsAppAdapter
     const card = extractCard(message);
     const cardResult = card ? cardToWhatsApp(card) : null;
 
-    const text = card
-    ? cardResult?.type === "interactive" ? ""
-      : convertEmojiPlaceholders(cardToFallbackText(card), "whatsapp")
-      : convertEmojiPlaceholders(this.renderPostableText(message), "whatsapp");
+    let text: string;
+
+    if (card) {
+      if (cardResult?.type === "interactive") {
+        text = "";
+      } else {
+        text = convertEmojiPlaceholders(cardToFallbackText(card), "whatsapp");
+      }
+    } else {
+      text = convertEmojiPlaceholders(
+        this.renderPostableText(message),
+        "whatsapp"
+      );
+    }
 
     const resolved = await Promise.all(
       mediaItems.map((item) => this.resolveMedia(item))

--- a/packages/adapter-whatsapp/src/index.ts
+++ b/packages/adapter-whatsapp/src/index.ts
@@ -950,8 +950,11 @@ export class WhatsAppAdapter
     mediaItems: Array<FileUpload | Attachment>
   ): Promise<RawMessage<WhatsAppRawMessage>> {
     const card = extractCard(message);
+    const cardResult = card ? cardToWhatsApp(card) : null;
+
     const text = card
-      ? convertEmojiPlaceholders(cardToFallbackText(card), "whatsapp")
+    ? cardResult?.type === "interactive" ? ""
+      : convertEmojiPlaceholders(cardToFallbackText(card), "whatsapp")
       : convertEmojiPlaceholders(this.renderPostableText(message), "whatsapp");
 
     const resolved = await Promise.all(
@@ -990,8 +993,7 @@ export class WhatsAppAdapter
       );
     }
 
-    if (card) {
-      const cardResult = cardToWhatsApp(card);
+    if (card && cardResult) {
       if (cardResult.type === "interactive") {
         const interactive = JSON.parse(
           convertEmojiPlaceholders(


### PR DESCRIPTION
## Description

Fixes a WhatsApp adapter bug where posting a **Card together with files** caused the card title (and other card text) to appear twice: once in the media caption (from `cardToFallbackText`) and again in the interactive message header/body (from `cardToWhatsApp`).

`postMessageWithMedia` now checks whether the card will be sent as an interactive message first. If so, it skips using the full card fallback as the media caption and lets the interactive message own the title, body, and buttons. Text-fallback cards + files keep the previous caption behavior (single message, no duplicate text).

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Refactoring (no functional changes)

## Related Issues

Fixes #735
Closes #735
Related to #735

<!-- Replace # with the issue number after opening the bug report -->

## Changes Made

- In `postMessageWithMedia`, compute `cardToWhatsApp(card)` first and reuse that result.
- When the card is **interactive**, do not set media caption from `cardToFallbackText` (empty caption text) so title/body are not duplicated on the image.
- When the card is **text fallback**, keep captioning media with `cardToFallbackText` and avoid sending a second text message (existing behavior).
- Expand unit coverage in `index.test.ts` for interactive + files (title once, no caption duplication for text/fields, multi-file, audio, HTTPS attachment) and text-fallback caption behavior.

## Testing

- [x] All existing tests pass
- [x] Added new tests for the changes
- [x] Manually tested the changes

### Test Coverage

- Built the package, then used `pnpm link` to link the built `dist` into a separate test project.
- Exercised `thread.post({ card, files })` against the reported bug scenario and confirmed the title no longer appears twice (caption empty for interactive cards; title only on the interactive message).
- Added / updated unit tests in `packages/adapter-whatsapp/src/index.test.ts`; all related tests pass locally (`pnpm --filter @chat-adapter/whatsapp test`).

## Screenshots/Demos

<!-- Paste before/after WhatsApp screenshots here -->

**Before (title duplicated on caption + interactive header):**

<img width="433" height="428" alt="image" src="https://github.com/user-attachments/assets/37c776fd-b4f6-48f3-a365-6e2073316576" />



**After (title only on interactive message; media uncaptioned):**

<img width="428" height="390" alt="image" src="https://github.com/user-attachments/assets/fb1f43d9-623a-4e22-83ea-dd96cd6d3877" />

<img width="408" height="405" alt="image" src="https://github.com/user-attachments/assets/3959eb04-e722-43f4-8b85-91b724faebcb" />


## Checklist

- [x] My code follows the project's code style
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have created a changeset (`pnpm changeset`)
- [x] All commits are signed and verified
- [ ] All commits are signed off for the DCO (`git commit -s`)
- [x] `pnpm validate` passes
- [x] Changeset added (or N/A — see [CONTRIBUTING.md](./CONTRIBUTING.md))
- [ ] Documentation updated (or N/A)

## Changeset

- [x] I have created a changeset for these changes

<!-- Reminder: behavioural package changes need `pnpm changeset` for `@chat-adapter/whatsapp` -->

## Additional Notes

- No change to `@chat-adapter/shared`’s `cardToFallbackText` — it remains correct as a full text fallback. The bug was reusing that full fallback as a caption while also sending a full interactive card.
- Card-only posts (no files) are unchanged.


