### PR TITLE
feat(teams): add targeted ephemeral messages

### DIFF
--- a/.changeset/teams-targeted-messages.md
+++ b/.changeset/teams-targeted-messages.md
@@ -1,0 +1,5 @@
+---
+"@chat-adapter/teams": minor
+---
+
+Add native Microsoft Teams targeted message support via `thread.postEphemeral()` and `channel.postEphemeral()`.

--- a/apps/docs/content/adapters/official/teams.mdx
+++ b/apps/docs/content/adapters/official/teams.mdx
@@ -34,7 +34,9 @@ features:
   removeReactions: yes
   typingIndicator: yes
   directMessages: yes
-  ephemeralMessages: no
+  ephemeralMessages:
+    status: yes
+    label: Targeted messages
   userLookup:
     status: partial
     label: Cached
@@ -231,6 +233,18 @@ console.log(user?.fullName); // "Alice Smith"
 ```
 
 The adapter caches each user's Azure AD object ID from incoming activities, so `getUser` only works for users who have previously interacted with the bot.
+
+### Targeted / ephemeral messages
+
+Teams targeted messages are available in public preview. Use `thread.postEphemeral()` or `channel.postEphemeral()` to send a native Teams message that only the selected conversation member can see:
+
+```typescript
+await thread.postEphemeral(message.author, "Only you can see this.", {
+  fallbackToDM: false,
+});
+```
+
+The result has `usedFallback: false` when Teams accepts the targeted message.
 
 ### Message history
 

--- a/apps/docs/content/docs/adapters.mdx
+++ b/apps/docs/content/docs/adapters.mdx
@@ -1,146 +1,159 @@
 ---
-title: Platform Adapters
-description: Platform-specific adapters that connect your bot to any messaging platform.
+title: Overview
+description: Overview of Chat SDK adapters and the static adapter catalog.
 type: overview
 prerequisites:
   - /docs/getting-started
 ---
 
-Adapters handle webhook verification, message parsing, and API calls for each platform. Install only the adapters you need. Browse all available adapters — including community-built ones — on the [Adapters](/adapters) page.
+Adapters connect Chat SDK to messaging platforms and state backends. Install only the adapters you need, then register them on your `Chat` instance.
 
-Need a browser chat UI? See the [Web adapter](/adapters/official/web) — it speaks the AI SDK UI stream protocol and works with React (`@ai-sdk/react`), Vue (`@ai-sdk/vue`), and Svelte (`@ai-sdk/svelte`), so the same bot serves Slack, Teams, **and** any browser framework out of the box.
+Use the dedicated guides for adapter-specific concepts:
+
+- [Platform Adapters](/docs/platform-adapters) cover webhook verification, message parsing, API calls, feature support, and multi-platform bots.
+- [State Adapters](/docs/state-adapters) cover subscriptions, distributed locking, and caching.
+- Browse all official, vendor-official, and community adapters on the [Adapters](/adapters) listing page.
 
 Ready to build your own? Follow the [building](/docs/contributing/building) guide.
 
-## Feature matrix
+## Adapter catalog (`chat/adapters`)
 
-<GlobalFeatureMatrix type="platform" />
-### Messaging
+The `chat/adapters` subpath is a static catalog of official and vendor-official adapters. It imports no adapter packages, so you can use it from setup screens, build scripts, or onboarding flows without pulling in Slack, Teams, Redis, or other platform SDKs.
 
-| Feature | [Slack](/adapters/slack) | [Teams](/adapters/teams) | [Google Chat](/adapters/google-chat) | [Discord](/adapters/discord) | [Telegram](/adapters/telegram) | [GitHub](/adapters/github) | [Linear](/adapters/linear) | [WhatsApp](/adapters/whatsapp) | [Messenger](/adapters/messenger) |
-|---------|-------|-------|-------------|---------|---------|--------|--------|-----------|-----------|
-| Post message | <Check /> | <Check /> | <Check /> | <Check /> | <Check /> | <Check /> | <Check /> | <Check /> | <Check /> |
-| Edit message | <Check /> | <Check /> | <Check /> | <Check /> | <Check /> | <Check /> | <Warn /> Partial | <Cross /> | <Cross /> |
-| Delete message | <Check /> | <Check /> | <Check /> | <Check /> | <Check /> | <Check /> | <Warn /> Partial | <Cross /> | <Cross /> |
-| File uploads | <Check /> | <Check /> | <Cross /> | <Check /> | <Warn /> Single file/media | <Cross /> | <Cross /> | <Check /> Images, audio, docs | <Cross /> |
-| Streaming | <Check /> Native | <Warn /> Native (DMs) / Buffered | <Warn /> Post+Edit | <Warn /> Post+Edit | <Warn /> Post+Edit | <Warn /> Buffered | <Warn /> Agent sessions / Post+Edit | <Warn /> Buffered | <Warn /> Buffered |
-| Scheduled messages | <Check /> Native | <Cross /> | <Cross /> | <Cross /> | <Cross /> | <Cross /> | <Cross /> | <Cross /> | <Cross /> |
+```typescript title="scripts/list-adapters.ts" lineNumbers
+import { ADAPTER_NAMES, getAdapter } from "chat/adapters";
 
-### Rich content
-
-| Feature | Slack | Teams | Google Chat | Discord | Telegram | GitHub | Linear | WhatsApp | Messenger |
-|---------|-------|-------|-------------|---------|----------|--------|--------|-----------|-----------|
-| Card format | Block Kit | Adaptive Cards | Google Chat Cards | Embeds | Markdown + inline keyboard buttons | GFM Markdown | Markdown | WhatsApp templates | Generic/Button Templates |
-| Buttons | <Check /> | <Check /> | <Check /> | <Check /> | <Warn /> Inline keyboard callbacks | <Cross /> | <Cross /> | <Check /> Interactive replies | <Warn /> Max 3, postback |
-| Link buttons | <Check /> | <Check /> | <Check /> | <Check /> | <Warn /> Inline keyboard URLs | <Cross /> | <Cross /> | <Cross /> | <Check /> |
-| Select menus | <Check /> | <Cross /> | <Check /> | <Cross /> | <Cross /> | <Cross /> | <Cross /> | <Cross /> | <Cross /> |
-| Tables | <Check /> Block Kit | <Check /> GFM | <Warn /> ASCII | <Check /> GFM | <Warn /> ASCII | <Check /> GFM | <Check /> GFM | <Cross /> | <Warn /> ASCII |
-| Fields | <Check /> | <Check /> | <Check /> | <Check /> | <Check /> | <Check /> | <Check /> | <Warn /> Template variables | <Warn /> ASCII |
-| Images in cards | <Check /> | <Check /> | <Check /> | <Check /> | <Cross /> | <Check /> | <Cross /> | <Check /> | <Check /> |
-| Modals | <Check /> | <Check /> | <Cross /> | <Cross /> | <Cross /> | <Cross /> | <Cross /> | <Cross /> | <Cross /> |
-
-### Conversations
-
-| Feature | Slack | Teams | Google Chat | Discord | Telegram | GitHub | Linear | WhatsApp | Messenger |
-|---------|-------|-------|-------------|---------|----------|--------|--------|-----------|-----------|
-| Slash commands | <Check /> | <Cross /> | <Cross /> | <Check /> | <Cross /> | <Cross /> | <Cross /> | <Cross /> | <Cross /> |
-| Mentions | <Check /> | <Check /> | <Check /> | <Check /> | <Check /> | <Check /> | <Check /> | <Cross /> | <Check /> |
-| Add reactions | <Check /> | <Cross /> | <Check /> | <Check /> | <Check /> | <Check /> | <Check /> | <Check /> | <Cross /> |
-| Remove reactions | <Check /> | <Cross /> | <Check /> | <Check /> | <Check /> | <Warn /> | <Warn /> | <Check /> | <Cross /> |
-| Typing indicator | <Check /> | <Check /> | <Cross /> | <Check /> | <Check /> | <Cross /> | <Warn /> Agent sessions | <Cross /> | <Check /> |
-| DMs | <Check /> | <Check /> | <Check /> | <Check /> | <Check /> | <Cross /> | <Cross /> | <Check /> | <Check /> |
-| Ephemeral messages | <Check /> Native | <Check /> Targeted | <Check /> Native | <Cross /> | <Cross /> | <Cross /> | <Cross /> | <Cross /> | <Cross /> |
-| User lookup ([`getUser`](/docs/api/chat#getuser)) | <Check /> | <Warn /> Cached | <Warn /> Cached | <Check /> | <Warn /> Seen users | <Check /> | <Check /> | <Cross /> | <Cross /> |
-| Parent subject ([`message.subject`](/docs/subject)) | <Cross /> | <Cross /> | <Cross /> | <Cross /> | <Cross /> | <Check /> | <Check /> | <Cross /> | <Cross /> |
-| Native client ([`.webClient` / `.octokit` / `.linearClient`](/docs/api/chat#getadapter)) | <Check /> | <Cross /> | <Cross /> | <Cross /> | <Cross /> | <Check /> | <Check /> | <Cross /> | <Cross /> |
-| Custom API endpoint (`apiUrl`) | <Check /> | <Check /> | <Check /> | <Check /> | <Check /> | <Check /> | <Check /> | <Check /> | <Check /> |
-
-### Message history
-
-| Feature | Slack | Teams | Google Chat | Discord | Telegram | GitHub | Linear | WhatsApp | Messenger |
-|---------|-------|-------|-------------|---------|----------|--------|--------|-----------|-----------|
-| Fetch messages | <Check /> | <Check /> | <Check /> | <Check /> | <Warn /> Cached | <Check /> | <Check /> | <Warn /> Cached sent messages only | <Warn /> Cached sent messages only |
-| Fetch single message | <Check /> | <Cross /> | <Cross /> | <Cross /> | <Warn /> Cached | <Cross /> | <Cross /> | <Cross /> | <Warn /> Cached |
-| Fetch thread info | <Check /> | <Check /> | <Check /> | <Check /> | <Check /> | <Check /> | <Check /> | <Check /> | <Check /> |
-| Fetch channel messages | <Check /> | <Check /> | <Check /> | <Check /> | <Warn /> Cached | <Check /> | <Cross /> | <Cross /> | <Warn /> Cached |
-| List threads | <Check /> | <Check /> | <Check /> | <Check /> | <Cross /> | <Check /> | <Cross /> | <Cross /> | <Cross /> |
-| Fetch channel info | <Check /> | <Check /> | <Check /> | <Check /> | <Check /> | <Check /> | <Cross /> | <Cross /> | <Check /> |
-| Post channel message | <Check /> | <Check /> | <Check /> | <Check /> | <Check /> | <Cross /> | <Cross /> | <Check /> | <Check /> |
-
-<Callout type="info">
-<Warn /> indicates partial support — the feature works with limitations. See individual adapter pages for details.
-</Callout>
-
-## How adapters work
-
-Each adapter implements a standard interface that the `Chat` class uses to route events and send messages. When a webhook arrives:
-
-1. The adapter verifies the request signature
-2. Parses the platform-specific payload into a normalized `Message`
-3. Routes to your handlers via the `Chat` class
-4. Converts outgoing messages from markdown/AST/cards to the platform's native format
-
-## Using multiple adapters
-
-Register multiple [adapters](/adapters) and your event handlers work across all of them:
-
-```typescript title="lib/bot.ts" lineNumbers
-import { Chat } from "chat";
-import { createSlackAdapter } from "@chat-adapter/slack";
-import { createTeamsAdapter } from "@chat-adapter/teams";
-import { createGoogleChatAdapter } from "@chat-adapter/gchat";
-import { createRedisState } from "@chat-adapter/state-redis";
-
-const bot = new Chat({
-  userName: "mybot",
-  adapters: {
-    slack: createSlackAdapter(),
-    teams: createTeamsAdapter(),
-    gchat: createGoogleChatAdapter(),
-  },
-  state: createRedisState(),
-});
-
-// This handler fires for mentions on any platform
-bot.onNewMention(async (thread) => {
-  await thread.subscribe();
-  await thread.post("Hello!");
-});
-```
-
-Each adapter auto-detects credentials from environment variables, so you only need to pass config when overriding defaults.
-
-<Callout type="info">
-  The examples above use Redis for state. See [State Adapters](/docs/state) for all available options.
-</Callout>
-
-Each adapter creates a webhook handler accessible via `bot.webhooks.<name>`.
-
-## Customizing an adapter via subclassing
-
-Each official adapter exposes its extension surface as `protected` members so you can subclass it to override or extend platform-specific behavior without forking the package. Use this when you need to handle a payload type the built-in adapter doesn't cover, intercept verification, or wrap an existing handler.
-
-```typescript title="lib/custom-telegram.ts" lineNumbers
-import { TelegramAdapter, type TelegramUpdate } from "@chat-adapter/telegram";
-import type { WebhookOptions } from "chat";
-
-export class CustomTelegramAdapter extends TelegramAdapter {
-  protected override processUpdate(
-    update: TelegramUpdate,
-    options?: WebhookOptions
-  ): void {
-    // Handle a payload type the base adapter doesn't, e.g. chat_join_request.
-    if ("chat_join_request" in update) {
-      this.logger.info("Received chat_join_request", { update });
-      return;
-    }
-    super.processUpdate(update, options);
-  }
+for (const slug of ADAPTER_NAMES) {
+  const adapter = getAdapter(slug);
+  console.log(adapter.name, adapter.packageName, adapter.peerDeps);
 }
 ```
 
-Construct your subclass anywhere you'd construct the base adapter — for example, `adapters: { telegram: new CustomTelegramAdapter({ ... }) }`. Members marked `private` (internal caches, in-flight runtime state, one-shot warning flags) intentionally remain inaccessible; if you find a hook you need that isn't `protected`, please open an issue.
+Use the env helpers when you need to show setup instructions or inject secrets for one adapter:
 
-<Callout type="warn">
-  The `protected` extension surface is intentionally broader than the public API but is not yet considered fully stable. Method signatures may evolve (renames, parameter changes, new hook splits) in minor releases as we learn from real-world subclasses. Pin the adapter version you build against, watch the changelog for the affected adapter, and prefer overriding the smallest hook that solves your problem so upgrades stay easy. If you rely on a particular hook, please open an issue so we can promote it to a stable, documented extension point.
-</Callout>
+```typescript lineNumbers
+import { getAdapter, getSecretEnvVars } from "chat/adapters";
+
+const slack = getAdapter("slack");
+const secrets = getSecretEnvVars("slack").map((envVar) => envVar.key);
+
+console.log(slack.name, secrets);
+```
+
+The catalog intentionally covers official and vendor-official adapters. Community adapters live on the [Adapters](/adapters) listing page.
+
+### Environment specs
+
+Each adapter entry includes an `env` spec:
+
+- `required` lists variables needed regardless of auth mode.
+- `credentialModes` groups mutually exclusive ways to authenticate, such as a bot token vs OAuth client credentials.
+- `optional` lists tuning variables that are safe to omit.
+- `config` lists constructor options that do not have an environment-variable equivalent.
+
+### Types
+
+The main `CatalogAdapter` metadata shape is:
+
+<TypeTable
+  type={{
+    slug: {
+      type: "string",
+      description: "Stable catalog slug. Matches the key in `ADAPTERS`.",
+    },
+    name: {
+      type: "string",
+      description: "Display name.",
+    },
+    description: {
+      type: "string",
+      description: "One-line summary of what the adapter connects to.",
+    },
+    packageName: {
+      type: "string",
+      description: "NPM package that provides the adapter implementation.",
+    },
+    type: {
+      type: '"platform" | "state"',
+      description: "Whether the adapter connects to a platform or stores Chat SDK state.",
+    },
+    group: {
+      type: '"official" | "vendor-official"',
+      description: "Catalog group used by the docs adapter listing.",
+    },
+    peerDeps: {
+      type: "readonly string[]",
+      description: "Runtime packages the adapter expects the consuming app to provide or install alongside it.",
+    },
+    env: {
+      type: "AdapterEnvSpec",
+      description: "Environment variables and constructor-only configuration.",
+    },
+  }}
+/>
+
+<TypeTable
+  type={{
+    required: {
+      type: "readonly EnvVar[]",
+      description: "Variables needed regardless of credential mode.",
+    },
+    credentialModes: {
+      type: "readonly EnvGroup[]",
+      description: "Mutually exclusive credential groups. A caller usually satisfies exactly one group.",
+    },
+    optional: {
+      type: "readonly EnvVar[]",
+      description: "Optional environment variables that tune behavior.",
+    },
+    config: {
+      type: "readonly string[]",
+      description: "Constructor options that have no environment-variable equivalent.",
+    },
+    notes: {
+      type: "string",
+      description: "Additional caveats that do not fit the structured fields.",
+    },
+  }}
+/>
+
+<TypeTable
+  type={{
+    label: {
+      type: "string",
+      description: "Human-readable name for this credential mode.",
+    },
+    vars: {
+      type: "readonly EnvVar[]",
+      description: "Variables that together satisfy this mode.",
+    },
+  }}
+/>
+
+<TypeTable
+  type={{
+    key: {
+      type: "string",
+      description: "Canonical environment variable name.",
+    },
+    description: {
+      type: "string",
+      description: "Short description of what the value configures.",
+    },
+    secret: {
+      type: "boolean",
+      description: "Whether the value should be masked in logs and setup UIs.",
+    },
+    aliases: {
+      type: "readonly string[]",
+      description: "Alternative variable names accepted for the same value.",
+    },
+  }}
+/>
+
+### Helpers
+
+- `getAdapter(slug)` returns one catalog entry, or `undefined` for unknown slugs.
+- `isAdapterSlug(slug)` narrows a string to `AdapterSlug`.
+- `listEnvVars(slug)` flattens required, credential-mode, and optional env vars, de-duplicated by key.
+- `getSecretEnvVars(slug)` returns the subset of `listEnvVars(slug)` marked as secrets.

--- a/apps/docs/content/docs/adapters.mdx
+++ b/apps/docs/content/docs/adapters.mdx
@@ -1,159 +1,146 @@
 ---
-title: Overview
-description: Overview of Chat SDK adapters and the static adapter catalog.
+title: Platform Adapters
+description: Platform-specific adapters that connect your bot to any messaging platform.
 type: overview
 prerequisites:
   - /docs/getting-started
 ---
 
-Adapters connect Chat SDK to messaging platforms and state backends. Install only the adapters you need, then register them on your `Chat` instance.
+Adapters handle webhook verification, message parsing, and API calls for each platform. Install only the adapters you need. Browse all available adapters — including community-built ones — on the [Adapters](/adapters) page.
 
-Use the dedicated guides for adapter-specific concepts:
-
-- [Platform Adapters](/docs/platform-adapters) cover webhook verification, message parsing, API calls, feature support, and multi-platform bots.
-- [State Adapters](/docs/state-adapters) cover subscriptions, distributed locking, and caching.
-- Browse all official, vendor-official, and community adapters on the [Adapters](/adapters) listing page.
+Need a browser chat UI? See the [Web adapter](/adapters/official/web) — it speaks the AI SDK UI stream protocol and works with React (`@ai-sdk/react`), Vue (`@ai-sdk/vue`), and Svelte (`@ai-sdk/svelte`), so the same bot serves Slack, Teams, **and** any browser framework out of the box.
 
 Ready to build your own? Follow the [building](/docs/contributing/building) guide.
 
-## Adapter catalog (`chat/adapters`)
+## Feature matrix
 
-The `chat/adapters` subpath is a static catalog of official and vendor-official adapters. It imports no adapter packages, so you can use it from setup screens, build scripts, or onboarding flows without pulling in Slack, Teams, Redis, or other platform SDKs.
+<GlobalFeatureMatrix type="platform" />
+### Messaging
 
-```typescript title="scripts/list-adapters.ts" lineNumbers
-import { ADAPTER_NAMES, getAdapter } from "chat/adapters";
+| Feature | [Slack](/adapters/slack) | [Teams](/adapters/teams) | [Google Chat](/adapters/google-chat) | [Discord](/adapters/discord) | [Telegram](/adapters/telegram) | [GitHub](/adapters/github) | [Linear](/adapters/linear) | [WhatsApp](/adapters/whatsapp) | [Messenger](/adapters/messenger) |
+|---------|-------|-------|-------------|---------|---------|--------|--------|-----------|-----------|
+| Post message | <Check /> | <Check /> | <Check /> | <Check /> | <Check /> | <Check /> | <Check /> | <Check /> | <Check /> |
+| Edit message | <Check /> | <Check /> | <Check /> | <Check /> | <Check /> | <Check /> | <Warn /> Partial | <Cross /> | <Cross /> |
+| Delete message | <Check /> | <Check /> | <Check /> | <Check /> | <Check /> | <Check /> | <Warn /> Partial | <Cross /> | <Cross /> |
+| File uploads | <Check /> | <Check /> | <Cross /> | <Check /> | <Warn /> Single file/media | <Cross /> | <Cross /> | <Check /> Images, audio, docs | <Cross /> |
+| Streaming | <Check /> Native | <Warn /> Native (DMs) / Buffered | <Warn /> Post+Edit | <Warn /> Post+Edit | <Warn /> Post+Edit | <Warn /> Buffered | <Warn /> Agent sessions / Post+Edit | <Warn /> Buffered | <Warn /> Buffered |
+| Scheduled messages | <Check /> Native | <Cross /> | <Cross /> | <Cross /> | <Cross /> | <Cross /> | <Cross /> | <Cross /> | <Cross /> |
 
-for (const slug of ADAPTER_NAMES) {
-  const adapter = getAdapter(slug);
-  console.log(adapter.name, adapter.packageName, adapter.peerDeps);
+### Rich content
+
+| Feature | Slack | Teams | Google Chat | Discord | Telegram | GitHub | Linear | WhatsApp | Messenger |
+|---------|-------|-------|-------------|---------|----------|--------|--------|-----------|-----------|
+| Card format | Block Kit | Adaptive Cards | Google Chat Cards | Embeds | Markdown + inline keyboard buttons | GFM Markdown | Markdown | WhatsApp templates | Generic/Button Templates |
+| Buttons | <Check /> | <Check /> | <Check /> | <Check /> | <Warn /> Inline keyboard callbacks | <Cross /> | <Cross /> | <Check /> Interactive replies | <Warn /> Max 3, postback |
+| Link buttons | <Check /> | <Check /> | <Check /> | <Check /> | <Warn /> Inline keyboard URLs | <Cross /> | <Cross /> | <Cross /> | <Check /> |
+| Select menus | <Check /> | <Cross /> | <Check /> | <Cross /> | <Cross /> | <Cross /> | <Cross /> | <Cross /> | <Cross /> |
+| Tables | <Check /> Block Kit | <Check /> GFM | <Warn /> ASCII | <Check /> GFM | <Warn /> ASCII | <Check /> GFM | <Check /> GFM | <Cross /> | <Warn /> ASCII |
+| Fields | <Check /> | <Check /> | <Check /> | <Check /> | <Check /> | <Check /> | <Check /> | <Warn /> Template variables | <Warn /> ASCII |
+| Images in cards | <Check /> | <Check /> | <Check /> | <Check /> | <Cross /> | <Check /> | <Cross /> | <Check /> | <Check /> |
+| Modals | <Check /> | <Check /> | <Cross /> | <Cross /> | <Cross /> | <Cross /> | <Cross /> | <Cross /> | <Cross /> |
+
+### Conversations
+
+| Feature | Slack | Teams | Google Chat | Discord | Telegram | GitHub | Linear | WhatsApp | Messenger |
+|---------|-------|-------|-------------|---------|----------|--------|--------|-----------|-----------|
+| Slash commands | <Check /> | <Cross /> | <Cross /> | <Check /> | <Cross /> | <Cross /> | <Cross /> | <Cross /> | <Cross /> |
+| Mentions | <Check /> | <Check /> | <Check /> | <Check /> | <Check /> | <Check /> | <Check /> | <Cross /> | <Check /> |
+| Add reactions | <Check /> | <Cross /> | <Check /> | <Check /> | <Check /> | <Check /> | <Check /> | <Check /> | <Cross /> |
+| Remove reactions | <Check /> | <Cross /> | <Check /> | <Check /> | <Check /> | <Warn /> | <Warn /> | <Check /> | <Cross /> |
+| Typing indicator | <Check /> | <Check /> | <Cross /> | <Check /> | <Check /> | <Cross /> | <Warn /> Agent sessions | <Cross /> | <Check /> |
+| DMs | <Check /> | <Check /> | <Check /> | <Check /> | <Check /> | <Cross /> | <Cross /> | <Check /> | <Check /> |
+| Ephemeral messages | <Check /> Native | <Check /> Targeted | <Check /> Native | <Cross /> | <Cross /> | <Cross /> | <Cross /> | <Cross /> | <Cross /> |
+| User lookup ([`getUser`](/docs/api/chat#getuser)) | <Check /> | <Warn /> Cached | <Warn /> Cached | <Check /> | <Warn /> Seen users | <Check /> | <Check /> | <Cross /> | <Cross /> |
+| Parent subject ([`message.subject`](/docs/subject)) | <Cross /> | <Cross /> | <Cross /> | <Cross /> | <Cross /> | <Check /> | <Check /> | <Cross /> | <Cross /> |
+| Native client ([`.webClient` / `.octokit` / `.linearClient`](/docs/api/chat#getadapter)) | <Check /> | <Cross /> | <Cross /> | <Cross /> | <Cross /> | <Check /> | <Check /> | <Cross /> | <Cross /> |
+| Custom API endpoint (`apiUrl`) | <Check /> | <Check /> | <Check /> | <Check /> | <Check /> | <Check /> | <Check /> | <Check /> | <Check /> |
+
+### Message history
+
+| Feature | Slack | Teams | Google Chat | Discord | Telegram | GitHub | Linear | WhatsApp | Messenger |
+|---------|-------|-------|-------------|---------|----------|--------|--------|-----------|-----------|
+| Fetch messages | <Check /> | <Check /> | <Check /> | <Check /> | <Warn /> Cached | <Check /> | <Check /> | <Warn /> Cached sent messages only | <Warn /> Cached sent messages only |
+| Fetch single message | <Check /> | <Cross /> | <Cross /> | <Cross /> | <Warn /> Cached | <Cross /> | <Cross /> | <Cross /> | <Warn /> Cached |
+| Fetch thread info | <Check /> | <Check /> | <Check /> | <Check /> | <Check /> | <Check /> | <Check /> | <Check /> | <Check /> |
+| Fetch channel messages | <Check /> | <Check /> | <Check /> | <Check /> | <Warn /> Cached | <Check /> | <Cross /> | <Cross /> | <Warn /> Cached |
+| List threads | <Check /> | <Check /> | <Check /> | <Check /> | <Cross /> | <Check /> | <Cross /> | <Cross /> | <Cross /> |
+| Fetch channel info | <Check /> | <Check /> | <Check /> | <Check /> | <Check /> | <Check /> | <Cross /> | <Cross /> | <Check /> |
+| Post channel message | <Check /> | <Check /> | <Check /> | <Check /> | <Check /> | <Cross /> | <Cross /> | <Check /> | <Check /> |
+
+<Callout type="info">
+<Warn /> indicates partial support — the feature works with limitations. See individual adapter pages for details.
+</Callout>
+
+## How adapters work
+
+Each adapter implements a standard interface that the `Chat` class uses to route events and send messages. When a webhook arrives:
+
+1. The adapter verifies the request signature
+2. Parses the platform-specific payload into a normalized `Message`
+3. Routes to your handlers via the `Chat` class
+4. Converts outgoing messages from markdown/AST/cards to the platform's native format
+
+## Using multiple adapters
+
+Register multiple [adapters](/adapters) and your event handlers work across all of them:
+
+```typescript title="lib/bot.ts" lineNumbers
+import { Chat } from "chat";
+import { createSlackAdapter } from "@chat-adapter/slack";
+import { createTeamsAdapter } from "@chat-adapter/teams";
+import { createGoogleChatAdapter } from "@chat-adapter/gchat";
+import { createRedisState } from "@chat-adapter/state-redis";
+
+const bot = new Chat({
+  userName: "mybot",
+  adapters: {
+    slack: createSlackAdapter(),
+    teams: createTeamsAdapter(),
+    gchat: createGoogleChatAdapter(),
+  },
+  state: createRedisState(),
+});
+
+// This handler fires for mentions on any platform
+bot.onNewMention(async (thread) => {
+  await thread.subscribe();
+  await thread.post("Hello!");
+});
+```
+
+Each adapter auto-detects credentials from environment variables, so you only need to pass config when overriding defaults.
+
+<Callout type="info">
+  The examples above use Redis for state. See [State Adapters](/docs/state) for all available options.
+</Callout>
+
+Each adapter creates a webhook handler accessible via `bot.webhooks.<name>`.
+
+## Customizing an adapter via subclassing
+
+Each official adapter exposes its extension surface as `protected` members so you can subclass it to override or extend platform-specific behavior without forking the package. Use this when you need to handle a payload type the built-in adapter doesn't cover, intercept verification, or wrap an existing handler.
+
+```typescript title="lib/custom-telegram.ts" lineNumbers
+import { TelegramAdapter, type TelegramUpdate } from "@chat-adapter/telegram";
+import type { WebhookOptions } from "chat";
+
+export class CustomTelegramAdapter extends TelegramAdapter {
+  protected override processUpdate(
+    update: TelegramUpdate,
+    options?: WebhookOptions
+  ): void {
+    // Handle a payload type the base adapter doesn't, e.g. chat_join_request.
+    if ("chat_join_request" in update) {
+      this.logger.info("Received chat_join_request", { update });
+      return;
+    }
+    super.processUpdate(update, options);
+  }
 }
 ```
 
-Use the env helpers when you need to show setup instructions or inject secrets for one adapter:
+Construct your subclass anywhere you'd construct the base adapter — for example, `adapters: { telegram: new CustomTelegramAdapter({ ... }) }`. Members marked `private` (internal caches, in-flight runtime state, one-shot warning flags) intentionally remain inaccessible; if you find a hook you need that isn't `protected`, please open an issue.
 
-```typescript lineNumbers
-import { getAdapter, getSecretEnvVars } from "chat/adapters";
-
-const slack = getAdapter("slack");
-const secrets = getSecretEnvVars("slack").map((envVar) => envVar.key);
-
-console.log(slack.name, secrets);
-```
-
-The catalog intentionally covers official and vendor-official adapters. Community adapters live on the [Adapters](/adapters) listing page.
-
-### Environment specs
-
-Each adapter entry includes an `env` spec:
-
-- `required` lists variables needed regardless of auth mode.
-- `credentialModes` groups mutually exclusive ways to authenticate, such as a bot token vs OAuth client credentials.
-- `optional` lists tuning variables that are safe to omit.
-- `config` lists constructor options that do not have an environment-variable equivalent.
-
-### Types
-
-The main `CatalogAdapter` metadata shape is:
-
-<TypeTable
-  type={{
-    slug: {
-      type: "string",
-      description: "Stable catalog slug. Matches the key in `ADAPTERS`.",
-    },
-    name: {
-      type: "string",
-      description: "Display name.",
-    },
-    description: {
-      type: "string",
-      description: "One-line summary of what the adapter connects to.",
-    },
-    packageName: {
-      type: "string",
-      description: "NPM package that provides the adapter implementation.",
-    },
-    type: {
-      type: '"platform" | "state"',
-      description: "Whether the adapter connects to a platform or stores Chat SDK state.",
-    },
-    group: {
-      type: '"official" | "vendor-official"',
-      description: "Catalog group used by the docs adapter listing.",
-    },
-    peerDeps: {
-      type: "readonly string[]",
-      description: "Runtime packages the adapter expects the consuming app to provide or install alongside it.",
-    },
-    env: {
-      type: "AdapterEnvSpec",
-      description: "Environment variables and constructor-only configuration.",
-    },
-  }}
-/>
-
-<TypeTable
-  type={{
-    required: {
-      type: "readonly EnvVar[]",
-      description: "Variables needed regardless of credential mode.",
-    },
-    credentialModes: {
-      type: "readonly EnvGroup[]",
-      description: "Mutually exclusive credential groups. A caller usually satisfies exactly one group.",
-    },
-    optional: {
-      type: "readonly EnvVar[]",
-      description: "Optional environment variables that tune behavior.",
-    },
-    config: {
-      type: "readonly string[]",
-      description: "Constructor options that have no environment-variable equivalent.",
-    },
-    notes: {
-      type: "string",
-      description: "Additional caveats that do not fit the structured fields.",
-    },
-  }}
-/>
-
-<TypeTable
-  type={{
-    label: {
-      type: "string",
-      description: "Human-readable name for this credential mode.",
-    },
-    vars: {
-      type: "readonly EnvVar[]",
-      description: "Variables that together satisfy this mode.",
-    },
-  }}
-/>
-
-<TypeTable
-  type={{
-    key: {
-      type: "string",
-      description: "Canonical environment variable name.",
-    },
-    description: {
-      type: "string",
-      description: "Short description of what the value configures.",
-    },
-    secret: {
-      type: "boolean",
-      description: "Whether the value should be masked in logs and setup UIs.",
-    },
-    aliases: {
-      type: "readonly string[]",
-      description: "Alternative variable names accepted for the same value.",
-    },
-  }}
-/>
-
-### Helpers
-
-- `getAdapter(slug)` returns one catalog entry, or `undefined` for unknown slugs.
-- `isAdapterSlug(slug)` narrows a string to `AdapterSlug`.
-- `listEnvVars(slug)` flattens required, credential-mode, and optional env vars, de-duplicated by key.
-- `getSecretEnvVars(slug)` returns the subset of `listEnvVars(slug)` marked as secrets.
+<Callout type="warn">
+  The `protected` extension surface is intentionally broader than the public API but is not yet considered fully stable. Method signatures may evolve (renames, parameter changes, new hook splits) in minor releases as we learn from real-world subclasses. Pin the adapter version you build against, watch the changelog for the affected adapter, and prefer overriding the smallest hook that solves your problem so upgrades stay easy. If you rely on a particular hook, please open an issue so we can promote it to a stable, documented extension point.
+</Callout>

--- a/apps/docs/content/docs/ephemeral-messages.mdx
+++ b/apps/docs/content/docs/ephemeral-messages.mdx
@@ -29,8 +29,8 @@ The `fallbackToDM` option is required and controls behavior on platforms without
 |----------|---------------|----------|-------------|
 | Slack | Yes | Ephemeral in channel | Session-only (disappears on reload) |
 | Google Chat | Yes | Private message in space | Persists until deleted |
+| Teams | Yes | Targeted message in conversation | Teams-managed |
 | Discord | No | DM fallback | Persists in DM |
-| Teams | No | DM fallback | Persists in DM |
 
 Discord slash command responses can be made ephemeral with the Discord adapter's [`interactionFlags` option](/adapters/official/discord#interaction-flags). Outside that interaction flow, `postEphemeral` still follows the fallback behavior.
 

--- a/packages/adapter-teams/README.md
+++ b/packages/adapter-teams/README.md
@@ -190,7 +190,7 @@ TEAMS_API_URL=...        # Optional, for GCC-High or sovereign-cloud deployments
 | Receive reactions | Yes |
 | Typing indicator | Yes |
 | DMs | Yes |
-| Ephemeral messages | No (DM fallback) |
+| Ephemeral messages | Yes (native targeted messages, public preview) |
 | User lookup (`getUser`) | Yes (requires `User.Read.All`) |
 
 ### Message history
@@ -221,6 +221,18 @@ console.log(user?.fullName); // "Alice Smith"
 Incoming message authors also include `email` when Graph resolves the sender. The adapter uses the activity's Azure AD object ID first and falls back to its cached ID, so missing permissions or lookup failures leave `message.author.email` undefined without preventing message delivery. This applies to live incoming messages only — authors on edited-message events and messages returned by `fetchMessages` are not hydrated with an email. Resolved profiles are cached in the state adapter for 1 hour (failed lookups for 5 minutes), so busy conversations don't trigger a Graph call per message.
 
 The adapter caches each user's Azure AD object ID from incoming activities for later `getUser` calls. `getUser` returns `null` if the user hasn't been seen or the Graph call fails.
+
+## Targeted / ephemeral messages
+
+Teams targeted messages are available in public preview. Use the standard Chat SDK `postEphemeral` API to send a message that is visible only to a specific Teams conversation member:
+
+```typescript
+await thread.postEphemeral(message.author, "Only you can see this.", {
+  fallbackToDM: false,
+});
+```
+
+The adapter sends these natively with Teams targeted message metadata. `usedFallback` is `false` when the Teams API accepts the message.
 
 ## Message history (`fetchMessages`)
 

--- a/packages/adapter-teams/src/index.test.ts
+++ b/packages/adapter-teams/src/index.test.ts
@@ -983,6 +983,118 @@ describe("TeamsAdapter", () => {
     });
   });
 
+  describe("postEphemeral", () => {
+    it("should send a targeted text message to the requested user", async () => {
+      const adapter = createTeamsAdapter({
+        appId: "test-app-id",
+        appPassword: "test",
+        logger,
+      });
+
+      const mockApp = (
+        adapter as unknown as { app: { send: ReturnType<typeof vi.fn> } }
+      ).app;
+      mockApp.send = vi.fn(async () => ({
+        id: "targeted-msg-123",
+        type: "message",
+      }));
+
+      const threadId = adapter.encodeThreadId({
+        conversationId: "19:abc@thread.tacv2",
+        serviceUrl: "https://smba.trafficmanager.net/teams/",
+      });
+
+      const result = await adapter.postEphemeral(threadId, "29:target-user", {
+        markdown: "Only you can see this",
+      });
+
+      expect(result.id).toBe("targeted-msg-123");
+      expect(result.threadId).toBe(threadId);
+      expect(result.usedFallback).toBe(false);
+      expect(mockApp.send).toHaveBeenCalledWith(
+        "19:abc@thread.tacv2",
+        expect.objectContaining({
+          recipient: expect.objectContaining({
+            id: "29:target-user",
+            isTargeted: true,
+            role: "user",
+          }),
+          textFormat: "markdown",
+        })
+      );
+    });
+
+    it("should send targeted adaptive cards", async () => {
+      const adapter = createTeamsAdapter({
+        appId: "test-app-id",
+        appPassword: "test",
+        logger,
+      });
+
+      const mockApp = (
+        adapter as unknown as { app: { send: ReturnType<typeof vi.fn> } }
+      ).app;
+      mockApp.send = vi.fn(async () => ({
+        id: "targeted-card-123",
+        type: "message",
+      }));
+
+      const threadId = adapter.encodeThreadId({
+        conversationId: "19:abc@thread.tacv2",
+        serviceUrl: "https://smba.trafficmanager.net/teams/",
+      });
+
+      const result = await adapter.postEphemeral(threadId, "29:target-user", {
+        card: {
+          type: "card",
+          title: "Private card",
+          children: [],
+        },
+      });
+
+      expect(result.id).toBe("targeted-card-123");
+      expect(result.usedFallback).toBe(false);
+      expect(mockApp.send).toHaveBeenCalledWith(
+        "19:abc@thread.tacv2",
+        expect.objectContaining({
+          attachments: expect.arrayContaining([
+            expect.objectContaining({
+              contentType: "application/vnd.microsoft.card.adaptive",
+            }),
+          ]),
+          recipient: expect.objectContaining({
+            id: "29:target-user",
+            isTargeted: true,
+          }),
+        })
+      );
+    });
+
+    it("should handle targeted send failure by calling handleTeamsError", async () => {
+      const adapter = createTeamsAdapter({
+        appId: "test-app-id",
+        appPassword: "test",
+        logger,
+      });
+
+      const mockApp = (
+        adapter as unknown as { app: { send: ReturnType<typeof vi.fn> } }
+      ).app;
+      mockApp.send = vi.fn(async () => {
+        throw new MockTeamsError({ statusCode: 401, message: "Unauthorized" });
+      });
+
+      const threadId = adapter.encodeThreadId({
+        conversationId: "19:abc@thread.tacv2",
+        serviceUrl: "https://smba.trafficmanager.net/teams/",
+      });
+
+      await expect(
+        adapter.postEphemeral(threadId, "29:target-user", "Private")
+      ).rejects.toThrow(AuthenticationError);
+    });
+  });
+
   describe("editMessage", () => {
     it("should call api.conversations.activities.update", async () => {
       const adapter = createTeamsAdapter({

--- a/packages/adapter-teams/src/index.test.ts
+++ b/packages/adapter-teams/src/index.test.ts
@@ -1093,6 +1093,39 @@ describe("TeamsAdapter", () => {
         adapter.postEphemeral(threadId, "29:target-user", "Private")
       ).rejects.toThrow(AuthenticationError);
     });
+
+    it("falls back to a normal post in a 1:1 chat instead of a targeted send", async () => {
+      const adapter = createTeamsAdapter({
+        appId: "test-app-id",
+        appPassword: "test",
+        logger,
+      });
+
+      const mockApp = (
+        adapter as unknown as { app: { send: ReturnType<typeof vi.fn> } }
+      ).app;
+      mockApp.send = vi.fn(async () => ({
+        id: "personal-msg-123",
+        type: "message",
+      }));
+
+      const threadId = adapter.encodeThreadId({
+        conversationId: "a:1personal-chat-id",
+        serviceUrl: "https://smba.trafficmanager.net/teams/",
+      });
+
+      const result = await adapter.postEphemeral(threadId, "29:target-user", {
+        markdown: "Only you can see this",
+      });
+
+      expect(result.id).toBe("personal-msg-123");
+      expect(result.usedFallback).toBe(true);
+
+      const sentActivity = mockApp.send.mock.calls[0]?.[1] as {
+        recipient?: { isTargeted?: boolean };
+      };
+      expect(sentActivity.recipient?.isTargeted).not.toBe(true);
+    });
   });
 
   describe("editMessage", () => {

--- a/packages/adapter-teams/src/index.ts
+++ b/packages/adapter-teams/src/index.ts
@@ -1099,6 +1099,16 @@ export class TeamsAdapter implements Adapter<TeamsThreadId, unknown> {
     userId: string,
     message: AdapterPostableMessage
   ): Promise<EphemeralMessage<unknown>> {
+    if (this.isDM(threadId)) {
+      const sent = await this.postMessage(threadId, message);
+      return {
+        id: sent.id,
+        threadId: sent.threadId,
+        usedFallback: true,
+        raw: sent.raw,
+      };
+    }
+
     const { conversationId } = this.decodeThreadId(threadId);
     const recipient = this.createTargetedRecipient(userId);
 

--- a/packages/adapter-teams/src/index.ts
+++ b/packages/adapter-teams/src/index.ts
@@ -7,6 +7,7 @@ import {
   ValidationError,
 } from "@chat-adapter/shared";
 import type {
+  Account,
   Activity,
   IAdaptiveCardActionInvokeActivity,
   IMessageActivity,
@@ -29,6 +30,7 @@ import type {
   ChannelInfo,
   ChatInstance,
   EmojiValue,
+  EphemeralMessage,
   FetchOptions,
   FetchResult,
   FileUpload,
@@ -823,7 +825,7 @@ export class TeamsAdapter implements Adapter<TeamsThreadId, unknown> {
     activity: Activity,
     threadId: string
   ): Message<unknown> {
-    const text = (activity as MessageActivity).text || "";
+    const text = (activity as IMessageActivity).text || "";
     const normalizedText = this.normalizeMentions(text);
 
     const isMe = this.isMessageFromSelf(activity);
@@ -847,7 +849,7 @@ export class TeamsAdapter implements Adapter<TeamsThreadId, unknown> {
           : new Date(),
         edited: false,
       },
-      attachments: ((activity as MessageActivity).attachments || [])
+      attachments: ((activity as IMessageActivity).attachments || [])
         .filter(
           (att) =>
             att.contentType !== "application/vnd.microsoft.card.adaptive" &&
@@ -1090,6 +1092,105 @@ export class TeamsAdapter implements Adapter<TeamsThreadId, unknown> {
       this.logger.error("Teams API: send failed", { conversationId, error });
       handleTeamsError(error, "postMessage");
     }
+  }
+
+  async postEphemeral(
+    threadId: string,
+    userId: string,
+    message: AdapterPostableMessage
+  ): Promise<EphemeralMessage<unknown>> {
+    const { conversationId } = this.decodeThreadId(threadId);
+    const recipient = this.createTargetedRecipient(userId);
+
+    const files = extractFiles(message);
+    const fileAttachments =
+      files.length > 0 ? await this.filesToAttachments(files) : [];
+
+    const card = extractCard(message);
+
+    if (card) {
+      const adaptiveCard = cardToAdaptiveCard(card);
+      const activity = new MessageActivity().withRecipient(recipient, true);
+      activity.attachments = [
+        {
+          contentType: "application/vnd.microsoft.card.adaptive",
+          content: adaptiveCard,
+        },
+        ...fileAttachments,
+      ];
+
+      this.logger.debug("Teams API: send (targeted adaptive card)", {
+        conversationId,
+        userId,
+        fileCount: fileAttachments.length,
+      });
+
+      try {
+        const sent = await this.app.send(conversationId, activity);
+
+        return {
+          id: sent.id || "",
+          threadId,
+          usedFallback: false,
+          raw: activity,
+        };
+      } catch (error) {
+        this.logger.error("Teams API: targeted send failed", {
+          conversationId,
+          userId,
+          error,
+        });
+        handleTeamsError(error, "postEphemeral");
+      }
+    }
+
+    const text = convertEmojiPlaceholders(
+      this.formatConverter.renderPostable(message),
+      "teams"
+    );
+
+    const activity = new MessageActivity(text).withRecipient(recipient, true);
+    activity.textFormat = "markdown";
+    if (fileAttachments.length > 0) {
+      activity.attachments = fileAttachments;
+    }
+
+    this.logger.debug("Teams API: send (targeted message)", {
+      conversationId,
+      userId,
+      textLength: text.length,
+      fileCount: fileAttachments.length,
+    });
+
+    try {
+      const sent = await this.app.send(conversationId, activity);
+
+      this.logger.debug("Teams API: targeted send response", {
+        messageId: sent.id,
+      });
+
+      return {
+        id: sent.id || "",
+        threadId,
+        usedFallback: false,
+        raw: activity,
+      };
+    } catch (error) {
+      this.logger.error("Teams API: targeted send failed", {
+        conversationId,
+        userId,
+        error,
+      });
+      handleTeamsError(error, "postEphemeral");
+    }
+  }
+
+  protected createTargetedRecipient(userId: string): Account {
+    return {
+      id: userId,
+      name: userId,
+      role: "user",
+    };
   }
 
   protected async filesToAttachments(

--- a/packages/chat/src/types.ts
+++ b/packages/chat/src/types.ts
@@ -1215,8 +1215,8 @@ export interface Thread<TState = Record<string, unknown>, TRawMessage = unknown>
    * **Platform Behavior:**
    * - **Slack**: Native ephemeral (session-dependent, disappears on reload)
    * - **Google Chat**: Native private message (persists, only target user sees it)
+   * - **Teams**: Native targeted message (public preview)
    * - **Discord**: No native support - requires fallbackToDM: true
-   * - **Teams**: No native support - requires fallbackToDM: true
    *
    * @param user - User ID string or Author object (from message.author or event.user)
    * @param message - Message content (string, markdown, card, etc.). Streaming is not supported.


### PR DESCRIPTION
## Summary

Microsoft Teams supports targeted messages that are visible only to a selected conversation member, but the Teams adapter did not expose that native behavior through the SDK's ephemeral-message API. This PR wires `postEphemeral` for Teams to send native targeted messages while preserving normal `postMessage` behavior by default.

The adapter now creates explicit targeted outbound activities with `MessageActivity.withRecipient(recipient, true)` for text and adaptive-card messages, returns `usedFallback: false`, and keeps the feature gated behind `thread.postEphemeral()` / `channel.postEphemeral()`. It also bumps the Teams SDK packages to `^2.0.13`, adds targeted coverage, updates public docs/matrices, and includes a changeset.

Live verification found that Teams targeted messages require the app to be installed in the shared conversation. Group chats and channels both worked after using the Teams install picker with `Open -> select placement -> Go`; personal bot chat targeted sends returned a Teams `BadArgument` response.

## Test plan

Previously validated with:

- `corepack pnpm --filter @chat-adapter/teams exec vitest run src/index.test.ts --coverage.enabled=false`
- `corepack pnpm --filter @chat-adapter/teams exec tsc --noEmit`
- `corepack pnpm --filter example-nextjs-chat exec tsc --noEmit`
- `corepack pnpm --filter chat exec vitest run src/emoji.test.ts --coverage.enabled=false`
- `corepack pnpm --filter @chat-adapter/teams exec tsup`
- Targeted `ultracite check` on changed files

Live verified `TeamsAdapter.postEphemeral(...)` in:

- Group chat `Demo Test 2`: Teams UI showed `Only you can see this message`.
- Channel `General / Teams SDK`: Teams returned message ID `1784749118197`, and the UI showed `Only you can see this message`.

<img width="884" height="299" alt="Screenshot 2026-07-22 at 12 41 41 PM" src="https://github.com/user-attachments/assets/cd350ac8-c158-4779-8028-3450eb8670f2" />
<img width="1098" height="559" alt="Screenshot 2026-07-22 at 12 41 33 PM" src="https://github.com/user-attachments/assets/bf6ea12b-ab11-46ee-a3a8-ff5e9583066d" />


## Checklist

- [ ] All commits are signed and verified - unsigned commit created after local GPG/SSH signing was unavailable and user approved continuing
- [ ] `pnpm validate` passes - full validate not run; targeted validation listed above
- [x] Changeset added (or N/A - see [CONTRIBUTING.md](./CONTRIBUTING.md))
- [x] Documentation updated (or N/A)
