### PR TITLE
docs(adapters): add QQ Bot and WeCom community adapters

### DIFF
--- a/apps/docs/adapters.json
+++ b/apps/docs/adapters.json
@@ -296,6 +296,26 @@
     "readme": "https://github.com/buiducnhat/chat-adapter-zalo/tree/a11acb91efa9752c6d15c0a00c759b92c479e6fa"
   },
   {
+    "name": "QQ Bot",
+    "slug": "qq",
+    "type": "platform",
+    "community": true,
+    "description": "Community QQ Bot adapter for Chat SDK with WebSocket and webhook modes, multi-scene support (DM, group, text channel), and rich media.",
+    "packageName": "@agentor/chat-qq",
+    "author": "DemoMacro",
+    "readme": "https://github.com/DemoMacro/agentor/tree/6248fcc6b09821cfc2fb7bc50ef16eec1526e756/packages/chat-qq"
+  },
+  {
+    "name": "WeCom",
+    "slug": "wecom",
+    "type": "platform",
+    "community": true,
+    "description": "Community WeCom (企业微信) adapter for Chat SDK covering group webhook bots, smart bots, and apps, with template cards and AES encryption.",
+    "packageName": "@agentor/chat-wecom",
+    "author": "DemoMacro",
+    "readme": "https://github.com/DemoMacro/agentor/tree/6248fcc6b09821cfc2fb7bc50ef16eec1526e756/packages/chat-wecom"
+  },
+  {
     "name": "Mattermost",
     "slug": "mattermost",
     "type": "platform",

--- a/apps/docs/content/adapters/community/meta.json
+++ b/apps/docs/content/adapters/community/meta.json
@@ -8,6 +8,8 @@
     "zalo",
     "mattermost",
     "weixin",
+    "qq",
+    "wecom",
     "zaileys",
     "---State---",
     "cloudflare-do",

--- a/apps/docs/content/adapters/community/qq.mdx
+++ b/apps/docs/content/adapters/community/qq.mdx
@@ -1,0 +1,145 @@
+---
+title: QQ Bot
+description: Community QQ Bot adapter for Chat SDK with WebSocket and webhook modes, multi-scene support (DM, group, text channel), rich media, and Ed25519 signature verification.
+packageName: "@agentor/chat-qq"
+slug: qq
+type: platform
+tagline: QQ Bot adapter for Chat SDK. Connects to the QQ Bot Gateway over WebSocket or HTTP callback, supporting DM, group, and text-channel scenes with images, video, voice, and files.
+community: true
+mdxBody: true
+features:
+  postMessage: yes
+  editMessage: no
+  deleteMessage: no
+  fileUploads: yes
+  streaming: no
+  scheduledMessages: no
+  cardFormat: no
+  buttons: no
+  linkButtons: no
+  selectMenus: no
+  tables: no
+  fields: no
+  imagesInCards: no
+  modals: no
+  slashCommands: no
+  mentions: no
+  addReactions: no
+  removeReactions: no
+  typingIndicator: no
+  directMessages: yes
+  ephemeralMessages: no
+  userLookup: no
+  customApiEndpoint: no
+  fetchMessages: no
+  fetchSingleMessage: no
+  fetchThreadInfo: no
+  fetchChannelMessages: no
+  listThreads: no
+  fetchChannelInfo: no
+  postChannelMessage: no
+---
+
+## Install
+
+<PackageInstall package="@agentor/chat-qq chat @chat-adapter/state-memory" />
+
+## Quick start
+
+### WebSocket mode
+
+Connect directly to the QQ Bot Gateway — no public endpoint required:
+
+```typescript title="lib/bot.ts" lineNumbers
+import { createQQBotAdapter } from "@agentor/chat-qq";
+
+const adapter = createQQBotAdapter({
+  appId: process.env.QQ_BOT_APP_ID,
+  clientSecret: process.env.QQ_BOT_CLIENT_SECRET,
+});
+
+await adapter.initialize({
+  processMessage: async (_adapter, threadId, factory) => {
+    const message = await factory();
+    await adapter.postMessage(threadId, message.text);
+  },
+});
+```
+
+### Webhook (callback) mode
+
+Receive events over HTTP with Ed25519 signature verification. Once an HTTPS
+callback URL is configured on the bot, WebSocket mode is no longer available —
+the two modes are mutually exclusive.
+
+```typescript title="lib/bot.ts" lineNumbers
+import { createQQBotAdapter } from "@agentor/chat-qq";
+
+const adapter = createQQBotAdapter({
+  mode: "callback",
+  appId: process.env.QQ_BOT_APP_ID,
+  clientSecret: process.env.QQ_BOT_CLIENT_SECRET,
+});
+```
+
+## Environment variables
+
+| Variable | Required | Description |
+| --- | --- | --- |
+| `QQ_BOT_APP_ID` | Yes | QQ Bot application ID. |
+| `QQ_BOT_CLIENT_SECRET` | Yes | QQ Bot client secret. |
+
+## Configuration
+
+<TypeTable
+  type={{
+    mode: {
+      type: '"websocket" | "callback"',
+      default: '"websocket"',
+      description: "Connection mode. The two modes are mutually exclusive.",
+    },
+    appId: { type: "string", description: "QQ Bot application ID." },
+    clientSecret: { type: "string", description: "QQ Bot client secret." },
+    intents: { type: "number", description: "Event intent bitmask." },
+    sandbox: {
+      type: "boolean",
+      default: "false",
+      description: "Use the sandbox environment (WebSocket mode).",
+    },
+    userName: {
+      type: "string",
+      default: '"QQ Bot"',
+      description: "Bot display name.",
+    },
+  }}
+/>
+
+## Rich media
+
+`postMessage` uploads local files (`FileUpload`) and URL attachments
+automatically, then sends them as rich-media messages; unsupported scenarios
+fall back to text.
+
+```typescript
+// Send a local file
+await adapter.postMessage(threadId, {
+  text: "Document",
+  files: [
+    {
+      data: buffer,
+      filename: "report.xlsx",
+      mimeType: "application/vnd.ms-excel",
+    },
+  ],
+});
+```
+
+## Scenes
+
+Supports QQ DM (C2C), QQ Group, Text Channel, and Channel DM. File upload in
+group chats is not currently available; text channels and channel DMs send
+images and videos via `msg_type: 7`.
+
+## Feature support
+
+<FeatureSupport />

--- a/apps/docs/content/adapters/community/wecom.mdx
+++ b/apps/docs/content/adapters/community/wecom.mdx
@@ -1,0 +1,153 @@
+---
+title: WeCom
+description: Community WeCom (企业微信) adapter for Chat SDK covering group webhook bots, smart bots, and apps, with template cards, rich media, and AES-256-CBC encryption.
+packageName: "@agentor/chat-wecom"
+slug: wecom
+type: platform
+tagline: WeCom (企业微信) adapter for Chat SDK. Group webhook bots, smart bots (callback or WebSocket), and apps, with template cards and AES encryption.
+community: true
+mdxBody: true
+features:
+  postMessage: yes
+  editMessage: no
+  deleteMessage:
+    status: partial
+    label: App adapter only
+  fileUploads: yes
+  streaming: no
+  scheduledMessages: no
+  cardFormat: yes
+  buttons: yes
+  linkButtons: no
+  selectMenus:
+    status: partial
+    label: Template card dropdown (multiple_interaction)
+  tables: no
+  fields: yes
+  imagesInCards: yes
+  modals: no
+  slashCommands: no
+  mentions:
+    status: partial
+    label: App adapter (@mentioned_list)
+  addReactions: no
+  removeReactions: no
+  typingIndicator: no
+  directMessages: yes
+  ephemeralMessages: no
+  userLookup: no
+  customApiEndpoint: no
+  fetchMessages: no
+  fetchSingleMessage: no
+  fetchThreadInfo: no
+  fetchChannelMessages: no
+  listThreads: no
+  fetchChannelInfo: no
+  postChannelMessage: no
+---
+
+## Install
+
+<PackageInstall package="@agentor/chat-wecom chat @chat-adapter/state-memory" />
+
+## Quick start
+
+### Webhook (group bot)
+
+One-way message push to a group chat:
+
+```typescript title="lib/bot.ts" lineNumbers
+import { createWeComWebhookAdapter } from "@agentor/chat-wecom";
+
+const adapter = createWeComWebhookAdapter({
+  key: process.env.WECOM_WEBHOOK_KEY,
+});
+
+const threadId = adapter.encodeThreadId({ key: process.env.WECOM_WEBHOOK_KEY });
+await adapter.postMessage(threadId, "Hello from @agentor/chat-wecom!");
+```
+
+### Smart bot (WebSocket)
+
+```typescript title="lib/bot.ts" lineNumbers
+import { createWeComBotAdapter } from "@agentor/chat-wecom";
+
+const adapter = createWeComBotAdapter({
+  botId: process.env.WECOM_BOT_WS_BOT_ID,
+  secret: process.env.WECOM_BOT_WS_SECRET,
+});
+
+await adapter.initialize({
+  processMessage: async (_adapter, threadId, factory) => {
+    const message = await factory();
+    await adapter.postMessage(threadId, message.text);
+  },
+});
+```
+
+### App (application)
+
+```typescript title="lib/bot.ts" lineNumbers
+import { createWeComAppAdapter } from "@agentor/chat-wecom";
+
+const adapter = createWeComAppAdapter({
+  corpId: process.env.WECOM_APP_CORP_ID,
+  corpSecret: process.env.WECOM_APP_CORP_SECRET,
+  agentId: Number(process.env.WECOM_APP_AGENT_ID),
+});
+```
+
+## Configuration
+
+<TypeTable
+  type={{
+    key: {
+      type: "string",
+      description: "Webhook group-bot key (webhook adapter).",
+    },
+    corpId: { type: "string", description: "WeCom corporation ID (app adapter)." },
+    corpSecret: {
+      type: "string",
+      description: "Application secret (app adapter).",
+    },
+    agentId: {
+      type: "number",
+      description: "Application AgentId (app adapter).",
+    },
+    botId: { type: "string", description: "Smart bot ID (bot, WebSocket)." },
+    secret: {
+      type: "string",
+      description: "Smart bot secret (bot, WebSocket).",
+    },
+    token: { type: "string", description: "Callback token (callback modes)." },
+    encodingAESKey: {
+      type: "string",
+      description: "Callback AES key (callback modes).",
+    },
+  }}
+/>
+
+## Template cards
+
+Chat SDK `CardElement` is converted automatically to a WeCom Template Card. The
+card type is inferred from the content:
+
+| Card type | Inferred from |
+| --- | --- |
+| `text_notice` | Default (text only). |
+| `news_notice` | Contains an image. |
+| `button_interaction` | Contains buttons. |
+| `vote_interaction` | Contains a single-select. |
+| `multiple_interaction` | Contains multi-select / dropdown. |
+
+Webhook and callback bots only support `text_notice` and `news_notice`;
+WebSocket and app adapters support all five card types.
+
+## Encryption
+
+All callback communication uses AES-256-CBC encryption with SHA1 signature
+verification.
+
+## Feature support
+
+<FeatureSupport />

--- a/packages/integration-tests/src/documentation-test-utils.ts
+++ b/packages/integration-tests/src/documentation-test-utils.ts
@@ -235,6 +235,8 @@ export const VALID_DOC_PACKAGES = [
   "chat-adapter-zalo",
   "@larksuite/vercel-chat-adapter",
   "chat-adapter-weixin",
+  "@agentor/chat-qq",
+  "@agentor/chat-wecom",
   "qrcode-terminal",
 ];
 


### PR DESCRIPTION
## Summary

Adds two community platform adapters to the docs and `adapters.json` registry:

- `@agentor/chat-qq` — QQ Bot. WebSocket or webhook (Ed25519) modes; QQ DM,
  group, and text-channel scenes; rich media.
- `@agentor/chat-wecom` — WeCom (企业微信). Group webhook bots, smart bots
  (callback or WebSocket), and apps; WeCom Template Cards (5 types) and
  AES-256-CBC callback encryption.

Follows the community-adapter flow: docs MDX pages, `meta.json`,
`adapters.json` entries, and `VALID_DOC_PACKAGES`. Community-only adapters
intentionally omit a `chat/adapters` catalog entry, a `create-chat-sdk`
scaffold-spec, and a changeset.

## Test plan

- [x] `pnpm install`
- [x] `pnpm --filter @chat-adapter/integration-tests test`
- [x] `pnpm validate`

## Checklist

- [x] All commits are signed and verified
- [x] All commits are signed off for the DCO (`git commit -s`)
- [x] `pnpm validate` passes
- [x] Changeset added (or N/A — community docs-only)
- [x] Documentation updated
