### PR TITLE
fix(telegram): preserve media identity and MIME metadata

### DIFF
--- a/.changeset/bright-photos-rest.md
+++ b/.changeset/bright-photos-rest.md
@@ -1,0 +1,5 @@
+---
+"@chat-adapter/telegram": patch
+---
+
+Preserve Telegram stable media identifiers in normalized attachment metadata and report photo attachments as JPEG.

--- a/apps/docs/content/adapters/official/telegram.mdx
+++ b/apps/docs/content/adapters/official/telegram.mdx
@@ -204,6 +204,7 @@ Pass `{ raw: "..." }` only if you need to ship a fully pre-escaped MarkdownV2 st
 - Telegram does not expose full historical message APIs to bots. `fetchMessages` returns adapter-cached messages from the current process.
 - `listThreads` is not available for Telegram chats.
 - Telegram callback data is limited to 64 bytes — keep `Button` `id`/`value` payloads short.
+- Incoming attachments preserve Telegram's downloadable `file_id` and stable `file_unique_id` as `fetchMetadata.fileId` and `fetchMetadata.fileUniqueId`. Photo attachments use the `image/jpeg` MIME type.
 - Multiple `files` or compatible `attachments` are sent as Telegram media groups. `files` upload as documents; `attachments` preserve image, audio, video, or file media type.
 - Other rich card elements (images, select menus, radios) render as fallback text.
 

--- a/packages/adapter-telegram/README.md
+++ b/packages/adapter-telegram/README.md
@@ -219,6 +219,7 @@ Behavior change in 4.27.0: previous versions used Telegram's legacy `Markdown` p
 - If `getWebhookInfo` fails in `mode: "auto"`, the adapter stays in webhook mode (safe fallback).
 - `Button` and `LinkButton` in card `Actions` render as inline keyboard buttons.
 - Telegram callback data is limited to 64 bytes. Keep button `id`/`value` payloads short.
+- Incoming attachments preserve Telegram's downloadable `file_id` and stable `file_unique_id` as `fetchMetadata.fileId` and `fetchMetadata.fileUniqueId`. Photo attachments use the `image/jpeg` MIME type.
 - `files` upload as Telegram documents. Multiple `files` are sent as Telegram media groups. `attachments` preserve image, audio, video, or file media type and also use media groups when multiple compatible attachments are posted. Use `data` or `fetchData` for private/authenticated files; URL-only attachments must be public URLs Telegram can fetch directly.
 - Other rich card elements (images/select menus/radios) render as fallback text only.
 

--- a/packages/adapter-telegram/sample-messages.md
+++ b/packages/adapter-telegram/sample-messages.md
@@ -1,0 +1,58 @@
+# Sample messages
+
+## Photo message
+
+Sanitized from a [captured Telegram webhook](https://gist.github.com/otnansirk/759ef10ad21aa889810c8af7cbcd03bc).
+
+```json
+{
+  "update_id": 312744884,
+  "message": {
+    "message_id": 17,
+    "from": {
+      "id": 100000001,
+      "is_bot": false,
+      "first_name": "Test User",
+      "username": "testuser",
+      "language_code": "en"
+    },
+    "chat": {
+      "id": 100000001,
+      "first_name": "Test User",
+      "username": "testuser",
+      "type": "private"
+    },
+    "date": 1753164384,
+    "photo": [
+      {
+        "file_id": "AgACAgUAAxkBAAMRaH8qXw-VQSGAG4X4VoCg9A5nE50AAvLGMRtBGPlXGt4-FX4l2_oBAAMCAANzAAM2BA",
+        "file_unique_id": "AQAD8sYxG0EY-Vd4",
+        "file_size": 1705,
+        "width": 72,
+        "height": 90
+      },
+      {
+        "file_id": "AgACAgUAAxkBAAMRaH8qXw-VQSGAG4X4VoCg9A5nE50AAvLGMRtBGPlXGt4-FX4l2_oBAAMCAANtAAM2BA",
+        "file_unique_id": "AQAD8sYxG0EY-Vdy",
+        "file_size": 32527,
+        "width": 255,
+        "height": 320
+      },
+      {
+        "file_id": "AgACAgUAAxkBAAMRaH8qXw-VQSGAG4X4VoCg9A5nE50AAvLGMRtBGPlXGt4-FX4l2_oBAAMCAAN4AAM2BA",
+        "file_unique_id": "AQAD8sYxG0EY-Vd9",
+        "file_size": 137906,
+        "width": 638,
+        "height": 800
+      },
+      {
+        "file_id": "AgACAgUAAxkBAAMRaH8qXw-VQSGAG4X4VoCg9A5nE50AAvLGMRtBGPlXGt4-FX4l2_oBAAMCAAN5AAM2BA",
+        "file_unique_id": "AQAD8sYxG0EY-Vd-",
+        "file_size": 173215,
+        "width": 816,
+        "height": 1023
+      }
+    ]
+  }
+}
+```

--- a/packages/adapter-telegram/src/index.test.ts
+++ b/packages/adapter-telegram/src/index.test.ts
@@ -10,7 +10,7 @@ import {
   mockLogger,
   threadIdContract,
 } from "@chat-adapter/tests";
-import type { ChatInstance } from "chat";
+import { type ChatInstance, Message } from "chat";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { encodeTelegramCallbackData } from "./cards";
 import {
@@ -3568,7 +3568,7 @@ describe("TelegramAdapter", () => {
     expect(parsedMessage.text).toBe("channel announcement");
   });
 
-  it("extracts photo attachments from photo messages", async () => {
+  it("preserves stable photo identity and JPEG metadata across resends and serialization", async () => {
     mockFetch.mockResolvedValueOnce(
       telegramOk({
         id: 999,
@@ -3587,23 +3587,69 @@ describe("TelegramAdapter", () => {
 
     await adapter.initialize(createMockChat());
 
-    const photoMessage = sampleMessage({
-      text: undefined,
-      photo: [
-        { file_id: "photo1", file_unique_id: "u1", width: 100, height: 100 },
-        { file_id: "photo2", file_unique_id: "u2", width: 800, height: 600 },
-      ],
-      caption: "Nice photo",
-    });
-
-    const parsed = adapter.parseMessage(photoMessage);
+    const parsed = adapter.parseMessage(
+      sampleMessage({
+        text: undefined,
+        photo: [
+          {
+            file_id: "photo-small",
+            file_unique_id: "photo-small-unique",
+            width: 100,
+            height: 100,
+          },
+          {
+            file_id: "photo-download-1",
+            file_unique_id: "photo-stable",
+            width: 800,
+            height: 600,
+          },
+        ],
+        caption: "Nice photo",
+      })
+    );
+    const resent = adapter.parseMessage(
+      sampleMessage({
+        photo: [
+          {
+            file_id: "photo-download-2",
+            file_unique_id: "photo-stable",
+            width: 800,
+            height: 600,
+          },
+        ],
+      })
+    );
 
     expect(parsed.attachments).toHaveLength(1);
     const attachment = parsed.attachments[0];
     expect(attachment?.type).toBe("image");
     expect(attachment?.width).toBe(800);
     expect(attachment?.height).toBe(600);
+    expect(attachment?.mimeType).toBe("image/jpeg");
+    expect(attachment?.fetchMetadata).toEqual({
+      fileId: "photo-download-1",
+      fileUniqueId: "photo-stable",
+    });
+    expect(resent.attachments[0]?.fetchMetadata).toEqual({
+      fileId: "photo-download-2",
+      fileUniqueId: "photo-stable",
+    });
     expect(parsed.text).toBe("Nice photo");
+
+    const restored = Message.fromJSON(
+      JSON.parse(JSON.stringify(parsed.toJSON()))
+    );
+    expect(restored.attachments[0]?.fetchMetadata).toEqual({
+      fileId: "photo-download-1",
+      fileUniqueId: "photo-stable",
+    });
+    const restoredAttachment = restored.attachments[0];
+    if (!restoredAttachment) {
+      throw new Error("Expected restored photo attachment");
+    }
+    expect(
+      adapter.rehydrateAttachment(restoredAttachment).fetchData
+    ).toBeTypeOf("function");
   });
 
   it("extracts document attachments from document messages", async () => {
@@ -3641,6 +3687,10 @@ describe("TelegramAdapter", () => {
     expect(attachment?.type).toBe("file");
     expect(attachment?.name).toBe("report.pdf");
     expect(attachment?.mimeType).toBe("application/pdf");
+    expect(attachment?.fetchMetadata).toEqual({
+      fileId: "doc1",
+      fileUniqueId: "u1",
+    });
   });
 
   it("extracts audio attachments from audio messages", async () => {
@@ -3681,6 +3731,47 @@ describe("TelegramAdapter", () => {
     expect(attachment?.name).toBe("track.mp3");
     expect(attachment?.mimeType).toBe("audio/mpeg");
     expect(attachment?.size).toBe(2048000);
+    expect(attachment?.fetchMetadata).toEqual({
+      fileId: "audio1",
+      fileUniqueId: "ua1",
+    });
+  });
+
+  it("preserves stable identity for voice attachments", async () => {
+    mockFetch.mockResolvedValueOnce(
+      telegramOk({
+        id: 999,
+        is_bot: true,
+        first_name: "Bot",
+        username: "mybot",
+      })
+    );
+
+    const adapter = createTelegramAdapter({
+      botToken: "token",
+      mode: "webhook",
+      logger: mockLogger,
+      userName: "mybot",
+    });
+
+    await adapter.initialize(createMockChat());
+
+    const parsed = adapter.parseMessage(
+      sampleMessage({
+        voice: {
+          file_id: "voice1",
+          file_unique_id: "voice-stable",
+          duration: 30,
+          mime_type: "audio/ogg",
+          file_size: 512000,
+        },
+      })
+    );
+
+    expect(parsed.attachments[0]?.fetchMetadata).toEqual({
+      fileId: "voice1",
+      fileUniqueId: "voice-stable",
+    });
   });
 
   it("extracts video attachments from video messages", async () => {
@@ -3723,6 +3814,10 @@ describe("TelegramAdapter", () => {
     expect(attachment?.width).toBe(1920);
     expect(attachment?.height).toBe(1080);
     expect(attachment?.mimeType).toBe("video/mp4");
+    expect(attachment?.fetchMetadata).toEqual({
+      fileId: "vid1",
+      fileUniqueId: "uv1",
+    });
   });
 
   it("extracts video_note attachments from round video messages", async () => {
@@ -3762,6 +3857,10 @@ describe("TelegramAdapter", () => {
     expect(attachment?.width).toBe(240);
     expect(attachment?.height).toBe(240);
     expect(attachment?.size).toBe(512000);
+    expect(attachment?.fetchMetadata).toEqual({
+      fileId: "vn1",
+      fileUniqueId: "uvn1",
+    });
   });
 
   it("isDM returns false for forum topic thread IDs", async () => {
@@ -4417,14 +4516,21 @@ describe("applyTelegramEntities", () => {
 
     expect(parsed.attachments).toMatchObject([
       {
-        fetchMetadata: { fileId: "large" },
+        fetchMetadata: {
+          fileId: "large",
+          fileUniqueId: "large-unique",
+        },
         height: 800,
+        mimeType: "image/jpeg",
         size: 2048,
         type: "image",
         width: 1200,
       },
       {
-        fetchMetadata: { fileId: "video" },
+        fetchMetadata: {
+          fileId: "video",
+          fileUniqueId: "video-unique",
+        },
         height: 720,
         mimeType: "video/mp4",
         name: "clip.mp4",

--- a/packages/adapter-telegram/src/index.test.ts
+++ b/packages/adapter-telegram/src/index.test.ts
@@ -2112,7 +2112,7 @@ describe("TelegramAdapter", () => {
     expect((formData.get("media1") as { name?: string }).name).toBe("two.txt");
   });
 
-  it("posts mixed image and video attachments as a Telegram media group", async () => {
+  it("posts and normalizes mixed image and video attachments as a Telegram media group", async () => {
     mockFetch
       .mockResolvedValueOnce(
         telegramOk({
@@ -2203,6 +2203,35 @@ describe("TelegramAdapter", () => {
     expect((formData.get("media1") as { name?: string }).name).toBe(
       "video.mp4"
     );
+
+    const cached = await adapter.fetchMessages("telegram:123", {
+      limit: 10,
+    });
+    expect(cached.messages).toMatchObject([
+      {
+        attachments: [
+          {
+            fetchMetadata: {
+              fileId: "photo-1",
+              fileUniqueId: "p1",
+            },
+            mimeType: "image/jpeg",
+            type: "image",
+          },
+        ],
+      },
+      {
+        attachments: [
+          {
+            fetchMetadata: {
+              fileId: "video-1",
+              fileUniqueId: "v1",
+            },
+            type: "video",
+          },
+        ],
+      },
+    ]);
   });
 
   it("rejects incompatible Telegram media group attachment types", async () => {

--- a/packages/adapter-telegram/src/index.test.ts
+++ b/packages/adapter-telegram/src/index.test.ts
@@ -10,7 +10,7 @@ import {
   mockLogger,
   threadIdContract,
 } from "@chat-adapter/tests";
-import { type ChatInstance, Message } from "chat";
+import { type Attachment, type ChatInstance, Message } from "chat";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { encodeTelegramCallbackData } from "./cards";
 import {
@@ -139,6 +139,15 @@ function readMediaGroup(callIndex: number): TelegramMediaGroupItem[] {
     throw new Error("Expected media group payload to be a string");
   }
   return JSON.parse(media) as TelegramMediaGroupItem[];
+}
+
+function roundTripAttachments(
+  adapter: TelegramAdapter,
+  message: Message
+): Attachment[] {
+  return Message.fromJSON(
+    JSON.parse(JSON.stringify(message.toJSON()))
+  ).attachments.map((attachment) => adapter.rehydrateAttachment(attachment));
 }
 
 function createAbortError(): Error {
@@ -2204,33 +2213,31 @@ describe("TelegramAdapter", () => {
       "video.mp4"
     );
 
-    const cached = await adapter.fetchMessages("telegram:123", {
-      limit: 10,
-    });
-    expect(cached.messages).toMatchObject([
-      {
-        attachments: [
-          {
-            fetchMetadata: {
-              fileId: "photo-1",
-              fileUniqueId: "p1",
-            },
-            mimeType: "image/jpeg",
-            type: "image",
+    const cached = await adapter.fetchMessages("telegram:123", { limit: 10 });
+    expect(
+      cached.messages.map((message) => roundTripAttachments(adapter, message))
+    ).toMatchObject([
+      [
+        {
+          fetchData: expect.any(Function),
+          fetchMetadata: {
+            fileId: "photo-1",
+            fileUniqueId: "p1",
           },
-        ],
-      },
-      {
-        attachments: [
-          {
-            fetchMetadata: {
-              fileId: "video-1",
-              fileUniqueId: "v1",
-            },
-            type: "video",
+          mimeType: "image/jpeg",
+          type: "image",
+        },
+      ],
+      [
+        {
+          fetchData: expect.any(Function),
+          fetchMetadata: {
+            fileId: "video-1",
+            fileUniqueId: "v1",
           },
-        ],
-      },
+          type: "video",
+        },
+      ],
     ]);
   });
 
@@ -3665,20 +3672,12 @@ describe("TelegramAdapter", () => {
     });
     expect(parsed.text).toBe("Nice photo");
 
-    const restored = Message.fromJSON(
-      JSON.parse(JSON.stringify(parsed.toJSON()))
-    );
-    expect(restored.attachments[0]?.fetchMetadata).toEqual({
+    const [restoredAttachment] = roundTripAttachments(adapter, parsed);
+    expect(restoredAttachment?.fetchMetadata).toEqual({
       fileId: "photo-download-1",
       fileUniqueId: "photo-stable",
     });
-    const restoredAttachment = restored.attachments[0];
-    if (!restoredAttachment) {
-      throw new Error("Expected restored photo attachment");
-    }
-    expect(
-      adapter.rehydrateAttachment(restoredAttachment).fetchData
-    ).toBeTypeOf("function");
+    expect(restoredAttachment?.fetchData).toBeTypeOf("function");
   });
 
   it("extracts document attachments from document messages", async () => {
@@ -4566,6 +4565,24 @@ describe("applyTelegramEntities", () => {
         size: 4096,
         type: "video",
         width: 1280,
+      },
+    ]);
+    expect(roundTripAttachments(adapter, parsed)).toMatchObject([
+      {
+        fetchData: expect.any(Function),
+        fetchMetadata: {
+          fileId: "large",
+          fileUniqueId: "large-unique",
+        },
+        mimeType: "image/jpeg",
+      },
+      {
+        fetchData: expect.any(Function),
+        fetchMetadata: {
+          fileId: "video",
+          fileUniqueId: "video-unique",
+        },
+        mimeType: "video/mp4",
       },
     ]);
   });

--- a/packages/adapter-telegram/src/index.ts
+++ b/packages/adapter-telegram/src/index.ts
@@ -1737,6 +1737,8 @@ export class TelegramAdapter
           size: photo.file_size,
           width: photo.width,
           height: photo.height,
+          fileUniqueId: photo.file_unique_id,
+          mimeType: "image/jpeg",
         })
       );
     }
@@ -1749,6 +1751,7 @@ export class TelegramAdapter
           height: raw.video.height,
           name: raw.video.file_name,
           mimeType: raw.video.mime_type,
+          fileUniqueId: raw.video.file_unique_id,
         })
       );
     }
@@ -1759,6 +1762,7 @@ export class TelegramAdapter
           size: raw.audio.file_size,
           name: raw.audio.file_name,
           mimeType: raw.audio.mime_type,
+          fileUniqueId: raw.audio.file_unique_id,
         })
       );
     }
@@ -1768,6 +1772,7 @@ export class TelegramAdapter
         this.createAttachment("audio", raw.voice.file_id, {
           size: raw.voice.file_size,
           mimeType: raw.voice.mime_type,
+          fileUniqueId: raw.voice.file_unique_id,
         })
       );
     }
@@ -1778,6 +1783,7 @@ export class TelegramAdapter
           size: raw.document.file_size,
           name: raw.document.file_name,
           mimeType: raw.document.mime_type,
+          fileUniqueId: raw.document.file_unique_id,
         })
       );
     }
@@ -1788,6 +1794,7 @@ export class TelegramAdapter
           size: raw.video_note.file_size,
           width: raw.video_note.length,
           height: raw.video_note.length,
+          fileUniqueId: raw.video_note.file_unique_id,
         })
       );
     }
@@ -1801,6 +1808,7 @@ export class TelegramAdapter
             height: media.height,
             name: media.name,
             mimeType: media.mimeType,
+            fileUniqueId: media.file.file_unique_id,
           })
         );
       }
@@ -1818,6 +1826,7 @@ export class TelegramAdapter
       height?: number;
       name?: string;
       mimeType?: string;
+      fileUniqueId?: string;
     }
   ): Attachment {
     return {
@@ -1827,7 +1836,12 @@ export class TelegramAdapter
       height: metadata?.height,
       name: metadata?.name,
       mimeType: metadata?.mimeType,
-      fetchMetadata: { fileId },
+      fetchMetadata: {
+        fileId,
+        ...(metadata?.fileUniqueId
+          ? { fileUniqueId: metadata.fileUniqueId }
+          : {}),
+      },
       fetchData: async () => this.downloadFile(fileId),
     };
   }

--- a/packages/adapter-telegram/src/rich.ts
+++ b/packages/adapter-telegram/src/rich.ts
@@ -389,6 +389,7 @@ function media(blocks: TelegramRichBlock[], result: RichMedia[]): void {
           result.push({
             file: photo,
             height: photo.height,
+            mimeType: "image/jpeg",
             type: "image",
             width: photo.width,
           });


### PR DESCRIPTION
## Summary

Preserve Telegram's stable `file_unique_id` alongside the current downloadable `file_id` in normalized attachment metadata. Telegram photo attachments now report `image/jpeg`, including rich-message photos.

This keeps adapter normalization in `@chat-adapter/telegram`; deduplication remains consumer-owned. After upgrading to the release containing this patch, Calories can remove `patches/@chat-adapter__telegram@4.35.0.patch` while retaining its perceptual-hash fallback for recompressed images.

## Test plan

- `pnpm --filter @chat-adapter/telegram test`
- `pnpm --filter @chat-adapter/telegram typecheck`
- `pnpm --filter @chat-adapter/telegram... build`
- `pnpm check`
- `pnpm konsistent`
- `pnpm validate`

## Checklist

- [x] All commits are signed and verified
- [x] All commits are signed off for the DCO (`git commit -s`)
- [x] `pnpm validate` passes
- [x] Changeset added
- [x] Documentation updated
