### PR TITLE
feat(chat): scope agent read tools to the active conversation

### DIFF
--- a/.changeset/clever-frogs-invite.md
+++ b/.changeset/clever-frogs-invite.md
@@ -1,0 +1,5 @@
+---
+"chat": minor
+---
+
+confine built-in agent read tools to the conversation being handled, with an optional scope override

--- a/apps/docs/content/docs/ai/ai-sdk-tools.mdx
+++ b/apps/docs/content/docs/ai/ai-sdk-tools.mdx
@@ -94,6 +94,51 @@ Omit `preset` entirely to get every tool (same as `'moderator'`).
 | `messenger` | `fetchMessages`, `fetchThread`, `getChannelInfo`, `getUser`, `postMessage`, `postChannelMessage`, `sendDirectMessage`, `addReaction`, `removeReaction`, `startTyping` |
 | `moderator` | All read tools plus `postMessage`, `postChannelMessage`, `sendDirectMessage`, `editMessage`, `deleteMessage`, `addReaction`, `removeReaction`, `subscribeThread`, `unsubscribeThread`, `startTyping` |
 
+## Limiting what the agent can read
+
+Read tools take a thread or channel id chosen by the model, and they run with your bot's platform access. A bot is usually a member of channels a given user is not, so an agent handling untrusted input can be talked into fetching a conversation the user could never open themselves, then repeating it back.
+
+Pass `scope` with the conversation the agent is handling. Reads that resolve to a different channel are rejected before the platform is called:
+
+```typescript title="lib/bot.ts" lineNumbers
+bot.onNewMention(async (thread, message) => {
+  const tools = createChatTools({
+    chat,
+    preset: "reader",
+    scope: thread,
+  });
+
+  const result = await generateText({
+    model: "openai/gpt-5",
+    tools,
+    prompt: message.text,
+  });
+});
+```
+
+`scope` accepts a `Thread`, a `Channel`, or a raw id. Scoping is per channel, so the agent can still follow other threads in the conversation it was invited to, but not reach into another one.
+
+Tools built inside a handler pick this up automatically, so the common case needs no extra argument:
+
+```typescript title="lib/bot.ts" lineNumbers
+bot.onNewMention(async (thread, message) => {
+  // Reads are confined to this conversation.
+  const tools = createChatTools({ chat, preset: "reader" });
+
+  const result = await generateText({
+    model: "openai/gpt-5",
+    tools,
+    prompt: message.text,
+  });
+});
+```
+
+Pass `scope` explicitly when the agent runs outside a handler, such as a queued job that still answers on a user's behalf. Scoping is per channel, so an agent can still follow other threads in its own conversation.
+
+<Callout type="warn">
+  Agents created outside a handler have no conversation to inherit, so their reads are unrestricted. Pass `scope` there, or `scope: false` to say workspace-wide reads are intended.
+</Callout>
+
 ## Approval control
 
 Write operations (posting, editing, deleting, reacting, subscribing) default to `needsApproval: true`. The AI SDK pauses execution and surfaces an approval request that your application is expected to confirm before the tool runs. This keeps a human in the loop for anything visible to the workspace.
@@ -214,9 +259,11 @@ type ChatToolsOptions = {
   requireApproval?: boolean | Partial<Record<ChatWriteToolName, boolean>>;
   preset?: ChatToolPreset | ChatToolPreset[];
   overrides?: Partial<Record<ChatToolName, ToolOverrides>>;
+  scope?: ReadScope | false;
 };
 
 type ChatToolPreset = "reader" | "messenger" | "moderator";
+type ReadScope = string | { id: string };
 ```
 
 | Option | Description |
@@ -225,3 +272,4 @@ type ChatToolPreset = "reader" | "messenger" | "moderator";
 | `preset` | Preset (or array of presets) restricting which tools are returned. Omit to get every tool. |
 | `requireApproval` | `true` (default), `false`, or per-tool overrides. Read tools and `startTyping` are never gated. |
 | `overrides` | Per-tool customization of any AI SDK `tool()` property except `execute`, `inputSchema`, and `outputSchema`. |
+| `scope` | Conversation the read tools are confined to. Defaults to the conversation being handled. Pass a `Thread`, `Channel`, or `false` to read across every conversation the bot can see. |

--- a/packages/chat/src/ai/index.test.ts
+++ b/packages/chat/src/ai/index.test.ts
@@ -1,6 +1,7 @@
 import type { Tool } from "ai";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { Chat } from "../chat";
+import { runInConversation } from "../context";
 import {
   createMockAdapter,
   createMockState,
@@ -14,6 +15,8 @@ const REQUIRES_CHAT_INSTANCE_REGEX = /requires a `chat` instance/;
 const NO_FETCH_CHANNEL_MESSAGES_REGEX =
   /does not support fetching channel messages/;
 const NO_LIST_THREADS_REGEX = /does not support listing threads/;
+const OUT_OF_SCOPE_REGEX = /reads are scoped to channel/;
+const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
 
 // Minimal tool execution options stub used by every test below. Derived from
 // `Tool["execute"]` so the same code typechecks against both ai v6 and v7
@@ -70,6 +73,7 @@ describe("createChatTools", () => {
     expect(() =>
       createChatTools({
         chat: undefined as unknown as Chat<{ slack: Adapter }>,
+        scope: false,
       })
     ).toThrow(REQUIRES_CHAT_INSTANCE_REGEX);
   });
@@ -131,7 +135,10 @@ describe("createChatTools", () => {
   });
 
   it("disables approval on every write tool when requireApproval is false", () => {
-    const tools = createChatTools({ chat, requireApproval: false });
+    const tools = createChatTools({
+      chat,
+      requireApproval: false,
+    });
     expect(tools.postMessage?.needsApproval).toBe(false);
     expect(tools.postChannelMessage?.needsApproval).toBe(false);
     expect(tools.sendDirectMessage?.needsApproval).toBe(false);
@@ -231,7 +238,10 @@ describe("createChatTools", () => {
   });
 
   it("postMessage dispatches via the adapter's postMessage", async () => {
-    const tools = createChatTools({ chat, requireApproval: false });
+    const tools = createChatTools({
+      chat,
+      requireApproval: false,
+    });
     const result = await tools.postMessage?.execute?.(
       { threadId: "slack:C123:1234.5678", message: "hello" },
       TOOL_OPTIONS
@@ -244,7 +254,10 @@ describe("createChatTools", () => {
   });
 
   it("postChannelMessage dispatches via the adapter's postChannelMessage", async () => {
-    const tools = createChatTools({ chat, requireApproval: false });
+    const tools = createChatTools({
+      chat,
+      requireApproval: false,
+    });
     await tools.postChannelMessage?.execute?.(
       {
         channelId: "slack:C123",
@@ -258,7 +271,10 @@ describe("createChatTools", () => {
   });
 
   it("sendDirectMessage opens a DM and posts in it", async () => {
-    const tools = createChatTools({ chat, requireApproval: false });
+    const tools = createChatTools({
+      chat,
+      requireApproval: false,
+    });
     await tools.sendDirectMessage?.execute?.(
       { userId: "U123456", message: "ping" },
       TOOL_OPTIONS
@@ -268,7 +284,10 @@ describe("createChatTools", () => {
   });
 
   it("addReaction dispatches via the adapter's addReaction", async () => {
-    const tools = createChatTools({ chat, requireApproval: false });
+    const tools = createChatTools({
+      chat,
+      requireApproval: false,
+    });
     await tools.addReaction?.execute?.(
       {
         threadId: "slack:C123:1234.5678",
@@ -285,7 +304,10 @@ describe("createChatTools", () => {
   });
 
   it("deleteMessage dispatches via the adapter's deleteMessage", async () => {
-    const tools = createChatTools({ chat, requireApproval: false });
+    const tools = createChatTools({
+      chat,
+      requireApproval: false,
+    });
     const result = await tools.deleteMessage?.execute?.(
       { threadId: "slack:C123:1234.5678", messageId: "msg-1" },
       TOOL_OPTIONS
@@ -298,7 +320,10 @@ describe("createChatTools", () => {
   });
 
   it("subscribeThread persists the subscription", async () => {
-    const tools = createChatTools({ chat, requireApproval: false });
+    const tools = createChatTools({
+      chat,
+      requireApproval: false,
+    });
     await tools.subscribeThread?.execute?.(
       { threadId: "slack:C123:1234.5678" },
       TOOL_OPTIONS
@@ -352,6 +377,231 @@ describe("createChatTools", () => {
     ]);
   });
 
+  describe("read scope", () => {
+    const CALLER_THREAD = "slack:C123:1234.5678";
+    const OTHER_THREAD = "slack:C999:1111.2222";
+
+    it("blocks reading a thread outside the scoped channel", async () => {
+      const tools = createChatTools({ chat, scope: CALLER_THREAD });
+      await expect(
+        tools.fetchMessages?.execute?.(
+          { threadId: OTHER_THREAD, limit: 5, direction: "backward" },
+          TOOL_OPTIONS
+        )
+      ).rejects.toThrow(OUT_OF_SCOPE_REGEX);
+      expect(mockAdapter.fetchMessages).not.toHaveBeenCalled();
+    });
+
+    it("allows reading another thread in the scoped channel", async () => {
+      const tools = createChatTools({ chat, scope: CALLER_THREAD });
+      await tools.fetchMessages?.execute?.(
+        { threadId: "slack:C123:9999.0000", limit: 5, direction: "backward" },
+        TOOL_OPTIONS
+      );
+      expect(mockAdapter.fetchMessages).toHaveBeenCalled();
+    });
+
+    it("blocks channel-addressed reads outside the scoped channel", async () => {
+      const tools = createChatTools({ chat, scope: CALLER_THREAD });
+      await expect(
+        tools.fetchChannelMessages?.execute?.(
+          { channelId: "slack:C999", limit: 5, direction: "backward" },
+          TOOL_OPTIONS
+        )
+      ).rejects.toThrow(OUT_OF_SCOPE_REGEX);
+      expect(mockAdapter.fetchChannelMessages).not.toHaveBeenCalled();
+    });
+
+    it("scopes every read tool", async () => {
+      const tools = createChatTools({ chat, scope: CALLER_THREAD });
+      await expect(
+        tools.fetchThread?.execute?.({ threadId: OTHER_THREAD }, TOOL_OPTIONS)
+      ).rejects.toThrow(OUT_OF_SCOPE_REGEX);
+      await expect(
+        tools.listThreads?.execute?.(
+          { channelId: "slack:C999", limit: 5 },
+          TOOL_OPTIONS
+        )
+      ).rejects.toThrow(OUT_OF_SCOPE_REGEX);
+      await expect(
+        tools.getThreadParticipants?.execute?.(
+          { threadId: OTHER_THREAD },
+          TOOL_OPTIONS
+        )
+      ).rejects.toThrow(OUT_OF_SCOPE_REGEX);
+      await expect(
+        tools.getChannelInfo?.execute?.(
+          { channelId: "slack:C999" },
+          TOOL_OPTIONS
+        )
+      ).rejects.toThrow(OUT_OF_SCOPE_REGEX);
+    });
+
+    it("accepts a Thread as the scope", async () => {
+      const tools = createChatTools({
+        chat,
+        scope: chat.thread(CALLER_THREAD),
+      });
+      await expect(
+        tools.fetchMessages?.execute?.(
+          { threadId: OTHER_THREAD, limit: 5, direction: "backward" },
+          TOOL_OPTIONS
+        )
+      ).rejects.toThrow(OUT_OF_SCOPE_REGEX);
+    });
+
+    it("blocks reads across adapters", async () => {
+      const tools = createChatTools({ chat, scope: CALLER_THREAD });
+      await expect(
+        tools.fetchMessages?.execute?.(
+          { threadId: "discord:C123:1.2", limit: 5, direction: "backward" },
+          TOOL_OPTIONS
+        )
+      ).rejects.toThrow(OUT_OF_SCOPE_REGEX);
+    });
+
+    it("inherits the conversation being handled when no scope is passed", async () => {
+      const tools = createChatTools({ chat });
+      await expect(
+        runInConversation(CALLER_THREAD, () =>
+          tools.fetchMessages?.execute?.(
+            { threadId: OTHER_THREAD, limit: 5, direction: "backward" },
+            TOOL_OPTIONS
+          )
+        )
+      ).rejects.toThrow(OUT_OF_SCOPE_REGEX);
+      expect(mockAdapter.fetchMessages).not.toHaveBeenCalled();
+    });
+
+    it("still reads its own conversation when inheriting", async () => {
+      const tools = createChatTools({ chat });
+      await runInConversation(CALLER_THREAD, () =>
+        tools.fetchMessages?.execute?.(
+          { threadId: CALLER_THREAD, limit: 5, direction: "backward" },
+          TOOL_OPTIONS
+        )
+      );
+      expect(mockAdapter.fetchMessages).toHaveBeenCalled();
+    });
+
+    it("lets an explicit scope override the handled conversation", async () => {
+      const tools = createChatTools({ chat, scope: OTHER_THREAD });
+      await runInConversation(CALLER_THREAD, () =>
+        tools.fetchMessages?.execute?.(
+          { threadId: OTHER_THREAD, limit: 5, direction: "backward" },
+          TOOL_OPTIONS
+        )
+      );
+      expect(mockAdapter.fetchMessages).toHaveBeenCalled();
+    });
+
+    it("keeps each concurrent conversation's scope separate", async () => {
+      const tools = createChatTools({ chat });
+      const read = (from: string, target: string) =>
+        runInConversation(from, async () => {
+          await sleep(0);
+          try {
+            await tools.fetchMessages?.execute?.(
+              { threadId: target, limit: 5, direction: "backward" },
+              TOOL_OPTIONS
+            );
+            return "allowed";
+          } catch {
+            return "blocked";
+          }
+        });
+
+      const results = await Promise.all([
+        read(CALLER_THREAD, "slack:C123:5555.0000"),
+        read(OTHER_THREAD, "slack:C123:5555.0000"),
+        read(CALLER_THREAD, OTHER_THREAD),
+        read(OTHER_THREAD, OTHER_THREAD),
+      ]);
+
+      expect(results).toEqual(["allowed", "blocked", "blocked", "allowed"]);
+    });
+
+    it("scopes reads during action dispatch", async () => {
+      let outcome = "not-run";
+      chat.onAction("do-thing", async () => {
+        const tools = createChatTools({ chat });
+        try {
+          await tools.fetchMessages?.execute?.(
+            { threadId: OTHER_THREAD, limit: 5, direction: "backward" },
+            TOOL_OPTIONS
+          );
+          outcome = "allowed";
+        } catch {
+          outcome = "blocked";
+        }
+      });
+
+      await chat.processAction(
+        {
+          actionId: "do-thing",
+          adapter: mockAdapter,
+          messageId: "m1",
+          threadId: CALLER_THREAD,
+          user: {
+            userId: "U1",
+            userName: "alice",
+            fullName: "Alice",
+            isBot: false,
+            isMe: false,
+          },
+          value: undefined,
+        } as unknown as Parameters<typeof chat.processAction>[0],
+        undefined
+      );
+
+      expect(outcome).toBe("blocked");
+    });
+
+    it("scopes reads during slash command dispatch", async () => {
+      let outcome = "not-run";
+      chat.onSlashCommand("/go", async () => {
+        const tools = createChatTools({ chat });
+        try {
+          await tools.fetchMessages?.execute?.(
+            { threadId: OTHER_THREAD, limit: 5, direction: "backward" },
+            TOOL_OPTIONS
+          );
+          outcome = "allowed";
+        } catch {
+          outcome = "blocked";
+        }
+      });
+
+      await chat.processSlashCommand(
+        {
+          adapter: mockAdapter,
+          channelId: "slack:C123",
+          command: "/go",
+          text: "",
+          user: {
+            userId: "U1",
+            userName: "alice",
+            fullName: "Alice",
+            isBot: false,
+            isMe: false,
+          },
+        } as unknown as Parameters<typeof chat.processSlashCommand>[0],
+        undefined
+      );
+
+      expect(outcome).toBe("blocked");
+    });
+
+    it("stays unscoped outside a handler when scope is omitted", async () => {
+      const tools = createChatTools({ chat });
+      await tools.fetchMessages?.execute?.(
+        { threadId: OTHER_THREAD, limit: 5, direction: "backward" },
+        TOOL_OPTIONS
+      );
+      expect(mockAdapter.fetchMessages).toHaveBeenCalled();
+    });
+  });
+
   it("getChannelInfo returns flattened metadata", async () => {
     const tools = createChatTools({ chat });
     const result = await tools.getChannelInfo?.execute?.(
@@ -366,7 +616,10 @@ describe("createChatTools", () => {
   });
 
   it("editMessage dispatches via the adapter's editMessage", async () => {
-    const tools = createChatTools({ chat, requireApproval: false });
+    const tools = createChatTools({
+      chat,
+      requireApproval: false,
+    });
     const result = await tools.editMessage?.execute?.(
       {
         threadId: "slack:C123:1234.5678",
@@ -384,7 +637,10 @@ describe("createChatTools", () => {
   });
 
   it("postMessage forwards a `raw` PostableInput unchanged", async () => {
-    const tools = createChatTools({ chat, requireApproval: false });
+    const tools = createChatTools({
+      chat,
+      requireApproval: false,
+    });
     await tools.postMessage?.execute?.(
       {
         threadId: "slack:C123:1234.5678",
@@ -399,7 +655,10 @@ describe("createChatTools", () => {
   });
 
   it("removeReaction dispatches via the adapter's removeReaction", async () => {
-    const tools = createChatTools({ chat, requireApproval: false });
+    const tools = createChatTools({
+      chat,
+      requireApproval: false,
+    });
     const result = await tools.removeReaction?.execute?.(
       {
         threadId: "slack:C123:1234.5678",
@@ -420,7 +679,10 @@ describe("createChatTools", () => {
     await mockState.subscribe("slack:C123:1234.5678");
     expect(await mockState.isSubscribed("slack:C123:1234.5678")).toBe(true);
 
-    const tools = createChatTools({ chat, requireApproval: false });
+    const tools = createChatTools({
+      chat,
+      requireApproval: false,
+    });
     const result = await tools.unsubscribeThread?.execute?.(
       { threadId: "slack:C123:1234.5678" },
       TOOL_OPTIONS

--- a/packages/chat/src/ai/index.ts
+++ b/packages/chat/src/ai/index.ts
@@ -1,3 +1,4 @@
+import { createScopeGuard, type ReadScope } from "./scope";
 import { getChannelInfo } from "./tools/channels";
 import {
   deleteMessage,
@@ -176,6 +177,24 @@ export interface ChatToolsOptions {
    * @see {@link ApprovalConfig}
    */
   requireApproval?: ApprovalConfig;
+  /**
+   * Confine read tools to a single conversation, so a thread or channel id
+   * the model supplies that resolves elsewhere is rejected.
+   *
+   * Defaults to the conversation being handled, so tools created inside a
+   * handler are already confined to it. Set this when the agent runs outside
+   * a handler and still reads on a user's behalf.
+   *
+   * Pass `false` to read across every conversation the bot can see.
+   *
+   * @example
+   * ```ts
+   * bot.onNewMention(async (thread) => {
+   *   const tools = createChatTools({ chat, preset: 'reader' })
+   * })
+   * ```
+   */
+  scope?: ReadScope | false;
 }
 
 function resolveApproval(
@@ -261,6 +280,7 @@ export function createChatTools({
   requireApproval = true,
   preset,
   overrides,
+  scope,
 }: ChatToolsOptions) {
   if (!chat) {
     throw new Error(
@@ -273,16 +293,18 @@ export function createChatTools({
   });
   const allowed = preset ? resolvePresetTools(preset) : null;
 
+  const guard = createScopeGuard(chat, scope);
+
   // Each entry is built lazily so a preset filter skips both the
   // `approval()` lookup and the underlying `tool({ ... })` (and its zod
   // schema) construction for tools the agent will never see.
   const factories = {
-    fetchMessages: () => fetchMessages(chat),
-    fetchChannelMessages: () => fetchChannelMessages(chat),
-    fetchThread: () => fetchThread(chat),
-    listThreads: () => listThreads(chat),
-    getThreadParticipants: () => getThreadParticipants(chat),
-    getChannelInfo: () => getChannelInfo(chat),
+    fetchMessages: () => fetchMessages(chat, guard),
+    fetchChannelMessages: () => fetchChannelMessages(chat, guard),
+    fetchThread: () => fetchThread(chat, guard),
+    listThreads: () => listThreads(chat, guard),
+    getThreadParticipants: () => getThreadParticipants(chat, guard),
+    getChannelInfo: () => getChannelInfo(chat, guard),
     getUser: () => getUser(chat),
     startTyping: () => startTyping(chat),
     postMessage: () => postMessage(chat, approval("postMessage")),
@@ -326,6 +348,7 @@ export {
   type ToAiMessagesOptions,
   toAiMessages,
 } from "./messages";
+export type { ReadScope } from "./scope";
 export { getChannelInfo } from "./tools/channels";
 export {
   deleteMessage,

--- a/packages/chat/src/ai/scope.ts
+++ b/packages/chat/src/ai/scope.ts
@@ -1,0 +1,53 @@
+import { activeConversation } from "../context";
+import type { ChatBinding } from "./types";
+
+/**
+ * The conversation a toolset's reads are confined to. Pass the `Thread` or
+ * `Channel` the agent is running in, or a raw thread/channel id.
+ */
+export type ReadScope = string | { id: string };
+
+export type ScopeGuard = (id: string) => void;
+
+function channelOf(chat: ChatBinding, id: string): string {
+  const prefix = id.split(":")[0];
+  const adapter = prefix ? chat.getAdapter(prefix) : undefined;
+  return (
+    adapter?.channelIdFromThreadId?.(id) ?? id.split(":").slice(0, 2).join(":")
+  );
+}
+
+/**
+ * Build the guard read tools call before touching the platform.
+ *
+ * The scope resolves per call: an explicit one wins, and a toolset built
+ * without one inherits the conversation currently being handled. Returns
+ * `undefined` only when the caller opted out with `scope: false`.
+ */
+export function createScopeGuard(
+  chat: ChatBinding,
+  scope: ReadScope | false | undefined
+): ScopeGuard | undefined {
+  if (scope === false) {
+    return;
+  }
+
+  let explicit: string | undefined;
+  if (scope !== undefined) {
+    explicit = typeof scope === "string" ? scope : scope.id;
+  }
+
+  return (id: string) => {
+    const active = explicit ?? activeConversation();
+    if (!active) {
+      return;
+    }
+
+    const channel = channelOf(chat, active);
+    if (channelOf(chat, id) !== channel) {
+      throw new Error(
+        `Tool call blocked: reads are scoped to channel "${channel}", but "${id}" resolves outside it.`
+      );
+    }
+  };
+}

--- a/packages/chat/src/ai/tools/channels.ts
+++ b/packages/chat/src/ai/tools/channels.ts
@@ -1,6 +1,7 @@
 import { type Tool, tool } from "ai";
 import { z } from "zod";
 import type { ChannelVisibility } from "../../types";
+import type { ScopeGuard } from "../scope";
 import type { ChatBinding } from "../types";
 
 // The explicit `Tool<Input, Output>` return type keeps the emitted
@@ -13,7 +14,8 @@ const GET_CHANNEL_INFO_INPUT = z.object({
 });
 
 export const getChannelInfo = (
-  chat: ChatBinding
+  chat: ChatBinding,
+  guard?: ScopeGuard
 ): Tool<
   z.infer<typeof GET_CHANNEL_INFO_INPUT>,
   {
@@ -29,6 +31,7 @@ export const getChannelInfo = (
       "Fetch metadata for a channel: name, member count, DM status, visibility, etc. Use to identify a channel before posting.",
     inputSchema: GET_CHANNEL_INFO_INPUT,
     execute: async ({ channelId }) => {
+      guard?.(channelId);
       const channel = chat.channel(channelId);
       const info = await channel.fetchMetadata();
       return {

--- a/packages/chat/src/ai/tools/threads.ts
+++ b/packages/chat/src/ai/tools/threads.ts
@@ -2,6 +2,7 @@ import { type Tool, tool } from "ai";
 import { z } from "zod";
 import type { Message } from "../../message";
 import type { ChannelVisibility, ThreadSummary } from "../../types";
+import type { ScopeGuard } from "../scope";
 import type { ChatBinding, ToolOptions } from "../types";
 
 const FETCH_DIRECTION = z
@@ -60,7 +61,8 @@ const FETCH_MESSAGES_INPUT = z.object({
 });
 
 export const fetchMessages = (
-  chat: ChatBinding
+  chat: ChatBinding,
+  guard?: ScopeGuard
 ): Tool<
   z.infer<typeof FETCH_MESSAGES_INPUT>,
   { messages: ProjectedMessage[]; nextCursor: string | undefined }
@@ -70,6 +72,7 @@ export const fetchMessages = (
       "Fetch recent messages from a thread, ordered chronologically (oldest first within the page). Use to read the conversation before responding.",
     inputSchema: FETCH_MESSAGES_INPUT,
     execute: async ({ threadId, limit, cursor, direction }) => {
+      guard?.(threadId);
       const thread = chat.thread(threadId);
       const result = await thread.adapter.fetchMessages(threadId, {
         limit,
@@ -91,7 +94,8 @@ const FETCH_CHANNEL_MESSAGES_INPUT = z.object({
 });
 
 export const fetchChannelMessages = (
-  chat: ChatBinding
+  chat: ChatBinding,
+  guard?: ScopeGuard
 ): Tool<
   z.infer<typeof FETCH_CHANNEL_MESSAGES_INPUT>,
   { messages: ProjectedMessage[]; nextCursor: string | undefined }
@@ -101,6 +105,7 @@ export const fetchChannelMessages = (
       "Fetch top-level messages in a channel (not thread replies). Returns messages in chronological order within the page.",
     inputSchema: FETCH_CHANNEL_MESSAGES_INPUT,
     execute: async ({ channelId, limit, cursor, direction }) => {
+      guard?.(channelId);
       const adapterName = channelId.split(":")[0];
       const adapter = adapterName ? chat.getAdapter(adapterName) : undefined;
       if (!adapter?.fetchChannelMessages) {
@@ -125,7 +130,8 @@ const FETCH_THREAD_INPUT = z.object({
 });
 
 export const fetchThread = (
-  chat: ChatBinding
+  chat: ChatBinding,
+  guard?: ScopeGuard
 ): Tool<
   z.infer<typeof FETCH_THREAD_INPUT>,
   {
@@ -141,6 +147,7 @@ export const fetchThread = (
       "Fetch metadata about a thread (channel id, channel name, visibility, DM status, etc).",
     inputSchema: FETCH_THREAD_INPUT,
     execute: async ({ threadId }) => {
+      guard?.(threadId);
       const thread = chat.thread(threadId);
       const info = await thread.adapter.fetchThread(threadId);
       return {
@@ -160,7 +167,8 @@ const LIST_THREADS_INPUT = z.object({
 });
 
 export const listThreads = (
-  chat: ChatBinding
+  chat: ChatBinding,
+  guard?: ScopeGuard
 ): Tool<
   z.infer<typeof LIST_THREADS_INPUT>,
   {
@@ -178,6 +186,7 @@ export const listThreads = (
       "List recent threads in a channel. Returns lightweight summaries with the root message of each thread.",
     inputSchema: LIST_THREADS_INPUT,
     execute: async ({ channelId, limit, cursor }) => {
+      guard?.(channelId);
       const adapterName = channelId.split(":")[0];
       const adapter = adapterName ? chat.getAdapter(adapterName) : undefined;
       if (!adapter?.listThreads) {
@@ -203,7 +212,8 @@ const GET_THREAD_PARTICIPANTS_INPUT = z.object({
 });
 
 export const getThreadParticipants = (
-  chat: ChatBinding
+  chat: ChatBinding,
+  guard?: ScopeGuard
 ): Tool<
   z.infer<typeof GET_THREAD_PARTICIPANTS_INPUT>,
   {
@@ -220,6 +230,7 @@ export const getThreadParticipants = (
       "Return the unique non-bot participants in a thread. Useful for deciding whether to subscribe (1:1) or stay quiet (group).",
     inputSchema: GET_THREAD_PARTICIPANTS_INPUT,
     execute: async ({ threadId }) => {
+      guard?.(threadId);
       const thread = chat.thread(threadId);
       const participants = await thread.getParticipants();
       return {

--- a/packages/chat/src/chat.ts
+++ b/packages/chat/src/chat.ts
@@ -9,6 +9,7 @@ import {
   hasChatSingleton,
   setChatSingleton,
 } from "./chat-singleton";
+import { runInConversation } from "./context";
 import { isJSX, toModalElement } from "./jsx-runtime";
 import { Message, type SerializedMessage, setMessageAdapter } from "./message";
 import type { ModalElement } from "./modals";
@@ -962,7 +963,9 @@ export class Chat<
     event: Omit<ReactionEvent, "adapter" | "thread"> & { adapter?: Adapter },
     options?: WebhookOptions
   ): void {
-    const task = this.handleReactionEvent(event).catch((err) => {
+    const task = runInConversation(event.threadId, () =>
+      this.handleReactionEvent(event)
+    ).catch((err) => {
       this.logger.error("Reaction processing error", {
         error: err,
         emoji: event.emoji,
@@ -983,7 +986,9 @@ export class Chat<
     event: Omit<ActionEvent, "thread" | "openModal"> & { adapter: Adapter },
     options: WebhookOptions | undefined
   ): Promise<void> {
-    const task = this.handleActionEvent(event, options).catch((err) => {
+    const task = runInConversation(event.threadId, () =>
+      this.handleActionEvent(event, options)
+    ).catch((err) => {
       this.logger.error("Action processing error", {
         error: err,
         actionId: event.actionId,
@@ -1284,6 +1289,18 @@ export class Chat<
       adapter: event.adapter,
       stateAdapter: this._stateAdapter,
     });
+    return runInConversation(event.channelId, () =>
+      this.dispatchSlashCommand(event, channel, options)
+    );
+  }
+
+  private async dispatchSlashCommand(
+    event: Omit<SlashCommandEvent<TState>, "channel" | "openModal"> & {
+      adapter: Adapter;
+    },
+    channel: ChannelImpl<TState>,
+    options: WebhookOptions | undefined
+  ): Promise<void> {
     const fullEvent: SlashCommandEvent<TState> = {
       ...event,
       channel,
@@ -2008,7 +2025,17 @@ export class Chat<
    * - Bot filtering: Messages from the bot itself are skipped
    * - Concurrency: Controlled by `concurrency` config (drop, queue, debounce, burst, concurrent)
    */
-  async handleIncomingMessage(
+  handleIncomingMessage(
+    adapter: Adapter,
+    threadId: string,
+    message: Message
+  ): Promise<void> {
+    return runInConversation(threadId, () =>
+      this.routeIncomingMessage(adapter, threadId, message)
+    );
+  }
+
+  private async routeIncomingMessage(
     adapter: Adapter,
     threadId: string,
     message: Message

--- a/packages/chat/src/context.ts
+++ b/packages/chat/src/context.ts
@@ -1,0 +1,20 @@
+import { AsyncLocalStorage } from "node:async_hooks";
+
+const conversationStorage = new AsyncLocalStorage<string>();
+
+/**
+ * Run `fn` with `threadId` marked as the conversation currently being handled.
+ * Chat wraps handler dispatch in this so tools invoked inside a handler can
+ * tell which conversation they are serving.
+ */
+export function runInConversation<T>(threadId: string, fn: () => T): T {
+  return conversationStorage.run(threadId, fn);
+}
+
+/**
+ * The conversation being handled on this async call stack, if any.
+ * Returns `undefined` outside a handler, such as in a cron job or a script.
+ */
+export function activeConversation(): string | undefined {
+  return conversationStorage.getStore();
+}


### PR DESCRIPTION
## summary

built-in agent read tools now stay inside the conversation they are handling, so a thread or channel id the model supplies that resolves elsewhere is rejected before the adapter is called

- `Chat` tracks the conversation being handled across message, action, slash command and reaction dispatch, using `AsyncLocalStorage`
- read tools (`fetchMessages`, `fetchChannelMessages`, `fetchThread`, `listThreads`, `getThreadParticipants`, `getChannelInfo`) inherit that conversation, so existing handlers get this with no code change
- scoping is per channel, so an agent can still follow other threads in its own conversation
- pass `scope` to set it explicitly, or `scope: false` for workspace-wide reads

this brings read tools in line with the least-privilege defaults write tools already have, where `needsApproval` is on unless you opt out

**not breaking:** `scope` is optional and every existing call site keeps working. agents that run outside a handler, such as a queued job or a resumed workflow step, have no conversation to inherit and should pass `scope`

## test plan

- read tools reject out-of-conversation ids and still serve in-conversation ones, per tool
- the conversation is inherited correctly through message, action, slash command and reaction dispatch
- concurrent conversations stay isolated, so one agent cannot inherit another's scope
- an explicit `scope` overrides the handled conversation, and `scope: false` restores workspace-wide reads
- ids resolve through `adapter.channelIdFromThreadId`, verified against the slack, teams, google chat, discord, telegram and whatsapp id shapes
- `pnpm validate` clean: workspace tests, typecheck, lint, knip and build all pass
