### PR TITLE
fix(telegram): combine incoming media groups

### DIFF
--- a/.changeset/swift-otters-group.md
+++ b/.changeset/swift-otters-group.md
@@ -1,0 +1,5 @@
+---
+"@chat-adapter/telegram": patch
+---
+
+Combine incoming Telegram media groups into one message with ordered attachments and the shared caption.

--- a/apps/docs/content/adapters/official/telegram.mdx
+++ b/apps/docs/content/adapters/official/telegram.mdx
@@ -205,6 +205,7 @@ Pass `{ raw: "..." }` only if you need to ship a fully pre-escaped MarkdownV2 st
 - `listThreads` is not available for Telegram chats.
 - Telegram callback data is limited to 64 bytes — keep `Button` `id`/`value` payloads short.
 - Multiple `files` or compatible `attachments` are sent as Telegram media groups. `files` upload as documents; `attachments` preserve image, audio, video, or file media type.
+- Incoming media groups are delivered as one message after the album settles, with attachments ordered by Telegram message ID and the shared caption preserved.
 - Other rich card elements (images, select menus, radios) render as fallback text.
 
 ## Feature support

--- a/packages/adapter-telegram/src/index.test.ts
+++ b/packages/adapter-telegram/src/index.test.ts
@@ -417,20 +417,6 @@ describe("TelegramAdapter", () => {
     };
     const messages = [
       sampleMessage({
-        message_id: 41,
-        media_group_id: "meal-album",
-        text: undefined,
-        caption: "I ate both pieces",
-        photo: [
-          {
-            file_id: "photo-1",
-            file_unique_id: "photo-unique-1",
-            width: 800,
-            height: 600,
-          },
-        ],
-      }),
-      sampleMessage({
         message_id: 42,
         media_group_id: "meal-album",
         text: undefined,
@@ -438,6 +424,20 @@ describe("TelegramAdapter", () => {
           {
             file_id: "photo-2",
             file_unique_id: "photo-unique-2",
+            width: 800,
+            height: 600,
+          },
+        ],
+      }),
+      sampleMessage({
+        message_id: 41,
+        media_group_id: "meal-album",
+        text: undefined,
+        caption: "/analyze both pieces",
+        photo: [
+          {
+            file_id: "photo-1",
+            file_unique_id: "photo-unique-1",
             width: 800,
             height: 600,
           },
@@ -483,7 +483,7 @@ describe("TelegramAdapter", () => {
     ];
     expect(threadId).toBe("telegram:123");
     expect(parsedMessage.id).toBe("123:42");
-    expect(parsedMessage.text).toBe("I ate both pieces");
+    expect(parsedMessage.text).toBe("/analyze both pieces");
     expect(
       parsedMessage.attachments.map(
         (attachment) => attachment.fetchMetadata?.fileId

--- a/packages/adapter-telegram/src/index.test.ts
+++ b/packages/adapter-telegram/src/index.test.ts
@@ -7,6 +7,7 @@ import {
 } from "@chat-adapter/shared";
 import {
   createMockChatInstance,
+  createMockState,
   mockLogger,
   threadIdContract,
 } from "@chat-adapter/tests";
@@ -58,6 +59,7 @@ afterEach(() => {
     }
   }
   vi.unstubAllGlobals();
+  vi.useRealTimers();
 });
 
 function telegramOk(result: unknown): Response {
@@ -380,6 +382,113 @@ describe("TelegramAdapter", () => {
         String(input).includes("/sendChatAction")
       )
     ).toBe(false);
+  });
+
+  it("combines an incoming media group into one ordered message", async () => {
+    vi.useFakeTimers();
+    mockFetch.mockResolvedValue(
+      telegramOk({
+        id: 999,
+        is_bot: true,
+        first_name: "Bot",
+        username: "mybot",
+      })
+    );
+
+    const state = createMockState();
+    const adapters = [0, 1].map(() =>
+      createTelegramAdapter({
+        botToken: "token",
+        mode: "webhook",
+        logger: mockLogger,
+        userName: "mybot",
+      })
+    );
+    const chats = [0, 1].map(() =>
+      createMockChatInstance({ logger: mockLogger, state, userName: "mybot" })
+    );
+    await Promise.all(
+      adapters.map((adapter, index) => adapter.initialize(chats[index]))
+    );
+
+    const pending: Promise<unknown>[] = [];
+    const waitUntil = (task: Promise<unknown>): void => {
+      pending.push(task);
+    };
+    const messages = [
+      sampleMessage({
+        message_id: 41,
+        media_group_id: "meal-album",
+        text: undefined,
+        caption: "I ate both pieces",
+        photo: [
+          {
+            file_id: "photo-1",
+            file_unique_id: "photo-unique-1",
+            width: 800,
+            height: 600,
+          },
+        ],
+      }),
+      sampleMessage({
+        message_id: 42,
+        media_group_id: "meal-album",
+        text: undefined,
+        photo: [
+          {
+            file_id: "photo-2",
+            file_unique_id: "photo-unique-2",
+            width: 800,
+            height: 600,
+          },
+        ],
+      }),
+    ];
+
+    for (const [index, message] of messages.entries()) {
+      await adapters[index].handleWebhook(
+        new Request("https://example.com/webhook", {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({ update_id: index + 1, message }),
+        }),
+        { waitUntil }
+      );
+    }
+
+    const processMessages = chats.map(
+      (chat) => chat.processMessage as ReturnType<typeof vi.fn>
+    );
+    expect(
+      processMessages.every(
+        (processMessage) => processMessage.mock.calls.length === 0
+      )
+    ).toBe(true);
+
+    await vi.runAllTimersAsync();
+    await Promise.all(pending);
+
+    const calls = processMessages.flatMap(
+      (processMessage) => processMessage.mock.calls
+    );
+    expect(calls).toHaveLength(1);
+    const [, threadId, parsedMessage] = calls[0] as [
+      unknown,
+      string,
+      {
+        attachments: Array<{ fetchMetadata?: { fileId?: string } }>;
+        id: string;
+        text: string;
+      },
+    ];
+    expect(threadId).toBe("telegram:123");
+    expect(parsedMessage.id).toBe("123:42");
+    expect(parsedMessage.text).toBe("I ate both pieces");
+    expect(
+      parsedMessage.attachments.map(
+        (attachment) => attachment.fetchMetadata?.fileId
+      )
+    ).toEqual(["photo-1", "photo-2"]);
   });
 
   it("rejects disallowed and identityless updates before dispatch", async () => {

--- a/packages/adapter-telegram/src/index.ts
+++ b/packages/adapter-telegram/src/index.ts
@@ -626,6 +626,7 @@ export class TelegramAdapter
 
     const handledSlashCommand =
       update.message !== undefined &&
+      !update.message.media_group_id &&
       this.handleSlashCommandUpdate(update.message, options);
 
     if (messageUpdate && !handledSlashCommand) {
@@ -688,19 +689,7 @@ export class TelegramAdapter
     const state = this.chat.getState();
     const mediaGroupKey = `${this.name}:incoming-media-group:${threadId}:${telegramMessage.media_group_id}`;
     const lockKey = `${mediaGroupKey}:lock`;
-
-    await state.appendToList(
-      mediaGroupKey,
-      {
-        message: telegramMessage,
-        receivedAt: Date.now(),
-      } satisfies TelegramIncomingMediaGroupEntry,
-      {
-        maxLength: TELEGRAM_MEDIA_GROUP_MAX,
-        ttlMs: TELEGRAM_INCOMING_MEDIA_GROUP_BUFFER_TTL_MS,
-      }
-    );
-    await this.sleep(TELEGRAM_INCOMING_MEDIA_GROUP_SETTLE_MS);
+    let appended = false;
 
     for (;;) {
       const lock = await state.acquireLock(
@@ -716,21 +705,31 @@ export class TelegramAdapter
       let remainingSettleMs = 0;
       try {
         entries =
-          await state.getList<TelegramIncomingMediaGroupEntry>(mediaGroupKey);
-        if (entries.length === 0) {
+          (await state.get<TelegramIncomingMediaGroupEntry[]>(mediaGroupKey)) ??
+          [];
+        if (!appended) {
+          entries.push({ message: telegramMessage, receivedAt: Date.now() });
+          await state.set(
+            mediaGroupKey,
+            entries.slice(-TELEGRAM_MEDIA_GROUP_MAX),
+            TELEGRAM_INCOMING_MEDIA_GROUP_BUFFER_TTL_MS
+          );
+          appended = true;
+          remainingSettleMs = TELEGRAM_INCOMING_MEDIA_GROUP_SETTLE_MS;
+        } else if (entries.length === 0) {
           return;
-        }
-
-        const newestReceivedAt = Math.max(
-          ...entries.map((entry) => entry.receivedAt)
-        );
-        remainingSettleMs = Math.max(
-          0,
-          TELEGRAM_INCOMING_MEDIA_GROUP_SETTLE_MS -
-            (Date.now() - newestReceivedAt)
-        );
-        if (remainingSettleMs === 0) {
-          await state.delete(mediaGroupKey);
+        } else {
+          const newestReceivedAt = Math.max(
+            ...entries.map((entry) => entry.receivedAt)
+          );
+          remainingSettleMs = Math.max(
+            0,
+            TELEGRAM_INCOMING_MEDIA_GROUP_SETTLE_MS -
+              (Date.now() - newestReceivedAt)
+          );
+          if (remainingSettleMs === 0) {
+            await state.delete(mediaGroupKey);
+          }
         }
       } finally {
         await state.releaseLock(lock);

--- a/packages/adapter-telegram/src/index.ts
+++ b/packages/adapter-telegram/src/index.ts
@@ -117,6 +117,10 @@ const TELEGRAM_DEFAULT_POLLING_TIMEOUT_SECONDS = 30;
 const TELEGRAM_DEFAULT_POLLING_LIMIT = 100;
 const TELEGRAM_DEFAULT_POLLING_RETRY_DELAY_MS = 1000;
 const TELEGRAM_DEFAULT_STREAM_UPDATE_INTERVAL_MS = 250;
+const TELEGRAM_INCOMING_MEDIA_GROUP_BUFFER_TTL_MS = 30_000;
+const TELEGRAM_INCOMING_MEDIA_GROUP_LOCK_TTL_MS = 5_000;
+const TELEGRAM_INCOMING_MEDIA_GROUP_RETRY_MS = 50;
+const TELEGRAM_INCOMING_MEDIA_GROUP_SETTLE_MS = 1_000;
 const TELEGRAM_MEDIA_GROUP_MIN = 2;
 const TELEGRAM_MEDIA_GROUP_MAX = 10;
 const TELEGRAM_MARKDOWN_PARSE_ERROR_PATTERN =
@@ -153,6 +157,11 @@ interface TelegramMediaGroupPart {
   mimeType?: string;
   type: TelegramInputMediaType;
   width?: number;
+}
+
+interface TelegramIncomingMediaGroupEntry {
+  message: TelegramMessage;
+  receivedAt: number;
 }
 
 type TelegramRuntimeMode = "webhook" | "polling";
@@ -645,12 +654,125 @@ export class TelegramAdapter
       messageThreadId: telegramMessage.message_thread_id,
     });
 
+    if (telegramMessage.media_group_id) {
+      const task = this.processIncomingMediaGroup(
+        telegramMessage,
+        threadId
+      ).catch((error) => {
+        this.logger.warn("Failed to process incoming Telegram media group", {
+          error: String(error),
+          mediaGroupId: telegramMessage.media_group_id,
+          threadId,
+        });
+      });
+      options?.waitUntil?.(task);
+      return;
+    }
+
     this.startTypingForPrivateMessage(telegramMessage, threadId, options);
 
     const parsedMessage = this.parseTelegramMessage(telegramMessage, threadId);
     this.cacheMessage(parsedMessage);
 
     this.chat.processMessage(this, threadId, parsedMessage, options);
+  }
+
+  protected async processIncomingMediaGroup(
+    telegramMessage: TelegramMessage,
+    threadId: string
+  ): Promise<void> {
+    if (!(this.chat && telegramMessage.media_group_id)) {
+      return;
+    }
+
+    const state = this.chat.getState();
+    const mediaGroupKey = `${this.name}:incoming-media-group:${threadId}:${telegramMessage.media_group_id}`;
+    const lockKey = `${mediaGroupKey}:lock`;
+
+    await state.appendToList(
+      mediaGroupKey,
+      {
+        message: telegramMessage,
+        receivedAt: Date.now(),
+      } satisfies TelegramIncomingMediaGroupEntry,
+      {
+        maxLength: TELEGRAM_MEDIA_GROUP_MAX,
+        ttlMs: TELEGRAM_INCOMING_MEDIA_GROUP_BUFFER_TTL_MS,
+      }
+    );
+    await this.sleep(TELEGRAM_INCOMING_MEDIA_GROUP_SETTLE_MS);
+
+    for (;;) {
+      const lock = await state.acquireLock(
+        lockKey,
+        TELEGRAM_INCOMING_MEDIA_GROUP_LOCK_TTL_MS
+      );
+      if (!lock) {
+        await this.sleep(TELEGRAM_INCOMING_MEDIA_GROUP_RETRY_MS);
+        continue;
+      }
+
+      let entries: TelegramIncomingMediaGroupEntry[] = [];
+      let remainingSettleMs = 0;
+      try {
+        entries =
+          await state.getList<TelegramIncomingMediaGroupEntry>(mediaGroupKey);
+        if (entries.length === 0) {
+          return;
+        }
+
+        const newestReceivedAt = Math.max(
+          ...entries.map((entry) => entry.receivedAt)
+        );
+        remainingSettleMs = Math.max(
+          0,
+          TELEGRAM_INCOMING_MEDIA_GROUP_SETTLE_MS -
+            (Date.now() - newestReceivedAt)
+        );
+        if (remainingSettleMs === 0) {
+          await state.delete(mediaGroupKey);
+        }
+      } finally {
+        await state.releaseLock(lock);
+      }
+
+      if (remainingSettleMs > 0) {
+        await this.sleep(remainingSettleMs);
+        continue;
+      }
+
+      const orderedMessages = entries
+        .map((entry) => entry.message)
+        .sort((left, right) => left.message_id - right.message_id);
+      const parsedMessages = orderedMessages.map((message) =>
+        this.parseTelegramMessage(message, threadId)
+      );
+      const latestMessage = parsedMessages.at(-1);
+      if (!latestMessage) {
+        return;
+      }
+
+      const contentMessage =
+        parsedMessages.find((message) => message.text.length > 0) ??
+        latestMessage;
+      const combinedMessage = new Message<TelegramRawMessage>({
+        id: latestMessage.id,
+        threadId,
+        text: contentMessage.text,
+        formatted: contentMessage.formatted,
+        raw: latestMessage.raw,
+        author: latestMessage.author,
+        metadata: latestMessage.metadata,
+        attachments: parsedMessages.flatMap((message) => message.attachments),
+        isMention: parsedMessages.some((message) => message.isMention),
+        links: parsedMessages.flatMap((message) => message.links),
+      });
+
+      this.startTypingForPrivateMessage(orderedMessages[0], threadId);
+      this.cacheMessage(combinedMessage);
+      await this.chat.processMessage(this, threadId, combinedMessage);
+      return;
+    }
   }
 
   protected handleSlashCommandUpdate(


### PR DESCRIPTION
## Summary

- buffer incoming Telegram updates that share a `media_group_id` and dispatch them once the album settles
- coordinate through the configured `StateAdapter` so separate serverless instances still produce one message
- preserve the shared caption and order attachments by Telegram message ID

## Test plan

- [x] `pnpm --filter @chat-adapter/telegram exec vitest run src/index.test.ts`
- [x] `pnpm --filter @chat-adapter/telegram typecheck`
- [x] `pnpm --filter @chat-adapter/telegram build`
- [x] `pnpm exec vitest run --reporter=dot` (88 files, 3,187 tests passed)
- [x] `pnpm exec ultracite check packages/adapter-telegram/src/index.ts packages/adapter-telegram/src/index.test.ts`

## Checklist

- [x] All commits are signed and verified
- [x] All commits are signed off for the DCO (`git commit -s`)
- [ ] `pnpm validate` passes
- [x] Changeset added
- [x] Documentation N/A: no public API or configuration changed