### PR TITLE
feat(modals): add DateInput and NumberInput modal children

### DIFF
--- a/.changeset/lucky-pandas-listen.md
+++ b/.changeset/lucky-pandas-listen.md
@@ -1,0 +1,9 @@
+---
+"@chat-adapter/slack": minor
+"@chat-adapter/teams": minor
+"chat": minor
+---
+
+Add `DateInput` and `NumberInput` modal children. The Slack adapter renders them as a `datepicker` and a `number_input`, the Teams adapter as `Input.Date` and `Input.Number`, and both submitted values arrive in `event.values` as strings.
+
+Teams submit values that arrive as JSON numbers are now stringified into `event.values` instead of being dropped. This fixes `Input.Number`, but applies to any numeric value a Teams dialog submits — a key that was previously absent from `event.values` will now be present as a string.

--- a/apps/docs/content/docs/api/modals.mdx
+++ b/apps/docs/content/docs/api/modals.mdx
@@ -7,7 +7,15 @@ type: reference
 Modals display form dialogs that collect structured user input. Currently supported on Slack and Teams.
 
 ```typescript
-import { Modal, TextInput, Select, RadioSelect, SelectOption } from "chat";
+import {
+  Modal,
+  TextInput,
+  DateInput,
+  NumberInput,
+  Select,
+  RadioSelect,
+  SelectOption,
+} from "chat";
 ```
 
 ## Modal
@@ -123,6 +131,101 @@ TextInput({
     },
   }}
 />
+
+## DateInput
+
+A date picker — a Slack `datepicker`, an Adaptive Card `Input.Date` on Teams.
+
+```typescript
+DateInput({
+  id: "due_date",
+  label: "Due date",
+  placeholder: "Pick a date",
+  initialValue: "2026-08-01",
+})
+```
+
+<TypeTable
+  type={{
+    id: {
+      description: 'Input ID — used as the key in event.values.',
+      type: 'string',
+    },
+    label: {
+      description: 'Label displayed above the input.',
+      type: 'string',
+    },
+    placeholder: {
+      description: 'Placeholder text.',
+      type: 'string',
+    },
+    initialValue: {
+      description: 'Pre-filled date as YYYY-MM-DD.',
+      type: 'string',
+    },
+    optional: {
+      description: 'Whether the field can be left empty.',
+      type: 'boolean',
+      default: 'false',
+    },
+  }}
+/>
+
+The submitted value arrives in `event.values` as an ISO `YYYY-MM-DD` string. An `initialValue` that is not a valid `YYYY-MM-DD` date is ignored with a warning — Slack rejects a malformed `initial_date` by failing the whole modal, so it is dropped rather than forwarded.
+
+## NumberInput
+
+A numeric input — a Slack `number_input`, an Adaptive Card `Input.Number` on Teams.
+
+```typescript
+NumberInput({
+  id: "quantity",
+  label: "Quantity",
+  min: 1,
+  max: 10,
+})
+```
+
+<TypeTable
+  type={{
+    id: {
+      description: 'Input ID — used as the key in event.values.',
+      type: 'string',
+    },
+    label: {
+      description: 'Label displayed above the input.',
+      type: 'string',
+    },
+    placeholder: {
+      description: 'Placeholder text.',
+      type: 'string',
+    },
+    initialValue: {
+      description: 'Pre-filled value.',
+      type: 'number',
+    },
+    min: {
+      description: 'Minimum accepted value.',
+      type: 'number',
+    },
+    max: {
+      description: 'Maximum accepted value.',
+      type: 'number',
+    },
+    decimal: {
+      description: 'Allow decimal values. Enforced by Slack; Adaptive Cards has no decimal switch, so Teams accepts decimals either way.',
+      type: 'boolean',
+      default: 'false',
+    },
+    optional: {
+      description: 'Whether the field can be left empty.',
+      type: 'boolean',
+      default: 'false',
+    },
+  }}
+/>
+
+Values in `event.values` are always strings — parse with `Number(...)` when you need a number.
 
 ## Select
 
@@ -266,6 +369,8 @@ The `children` array in `Modal` accepts these element types:
 | Type | Created by |
 |------|-----------|
 | `TextInputElement` | `TextInput()` |
+| `DateInputElement` | `DateInput()` |
+| `NumberInputElement` | `NumberInput()` |
 | `SelectElement` | `Select()` |
 | `RadioSelectElement` | `RadioSelect()` |
 | `TextElement` | `Text()` — static text content |

--- a/apps/docs/content/docs/modals.mdx
+++ b/apps/docs/content/docs/modals.mdx
@@ -13,7 +13,7 @@ Modals open form dialogs in response to button clicks or [slash commands](/docs/
 Modals are opened from [action handlers](/docs/actions) or [slash command handlers](/docs/slash-commands) using `event.openModal()`:
 
 ```tsx title="lib/bot.tsx" lineNumbers
-import { Modal, TextInput, Select, SelectOption } from "chat";
+import { Modal, TextInput, DateInput, Select, SelectOption } from "chat";
 
 bot.onAction("feedback", async (event) => {
   await event.openModal(
@@ -35,6 +35,7 @@ bot.onAction("feedback", async (event) => {
         <SelectOption label="Feature Request" value="feature" />
         <SelectOption label="General" value="general" />
       </Select>
+      <DateInput id="due_date" label="Follow up by" optional />
       <TextInput
         id="email"
         label="Email (optional)"
@@ -75,6 +76,41 @@ A text field for user input.
 | `multiline` | `boolean` (optional) | Render as textarea |
 | `optional` | `boolean` (optional) | Allow empty submission |
 | `maxLength` | `number` (optional) | Maximum character count |
+
+### DateInput
+
+A date picker. Renders a Slack `datepicker` and an Adaptive Card `Input.Date`.
+
+| Prop | Type | Description |
+|------|------|-------------|
+| `id` | `string` | Field identifier (key in `event.values`) |
+| `label` | `string` | Field label |
+| `placeholder` | `string` (optional) | Placeholder text |
+| `initialValue` | `string` (optional) | Pre-filled date as `YYYY-MM-DD` |
+| `optional` | `boolean` (optional) | Allow empty submission |
+
+The submitted value is an ISO `YYYY-MM-DD` string. An `initialValue` that is not a valid `YYYY-MM-DD` date is ignored with a warning, because Slack rejects a malformed `initial_date` by refusing to open the modal at all.
+
+### NumberInput
+
+A numeric field. Renders a Slack `number_input` and an Adaptive Card `Input.Number`.
+
+| Prop | Type | Description |
+|------|------|-------------|
+| `id` | `string` | Field identifier (key in `event.values`) |
+| `label` | `string` | Field label |
+| `placeholder` | `string` (optional) | Placeholder text |
+| `initialValue` | `number` (optional) | Pre-filled value |
+| `min` | `number` (optional) | Minimum accepted value |
+| `max` | `number` (optional) | Maximum accepted value |
+| `decimal` | `boolean` (optional) | Allow decimals — defaults to integers only |
+| `optional` | `boolean` (optional) | Allow empty submission |
+
+Like every other field, the submitted value arrives in `event.values` as a string — parse it with `Number(...)` if you need a number.
+
+<Callout type="info">
+  `decimal` is enforced by Slack. Adaptive Cards has no decimal switch, so `Input.Number` accepts decimals on Teams regardless — validate server-side if the distinction matters.
+</Callout>
 
 ### Select
 

--- a/packages/adapter-slack/src/index.test.ts
+++ b/packages/adapter-slack/src/index.test.ts
@@ -805,6 +805,52 @@ describe("handleWebhook - interactive payloads", () => {
     expect(response.status).toBe(200);
   });
 
+  it("flattens datepicker and number_input state into submitted values", async () => {
+    const state = createMockState();
+    const chatInstance = createMockChatInstance({ state });
+    chatInstance.processModalSubmit = vi.fn().mockResolvedValue({
+      action: "close",
+    });
+
+    const adapter = createSlackAdapter({
+      botToken: "xoxb-test-token",
+      signingSecret: secret,
+      logger: mockLogger,
+    });
+    await adapter.initialize(chatInstance);
+
+    const payload = JSON.stringify({
+      type: "view_submission",
+      trigger_id: "trigger123",
+      user: { id: "U123", username: "testuser", name: "Test User" },
+      view: {
+        id: "V123",
+        callback_id: "renewal_form",
+        state: {
+          values: {
+            renewal_date: { renewal_date: { selected_date: "2026-08-01" } },
+            quantity: { quantity: { value: "3" } },
+          },
+        },
+      },
+    });
+    const body = `payload=${encodeURIComponent(payload)}`;
+    const request = createWebhookRequest(body, secret, {
+      contentType: "application/x-www-form-urlencoded",
+    });
+
+    const response = await adapter.handleWebhook(request);
+    expect(response.status).toBe(200);
+    expect(chatInstance.processModalSubmit).toHaveBeenCalledWith(
+      expect.objectContaining({
+        callbackId: "renewal_form",
+        values: { renewal_date: "2026-08-01", quantity: "3" },
+      }),
+      undefined,
+      undefined
+    );
+  });
+
   it("responds with response_action: clear when handler returns clear", async () => {
     const state = createMockState();
     const chatInstance = createMockChatInstance({ state });

--- a/packages/adapter-slack/src/index.ts
+++ b/packages/adapter-slack/src/index.ts
@@ -534,7 +534,14 @@ interface SlackViewSubmissionPayload {
     state: {
       values: Record<
         string,
-        Record<string, { value?: string; selected_option?: { value: string } }>
+        Record<
+          string,
+          {
+            value?: string;
+            selected_date?: string;
+            selected_option?: { value: string };
+          }
+        >
       >;
     };
   };
@@ -2028,7 +2035,11 @@ export class SlackAdapter implements Adapter<SlackThreadId, unknown> {
     const values: Record<string, string> = {};
     for (const blockValues of Object.values(payload.view.state.values)) {
       for (const [actionId, input] of Object.entries(blockValues)) {
-        values[actionId] = input.value ?? input.selected_option?.value ?? "";
+        values[actionId] =
+          input.value ??
+          input.selected_date ??
+          input.selected_option?.value ??
+          "";
       }
     }
 

--- a/packages/adapter-slack/src/modals.test.ts
+++ b/packages/adapter-slack/src/modals.test.ts
@@ -1,12 +1,14 @@
 import {
+  DateInput,
   ExternalSelect,
   Modal,
+  NumberInput,
   RadioSelect,
   Select,
   SelectOption,
   TextInput,
 } from "chat";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import {
   decodeModalMetadata,
   encodeModalMetadata,
@@ -654,6 +656,162 @@ describe("modalToSlackView with select option descriptions", () => {
     expect(element.options[1].description).toEqual({
       type: "mrkdwn",
       text: "For _teams_",
+    });
+  });
+});
+
+describe("date and number inputs", () => {
+  it("converts a date input to a Block Kit datepicker", () => {
+    const modal = Modal({
+      callbackId: "renewal_form",
+      title: "Renewal",
+      children: [
+        DateInput({
+          id: "renewal_date",
+          label: "Renewal Date",
+          placeholder: "Pick a date",
+          initialValue: "2026-08-01",
+        }),
+      ],
+    });
+
+    const view = modalToSlackView(modal);
+
+    expect(view.blocks[0]).toEqual({
+      type: "input",
+      block_id: "renewal_date",
+      optional: false,
+      label: { type: "plain_text", text: "Renewal Date" },
+      element: {
+        type: "datepicker",
+        action_id: "renewal_date",
+        placeholder: { type: "plain_text", text: "Pick a date" },
+        initial_date: "2026-08-01",
+      },
+    });
+  });
+
+  it("omits datepicker fields that were not provided", () => {
+    const modal = Modal({
+      callbackId: "renewal_form",
+      title: "Renewal",
+      children: [
+        DateInput({
+          id: "renewal_date",
+          label: "Renewal Date",
+          optional: true,
+        }),
+      ],
+    });
+
+    const view = modalToSlackView(modal);
+
+    expect(view.blocks[0]).toEqual({
+      type: "input",
+      block_id: "renewal_date",
+      optional: true,
+      label: { type: "plain_text", text: "Renewal Date" },
+      element: { type: "datepicker", action_id: "renewal_date" },
+    });
+  });
+
+  it("drops an initial date that Slack would reject", () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {
+      // silence the expected warning
+    });
+
+    for (const initialValue of [
+      "30 days from signing",
+      "2026-2-1",
+      "2026-02-31",
+      "not a date",
+    ]) {
+      const view = modalToSlackView(
+        Modal({
+          callbackId: "renewal_form",
+          title: "Renewal",
+          children: [
+            DateInput({
+              id: "renewal_date",
+              label: "Renewal Date",
+              initialValue,
+            }),
+          ],
+        })
+      );
+
+      expect(view.blocks[0]).toEqual({
+        type: "input",
+        block_id: "renewal_date",
+        optional: false,
+        label: { type: "plain_text", text: "Renewal Date" },
+        element: { type: "datepicker", action_id: "renewal_date" },
+      });
+    }
+
+    expect(warn).toHaveBeenCalledTimes(4);
+    warn.mockRestore();
+  });
+
+  it("converts a number input to a Block Kit number_input with string bounds", () => {
+    const modal = Modal({
+      callbackId: "order_form",
+      title: "Order",
+      children: [
+        NumberInput({
+          id: "quantity",
+          label: "Quantity",
+          placeholder: "How many?",
+          initialValue: 3,
+          min: 1,
+          max: 10,
+          decimal: true,
+        }),
+      ],
+    });
+
+    const view = modalToSlackView(modal);
+
+    expect(view.blocks[0]).toEqual({
+      type: "input",
+      block_id: "quantity",
+      optional: false,
+      label: { type: "plain_text", text: "Quantity" },
+      element: {
+        type: "number_input",
+        action_id: "quantity",
+        is_decimal_allowed: true,
+        placeholder: { type: "plain_text", text: "How many?" },
+        initial_value: "3",
+        min_value: "1",
+        max_value: "10",
+      },
+    });
+  });
+
+  it("defaults number_input to integers only and keeps zero bounds", () => {
+    const modal = Modal({
+      callbackId: "order_form",
+      title: "Order",
+      children: [
+        NumberInput({
+          id: "quantity",
+          label: "Quantity",
+          initialValue: 0,
+          min: 0,
+        }),
+      ],
+    });
+
+    const view = modalToSlackView(modal);
+
+    expect(view.blocks[0]).toMatchObject({
+      element: {
+        type: "number_input",
+        is_decimal_allowed: false,
+        initial_value: "0",
+        min_value: "0",
+      },
     });
   });
 });

--- a/packages/adapter-slack/src/modals.ts
+++ b/packages/adapter-slack/src/modals.ts
@@ -4,9 +4,11 @@
  */
 
 import type {
+  DateInputElement,
   ExternalSelectElement,
   ModalChild,
   ModalElement,
+  NumberInputElement,
   RadioSelectElement,
   SelectElement,
   SelectOptionElement,
@@ -115,6 +117,10 @@ function modalChildToBlock(child: ModalChild): SlackBlock {
   switch (child.type) {
     case "text_input":
       return textInputToBlock(child);
+    case "date_input":
+      return dateInputToBlock(child);
+    case "number_input":
+      return numberInputToBlock(child);
     case "select":
       return selectToBlock(child);
     case "external_select":
@@ -159,6 +165,90 @@ function textInputToBlock(input: TextInputElement): SlackBlock {
   }
   if (input.maxLength) {
     element.max_length = input.maxLength;
+  }
+
+  return {
+    type: "input",
+    block_id: input.id,
+    optional: input.optional ?? false,
+    label: { type: "plain_text", text: input.label },
+    element,
+  };
+}
+
+const ISO_DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
+
+/**
+ * Slack rejects a `datepicker` whose `initial_date` is not a real `YYYY-MM-DD` date, and it fails the
+ * WHOLE `views.open` with `invalid_arguments` rather than degrading the one field — so a modal built from
+ * user- or template-supplied dates never opens at all. Adaptive Cards is lenient with a bad `Input.Date`
+ * value, so forwarding it verbatim would make the same modal work on Teams and die on Slack. Drop it with
+ * a warning instead, matching how `filterModalChildren` handles unsupported children.
+ */
+function toInitialDate(value: string | undefined): string | undefined {
+  if (!value) {
+    return;
+  }
+  // `Date` rolls impossible dates over (2026-02-31 becomes Mar 3), so round-trip rather than trust a parse.
+  const parsed = ISO_DATE_RE.test(value)
+    ? new Date(`${value}T00:00:00Z`)
+    : null;
+  if (
+    !parsed ||
+    Number.isNaN(parsed.getTime()) ||
+    parsed.toISOString().slice(0, 10) !== value
+  ) {
+    console.warn(
+      `[chat] DateInput "${value}" is not a YYYY-MM-DD date — ignoring initialValue`
+    );
+    return;
+  }
+  return value;
+}
+
+function dateInputToBlock(input: DateInputElement): SlackBlock {
+  const element: Record<string, unknown> = {
+    type: "datepicker",
+    action_id: input.id,
+  };
+
+  if (input.placeholder) {
+    element.placeholder = { type: "plain_text", text: input.placeholder };
+  }
+  const initialDate = toInitialDate(input.initialValue);
+  if (initialDate) {
+    element.initial_date = initialDate;
+  }
+
+  return {
+    type: "input",
+    block_id: input.id,
+    optional: input.optional ?? false,
+    label: { type: "plain_text", text: input.label },
+    element,
+  };
+}
+
+function numberInputToBlock(input: NumberInputElement): SlackBlock {
+  // Slack's number_input requires is_decimal_allowed, and takes its numeric
+  // bounds/initial value as strings.
+  const element: Record<string, unknown> = {
+    type: "number_input",
+    action_id: input.id,
+    is_decimal_allowed: input.decimal ?? false,
+  };
+
+  if (input.placeholder) {
+    element.placeholder = { type: "plain_text", text: input.placeholder };
+  }
+  if (input.initialValue !== undefined) {
+    element.initial_value = String(input.initialValue);
+  }
+  if (input.min !== undefined) {
+    element.min_value = String(input.min);
+  }
+  if (input.max !== undefined) {
+    element.max_value = String(input.max);
   }
 
   return {

--- a/packages/adapter-teams/src/modals-primitives/index.test.ts
+++ b/packages/adapter-teams/src/modals-primitives/index.test.ts
@@ -187,11 +187,13 @@ describe("Teams modal primitives", () => {
     });
   });
 
-  it("ignores non-string submit values", () => {
-    expect(parseTeamsDialogSubmitValues({ count: 5, note: "ok" })).toEqual({
+  it("stringifies numeric submit values and ignores other non-strings", () => {
+    expect(
+      parseTeamsDialogSubmitValues({ count: 5, note: "ok", flag: true })
+    ).toEqual({
       callbackId: undefined,
       contextId: undefined,
-      values: { note: "ok" },
+      values: { count: "5", note: "ok" },
     });
   });
 

--- a/packages/adapter-teams/src/modals-primitives/index.ts
+++ b/packages/adapter-teams/src/modals-primitives/index.ts
@@ -3,7 +3,9 @@ import type {
   TeamsDialogSubmitValues,
   TeamsFieldsModalElement,
   TeamsModalChild,
+  TeamsModalDateInputElement,
   TeamsModalElement,
+  TeamsModalNumberInputElement,
   TeamsModalRadioSelectElement,
   TeamsModalResponse,
   TeamsModalSelectElement,
@@ -53,6 +55,9 @@ export function parseTeamsDialogSubmitValues(
     }
     if (typeof value === "string") {
       values[key] = value;
+    } else if (typeof value === "number") {
+      // Input.Number submits a JSON number
+      values[key] = String(value);
     }
   }
 
@@ -109,6 +114,10 @@ function modalChildToAdaptiveElements(child: TeamsModalChild): unknown[] {
       return [fieldsBlock(child)];
     case "text_input":
       return [textInput(child)];
+    case "date_input":
+      return [dateInput(child)];
+    case "number_input":
+      return [numberInput(child)];
     case "select":
       return [choiceSet(child, "compact")];
     case "radio_select":
@@ -148,6 +157,30 @@ function textInput(input: TeamsModalTextInputElement): unknown {
     ...(input.placeholder ? { placeholder: input.placeholder } : {}),
     ...(input.initialValue ? { value: input.initialValue } : {}),
     type: "Input.Text",
+  };
+}
+
+function dateInput(input: TeamsModalDateInputElement): unknown {
+  return {
+    id: input.id,
+    isRequired: !(input.optional ?? false),
+    label: input.label,
+    ...(input.placeholder ? { placeholder: input.placeholder } : {}),
+    ...(input.initialValue ? { value: input.initialValue } : {}),
+    type: "Input.Date",
+  };
+}
+
+function numberInput(input: TeamsModalNumberInputElement): unknown {
+  return {
+    id: input.id,
+    isRequired: !(input.optional ?? false),
+    label: input.label,
+    ...(input.max === undefined ? {} : { max: input.max }),
+    ...(input.min === undefined ? {} : { min: input.min }),
+    ...(input.placeholder ? { placeholder: input.placeholder } : {}),
+    ...(input.initialValue === undefined ? {} : { value: input.initialValue }),
+    type: "Input.Number",
   };
 }
 

--- a/packages/adapter-teams/src/modals-primitives/types.ts
+++ b/packages/adapter-teams/src/modals-primitives/types.ts
@@ -12,6 +12,8 @@ export type TeamsModalChild =
   | TeamsFieldsModalElement
   | TeamsModalTextElement
   | TeamsModalTextInputElement
+  | TeamsModalDateInputElement
+  | TeamsModalNumberInputElement
   | TeamsModalSelectElement
   | TeamsModalRadioSelectElement;
 
@@ -40,6 +42,26 @@ export interface TeamsModalTextInputElement {
   optional?: boolean;
   placeholder?: string;
   type: "text_input";
+}
+
+export interface TeamsModalDateInputElement {
+  id: string;
+  initialValue?: string;
+  label: string;
+  optional?: boolean;
+  placeholder?: string;
+  type: "date_input";
+}
+
+export interface TeamsModalNumberInputElement {
+  id: string;
+  initialValue?: number;
+  label: string;
+  max?: number;
+  min?: number;
+  optional?: boolean;
+  placeholder?: string;
+  type: "number_input";
 }
 
 export interface TeamsModalSelectElement {

--- a/packages/adapter-teams/src/modals.test.ts
+++ b/packages/adapter-teams/src/modals.test.ts
@@ -7,9 +7,11 @@ import type {
 } from "chat";
 import {
   CardText,
+  DateInput,
   Field,
   Fields,
   Modal,
+  NumberInput,
   RadioSelect,
   Select,
   SelectOption,
@@ -307,5 +309,104 @@ describe("modalResponseToTaskModuleResponse", () => {
     };
     expect(card.body.length).toBeGreaterThanOrEqual(3);
     expect(card.body[0].text).toContain("Please fix");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Date and number inputs
+// ---------------------------------------------------------------------------
+
+describe("date and number inputs", () => {
+  it("renders a date input as Input.Date", () => {
+    const card = modalToAdaptiveCard(
+      makeModal({
+        children: [
+          DateInput({
+            id: "renewal_date",
+            label: "Renewal Date",
+            placeholder: "Pick a date",
+            initialValue: "2026-08-01",
+          }),
+        ],
+      }),
+      "ctx-1",
+      "cb-1"
+    );
+
+    expect(card.body?.[0]).toMatchObject({
+      type: "Input.Date",
+      id: "renewal_date",
+      label: "Renewal Date",
+      placeholder: "Pick a date",
+      value: "2026-08-01",
+      isRequired: true,
+    });
+  });
+
+  it("marks an optional date input as not required", () => {
+    const card = modalToAdaptiveCard(
+      makeModal({
+        children: [
+          DateInput({
+            id: "renewal_date",
+            label: "Renewal Date",
+            optional: true,
+          }),
+        ],
+      }),
+      "ctx-1",
+      "cb-1"
+    );
+
+    expect(card.body?.[0]).toMatchObject({
+      type: "Input.Date",
+      isRequired: false,
+    });
+  });
+
+  it("renders a number input as Input.Number with numeric bounds", () => {
+    const card = modalToAdaptiveCard(
+      makeModal({
+        children: [
+          NumberInput({
+            id: "quantity",
+            label: "Quantity",
+            placeholder: "How many?",
+            initialValue: 3,
+            min: 1,
+            max: 10,
+          }),
+        ],
+      }),
+      "ctx-1",
+      "cb-1"
+    );
+
+    expect(card.body?.[0]).toMatchObject({
+      type: "Input.Number",
+      id: "quantity",
+      label: "Quantity",
+      placeholder: "How many?",
+      value: 3,
+      min: 1,
+      max: 10,
+      isRequired: true,
+    });
+  });
+
+  it("stringifies numeric submit values", () => {
+    const parsed = parseDialogSubmitValues({
+      __contextId: "ctx-1",
+      __callbackId: "cb-1",
+      renewal_date: "2026-08-01",
+      quantity: 3,
+      ratio: 0,
+    });
+
+    expect(parsed.values).toEqual({
+      renewal_date: "2026-08-01",
+      quantity: "3",
+      ratio: "0",
+    });
   });
 });

--- a/packages/adapter-teams/src/modals.ts
+++ b/packages/adapter-teams/src/modals.ts
@@ -10,23 +10,29 @@ import type {
   ActionStyle,
   CardElementArray,
   ChoiceSetInputOptions,
+  DateInputOptions,
+  NumberInputOptions,
   TextInputOptions,
 } from "@microsoft/teams.cards";
 import {
   AdaptiveCard,
   Choice,
   ChoiceSetInput,
+  DateInput,
   Fact,
   FactSet,
+  NumberInput,
   SubmitAction,
   TextBlock,
   TextInput,
 } from "@microsoft/teams.cards";
 import type {
+  DateInputElement,
   FieldsElement,
   ModalChild,
   ModalElement,
   ModalResponse,
+  NumberInputElement,
   RadioSelectElement,
   SelectElement,
   TextElement,
@@ -94,6 +100,10 @@ function modalChildToAdaptiveElements(child: ModalChild): CardElementArray {
   switch (child.type) {
     case "text_input":
       return [textInputToAdaptive(child)];
+    case "date_input":
+      return [dateInputToAdaptive(child)];
+    case "number_input":
+      return [numberInputToAdaptive(child)];
     case "select":
       return [selectToAdaptive(child)];
     case "external_select":
@@ -121,6 +131,34 @@ function textInputToAdaptive(input: TextInputElement): TextInput {
   };
 
   return new TextInput(options);
+}
+
+function dateInputToAdaptive(input: DateInputElement): DateInput {
+  const options: DateInputOptions = {
+    id: input.id,
+    label: convertEmoji(input.label),
+    isRequired: !(input.optional ?? false),
+    placeholder: input.placeholder,
+    value: input.initialValue,
+  };
+
+  return new DateInput(options);
+}
+
+function numberInputToAdaptive(input: NumberInputElement): NumberInput {
+  // Adaptive Cards has no decimal switch — Input.Number always accepts
+  // decimals, so `decimal: false` is enforced by Slack only.
+  const options: NumberInputOptions = {
+    id: input.id,
+    label: convertEmoji(input.label),
+    isRequired: !(input.optional ?? false),
+    placeholder: input.placeholder,
+    value: input.initialValue,
+    min: input.min,
+    max: input.max,
+  };
+
+  return new NumberInput(options);
 }
 
 function selectToAdaptive(select: SelectElement): ChoiceSetInput {
@@ -211,6 +249,9 @@ export function parseDialogSubmitValues(
     }
     if (typeof val === "string") {
       values[key] = val;
+    } else if (typeof val === "number") {
+      // Input.Number submits a JSON number
+      values[key] = String(val);
     }
   }
 

--- a/packages/chat/src/index.ts
+++ b/packages/chat/src/index.ts
@@ -98,6 +98,7 @@ import type {
   CardComponent,
   CardLinkComponent,
   ChartComponent,
+  DateInputComponent,
   DividerComponent,
   ExternalSelectComponent,
   FieldComponent,
@@ -105,6 +106,7 @@ import type {
   ImageComponent,
   LinkButtonComponent,
   ModalComponent,
+  NumberInputComponent,
   RadioSelectComponent,
   SectionComponent,
   SelectComponent,
@@ -142,10 +144,12 @@ export const toModalElement = _toModalElement;
 
 // Modal builders
 import {
+  DateInput as _DateInput,
   ExternalSelect as _ExternalSelect,
   fromReactModalElement as _fromReactModalElement,
   isModalElement as _isModalElement,
   Modal as _Modal,
+  NumberInput as _NumberInput,
   RadioSelect as _RadioSelect,
   Select as _Select,
   SelectOption as _SelectOption,
@@ -153,9 +157,11 @@ import {
 } from "./modals";
 export const fromReactModalElement = _fromReactModalElement;
 export const isModalElement = _isModalElement;
+export const DateInput = _DateInput as unknown as DateInputComponent;
 export const ExternalSelect =
   _ExternalSelect as unknown as ExternalSelectComponent;
 export const Modal = _Modal as unknown as ModalComponent;
+export const NumberInput = _NumberInput as unknown as NumberInputComponent;
 export const RadioSelect = _RadioSelect as unknown as RadioSelectComponent;
 export const Select = _Select as unknown as SelectComponent;
 export const SelectOption = _SelectOption as unknown as SelectOptionComponent;
@@ -216,6 +222,8 @@ export type {
   CardProps,
   ChatElement,
   ContainerProps,
+  DateInputComponent,
+  DateInputProps,
   DividerComponent,
   DividerProps,
   ExternalSelectComponent,
@@ -229,6 +237,8 @@ export type {
   LinkButtonProps,
   ModalComponent,
   ModalProps,
+  NumberInputComponent,
+  NumberInputProps,
   RadioSelectComponent,
   SectionComponent,
   SelectComponent,
@@ -307,11 +317,15 @@ export {
 } from "./markdown";
 // Modal types
 export type {
+  DateInputElement,
+  DateInputOptions,
   ExternalSelectElement,
   ExternalSelectOptions,
   ModalChild,
   ModalElement,
   ModalOptions,
+  NumberInputElement,
+  NumberInputOptions,
   RadioSelectElement,
   RadioSelectOptions,
   SelectElement,

--- a/packages/chat/src/jsx-runtime.ts
+++ b/packages/chat/src/jsx-runtime.ts
@@ -66,6 +66,9 @@ import {
 } from "./cards";
 
 import {
+  DateInput,
+  type DateInputElement,
+  type DateInputOptions,
   ExternalSelect,
   type ExternalSelectElement,
   type ExternalSelectOptions,
@@ -75,6 +78,9 @@ import {
   type ModalChild,
   type ModalElement,
   type ModalOptions,
+  NumberInput,
+  type NumberInputElement,
+  type NumberInputOptions,
   RadioSelect,
   type RadioSelectElement,
   type RadioSelectOptions,
@@ -180,6 +186,27 @@ export interface TextInputProps {
   placeholder?: string;
 }
 
+/** Props for DateInput component in JSX */
+export interface DateInputProps {
+  id: string;
+  initialValue?: string;
+  label: string;
+  optional?: boolean;
+  placeholder?: string;
+}
+
+/** Props for NumberInput component in JSX */
+export interface NumberInputProps {
+  decimal?: boolean;
+  id: string;
+  initialValue?: number;
+  label: string;
+  max?: number;
+  min?: number;
+  optional?: boolean;
+  placeholder?: string;
+}
+
 /** Props for Select component in JSX */
 export interface SelectProps {
   children?: unknown;
@@ -234,6 +261,8 @@ export type CardJSXProps =
   | DividerProps
   | ModalProps
   | TextInputProps
+  | DateInputProps
+  | NumberInputProps
   | SelectProps
   | ExternalSelectProps
   | SelectOptionProps
@@ -255,6 +284,8 @@ type CardComponentFunction =
   | typeof Fields
   | typeof Modal
   | typeof TextInput
+  | typeof DateInput
+  | typeof NumberInput
   | typeof Select
   | typeof ExternalSelect
   | typeof RadioSelect
@@ -289,6 +320,8 @@ export type ChatElement =
   | FieldElement
   | ModalElement
   | TextInputElement
+  | DateInputElement
+  | NumberInputElement
   | SelectElement
   | ExternalSelectElement
   | SelectOptionElement
@@ -370,6 +403,16 @@ export interface ModalComponent {
 export interface TextInputComponent {
   (options: TextInputOptions): TextInputElement;
   (props: TextInputProps): ChatElement;
+}
+
+export interface DateInputComponent {
+  (options: DateInputOptions): DateInputElement;
+  (props: DateInputProps): ChatElement;
+}
+
+export interface NumberInputComponent {
+  (options: NumberInputOptions): NumberInputElement;
+  (props: NumberInputProps): ChatElement;
 }
 
 export interface SelectComponent {
@@ -568,6 +611,29 @@ function isTextInputProps(props: CardJSXProps): props is TextInputProps {
 }
 
 /**
+ * DateInput and NumberInput carry no discriminating prop beyond the id/label every input has — they are
+ * told apart by the component identity already matched in `resolveJSXElement`, so both guards share one
+ * predicate and differ only in the type they narrow to.
+ */
+function hasIdAndLabel(props: CardJSXProps): boolean {
+  return "id" in props && "label" in props;
+}
+
+/**
+ * Type guard to check if props match DateInputProps
+ */
+function isDateInputProps(props: CardJSXProps): props is DateInputProps {
+  return hasIdAndLabel(props);
+}
+
+/**
+ * Type guard to check if props match NumberInputProps
+ */
+function isNumberInputProps(props: CardJSXProps): props is NumberInputProps {
+  return hasIdAndLabel(props);
+}
+
+/**
  * Type guard to check if props match SelectProps
  */
 function isSelectProps(props: CardJSXProps): props is SelectProps {
@@ -748,6 +814,35 @@ function resolveJSXElement(element: JSXElement): AnyCardElement {
       multiline: props.multiline,
       optional: props.optional,
       maxLength: props.maxLength,
+    });
+  }
+
+  if (type === DateInput) {
+    if (!isDateInputProps(props)) {
+      throw new Error("DateInput requires 'id' and 'label' props");
+    }
+    return DateInput({
+      id: props.id,
+      label: props.label,
+      placeholder: props.placeholder,
+      initialValue: props.initialValue,
+      optional: props.optional,
+    });
+  }
+
+  if (type === NumberInput) {
+    if (!isNumberInputProps(props)) {
+      throw new Error("NumberInput requires 'id' and 'label' props");
+    }
+    return NumberInput({
+      id: props.id,
+      label: props.label,
+      placeholder: props.placeholder,
+      initialValue: props.initialValue,
+      optional: props.optional,
+      min: props.min,
+      max: props.max,
+      decimal: props.decimal,
     });
   }
 

--- a/packages/chat/src/modals.test.ts
+++ b/packages/chat/src/modals.test.ts
@@ -1,10 +1,12 @@
 import { describe, expect, it, vi } from "vitest";
 import {
+  DateInput,
   ExternalSelect,
   filterModalChildren,
   fromReactModalElement,
   isModalElement,
   Modal,
+  NumberInput,
   RadioSelect,
   Select,
   SelectOption,
@@ -128,6 +130,65 @@ describe("Builder Functions", () => {
     });
   });
 
+  describe("DateInput", () => {
+    it("should create with required fields", () => {
+      const input = DateInput({ id: "d1", label: "Due date" });
+      expect(input.type).toBe("date_input");
+      expect(input.id).toBe("d1");
+      expect(input.label).toBe("Due date");
+    });
+
+    it("should include optional fields", () => {
+      const input = DateInput({
+        id: "d1",
+        label: "Due date",
+        placeholder: "Pick a date",
+        initialValue: "2026-08-01",
+        optional: true,
+      });
+      expect(input.placeholder).toBe("Pick a date");
+      expect(input.initialValue).toBe("2026-08-01");
+      expect(input.optional).toBe(true);
+    });
+  });
+
+  describe("NumberInput", () => {
+    it("should create with required fields", () => {
+      const input = NumberInput({ id: "n1", label: "Quantity" });
+      expect(input.type).toBe("number_input");
+      expect(input.id).toBe("n1");
+      expect(input.label).toBe("Quantity");
+    });
+
+    it("should include optional fields", () => {
+      const input = NumberInput({
+        id: "n1",
+        label: "Quantity",
+        placeholder: "How many?",
+        initialValue: 3,
+        min: 1,
+        max: 10,
+        decimal: true,
+        optional: true,
+      });
+      expect(input.placeholder).toBe("How many?");
+      expect(input.initialValue).toBe(3);
+      expect(input.min).toBe(1);
+      expect(input.max).toBe(10);
+      expect(input.decimal).toBe(true);
+      expect(input.optional).toBe(true);
+    });
+
+    it("should keep a zero initial value", () => {
+      const input = NumberInput({
+        id: "n1",
+        label: "Quantity",
+        initialValue: 0,
+      });
+      expect(input.initialValue).toBe(0);
+    });
+  });
+
   describe("SelectOption", () => {
     it("should create with label and value", () => {
       const opt = SelectOption({ label: "Option A", value: "a" });
@@ -183,6 +244,8 @@ describe("Type Guards", () => {
     it("should keep valid child types", () => {
       const children = [
         TextInput({ id: "t1", label: "Name" }),
+        DateInput({ id: "d1", label: "Due date" }),
+        NumberInput({ id: "n1", label: "Quantity" }),
         ExternalSelect({ id: "person", label: "Person" }),
         Select({
           id: "s1",
@@ -191,7 +254,7 @@ describe("Type Guards", () => {
         }),
       ];
       const result = filterModalChildren(children);
-      expect(result).toHaveLength(3);
+      expect(result).toHaveLength(5);
     });
 
     it("should filter invalid children and warn", () => {
@@ -245,6 +308,38 @@ describe("JSX Support", () => {
       expect(result).not.toBeNull();
       if (result && "type" in result) {
         expect(result.type).toBe("text_input");
+      }
+    });
+
+    it("should convert a DateInput react element", () => {
+      const el = makeReactElement(DateInput, {
+        id: "d1",
+        label: "Due date",
+        initialValue: "2026-08-01",
+      });
+      const result = fromReactModalElement(el);
+      expect(result).not.toBeNull();
+      if (result && "type" in result && result.type === "date_input") {
+        expect(result.initialValue).toBe("2026-08-01");
+      } else {
+        expect.unreachable("expected a date_input element");
+      }
+    });
+
+    it("should convert a NumberInput react element", () => {
+      const el = makeReactElement(NumberInput, {
+        id: "n1",
+        label: "Quantity",
+        min: 1,
+        max: 10,
+      });
+      const result = fromReactModalElement(el);
+      expect(result).not.toBeNull();
+      if (result && "type" in result && result.type === "number_input") {
+        expect(result.min).toBe(1);
+        expect(result.max).toBe(10);
+      } else {
+        expect.unreachable("expected a number_input element");
       }
     });
 

--- a/packages/chat/src/modals.ts
+++ b/packages/chat/src/modals.ts
@@ -10,6 +10,8 @@ import type { FieldsElement, TextElement } from "./cards";
 
 export const VALID_MODAL_CHILD_TYPES = [
   "text_input",
+  "date_input",
+  "number_input",
   "select",
   "external_select",
   "radio_select",
@@ -19,6 +21,8 @@ export const VALID_MODAL_CHILD_TYPES = [
 
 export type ModalChild =
   | TextInputElement
+  | DateInputElement
+  | NumberInputElement
   | SelectElement
   | ExternalSelectElement
   | RadioSelectElement
@@ -48,6 +52,29 @@ export interface TextInputElement {
   optional?: boolean;
   placeholder?: string;
   type: "text_input";
+}
+
+export interface DateInputElement {
+  id: string;
+  /** Pre-filled date as `YYYY-MM-DD`. */
+  initialValue?: string;
+  label: string;
+  optional?: boolean;
+  placeholder?: string;
+  type: "date_input";
+}
+
+export interface NumberInputElement {
+  /** Allow decimal values. Defaults to false (integers only). */
+  decimal?: boolean;
+  id: string;
+  initialValue?: number;
+  label: string;
+  max?: number;
+  min?: number;
+  optional?: boolean;
+  placeholder?: string;
+  type: "number_input";
 }
 
 export interface SelectElement {
@@ -166,6 +193,52 @@ export function TextInput(options: TextInputOptions): TextInputElement {
   };
 }
 
+export interface DateInputOptions {
+  id: string;
+  /** Pre-filled date as `YYYY-MM-DD`. */
+  initialValue?: string;
+  label: string;
+  optional?: boolean;
+  placeholder?: string;
+}
+
+export function DateInput(options: DateInputOptions): DateInputElement {
+  return {
+    type: "date_input",
+    id: options.id,
+    label: options.label,
+    placeholder: options.placeholder,
+    initialValue: options.initialValue,
+    optional: options.optional,
+  };
+}
+
+export interface NumberInputOptions {
+  /** Allow decimal values. Defaults to false (integers only). */
+  decimal?: boolean;
+  id: string;
+  initialValue?: number;
+  label: string;
+  max?: number;
+  min?: number;
+  optional?: boolean;
+  placeholder?: string;
+}
+
+export function NumberInput(options: NumberInputOptions): NumberInputElement {
+  return {
+    type: "number_input",
+    id: options.id,
+    label: options.label,
+    placeholder: options.placeholder,
+    initialValue: options.initialValue,
+    optional: options.optional,
+    min: options.min,
+    max: options.max,
+    decimal: options.decimal,
+  };
+}
+
 export interface SelectOptions {
   id: string;
   initialOption?: string;
@@ -277,6 +350,8 @@ type AnyModalElement = ModalElement | ModalChild | SelectOptionElement;
 const modalComponentMap = new Map<unknown, string>([
   [Modal, "Modal"],
   [TextInput, "TextInput"],
+  [DateInput, "DateInput"],
+  [NumberInput, "NumberInput"],
   [Select, "Select"],
   [ExternalSelect, "ExternalSelect"],
   [RadioSelect, "RadioSelect"],
@@ -331,6 +406,27 @@ export function fromReactModalElement(
         multiline: props.multiline as boolean | undefined,
         optional: props.optional as boolean | undefined,
         maxLength: props.maxLength as number | undefined,
+      });
+
+    case "DateInput":
+      return DateInput({
+        id: props.id as string,
+        label: props.label as string,
+        placeholder: props.placeholder as string | undefined,
+        initialValue: props.initialValue as string | undefined,
+        optional: props.optional as boolean | undefined,
+      });
+
+    case "NumberInput":
+      return NumberInput({
+        id: props.id as string,
+        label: props.label as string,
+        placeholder: props.placeholder as string | undefined,
+        initialValue: props.initialValue as number | undefined,
+        optional: props.optional as boolean | undefined,
+        min: props.min as number | undefined,
+        max: props.max as number | undefined,
+        decimal: props.decimal as boolean | undefined,
       });
 
     case "Select":


### PR DESCRIPTION
## Summary

`ModalChild` is `TextInput | Select | ExternalSelect | RadioSelect | Text | Fields` — there is no date or number primitive. A bot collecting a renewal date or a quantity has to render a text input with a `YYYY-MM-DD` hint and validate the string on submit, on every platform, even though neither platform is the constraint:

- Slack Block Kit has a native [`datepicker`](https://docs.slack.dev/reference/block-kit/block-elements/date-picker-element) and [`number_input`](https://docs.slack.dev/reference/block-kit/block-elements/number-input-element).
- Adaptive Cards has `Input.Date` and `Input.Number`, both already exported by `@microsoft/teams.cards`.

One addition to the union lifts both surfaces. `ModalSubmitEvent.values` stays `Record<string, string>`, so this is additive for existing handlers.

## Changes

- `DateInput` / `NumberInput` element types, builders, and options in `packages/chat/src/modals.ts`, added to `ModalChild` + `VALID_MODAL_CHILD_TYPES`.
- JSX/React support: props, component overloads, `modalComponentMap`, and `fromReactModalElement` branches.
- Slack renderer: `datepicker` (`initial_date`, `placeholder`) and `number_input` (`is_decimal_allowed`, `initial_value`, `min_value`, `max_value` — Slack takes these as strings).
- Teams renderer: `Input.Date` / `Input.Number`, in both `modals.ts` (`@microsoft/teams.cards`) and the dependency-free `modals-primitives`.
- Docs: `docs/modals.mdx` component tables and `docs/api/modals.mdx` reference + `ModalChild` table.
- Changeset (`chat`, `@chat-adapter/slack`, `@chat-adapter/teams`: minor).

### Two runtime decode gaps this had to close

- Slack reports a datepicker as `selected_date`, not `value`, so view-submission flattening now reads `value ?? selected_date ?? selected_option?.value`. `number_input` already arrives as `value`.
- Teams' `Input.Number` submits a JSON **number**, which the previous `typeof val === "string"` filter dropped silently. Numbers are now stringified in both `parseDialogSubmitValues` and `parseTeamsDialogSubmitValues`. This applies to any numeric value a Teams dialog submits, not only `Input.Number` — a key that used to be absent from `event.values` is now present as a string. Called out in the changeset; one existing test updated. Non-scalar values are still dropped.

### Deliberate asymmetries

- `DateInput` has no `min`/`max` — Slack's `datepicker` has no bounds, and a prop that silently does nothing on one platform is worse than its absence.
- `NumberInput.decimal` maps to Slack's required `is_decimal_allowed`. Adaptive Cards has no decimal switch, so Teams accepts decimals either way; this is called out in the docs.
- A `DateInput` `initialValue` that is not a real `YYYY-MM-DD` date is dropped with a warning instead of forwarded. Slack rejects a malformed `initial_date` by failing the entire `views.open` with `invalid_arguments` — the modal never opens, and the error surfaces as a JSON pointer rather than anything actionable. Adaptive Cards just renders the field empty, so forwarding verbatim would make the same modal work on Teams and die on Slack. The drop matches how `filterModalChildren` handles unsupported children. Validation round-trips through `Date` because it rolls impossible dates over (`2026-02-31` → Mar 3) instead of rejecting them.

## Test plan

- [x] `pnpm validate` (knip + check + typecheck + test + build) — clean
- [x] New unit tests: builders, `filterModalChildren`, React/JSX conversion, Slack Block Kit output (both inputs, defaults, zero-value handling, invalid-date drop), Slack view-submission flattening, Teams Adaptive Card output, numeric submit-value stringification
- [x] Emitted Slack view and Adaptive Card checked as JSON against Block Kit / Adaptive Card 1.4 shapes
- [x] Exercised end-to-end against live Slack and Teams clients from a local build of this branch — native date picker renders on both, and the submitted value round-trips as `YYYY-MM-DD` through a real handler. The invalid-`initial_date` behavior above was found this way.
