### PR TITLE
fix(slack): preserve channel id and normalize frequently hallucinated link format

### DIFF
--- a/.changeset/two-corners-rescue.md
+++ b/.changeset/two-corners-rescue.md
@@ -2,4 +2,4 @@
 "@chat-adapter/slack": patch
 ---
 
-Preserve Slack channel ID to allow agent use channel tools with it and normalize commonly hallucinated Slack link format
+Preserve the Slack channel ID when converting labeled channel tokens (`<#C123|general>` now becomes `#general (C123)`) so agents can pass the ID to channel tools, and normalize the commonly hallucinated `<label|url>` link order before Markdown conversion

--- a/.changeset/two-corners-rescue.md
+++ b/.changeset/two-corners-rescue.md
@@ -1,0 +1,5 @@
+---
+"@chat-adapter/slack": patch
+---
+
+Preserve Slack channel ID to allow agent use channel tools with it and normalize commonly hallucinated Slack link format

--- a/packages/adapter-slack/src/format/index.test.ts
+++ b/packages/adapter-slack/src/format/index.test.ts
@@ -91,7 +91,16 @@ describe("Slack format primitives", () => {
         "Hey <@U123|jane> in <#C123|general>, see <https://example.com|this> and *bold* ~done~"
       )
     ).toBe(
-      "Hey @jane in #general, see [this](https://example.com) and **bold** ~~done~~"
+      "Hey @jane in #general (C123), see [this](https://example.com) and **bold** ~~done~~"
+    );
+  });
+
+  it("preserves the channel ID for labeled channel tokens", () => {
+    expect(slackMrkdwnToMarkdown("Post in <#C042BLND6R6|general>")).toBe(
+      "Post in #general (C042BLND6R6)"
+    );
+    expect(slackMrkdwnToMarkdown("Post in <#C042BLND6R6>")).toBe(
+      "Post in #C042BLND6R6"
     );
   });
 
@@ -107,6 +116,12 @@ describe("Slack format primitives", () => {
         "See <docs|https://example.com> and <https://a.com|A>"
       )
     ).toBe("See [docs](https://example.com) and [A](https://a.com)");
+  });
+
+  it("does not invert links whose display label is itself a URL", () => {
+    expect(slackMrkdwnToMarkdown("See <https://a.com|https://b.com>")).toBe(
+      "See [https://b.com](https://a.com)"
+    );
   });
 
   it("converts basic Markdown bold to Slack mrkdwn bold", () => {

--- a/packages/adapter-slack/src/format/index.test.ts
+++ b/packages/adapter-slack/src/format/index.test.ts
@@ -101,6 +101,14 @@ describe("Slack format primitives", () => {
     );
   });
 
+  it("normalizes inverted Slack link tokens before Markdown conversion", () => {
+    expect(
+      slackMrkdwnToMarkdown(
+        "See <docs|https://example.com> and <https://a.com|A>"
+      )
+    ).toBe("See [docs](https://example.com) and [A](https://a.com)");
+  });
+
   it("converts basic Markdown bold to Slack mrkdwn bold", () => {
     expect(markdownBoldToSlackMrkdwn("The **domain** is example.com")).toBe(
       "The *domain* is example.com"

--- a/packages/adapter-slack/src/format/index.ts
+++ b/packages/adapter-slack/src/format/index.ts
@@ -113,9 +113,12 @@ export function slackMrkdwnToMarkdown(mrkdwn: string): string {
   let markdown = mrkdwn;
   markdown = markdown.replace(/<@([A-Z0-9_]+)\|([^<>]+)>/g, "@$2");
   markdown = markdown.replace(/<@([A-Z0-9_]+)>/g, "@$1");
-  markdown = markdown.replace(/<#([A-Z0-9_]+)\|([^<>]+)>/g, "#$2");
+  markdown = markdown.replace(/<#([A-Z0-9_]+)\|([^<>]+)>/g, "#$2 ($1)");
   markdown = markdown.replace(/<#([A-Z0-9_]+)>/g, "#$1");
-  markdown = markdown.replace(/<([^<>|]+)\|(https?:\/\/[^|<>]+)>/g, "<$2|$1>");
+  markdown = markdown.replace(
+    /<(?!https?:\/\/)([^<>|]+)\|(https?:\/\/[^|<>]+)>/g,
+    "<$2|$1>"
+  );
   markdown = markdown.replace(/<(https?:\/\/[^|<>]+)\|([^<>]+)>/g, "[$2]($1)");
   markdown = markdown.replace(/<(https?:\/\/[^<>]+)>/g, "$1");
   markdown = markdown.replace(/(?<![_*\\])\*([^*\n]+)\*(?![_*])/g, "**$1**");

--- a/packages/adapter-slack/src/format/index.ts
+++ b/packages/adapter-slack/src/format/index.ts
@@ -113,8 +113,9 @@ export function slackMrkdwnToMarkdown(mrkdwn: string): string {
   let markdown = mrkdwn;
   markdown = markdown.replace(/<@([A-Z0-9_]+)\|([^<>]+)>/g, "@$2");
   markdown = markdown.replace(/<@([A-Z0-9_]+)>/g, "@$1");
-  markdown = markdown.replace(/<#[A-Z0-9_]+\|([^<>]+)>/g, "#$1");
+  markdown = markdown.replace(/<#([A-Z0-9_]+)\|([^<>]+)>/g, "#$2");
   markdown = markdown.replace(/<#([A-Z0-9_]+)>/g, "#$1");
+  markdown = markdown.replace(/<([^<>|]+)\|(https?:\/\/[^|<>]+)>/g, "<$2|$1>");
   markdown = markdown.replace(/<(https?:\/\/[^|<>]+)\|([^<>]+)>/g, "[$2]($1)");
   markdown = markdown.replace(/<(https?:\/\/[^<>]+)>/g, "$1");
   markdown = markdown.replace(/(?<![_*\\])\*([^*\n]+)\*(?![_*])/g, "**$1**");


### PR DESCRIPTION
This change fixes two conversion issues in `slackMrkdwnToMarkdown`, which runs on every incoming Slack message.

**1. Preserve channel IDs in labeled channel tokens**

Previously the channel ID was dropped during conversion, so agents reading `message.text` had no ID to pass to channel tools. Labeled tokens now keep both the readable name and the ID:

```
<#C042BLND6R6|general>   →   #general (C042BLND6R6)
<#C042BLND6R6>           →   #C042BLND6R6            (unchanged)
```

Bare channel mentions are still enriched with the channel name via `conversations.info`, so incoming messages end up with both the name and the ID either way.

**2. Normalize the commonly hallucinated link order**

AI models frequently emit Slack links with the label and URL swapped. These are now normalized before Markdown conversion:

```
<docs|https://example.com>   →   [docs](https://example.com)
```

Valid links whose display label is itself a URL (common with Slack's truncated link displays) are detected and left in the correct order:

```
<https://a.com|https://b.com>   →   [https://b.com](https://a.com)
```
