### PR TITLE
chore(docs): use Geist heading tokens on adapter pages

### DIFF
--- a/apps/docs/app/[lang]/adapters/(listing)/page.tsx
+++ b/apps/docs/app/[lang]/adapters/(listing)/page.tsx
@@ -28,7 +28,7 @@ const AdaptersPage = () => (
       type="application/ld+json"
     />
     <section className="mt-(--fd-nav-height) space-y-4 px-4 pt-16 pb-8 sm:pt-24">
-      <h1 className="text-balance font-semibold text-4xl leading-[1.1] tracking-tight sm:text-[44px]">
+      <h1 className="text-balance text-heading-40 sm:text-heading-48">
         Adapters
       </h1>
       <p className="max-w-2xl text-[15px] text-muted-foreground leading-[1.55]">

--- a/apps/docs/app/[lang]/adapters/components/adapters-grid.tsx
+++ b/apps/docs/app/[lang]/adapters/components/adapters-grid.tsx
@@ -100,9 +100,7 @@ export const AdaptersGrid = ({ adapters }: AdaptersGridProps) => {
           {officialPlatform.length > 0 ? (
             <section className="grid gap-5">
               <div className="grid gap-1">
-                <h2 className="font-medium text-base tracking-tight">
-                  Official
-                </h2>
+                <h2 className="text-heading-16">Official</h2>
                 <p className="text-[13px] text-muted-foreground">
                   Published under <code>@chat-adapter/*</code> and maintained by
                   Vercel.
@@ -123,9 +121,7 @@ export const AdaptersGrid = ({ adapters }: AdaptersGridProps) => {
           {vendorOfficialPlatform.length > 0 ? (
             <section className="grid gap-5">
               <div className="grid gap-1">
-                <h2 className="font-medium text-base tracking-tight">
-                  Vendor Official
-                </h2>
+                <h2 className="text-heading-16">Vendor Official</h2>
                 <p className="text-[13px] text-muted-foreground">
                   Built and maintained by the platform vendor.
                 </p>
@@ -147,9 +143,7 @@ export const AdaptersGrid = ({ adapters }: AdaptersGridProps) => {
           {communityPlatform.length > 0 ? (
             <section className="grid gap-5">
               <div className="grid gap-1">
-                <h2 className="font-medium text-base tracking-tight">
-                  Community
-                </h2>
+                <h2 className="text-heading-16">Community</h2>
                 <p className="text-[13px] text-muted-foreground">
                   Built by third-party developers.
                 </p>
@@ -175,9 +169,7 @@ export const AdaptersGrid = ({ adapters }: AdaptersGridProps) => {
           className={`grid gap-10 ${showPlatformSection && activeTab === "all" ? "mt-16 border-t pt-16" : ""}`}
         >
           <div className="grid gap-1">
-            <h2 className="font-semibold text-lg tracking-tight">
-              State Adapters
-            </h2>
+            <h2 className="text-heading-20">State Adapters</h2>
             <p className="text-[13px] text-muted-foreground">
               Pluggable state adapters for thread subscriptions, distributed
               locking, and caching.
@@ -187,9 +179,7 @@ export const AdaptersGrid = ({ adapters }: AdaptersGridProps) => {
           {officialState.length > 0 ? (
             <section className="grid gap-5">
               <div className="grid gap-1">
-                <h3 className="font-medium text-base tracking-tight">
-                  Official
-                </h3>
+                <h3 className="text-heading-16">Official</h3>
                 <p className="text-[13px] text-muted-foreground">
                   Published under <code>@chat-adapter/*</code> and maintained by
                   Vercel.
@@ -210,9 +200,7 @@ export const AdaptersGrid = ({ adapters }: AdaptersGridProps) => {
           {communityState.length > 0 ? (
             <section className="grid gap-5">
               <div className="grid gap-1">
-                <h3 className="font-medium text-base tracking-tight">
-                  Community
-                </h3>
+                <h3 className="text-heading-16">Community</h3>
                 <p className="text-[13px] text-muted-foreground">
                   Built by third-party developers.
                 </p>

--- a/apps/docs/components/geistdocs/adapter-hero.tsx
+++ b/apps/docs/components/geistdocs/adapter-hero.tsx
@@ -60,9 +60,7 @@ export const AdapterHero = ({ logo, name, tagline }: AdapterHeroProps) => {
             <Icon className="size-8" />
           </span>
         ) : null}
-        <h1 className="min-w-0 flex-1 font-semibold text-[34px] leading-[1.1] tracking-tight">
-          {name}
-        </h1>
+        <h1 className="min-w-0 flex-1 text-heading-32">{name}</h1>
       </div>
       <p className="max-w-3xl text-balance text-[17px] text-muted-foreground leading-[1.6]">
         {tagline}

--- a/apps/docs/components/geistdocs/adapter-slug-list.tsx
+++ b/apps/docs/components/geistdocs/adapter-slug-list.tsx
@@ -51,7 +51,7 @@ export const AdapterSlugList = () => {
       <div className="mt-4 grid gap-4 md:grid-cols-3">
         {groups.map((group) => (
           <section key={group.label}>
-            <h3 className="font-medium text-sm">{group.label}</h3>
+            <h3 className="text-heading-14">{group.label}</h3>
             <ul className="mt-2 space-y-1 text-sm">
               {group.adapters.map((adapter) => (
                 <li key={adapter.slug}>


### PR DESCRIPTION
Follow-up to #762 — this commit was left out when that PR merged (Docs-only styling change)
