### PR TITLE
fix(chat): preserve queued webhook lifetimes

### DIFF
--- a/.changeset/calm-chats-wait.md
+++ b/.changeset/calm-chats-wait.md
@@ -1,0 +1,5 @@
+---
+"chat": patch
+---
+
+Keep queued message webhooks active until a live request claims and finishes the collapsed handler.

--- a/apps/docs/content/docs/concurrency.mdx
+++ b/apps/docs/content/docs/concurrency.mdx
@@ -26,7 +26,7 @@ const bot = new Chat({
 
 ### Queue
 
-Messages that arrive while a handler is running are enqueued. When the current handler finishes, only the **latest** queued message is dispatched. All intermediate messages are provided as `context.skipped`, giving your handler full visibility into what happened while it was busy.
+Messages that arrive while a handler is running are enqueued. Each webhook keeps its own background task waiting to claim the lock instead of attaching queued work to the earlier webhook's lifetime. When a queued webhook claims the lock, only the **latest** queued message is dispatched. All intermediate messages are provided as `context.skipped`, giving your handler full visibility into what happened while it was busy.
 
 ```typescript title="lib/bot.ts" lineNumbers
 const bot = new Chat({
@@ -50,12 +50,16 @@ bot.onNewMention(async (thread, message, context) => {
 
 ```
 A arrives  → acquire lock → process A
-B arrives  → lock busy → enqueue B
-C arrives  → lock busy → enqueue C
-D arrives  → lock busy → enqueue D
-A done     → drain: [B, C, D] → handler(D, { skipped: [B, C] })
-D done     → queue empty → release lock
+B arrives  → lock busy → enqueue B → wait to claim
+C arrives  → lock busy → enqueue C → wait to claim
+D arrives  → lock busy → enqueue D → wait to claim
+A done     → release lock
+B/C/D      → one webhook claims lock
+           → drain: [B, C, D] → handler(D, { skipped: [B, C] })
+D done     → release lock; remaining webhook tasks see their batch was claimed
 ```
+
+Messages that arrive while the claimed handler runs form the next queued batch. A live webhook task claims the lock after the current batch releases it, so the current request does not pull newer work into its own lifetime. Hosts may still terminate background tasks before `queueEntryTtlMs`; handlers must release the lock while at least one later webhook's execution lease remains live.
 
 ### Burst
 

--- a/packages/chat/src/chat.test.ts
+++ b/packages/chat/src/chat.test.ts
@@ -23,6 +23,7 @@ import { Modal, type ModalElement, TextInput } from "./modals";
 import type {
   ActionEvent,
   Adapter,
+  MentionHandler,
   ModalSubmitEvent,
   ReactionEvent,
   StateAdapter,
@@ -3453,6 +3454,384 @@ describe("Chat", () => {
   });
 
   describe("concurrency: queue", () => {
+    it("should process a queued webhook in its own background lifetime", async () => {
+      const state = createMockState();
+      const ownerAdapter = createMockAdapter("slack");
+      const queuedAdapter = createMockAdapter("slack");
+      const latestAdapter = createMockAdapter("slack");
+      const threadId = "slack:C123:queued-lifetime";
+
+      const ownerChat = new Chat({
+        userName: "testbot",
+        adapters: { slack: ownerAdapter },
+        state,
+        logger: mockLogger,
+        concurrency: "queue",
+      });
+      const queuedChat = new Chat({
+        userName: "testbot",
+        adapters: { slack: queuedAdapter },
+        state,
+        logger: mockLogger,
+        concurrency: "queue",
+      });
+      const latestChat = new Chat({
+        userName: "testbot",
+        adapters: { slack: latestAdapter },
+        state,
+        logger: mockLogger,
+        concurrency: "queue",
+      });
+
+      await Promise.all([
+        ownerChat.webhooks.slack(
+          new Request("http://test.com", { method: "POST" })
+        ),
+        queuedChat.webhooks.slack(
+          new Request("http://test.com", { method: "POST" })
+        ),
+        latestChat.webhooks.slack(
+          new Request("http://test.com", { method: "POST" })
+        ),
+      ]);
+
+      let releaseOwner = () => {
+        throw new Error("releaseOwner not assigned");
+      };
+      let notifyOwnerStarted = () => {
+        throw new Error("notifyOwnerStarted not assigned");
+      };
+      const ownerStarted = new Promise<void>((resolve) => {
+        notifyOwnerStarted = resolve;
+      });
+      const ownerBlocked = new Promise<void>((resolve) => {
+        releaseOwner = resolve;
+      });
+      let ownerLifetimeActive = true;
+      const ownerMessages: string[] = [];
+      const claimedMessages: Array<{
+        id: string;
+        skipped: string[];
+        totalSinceLastHandler: number | undefined;
+      }> = [];
+
+      vi.mocked(ownerAdapter.postMessage).mockImplementation(async () => {
+        if (!ownerLifetimeActive) {
+          throw new Error("owner background lifetime expired");
+        }
+        return { id: "owner-delivery", threadId, raw: {} };
+      });
+
+      ownerChat.onNewMention(async (thread, message) => {
+        ownerMessages.push(message.id);
+        if (message.id === "msg-owner") {
+          notifyOwnerStarted();
+          await ownerBlocked;
+          return;
+        }
+        await thread.post("final response");
+      });
+      const queuedHandler: MentionHandler = async (
+        thread,
+        message,
+        context
+      ) => {
+        expect(ownerLifetimeActive).toBe(false);
+        claimedMessages.push({
+          id: message.id,
+          skipped: context?.skipped.map((skipped) => skipped.id) ?? [],
+          totalSinceLastHandler: context?.totalSinceLastHandler,
+        });
+        await thread.post("final response");
+      };
+      queuedChat.onNewMention(queuedHandler);
+      latestChat.onNewMention(queuedHandler);
+
+      const ownerBackgroundTasks: Promise<unknown>[] = [];
+      const queuedBackgroundTasks: Promise<unknown>[] = [];
+      const latestBackgroundTasks: Promise<unknown>[] = [];
+      const ownerTask = ownerChat.processMessage(
+        ownerAdapter,
+        threadId,
+        createTestMessage("msg-owner", "Hey @slack-bot first"),
+        { waitUntil: (task) => ownerBackgroundTasks.push(task) }
+      );
+      await ownerStarted;
+
+      const queuedTask = queuedChat.processMessage(
+        queuedAdapter,
+        threadId,
+        createTestMessage("msg-queued", "Hey @slack-bot second"),
+        { waitUntil: (task) => queuedBackgroundTasks.push(task) }
+      );
+      const latestTask = latestChat.processMessage(
+        latestAdapter,
+        threadId,
+        createTestMessage("msg-latest", "Hey @slack-bot third"),
+        { waitUntil: (task) => latestBackgroundTasks.push(task) }
+      );
+      await vi.waitFor(async () => {
+        expect(await state.queueDepth(threadId)).toBe(2);
+      });
+      expect(queuedBackgroundTasks).toHaveLength(1);
+      expect(latestBackgroundTasks).toHaveLength(1);
+      let queuedLifetimeSettled = false;
+      const queuedLifetime = Promise.all([
+        queuedBackgroundTasks[0],
+        latestBackgroundTasks[0],
+      ]).then(() => {
+        queuedLifetimeSettled = true;
+      });
+
+      try {
+        await new Promise((resolve) => setTimeout(resolve, 0));
+        expect(queuedLifetimeSettled).toBe(false);
+      } finally {
+        ownerLifetimeActive = false;
+        releaseOwner();
+        await Promise.allSettled([
+          ownerTask,
+          queuedTask,
+          latestTask,
+          ...ownerBackgroundTasks,
+          queuedLifetime,
+        ]);
+      }
+
+      expect(ownerMessages).toEqual(["msg-owner"]);
+      expect(claimedMessages).toEqual([
+        {
+          id: "msg-latest",
+          skipped: ["msg-queued"],
+          totalSinceLastHandler: 2,
+        },
+      ]);
+      expect(queuedLifetimeSettled).toBe(true);
+      expect(ownerAdapter.postMessage).not.toHaveBeenCalled();
+      expect(
+        vi.mocked(queuedAdapter.postMessage).mock.calls.length +
+          vi.mocked(latestAdapter.postMessage).mock.calls.length
+      ).toBe(1);
+    });
+
+    it("should collapse an existing queue before a fresh webhook can overtake it", async () => {
+      const state = createMockState();
+      const queuedAdapter = createMockAdapter("slack");
+      const freshAdapter = createMockAdapter("slack");
+      const threadId = "slack:C123:queue-order";
+      const config = {
+        strategy: "queue" as const,
+        maxQueueSize: 1,
+        onQueueFull: "drop-newest" as const,
+      };
+      const queuedChat = new Chat({
+        userName: "testbot",
+        adapters: { slack: queuedAdapter },
+        state,
+        logger: mockLogger,
+        concurrency: config,
+      });
+      const freshChat = new Chat({
+        userName: "testbot",
+        adapters: { slack: freshAdapter },
+        state,
+        logger: mockLogger,
+        concurrency: config,
+      });
+
+      await Promise.all([
+        queuedChat.webhooks.slack(
+          new Request("http://test.com", { method: "POST" })
+        ),
+        freshChat.webhooks.slack(
+          new Request("http://test.com", { method: "POST" })
+        ),
+      ]);
+
+      const received: Array<{ id: string; skipped: string[] }> = [];
+      const handler: MentionHandler = async (_thread, message, context) => {
+        received.push({
+          id: message.id,
+          skipped: context?.skipped.map((skipped) => skipped.id) ?? [],
+        });
+      };
+      queuedChat.onNewMention(handler);
+      freshChat.onNewMention(handler);
+
+      const externalLock = await state.acquireLock(threadId, 30_000);
+      if (!externalLock) {
+        throw new Error("expected external lock");
+      }
+      const queuedTask = queuedChat.processMessage(
+        queuedAdapter,
+        threadId,
+        createTestMessage("msg-waiting", "Hey @slack-bot waiting")
+      );
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      expect(await state.queueDepth(threadId)).toBe(1);
+
+      await state.releaseLock(externalLock);
+      const freshTask = freshChat.processMessage(
+        freshAdapter,
+        threadId,
+        createTestMessage("msg-fresh", "Hey @slack-bot fresh")
+      );
+      await Promise.all([queuedTask, freshTask]);
+
+      expect(received).toEqual([{ id: "msg-fresh", skipped: ["msg-waiting"] }]);
+    });
+
+    it("should omit queued context for an idle webhook", async () => {
+      const state = createMockState();
+      const adapter = createMockAdapter("slack");
+      const queueChat = new Chat({
+        userName: "testbot",
+        adapters: { slack: adapter },
+        state,
+        logger: mockLogger,
+        concurrency: "queue",
+      });
+      await queueChat.webhooks.slack(
+        new Request("http://test.com", { method: "POST" })
+      );
+
+      const contexts: Parameters<MentionHandler>[2][] = [];
+      queueChat.onNewMention(async (_thread, _message, context) => {
+        contexts.push(context);
+      });
+
+      await queueChat.processMessage(
+        adapter,
+        "slack:C123:idle-context",
+        createTestMessage("msg-idle", "Hey @slack-bot idle")
+      );
+
+      expect(contexts).toEqual([undefined]);
+    });
+
+    it("should release a claimed batch to messages from newer webhooks", async () => {
+      const state = createMockState();
+      const firstAdapter = createMockAdapter("slack");
+      const nextAdapter = createMockAdapter("slack");
+      const threadId = "slack:C123:claimed-batch";
+      const firstChat = new Chat({
+        userName: "testbot",
+        adapters: { slack: firstAdapter },
+        state,
+        logger: mockLogger,
+        concurrency: "queue",
+      });
+      const nextChat = new Chat({
+        userName: "testbot",
+        adapters: { slack: nextAdapter },
+        state,
+        logger: mockLogger,
+        concurrency: "queue",
+      });
+
+      await Promise.all([
+        firstChat.webhooks.slack(
+          new Request("http://test.com", { method: "POST" })
+        ),
+        nextChat.webhooks.slack(
+          new Request("http://test.com", { method: "POST" })
+        ),
+      ]);
+
+      let releaseFirstHandler = () => {
+        throw new Error("releaseFirstHandler not assigned");
+      };
+      let notifyFirstHandlerStarted = () => {
+        throw new Error("notifyFirstHandlerStarted not assigned");
+      };
+      const firstHandlerStarted = new Promise<void>((resolve) => {
+        notifyFirstHandlerStarted = resolve;
+      });
+      const firstHandlerBlocked = new Promise<void>((resolve) => {
+        releaseFirstHandler = resolve;
+      });
+      const firstMessages: string[] = [];
+      const nextMessages: string[] = [];
+
+      firstChat.onNewMention(async (_thread, message) => {
+        firstMessages.push(message.id);
+        notifyFirstHandlerStarted();
+        await firstHandlerBlocked;
+      });
+      nextChat.onNewMention(async (_thread, message) => {
+        nextMessages.push(message.id);
+      });
+
+      await state.acquireLock(threadId, 30_000);
+      const firstTask = firstChat.processMessage(
+        firstAdapter,
+        threadId,
+        createTestMessage("msg-first-claim", "Hey @slack-bot first")
+      );
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      expect(await state.queueDepth(threadId)).toBe(1);
+
+      await state.forceReleaseLock(threadId);
+      await firstHandlerStarted;
+      const nextTask = nextChat.processMessage(
+        nextAdapter,
+        threadId,
+        createTestMessage("msg-next-claim", "Hey @slack-bot next")
+      );
+
+      try {
+        await new Promise((resolve) => setTimeout(resolve, 0));
+        expect(await state.queueDepth(threadId)).toBe(1);
+      } finally {
+        releaseFirstHandler();
+        await Promise.allSettled([firstTask, nextTask]);
+      }
+
+      expect(firstMessages).toEqual(["msg-first-claim"]);
+      expect(nextMessages).toEqual(["msg-next-claim"]);
+    });
+
+    it("should preserve the handler error when writing claim markers fails", async () => {
+      const state = createMockState();
+      const adapter = createMockAdapter("slack");
+      const threadId = "slack:C123:claim-marker-failure";
+      const queueChat = new Chat({
+        userName: "testbot",
+        adapters: { slack: adapter },
+        state,
+        logger: mockLogger,
+        concurrency: "queue",
+      });
+      await queueChat.webhooks.slack(
+        new Request("http://test.com", { method: "POST" })
+      );
+
+      const handler = vi
+        .fn()
+        .mockRejectedValue(new Error("queued handler failed"));
+      queueChat.onNewMention(handler);
+
+      const externalLock = await state.acquireLock(threadId, 30_000);
+      if (!externalLock) {
+        throw new Error("expected external lock");
+      }
+      const task = queueChat.processMessage(
+        adapter,
+        threadId,
+        createTestMessage("msg-claim-marker", "Hey @slack-bot queued")
+      );
+      await vi.waitFor(async () => {
+        expect(await state.queueDepth(threadId)).toBe(1);
+      });
+      vi.mocked(state.set).mockRejectedValueOnce(
+        new Error("claim marker unavailable")
+      );
+
+      await state.releaseLock(externalLock);
+      await expect(task).rejects.toThrow("queued handler failed");
+      expect(handler).toHaveBeenCalledOnce();
+    });
+
     it("should process queued messages with skipped context after handler finishes", async () => {
       const state = createMockState();
       const adapter = createMockAdapter("slack");

--- a/packages/chat/src/chat.ts
+++ b/packages/chat/src/chat.ts
@@ -73,6 +73,12 @@ import type {
 import { ChatError, ConsoleLogger, LockError } from "./types";
 
 const DEFAULT_LOCK_TTL_MS = 30_000; // 30 seconds
+const QUEUE_LOCK_RETRY_INITIAL_MS = 25;
+const QUEUE_LOCK_RETRY_MAX_MS = 1000;
+
+type QueueLifecycle = "drain" | "request-claim";
+type QueueDrainMode = "continuous" | "single-batch";
+type QueueEnqueueMode = "lock-owner" | "pending";
 
 /** Promise-based sleep for debounce timing. */
 function sleep(ms: number): Promise<void> {
@@ -937,7 +943,9 @@ export class Chat<
         typeof messageOrFactory === "function"
           ? await messageOrFactory()
           : messageOrFactory;
-      await this.handleIncomingMessage(adapter, threadId, message);
+      await runInConversation(threadId, () =>
+        this.routeIncomingMessage(adapter, threadId, message, "request-claim")
+      );
     })();
 
     // Track via waitUntil with errors swallowed (existing webhook semantics —
@@ -2038,7 +2046,8 @@ export class Chat<
   private async routeIncomingMessage(
     adapter: Adapter,
     threadId: string,
-    message: Message
+    message: Message,
+    queueLifecycle: QueueLifecycle = "drain"
   ): Promise<void> {
     setMessageAdapter(message, adapter);
 
@@ -2112,7 +2121,8 @@ export class Chat<
         threadId,
         lockKey,
         message,
-        strategy
+        strategy,
+        queueLifecycle
       );
       return;
     }
@@ -2176,17 +2186,16 @@ export class Chat<
     }
   }
 
-  /**
-   * Queue/Debounce strategy: enqueue if lock is busy, drain after processing.
-   */
+  /** Queue/Debounce strategy: enqueue if the lock is busy. */
   private async handleQueueOrDebounce(
     adapter: Adapter,
     threadId: string,
     lockKey: string,
     message: Message,
-    strategy: "queue" | "debounce" | "burst"
+    strategy: "queue" | "debounce" | "burst",
+    queueLifecycle: QueueLifecycle
   ): Promise<void> {
-    const { maxQueueSize, queueEntryTtlMs, onQueueFull, debounceMs } =
+    const { maxQueueSize, queueEntryTtlMs, debounceMs } =
       this._concurrencyConfig;
 
     // Try to acquire lock
@@ -2196,43 +2205,25 @@ export class Chat<
     );
 
     if (!lock) {
-      // Lock is busy — enqueue this message for later processing
-      const effectiveMaxSize = maxQueueSize;
-      const depth = await this._stateAdapter.queueDepth(lockKey);
-
-      if (
-        depth >= effectiveMaxSize &&
-        strategy !== "debounce" &&
-        onQueueFull === "drop-newest"
-      ) {
-        this.logger.info("message-dropped", {
-          threadId,
-          lockKey,
-          messageId: message.id,
-          reason: "queue-full",
-        });
-        return;
-      }
-
-      await this._stateAdapter.enqueue(
+      const expiresAt = await this.enqueueMessage(
+        threadId,
         lockKey,
-        {
-          message,
-          enqueuedAt: Date.now(),
-          expiresAt: Date.now() + queueEntryTtlMs,
-        },
-        effectiveMaxSize
+        message,
+        strategy
       );
-
-      this.logger.info(
-        strategy === "debounce" ? "message-debounce-reset" : "message-queued",
-        {
+      if (
+        expiresAt !== null &&
+        strategy === "queue" &&
+        queueLifecycle === "request-claim"
+      ) {
+        await this.claimQueuedMessages(
+          adapter,
           threadId,
           lockKey,
-          messageId: message.id,
-          queueDepth: Math.min(depth + 1, effectiveMaxSize),
-        }
-      );
+          message.id,
+          expiresAt
+        );
+      }
       return;
     }
 
@@ -2281,15 +2272,133 @@ export class Chat<
         await sleep(debounceMs);
         await this._stateAdapter.extendLock(lock, DEFAULT_LOCK_TTL_MS);
         await this.drainQueue(lock, adapter, threadId, lockKey);
+      } else if (
+        queueLifecycle === "request-claim" &&
+        (await this._stateAdapter.queueDepth(lockKey)) > 0
+      ) {
+        await this.enqueueMessage(
+          threadId,
+          lockKey,
+          message,
+          strategy,
+          "lock-owner"
+        );
+        await this.drainQueue(lock, adapter, threadId, lockKey, "single-batch");
       } else {
-        // Queue: process our message immediately, then drain any queued messages
         await this.dispatchToHandlers(adapter, threadId, message);
-        await this.drainQueue(lock, adapter, threadId, lockKey);
+        if (queueLifecycle === "drain") {
+          await this.drainQueue(lock, adapter, threadId, lockKey);
+        }
       }
     } finally {
       await this._stateAdapter.releaseLock(lock);
       this.logger.debug("Lock released", { threadId, lockKey });
     }
+  }
+
+  private async enqueueMessage(
+    threadId: string,
+    lockKey: string,
+    message: Message,
+    strategy: "queue" | "debounce" | "burst",
+    mode: QueueEnqueueMode = "pending"
+  ): Promise<number | null> {
+    const { maxQueueSize, queueEntryTtlMs, onQueueFull } =
+      this._concurrencyConfig;
+    const depth = await this._stateAdapter.queueDepth(lockKey);
+
+    if (
+      mode === "pending" &&
+      depth >= maxQueueSize &&
+      strategy !== "debounce" &&
+      onQueueFull === "drop-newest"
+    ) {
+      this.logger.info("message-dropped", {
+        threadId,
+        lockKey,
+        messageId: message.id,
+        reason: "queue-full",
+      });
+      return null;
+    }
+
+    const expiresAt = Date.now() + queueEntryTtlMs;
+    const capacity = mode === "lock-owner" ? maxQueueSize + 1 : maxQueueSize;
+    await this._stateAdapter.enqueue(
+      lockKey,
+      { message, enqueuedAt: Date.now(), expiresAt },
+      capacity
+    );
+
+    this.logger.info(
+      strategy === "debounce" ? "message-debounce-reset" : "message-queued",
+      {
+        threadId,
+        lockKey,
+        messageId: message.id,
+        queueDepth: Math.min(depth + 1, capacity),
+      }
+    );
+    return expiresAt;
+  }
+
+  private async claimQueuedMessages(
+    adapter: Adapter,
+    threadId: string,
+    lockKey: string,
+    messageId: string,
+    expiresAt: number
+  ): Promise<void> {
+    let retryMs = QUEUE_LOCK_RETRY_INITIAL_MS;
+    const claimKey = this.queueClaimKey(adapter, lockKey, messageId);
+
+    while (Date.now() <= expiresAt) {
+      if (await this._stateAdapter.get(claimKey)) {
+        return;
+      }
+
+      const lock = await this._stateAdapter.acquireLock(
+        lockKey,
+        DEFAULT_LOCK_TTL_MS
+      );
+      if (lock) {
+        try {
+          if (await this._stateAdapter.get(claimKey)) {
+            return;
+          }
+          await this.drainQueue(
+            lock,
+            adapter,
+            threadId,
+            lockKey,
+            "single-batch"
+          );
+        } finally {
+          await this._stateAdapter.releaseLock(lock);
+          this.logger.debug("Lock released", { threadId, lockKey });
+        }
+        return;
+      }
+
+      if ((await this._stateAdapter.queueDepth(lockKey)) === 0) {
+        return;
+      }
+
+      const remainingMs = expiresAt - Date.now();
+      if (remainingMs <= 0) {
+        return;
+      }
+      await sleep(Math.min(retryMs, remainingMs));
+      retryMs = Math.min(retryMs * 2, QUEUE_LOCK_RETRY_MAX_MS);
+    }
+  }
+
+  private queueClaimKey(
+    adapter: Adapter,
+    lockKey: string,
+    messageId: string
+  ): string {
+    return `chat:queue-claim:${adapter.name}:${lockKey}:${messageId}`;
   }
 
   /**
@@ -2373,16 +2482,19 @@ export class Chat<
     lock: Lock,
     adapter: Adapter,
     threadId: string,
-    lockKey: string
+    lockKey: string,
+    mode: QueueDrainMode = "continuous"
   ): Promise<void> {
     while (true) {
       // Collect all pending messages, rehydrating after JSON roundtrip
       const pending: Array<{ message: Message; expiresAt: number }> = [];
+      const claimedMessageIds: string[] = [];
       while (true) {
         const entry = await this._stateAdapter.dequeue(lockKey);
         if (!entry) {
           break;
         }
+        claimedMessageIds.push(entry.message.id);
         const msg = this.rehydrateMessage(entry.message, adapter);
         if (Date.now() <= entry.expiresAt) {
           pending.push({ message: msg, expiresAt: entry.expiresAt });
@@ -2395,37 +2507,66 @@ export class Chat<
         }
       }
 
-      if (pending.length === 0) {
-        return;
+      try {
+        if (pending.length === 0) {
+          return;
+        }
+
+        await this._stateAdapter.extendLock(lock, DEFAULT_LOCK_TTL_MS);
+
+        // Latest message is the one we process
+        const latest = pending.at(-1);
+        if (!latest) {
+          return;
+        }
+        // Everything before it is "skipped" context
+        const skipped = pending.slice(0, -1).map((e) => e.message);
+
+        this.logger.info("message-dequeued", {
+          threadId,
+          lockKey,
+          messageId: latest.message.id,
+          skippedCount: skipped.length,
+          totalSinceLastHandler: pending.length,
+        });
+
+        const context: MessageContext = {
+          skipped,
+          totalSinceLastHandler: pending.length,
+        };
+
+        await this.dispatchToHandlers(
+          adapter,
+          threadId,
+          latest.message,
+          context
+        );
+
+        if (mode === "single-batch") {
+          return;
+        }
+      } finally {
+        if (mode === "single-batch") {
+          const results = await Promise.allSettled(
+            claimedMessageIds.map((messageId) =>
+              this._stateAdapter.set(
+                this.queueClaimKey(adapter, lockKey, messageId),
+                true,
+                this._concurrencyConfig.queueEntryTtlMs
+              )
+            )
+          );
+          for (const [index, result] of results.entries()) {
+            if (result.status === "rejected") {
+              this.logger.error("queue-claim-marker-error", {
+                error: result.reason,
+                lockKey,
+                messageId: claimedMessageIds[index],
+              });
+            }
+          }
+        }
       }
-
-      await this._stateAdapter.extendLock(lock, DEFAULT_LOCK_TTL_MS);
-
-      // Latest message is the one we process
-      const latest = pending.at(-1);
-      if (!latest) {
-        return;
-      }
-      // Everything before it is "skipped" context
-      const skipped = pending.slice(0, -1).map((e) => e.message);
-
-      this.logger.info("message-dequeued", {
-        threadId,
-        lockKey,
-        messageId: latest.message.id,
-        skippedCount: skipped.length,
-        totalSinceLastHandler: pending.length,
-      });
-
-      const context: MessageContext = {
-        skipped,
-        totalSinceLastHandler: pending.length,
-      };
-
-      await this.dispatchToHandlers(adapter, threadId, latest.message, context);
-
-      // After processing, check if MORE messages arrived during this handler
-      // (loop continues)
     }
   }
 


### PR DESCRIPTION
## Summary

Queued message webhooks now keep their own background task alive and claim one collapsed queue batch after the active handler releases the lock. The active webhook no longer drains later messages through its older request context.

The claim protocol preserves latest-message collapse, `context.skipped`, queue ordering, and `maxQueueSize`. Claim markers retire every webhook represented by a batch, while messages arriving during the claimed handler remain queued for a newer webhook lifetime. Marker-write failures are logged after dispatch, so coordination bookkeeping cannot drop a claimed batch or mask the handler's result.

## Test plan

- Regression on base `629e6555782f5fa5a44fafd81b43e2019e427b15`: the queued `waitUntil` tasks settle immediately, failing `expected true to be false` before the owner lifetime is released.
- `pnpm --filter chat test` — 26 files and 1,108 tests passed, including bounded webhook lifetime, queue collapse/order/capacity, and handler-plus-marker failure coverage.
- `pnpm --filter chat typecheck`
- `pnpm --filter chat build`
- `pnpm validate` passed knip, formatting, and all 39 workspace typechecks. The managed sandbox denied localhost emulator binds during the integration test stage (`listen EPERM 127.0.0.1`); the affected integration and Slack packages passed outside that restriction with 1,345 and 626 tests respectively.
- GitHub Actions passed typecheck, lint, changeset, consistency, AI SDK compatibility, and build-and-test on Node 22 and Node 24. The two Vercel preview statuses require authorization for fork deployments.

## Checklist

- [x] All commits are signed and verified
- [x] All commits are signed off for the DCO (`git commit -s`)
- [ ] `pnpm validate` passes
- [x] Changeset added (or N/A — see [CONTRIBUTING.md](./CONTRIBUTING.md))
- [x] Documentation updated (or N/A)
