### PR TITLE
feat(telegram): add user allowlist

### DIFF
--- a/.changeset/telegram-user-allowlist.md
+++ b/.changeset/telegram-user-allowlist.md
@@ -1,0 +1,5 @@
+---
+"@chat-adapter/telegram": minor
+---
+
+Add an optional Telegram user allowlist via `allowedUserIds` or the comma-separated `TELEGRAM_ALLOWED_USER_IDS` environment variable.

--- a/apps/docs/content/adapters/official/telegram.mdx
+++ b/apps/docs/content/adapters/official/telegram.mdx
@@ -65,7 +65,7 @@ features:
 ## Quick start
 
 <Callout type="info">
-The adapter auto-detects `TELEGRAM_BOT_TOKEN`, `TELEGRAM_WEBHOOK_SECRET_TOKEN`, and `TELEGRAM_BOT_USERNAME` from the environment.
+The adapter auto-detects `TELEGRAM_ALLOWED_USER_IDS`, `TELEGRAM_BOT_TOKEN`, `TELEGRAM_WEBHOOK_SECRET_TOKEN`, and `TELEGRAM_BOT_USERNAME` from the environment.
 </Callout>
 
 ```typescript title="lib/bot.ts" lineNumbers
@@ -107,6 +107,11 @@ curl -X POST "https://api.telegram.org/bot$TELEGRAM_BOT_TOKEN/setWebhook" \
 
 <TypeTable
   type={{
+    allowedUserIds: {
+      type: "Array<number | string>",
+      description:
+        "Telegram user IDs allowed to trigger the adapter. Auto-detected from `TELEGRAM_ALLOWED_USER_IDS` (comma-separated). All users are allowed when omitted or empty.",
+    },
     botToken: {
       type: "string",
       description: "Telegram bot token. Auto-detected from `TELEGRAM_BOT_TOKEN`.",

--- a/packages/adapter-telegram/README.md
+++ b/packages/adapter-telegram/README.md
@@ -129,6 +129,7 @@ All options are auto-detected from environment variables when not provided.
 
 | Option | Required | Description |
 |--------|----------|-------------|
+| `allowedUserIds` | No | Telegram user IDs allowed to trigger the adapter. Auto-detected from `TELEGRAM_ALLOWED_USER_IDS` (comma-separated). All users are allowed when omitted or empty |
 | `botToken` | No* | Telegram bot token. Auto-detected from `TELEGRAM_BOT_TOKEN` |
 | `secretToken` | No | Optional webhook secret token. Auto-detected from `TELEGRAM_WEBHOOK_SECRET_TOKEN` |
 | `mode` | No | Adapter mode: `auto` (default), `webhook`, or `polling` |
@@ -142,6 +143,7 @@ All options are auto-detected from environment variables when not provided.
 ## Environment variables
 
 ```bash
+TELEGRAM_ALLOWED_USER_IDS=123456789,987654321
 TELEGRAM_BOT_TOKEN=123456:ABCDEF...
 TELEGRAM_WEBHOOK_SECRET_TOKEN=your-webhook-secret
 TELEGRAM_BOT_USERNAME=mybot

--- a/packages/adapter-telegram/src/index.test.ts
+++ b/packages/adapter-telegram/src/index.test.ts
@@ -20,6 +20,7 @@ import {
   type TelegramMessage,
   type TelegramReactionType,
   type TelegramThreadId,
+  type TelegramUpdate,
 } from "./index";
 import {
   TELEGRAM_CAPTION_LIMIT,
@@ -231,6 +232,24 @@ describe("constructor env var resolution", () => {
     expect(adapter).toBeInstanceOf(TelegramAdapter);
   });
 
+  it("should resolve allowedUserIds from TELEGRAM_ALLOWED_USER_IDS env var", () => {
+    process.env.TELEGRAM_BOT_TOKEN = "env-bot-token";
+    process.env.TELEGRAM_ALLOWED_USER_IDS = "123, 456";
+    const adapter = new TelegramAdapter();
+    expect(
+      (adapter as unknown as { allowedUserIds: Set<string> }).allowedUserIds
+    ).toEqual(new Set(["123", "456"]));
+  });
+
+  it("should allow all users when TELEGRAM_ALLOWED_USER_IDS is empty", () => {
+    process.env.TELEGRAM_BOT_TOKEN = "env-bot-token";
+    process.env.TELEGRAM_ALLOWED_USER_IDS = " , ";
+    const adapter = new TelegramAdapter();
+    expect(
+      (adapter as unknown as { allowedUserIds?: Set<string> }).allowedUserIds
+    ).toBeUndefined();
+  });
+
   it("should accept apiUrl config and prefer it over apiBaseUrl", () => {
     process.env.TELEGRAM_BOT_TOKEN = "env-bot-token";
     const adapter = new TelegramAdapter({
@@ -361,6 +380,84 @@ describe("TelegramAdapter", () => {
         String(input).includes("/sendChatAction")
       )
     ).toBe(false);
+  });
+
+  it("rejects disallowed and identityless updates before dispatch", async () => {
+    mockFetch.mockResolvedValueOnce(
+      telegramOk({
+        id: 999,
+        is_bot: true,
+        first_name: "Bot",
+        username: "mybot",
+      })
+    );
+
+    class TestTelegramAdapter extends TelegramAdapter {
+      dispatch(update: TelegramUpdate): void {
+        this.processUpdate(update);
+      }
+    }
+
+    const adapter = new TestTelegramAdapter({
+      allowedUserIds: [456],
+      botToken: "token",
+      mode: "webhook",
+      logger: mockLogger,
+      userName: "mybot",
+    });
+    const chat = createMockChat();
+    await adapter.initialize(chat);
+
+    const disallowedUser = {
+      id: 789,
+      is_bot: false,
+      first_name: "Other User",
+    };
+    const groupMessage = sampleMessage({
+      chat: { id: -100123, type: "supergroup", title: "General" },
+    });
+
+    const updates: TelegramUpdate[] = [
+      {
+        update_id: 1,
+        message: { ...groupMessage, from: disallowedUser },
+      },
+      {
+        update_id: 2,
+        callback_query: {
+          id: "callback-1",
+          from: disallowedUser,
+          message: groupMessage,
+          chat_instance: "ci_1",
+          data: "approve",
+        },
+      },
+      {
+        update_id: 3,
+        message_reaction: {
+          chat: groupMessage.chat,
+          message_id: groupMessage.message_id,
+          date: groupMessage.date,
+          old_reaction: [],
+          new_reaction: [{ type: "emoji", emoji: "👍" }],
+          user: disallowedUser,
+        },
+      },
+      {
+        update_id: 4,
+        channel_post: { ...groupMessage, from: undefined },
+      },
+    ];
+
+    for (const update of updates) {
+      adapter.dispatch(update);
+    }
+    adapter.dispatch({ update_id: 5, message: groupMessage });
+
+    expect(chat.processMessage).toHaveBeenCalledTimes(1);
+    expect(chat).not.toHaveDispatched("processSlashCommand");
+    expect(chat).not.toHaveDispatched("processAction");
+    expect(chat).not.toHaveDispatched("processReaction");
   });
 
   it("starts typing before processing private message updates", async () => {

--- a/packages/adapter-telegram/src/index.ts
+++ b/packages/adapter-telegram/src/index.ts
@@ -252,6 +252,7 @@ export class TelegramAdapter
   readonly lockScope = "channel" as const;
   readonly persistThreadHistory = true;
 
+  protected readonly allowedUserIds?: Set<string>;
   protected readonly botToken: string;
   protected readonly apiBaseUrl: string;
   protected readonly secretToken?: string;
@@ -312,6 +313,15 @@ export class TelegramAdapter
     );
     this.secretToken =
       config.secretToken ?? process.env.TELEGRAM_WEBHOOK_SECRET_TOKEN;
+    const allowedUserIds =
+      config.allowedUserIds ??
+      process.env.TELEGRAM_ALLOWED_USER_IDS?.split(",");
+    const normalizedAllowedUserIds = allowedUserIds
+      ?.map((id) => String(id).trim())
+      .filter(Boolean);
+    this.allowedUserIds = normalizedAllowedUserIds?.length
+      ? new Set(normalizedAllowedUserIds)
+      : undefined;
     this.logger = config.logger ?? new ConsoleLogger("info").child("telegram");
     const userName = config.userName ?? process.env.TELEGRAM_BOT_USERNAME;
     this._userName = this.normalizeUserName(userName ?? "bot");
@@ -593,6 +603,17 @@ export class TelegramAdapter
       update.edited_message ??
       update.channel_post ??
       update.edited_channel_post;
+    const userId =
+      update.callback_query?.from.id ??
+      update.message_reaction?.user?.id ??
+      messageUpdate?.from?.id;
+
+    if (
+      this.allowedUserIds &&
+      (userId === undefined || !this.allowedUserIds.has(String(userId)))
+    ) {
+      return;
+    }
 
     const handledSlashCommand =
       update.message !== undefined &&

--- a/packages/adapter-telegram/src/types.ts
+++ b/packages/adapter-telegram/src/types.ts
@@ -8,6 +8,8 @@ import type { Logger } from "chat";
  * Telegram adapter configuration.
  */
 export interface TelegramAdapterConfig {
+  /** Telegram user IDs allowed to trigger the adapter. Defaults to TELEGRAM_ALLOWED_USER_IDS env var (comma-separated). All users are allowed when omitted or empty. */
+  allowedUserIds?: Array<number | string>;
   /** Optional custom API base URL (defaults to https://api.telegram.org). Defaults to TELEGRAM_API_BASE_URL env var. */
   apiBaseUrl?: string;
   /** Override the Telegram API base URL. Alias for apiBaseUrl — apiUrl takes precedence if both are set. Defaults to TELEGRAM_API_BASE_URL env var. */

--- a/packages/chat/src/adapters/index.ts
+++ b/packages/chat/src/adapters/index.ts
@@ -907,6 +907,10 @@ export const ADAPTERS = {
       "Connect to Telegram with support for groups, channels, and inline keyboards.",
     env: {
       optional: [
+        env(
+          "TELEGRAM_ALLOWED_USER_IDS",
+          "Comma-separated Telegram user IDs allowed to trigger the adapter."
+        ),
         secretEnv(
           "TELEGRAM_WEBHOOK_SECRET_TOKEN",
           "Optional webhook secret token."


### PR DESCRIPTION
## Summary

Add an opt-in `allowedUserIds` Telegram adapter option, with `TELEGRAM_ALLOWED_USER_IDS` as a comma-separated environment fallback. Updates from other or unidentified users are ignored before dispatch.

This follows the adapter-level targeting pattern from [the Discord channel response allowlist](https://github.com/vercel/chat/pull/715), while enforcing an ingress allowlist instead of expanding mention routing.

## Test plan

- `pnpm --filter @chat-adapter/telegram test`
- `pnpm --filter @chat-adapter/telegram typecheck`
- `pnpm check`
- `pnpm konsistent`
- `TURBO_CONCURRENCY=2 pnpm validate`

## Checklist

- [x] All commits are signed and verified
- [x] All commits are signed off for the DCO (`git commit -s`)
- [x] `pnpm validate` passes
- [x] Changeset added (or N/A — see [CONTRIBUTING.md](./CONTRIBUTING.md))
- [x] Documentation updated (or N/A)
