### PR TITLE
fix(chat): stop treating email addresses as bot mentions

### DIFF
--- a/.changeset/nice-peaches-watch.md
+++ b/.changeset/nice-peaches-watch.md
@@ -1,0 +1,5 @@
+---
+"chat": patch
+---
+
+Stop treating email addresses as bot mentions. A message containing `jane@acme.com` no longer triggers a bot named `acme`, because the `@` in `detectMention` must not follow a word character. Real mentions are unaffected, including at the start of a message, after punctuation, and suffixed names such as GitHub's `mybot[bot]`.

--- a/packages/chat/src/chat.test.ts
+++ b/packages/chat/src/chat.test.ts
@@ -606,6 +606,47 @@ describe("Chat", () => {
       expect(receivedMessage.isMention).toBe(false);
     });
 
+    it.each([
+      ["jane@slack-bot.com", "an email whose domain starts with the bot name"],
+      ["foo.bar@slack-bot.com", "a dotted email local part"],
+      ["foo-bar@slack-bot.com", "a hyphenated email local part"],
+      ["https://user@slack-bot.com", "url userinfo"],
+    ])("should not treat %s as a mention (%s)", async (text) => {
+      const handler = vi.fn().mockResolvedValue(undefined);
+      chat.onNewMessage(/.*/, handler);
+
+      await chat.handleIncomingMessage(
+        mockAdapter,
+        "slack:C123:1234.5678",
+        createTestMessage("msg-1", text)
+      );
+
+      expect(handler).toHaveBeenCalled();
+      const [, receivedMessage] = handler.mock.calls[0];
+      expect(receivedMessage.isMention).toBe(false);
+    });
+
+    it.each([
+      ["@slack-bot help", "at the start"],
+      ["hey @slack-bot", "after a space"],
+      ["(@slack-bot)", "wrapped in parentheses"],
+      ["cc:@slack-bot", "after a colon"],
+      ["wait...@slack-bot", "after an ellipsis"],
+    ])("should still detect %s as a mention (%s)", async (text) => {
+      const handler = vi.fn().mockResolvedValue(undefined);
+      chat.onNewMention(handler);
+
+      await chat.handleIncomingMessage(
+        mockAdapter,
+        "slack:C123:1234.5678",
+        createTestMessage("msg-1", text)
+      );
+
+      expect(handler).toHaveBeenCalled();
+      const [, receivedMessage] = handler.mock.calls[0];
+      expect(receivedMessage.isMention).toBe(true);
+    });
+
     it("should set isMention=true in subscribed thread when mentioned", async () => {
       const handler = vi.fn().mockResolvedValue(undefined);
       chat.onSubscribedMessage(handler);

--- a/packages/chat/src/chat.test.ts
+++ b/packages/chat/src/chat.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
+const ANY_REGEX = /.*/;
 const HELP_REGEX = /help/i;
 const HELLO_REGEX = /hello/i;
 
@@ -613,7 +614,7 @@ describe("Chat", () => {
       ["https://user@slack-bot.com", "url userinfo"],
     ])("should not treat %s as a mention (%s)", async (text) => {
       const handler = vi.fn().mockResolvedValue(undefined);
-      chat.onNewMessage(/.*/, handler);
+      chat.onNewMessage(ANY_REGEX, handler);
 
       await chat.handleIncomingMessage(
         mockAdapter,

--- a/packages/chat/src/chat.ts
+++ b/packages/chat/src/chat.ts
@@ -2672,6 +2672,11 @@ export class Chat<
   /**
    * Detect if the bot was mentioned in the message.
    * All adapters normalize mentions to @name format, so we just check for @username.
+   *
+   * The `@` must not follow a word character, so email addresses and URL
+   * userinfo (`jane@acme.com`) are not read as a mention of a bot named
+   * `acme`. The trailing guard keeps `@bot` from matching `@botlong` while
+   * still allowing suffixed names such as GitHub's `mybot[bot]`.
    */
   private detectMention(adapter: Adapter, message: Message): boolean {
     const botUserName = adapter.userName || this.userName;
@@ -2679,7 +2684,7 @@ export class Chat<
 
     // Primary check: @username format (normalized by all adapters)
     const usernamePattern = new RegExp(
-      `@${this.escapeRegex(botUserName)}(?![\\w-])`,
+      `(?<!\\w)@${this.escapeRegex(botUserName)}(?![\\w-])`,
       "i"
     );
     if (usernamePattern.test(message.text)) {
@@ -2689,7 +2694,7 @@ export class Chat<
     // Fallback: check for user ID mention if available (e.g., @U_BOT_123)
     if (botUserId) {
       const userIdPattern = new RegExp(
-        `@${this.escapeRegex(botUserId)}(?![\\w-])`,
+        `(?<!\\w)@${this.escapeRegex(botUserId)}(?![\\w-])`,
         "i"
       );
       if (userIdPattern.test(message.text)) {


### PR DESCRIPTION
## summary

a message containing an email address like `jane@acme.com` was treated as a mention of a bot named `acme`, so the bot engaged on every pasted colleague email

`detectMention` now requires the `@` not to follow a word character:

```ts
`(?<!\\w)@${escapeRegex(botUserName)}(?![\\w-])`
```

- applies to both the username and the user id pattern
- an email local part always ends in a word character, so `jane@acme.com`, `foo.bar@acme.com`, `foo-bar@acme.com` and url userinfo are all excluded
- real mentions are unaffected: start of a message, after a space, after punctuation like `(` or `:`, and after an ellipsis

fixes #759
