### PR TITLE
feat(teams): add message reaction support

### DIFF
--- a/.changeset/teams-reactions.md
+++ b/.changeset/teams-reactions.md
@@ -1,0 +1,6 @@
+---
+"@chat-adapter/teams": minor
+"chat": minor
+---
+
+Add first-class Microsoft Teams message reaction support, including outbound reaction add/remove operations and Teams reaction ID normalization.

--- a/apps/docs/content/adapters/official/teams.mdx
+++ b/apps/docs/content/adapters/official/teams.mdx
@@ -30,8 +30,8 @@ features:
   modals: yes
   slashCommands: no
   mentions: yes
-  addReactions: no
-  removeReactions: no
+  addReactions: yes
+  removeReactions: yes
   typingIndicator: yes
   directMessages: yes
   ephemeralMessages: no
@@ -208,6 +208,20 @@ console.log(user?.fullName); // "Alice Smith"
 ```
 
 The adapter caches each user's Azure AD object ID from incoming activities, so `getUser` only works for users who have previously interacted with the bot.
+
+### Reactions
+
+Teams message reactions are available through the standard Chat SDK reaction APIs:
+
+```typescript
+bot.onReaction(["thumbs_up"], async (event) => {
+  await event.thread.post(`${event.user.userName} liked a message`);
+});
+```
+
+Use `message.addReaction("thumbs_up")` and `message.removeReaction("thumbs_up")`
+to react from the bot. The adapter maps normalized emoji names to Teams reaction
+IDs and passes custom Teams reaction IDs through unchanged.
 
 ### Message history
 

--- a/packages/adapter-teams/README.md
+++ b/packages/adapter-teams/README.md
@@ -169,8 +169,8 @@ TEAMS_API_URL=...        # Optional, for GCC-High or sovereign-cloud deployments
 |---------|-----------|
 | Slash commands | No |
 | Mentions | Yes |
-| Add reactions | No |
-| Remove reactions | No |
+| Add reactions | Yes |
+| Remove reactions | Yes |
 | Receive reactions | Yes |
 | Typing indicator | Yes |
 | DMs | Yes |
@@ -233,6 +233,14 @@ az ad app permission admin-consent --id <appId>
 ```
 
 Without any of these permissions, `fetchMessages` will throw a `NotImplementedError`.
+
+## Reactions
+
+The adapter supports `message.addReaction()`, `message.removeReaction()`, and
+`chat.onReaction()` for Teams message reactions. Normalized emoji names are
+mapped to Teams reaction IDs where Teams has first-class support, and custom
+Teams reaction IDs such as `1f44b_wavinghand-tone4` can be passed through
+directly.
 
 ### Receiving all messages
 

--- a/packages/adapter-teams/src/index.test.ts
+++ b/packages/adapter-teams/src/index.test.ts
@@ -2,7 +2,9 @@ import { execSync } from "node:child_process";
 import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
 import { AuthenticationError, ValidationError } from "@chat-adapter/shared";
-import { ConsoleLogger } from "chat";
+import type { IMessageReactionActivity } from "@microsoft/teams.api";
+import type { IActivityContext } from "@microsoft/teams.apps";
+import { ConsoleLogger, emoji } from "chat";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { createTeamsAdapter, TeamsAdapter } from "./index";
 
@@ -959,6 +961,153 @@ describe("TeamsAdapter", () => {
         adapter.deleteMessage(threadId, "del-msg-1")
       ).resolves.not.toThrow();
       expect(mockDelete).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("reactions", () => {
+    it("should add a Teams reaction using a normalized emoji", async () => {
+      const adapter = createTeamsAdapter({
+        appId: "test-app-id",
+        appPassword: "test",
+        logger,
+      });
+
+      const mockAddReaction = vi.fn(async () => undefined);
+      const mockApp = (adapter as unknown as { app: { api: unknown } }).app;
+      mockApp.api = {
+        reactions: {
+          add: mockAddReaction,
+          remove: vi.fn(),
+        },
+      };
+
+      const threadId = adapter.encodeThreadId({
+        conversationId: "19:abc@thread.tacv2",
+        serviceUrl: "https://smba.trafficmanager.net/teams/",
+      });
+
+      await adapter.addReaction(threadId, "msg-1", emoji.thumbs_up);
+
+      expect(mockAddReaction).toHaveBeenCalledWith(
+        "19:abc@thread.tacv2",
+        "msg-1",
+        "like"
+      );
+    });
+
+    it("should remove a Teams reaction using a normalized emoji", async () => {
+      const adapter = createTeamsAdapter({
+        appId: "test-app-id",
+        appPassword: "test",
+        logger,
+      });
+
+      const mockRemoveReaction = vi.fn(async () => undefined);
+      const mockApp = (adapter as unknown as { app: { api: unknown } }).app;
+      mockApp.api = {
+        reactions: {
+          add: vi.fn(),
+          remove: mockRemoveReaction,
+        },
+      };
+
+      const threadId = adapter.encodeThreadId({
+        conversationId: "19:abc@thread.tacv2",
+        serviceUrl: "https://smba.trafficmanager.net/teams/",
+      });
+
+      await adapter.removeReaction(threadId, "msg-1", "check");
+
+      expect(mockRemoveReaction).toHaveBeenCalledWith(
+        "19:abc@thread.tacv2",
+        "msg-1",
+        "2705_whiteheavycheckmark"
+      );
+    });
+
+    it("should pass custom Teams reaction IDs through unchanged", async () => {
+      const adapter = createTeamsAdapter({
+        appId: "test-app-id",
+        appPassword: "test",
+        logger,
+      });
+
+      const mockAddReaction = vi.fn(async () => undefined);
+      const mockApp = (adapter as unknown as { app: { api: unknown } }).app;
+      mockApp.api = {
+        reactions: {
+          add: mockAddReaction,
+          remove: vi.fn(),
+        },
+      };
+
+      const threadId = adapter.encodeThreadId({
+        conversationId: "19:abc@thread.tacv2",
+        serviceUrl: "https://smba.trafficmanager.net/teams/",
+      });
+
+      await adapter.addReaction(threadId, "msg-1", "1f44b_wavinghand-tone4");
+
+      expect(mockAddReaction).toHaveBeenCalledWith(
+        "19:abc@thread.tacv2",
+        "msg-1",
+        "1f44b_wavinghand-tone4"
+      );
+    });
+
+    it("should emit normalized reaction events for Teams reaction activities", () => {
+      class TestTeamsAdapter extends TeamsAdapter {
+        setChat(chat: Parameters<TeamsAdapter["initialize"]>[0]) {
+          this.chat = chat;
+        }
+
+        receiveReaction(activity: unknown) {
+          this.handleReactionFromContext({
+            activity,
+          } as IActivityContext<IMessageReactionActivity>);
+        }
+      }
+
+      const adapter = new TestTeamsAdapter({
+        appId: "test-app-id",
+        appPassword: "test",
+        logger,
+      });
+      const processReaction = vi.fn();
+      adapter.setChat({
+        processReaction,
+      } as unknown as Parameters<TeamsAdapter["initialize"]>[0]);
+
+      adapter.receiveReaction({
+        type: "messageReaction",
+        id: "reaction-activity-1",
+        serviceUrl: "https://smba.trafficmanager.net/teams/",
+        conversation: {
+          id: "19:abc@thread.tacv2;messageid=1767297849909",
+        },
+        from: { id: "29:user-1", name: "Alice" },
+        reactionsAdded: [{ type: "1f440_eyes" }],
+        reactionsRemoved: [{ type: "like" }],
+      });
+
+      expect(processReaction).toHaveBeenCalledTimes(2);
+      expect(processReaction.mock.calls[0]?.[0]).toMatchObject({
+        added: true,
+        messageId: "1767297849909",
+        rawEmoji: "1f440_eyes",
+        user: {
+          userId: "29:user-1",
+          userName: "Alice",
+          isMe: false,
+        },
+      });
+      expect(processReaction.mock.calls[0]?.[0].emoji.name).toBe("eyes");
+      expect(processReaction.mock.calls[1]?.[0]).toMatchObject({
+        added: false,
+        messageId: "1767297849909",
+        rawEmoji: "like",
+      });
+      expect(processReaction.mock.calls[1]?.[0].emoji.name).toBe("thumbs_up");
     });
   });
 

--- a/packages/adapter-teams/src/index.ts
+++ b/packages/adapter-teams/src/index.ts
@@ -49,7 +49,6 @@ import {
   convertEmojiPlaceholders,
   defaultEmojiResolver,
   Message,
-  NotImplementedError,
 } from "chat";
 import { BridgeHttpAdapter } from "./bridge-adapter";
 import { AUTO_SUBMIT_ACTION_ID, cardToAdaptiveCard } from "./cards";
@@ -1131,25 +1130,69 @@ export class TeamsAdapter implements Adapter<TeamsThreadId, unknown> {
   }
 
   async addReaction(
-    _threadId: string,
-    _messageId: string,
-    _emoji: EmojiValue | string
+    threadId: string,
+    messageId: string,
+    emoji: EmojiValue | string
   ): Promise<void> {
-    throw new NotImplementedError(
-      "addReaction is not yet supported by the Teams SDK",
-      "addReaction"
-    );
+    const { conversationId } = this.decodeThreadId(threadId);
+    const teamsReaction = defaultEmojiResolver.toTeams(emoji);
+
+    this.logger.debug("Teams API: reactions.add", {
+      conversationId,
+      messageId,
+      emoji: teamsReaction,
+    });
+
+    try {
+      await this.app.api.reactions.add(
+        conversationId,
+        messageId,
+        teamsReaction
+      );
+    } catch (error) {
+      this.logger.error("Teams API: reactions.add failed", {
+        conversationId,
+        messageId,
+        emoji: teamsReaction,
+        error,
+      });
+      handleTeamsError(error, "addReaction");
+    }
+
+    this.logger.debug("Teams API: reactions.add response", { ok: true });
   }
 
   async removeReaction(
-    _threadId: string,
-    _messageId: string,
-    _emoji: EmojiValue | string
+    threadId: string,
+    messageId: string,
+    emoji: EmojiValue | string
   ): Promise<void> {
-    throw new NotImplementedError(
-      "removeReaction is not yet supported by the Teams SDK",
-      "removeReaction"
-    );
+    const { conversationId } = this.decodeThreadId(threadId);
+    const teamsReaction = defaultEmojiResolver.toTeams(emoji);
+
+    this.logger.debug("Teams API: reactions.remove", {
+      conversationId,
+      messageId,
+      emoji: teamsReaction,
+    });
+
+    try {
+      await this.app.api.reactions.remove(
+        conversationId,
+        messageId,
+        teamsReaction
+      );
+    } catch (error) {
+      this.logger.error("Teams API: reactions.remove failed", {
+        conversationId,
+        messageId,
+        emoji: teamsReaction,
+        error,
+      });
+      handleTeamsError(error, "removeReaction");
+    }
+
+    this.logger.debug("Teams API: reactions.remove response", { ok: true });
   }
 
   async startTyping(threadId: string, _status?: string): Promise<void> {

--- a/packages/chat/src/emoji.test.ts
+++ b/packages/chat/src/emoji.test.ts
@@ -75,12 +75,35 @@ describe("EmojiResolver", () => {
       expect(resolver.fromTeams("surprised").name).toBe("surprised");
       expect(resolver.fromTeams("sad").name).toBe("sad");
       expect(resolver.fromTeams("angry").name).toBe("angry");
+      expect(resolver.fromTeams("1f440_eyes").name).toBe("eyes");
+      expect(resolver.fromTeams("2705_whiteheavycheckmark").name).toBe("check");
+      expect(resolver.fromTeams("launch").name).toBe("rocket");
+      expect(resolver.fromTeams("1f4cc_pushpin").name).toBe("pin");
     });
 
     it("should return EmojiValue with raw name if no mapping exists", () => {
       const resolver = new EmojiResolver();
       const result = resolver.fromTeams("custom_reaction");
       expect(result.name).toBe("custom_reaction");
+    });
+  });
+
+  describe("toTeams", () => {
+    it("should convert normalized emoji to Teams reaction IDs", () => {
+      const resolver = new EmojiResolver();
+      expect(resolver.toTeams("thumbs_up")).toBe("like");
+      expect(resolver.toTeams("heart")).toBe("heart");
+      expect(resolver.toTeams("eyes")).toBe("1f440_eyes");
+      expect(resolver.toTeams("check")).toBe("2705_whiteheavycheckmark");
+      expect(resolver.toTeams("rocket")).toBe("launch");
+      expect(resolver.toTeams("pin")).toBe("1f4cc_pushpin");
+    });
+
+    it("should return raw reaction ID if no mapping exists", () => {
+      const resolver = new EmojiResolver();
+      expect(resolver.toTeams("1f44b_wavinghand-tone4")).toBe(
+        "1f44b_wavinghand-tone4"
+      );
     });
   });
 

--- a/packages/chat/src/emoji.ts
+++ b/packages/chat/src/emoji.ts
@@ -171,6 +171,26 @@ export const DEFAULT_EMOJI_MAP: Record<string, EmojiFormats> = {
   rainbow: { slack: "rainbow", gchat: "🌈" },
 };
 
+const TEAMS_REACTION_TO_NORMALIZED: Record<string, string> = {
+  "1f440_eyes": "eyes",
+  "1f4cc_pushpin": "pin",
+  "2705_whiteheavycheckmark": "check",
+  angry: "angry",
+  heart: "heart",
+  laugh: "laugh",
+  launch: "rocket",
+  like: "thumbs_up",
+  sad: "sad",
+  surprised: "surprised",
+};
+
+const NORMALIZED_TO_TEAMS_REACTION: Record<string, string> = Object.fromEntries(
+  Object.entries(TEAMS_REACTION_TO_NORMALIZED).map(([teams, normalized]) => [
+    normalized,
+    teams,
+  ])
+);
+
 /**
  * Emoji resolver that handles conversion between platform formats and normalized names.
  */
@@ -228,19 +248,13 @@ export class EmojiResolver {
 
   /**
    * Convert a Teams reaction type to normalized EmojiValue.
-   * Teams uses specific names: like, heart, laugh, surprised, sad, angry
+   * Teams uses specific names: like, heart, laugh, surprised, sad, angry,
+   * and codepoint-based IDs for newer reaction types.
    * Returns an EmojiValue for the raw reaction if no mapping exists.
    */
   fromTeams(teamsReaction: string): EmojiValue {
-    const teamsMap: Record<string, string> = {
-      like: "thumbs_up",
-      heart: "heart",
-      laugh: "laugh",
-      surprised: "surprised",
-      sad: "sad",
-      angry: "angry",
-    };
-    const normalized = teamsMap[teamsReaction] ?? teamsReaction;
+    const normalized =
+      TEAMS_REACTION_TO_NORMALIZED[teamsReaction] ?? teamsReaction;
     return getEmoji(normalized);
   }
 
@@ -277,6 +291,15 @@ export class EmojiResolver {
   toDiscord(emoji: EmojiValue | string): string {
     // Discord uses unicode emoji like GChat
     return this.toGChat(emoji);
+  }
+
+  /**
+   * Convert a normalized emoji (or EmojiValue) to a Teams reaction ID.
+   * Returns the raw name for unsupported/custom Teams reaction IDs.
+   */
+  toTeams(emoji: EmojiValue | string): string {
+    const name = typeof emoji === "string" ? emoji : emoji.name;
+    return NORMALIZED_TO_TEAMS_REACTION[name] ?? name;
   }
 
   /**


### PR DESCRIPTION
## Summary

Teams already receives reaction events, but outbound message reaction APIs were still unimplemented. This PR adds first-class Teams reaction support by wiring `message.addReaction()` and `message.removeReaction()` to the Teams SDK reactions API and sharing Teams reaction ID normalization through the core emoji resolver.

The adapter now maps supported normalized emoji names to Teams reaction IDs, preserves custom Teams reaction IDs as passthrough values, and continues to normalize inbound `messageReaction` events for `chat.onReaction()` handlers. The Teams README, docs page, tests, and changeset are updated to reflect the new support.

Note: the commit is unsigned because GPG signing was unavailable in this local environment (`No secret key`); the user approved proceeding with an unsigned commit for this PR.

## Checklist

- [ ] All commits are signed and verified
- [ ] `pnpm validate` passes
- [x] Changeset added (or N/A -- see [CONTRIBUTING.md](./CONTRIBUTING.md))
- [x] Documentation updated (or N/A)