### PR TITLE
fix: remove duplicate lockfile entries

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10066,11 +10066,6 @@ packages:
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
-  nanoid@3.3.16:
-    resolution: {integrity: sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==}
-    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
-    hasBin: true
-
   nanoid@5.1.6:
     resolution: {integrity: sha512-c7+7RQ+dMB5dPwwCp4ee1/iV/q2P6aK1mTZcfr1BTuVlyW9hJYiMPybJCcnBlQtuSmTIWNeazm/zqNoZSSElBg==}
     engines: {node: ^18 || >=20}
@@ -10762,10 +10757,6 @@ packages:
 
   postcss@8.4.31:
     resolution: {integrity: sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==}
-    engines: {node: ^10 || ^12 || >=14}
-
-  postcss@8.5.25:
-    resolution: {integrity: sha512-DTPx3RWSSnWyzLxQnlH0rJP+EW5ekl16ZU4/psbIhA0e53kJfdgaN5vKM+xP7yJtXVu+nfdVFmlgFDEKAe4Pyw==}
     engines: {node: ^10 || ^12 || >=14}
 
   postcss@8.5.25:
@@ -22753,8 +22744,6 @@ snapshots:
 
   nanoid@3.3.16: {}
 
-  nanoid@3.3.16: {}
-
   nanoid@5.1.6: {}
 
   nanotar@0.3.0: {}
@@ -23697,12 +23686,6 @@ snapshots:
   postcss-value-parser@4.2.0: {}
 
   postcss@8.4.31:
-    dependencies:
-      nanoid: 3.3.16
-      picocolors: 1.1.1
-      source-map-js: 1.2.1
-
-  postcss@8.5.25:
     dependencies:
       nanoid: 3.3.16
       picocolors: 1.1.1


### PR DESCRIPTION
## summary

`pnpm-lock.yaml` on main has duplicated `nanoid@3.3.16` and `postcss@8.5.25` keys after #740 and #744 merged back to back, so `pnpm install --frozen-lockfile` fails and every ci job on main is red

```
ERR_PNPM_BROKEN_LOCKFILE  duplicated mapping key (10069:3)
```

the duplicate blocks are byte identical, so this deletes the extras and changes no versions. regenerating the lockfile was not an option: `.npmrc` sets `min-release-age=2`, which re-resolves to older packages and would have reverted both bumps