### PR TITLE
fix(chat): follow-up hardening and docs for agent read-tool scoping

### DIFF
--- a/.changeset/scoped-agent-reads.md
+++ b/.changeset/scoped-agent-reads.md
@@ -1,0 +1,5 @@
+---
+"chat": patch
+---
+
+Close residual gaps in agent read-tool scoping. `createChatTools`'s read guard now wraps modal, assistant-thread, assistant-context, app-home, app-context, and member-joined dispatch so tools built in those handlers inherit the active conversation, and it logs a warning (instead of failing open silently) when a read runs with no resolvable scope. Scoping stays channel-level by default, so a thread scope still permits sibling threads in its channel. Pass the new `strictScope: true` to tighten a thread scope to that thread alone, rejecting sibling threads on platforms with per-thread ACLs (Discord, GitHub).

--- a/.changeset/scoped-agent-reads.md
+++ b/.changeset/scoped-agent-reads.md
@@ -1,5 +1,7 @@
 ---
-"chat": patch
+"chat": minor
 ---
 
-Close residual gaps in agent read-tool scoping. `createChatTools`'s read guard now wraps modal, assistant-thread, assistant-context, app-home, app-context, and member-joined dispatch so tools built in those handlers inherit the active conversation, and it logs a warning (instead of failing open silently) when a read runs with no resolvable scope. Scoping stays channel-level by default, so a thread scope still permits sibling threads in its channel. Pass the new `strictScope: true` to tighten a thread scope to that thread alone, rejecting sibling threads on platforms with per-thread ACLs (Discord, GitHub).
+Close residual gaps in agent read-tool scoping. `createChatTools`'s read guard now wraps modal, assistant-thread, assistant-context, app-home, app-context, and member-joined dispatch so tools built in those handlers inherit the active conversation, and it logs a warning (instead of failing open silently) when a read runs with no resolvable scope. Scoping stays channel-level by default, so a thread scope still permits sibling threads in its channel. Pass the new `strictScope: true` to confine a thread scope to that thread alone, rejecting both sibling threads and the parent channel, which matters on platforms where a channel is the widest read available (a GitHub channel is an entire repo).
+
+Note that reads inside those newly wrapped handlers were previously unscoped. An agent built in an `onModalSubmit`, `onAppHomeOpened`, or `onMemberJoinedChannel` handler that reads another channel will now be rejected. Pass an explicit `scope`, or `scope: false` for intentionally workspace-wide reads.

--- a/apps/docs/content/docs/ai/ai-sdk-tools.mdx
+++ b/apps/docs/content/docs/ai/ai-sdk-tools.mdx
@@ -98,7 +98,7 @@ Omit `preset` entirely to get every tool (same as `'moderator'`).
 
 Read tools take a thread or channel id chosen by the model, and they run with your bot's platform access. A bot is usually a member of channels a given user is not, so an agent handling untrusted input can be talked into fetching a conversation the user could never open themselves, then repeating it back.
 
-Pass `scope` with the conversation the agent is handling. Reads that resolve to a different channel are rejected before the platform is called:
+Pass `scope` with the conversation the agent is handling. Reads that resolve outside it are rejected before the platform is called:
 
 ```typescript title="lib/bot.ts" lineNumbers
 bot.onNewMention(async (thread, message) => {
@@ -116,7 +116,7 @@ bot.onNewMention(async (thread, message) => {
 });
 ```
 
-`scope` accepts a `Thread`, a `Channel`, or a raw id. Scoping is per channel, so the agent can still follow other threads in the conversation it was invited to, but not reach into another one.
+`scope` accepts a `Thread`, a `Channel`, or a raw id. By default scoping is **channel-level**: a read is allowed when it resolves to the same channel as the scoped conversation. That blocks the cross-channel read above, and — matching a channel-membership model — still lets the agent read sibling threads within the channel.
 
 Tools built inside a handler pick this up automatically, so the common case needs no extra argument:
 
@@ -133,11 +133,45 @@ bot.onNewMention(async (thread, message) => {
 });
 ```
 
-Pass `scope` explicitly when the agent runs outside a handler, such as a queued job that still answers on a user's behalf. Scoping is per channel, so an agent can still follow other threads in its own conversation.
+Pass `scope` explicitly when the agent runs outside a handler, such as a queued job that still answers on a user's behalf. Pass a channel id there if the agent legitimately needs to read across the threads in a channel.
 
 <Callout type="warn">
-  Agents created outside a handler have no conversation to inherit, so their reads are unrestricted. Pass `scope` there, or `scope: false` to say workspace-wide reads are intended.
+  Agents created outside a handler have no conversation to inherit, so their reads are unrestricted and a warning is logged. Pass `scope` there, or `scope: false` to say workspace-wide reads are intended.
 </Callout>
+
+### What `scope` does not do
+
+`scope` confines reads to a conversation using your bot's own access; it is **not** a per-user access check. It does not verify that the end user the agent is answering for is themselves a member of the target — that would require per-platform membership calls the SDK does not make.
+
+So within the scope you grant, reads follow the bot's access, not the user's:
+
+- A **thread** scope still allows reading the parent channel and its sibling threads, matching Slack's channel-membership model (a user who can see a thread can see the channel around it).
+- A **channel** scope allows any thread in that channel, including independently permissioned threads on Discord or GitHub that the end user may not have access to.
+
+This channel-level default is coarser than the per-thread ACLs on platforms like Discord and GitHub, where one channel or repo holds independently permissioned threads. `scope` alone will not enforce per-user permissions there.
+
+### Tightening to a single thread
+
+Set `strictScope` to confine a **thread** scope to that thread and its parent channel only — sibling threads are then rejected. Recommended when the agent handles untrusted input on a per-thread-ACL platform:
+
+```typescript title="lib/bot.ts" lineNumbers
+bot.onNewMention(async (thread, message) => {
+  const tools = createChatTools({
+    chat,
+    preset: "reader",
+    scope: thread,
+    strictScope: true, // sibling threads in the channel are rejected
+  });
+
+  const result = await generateText({
+    model: "openai/gpt-5",
+    tools,
+    prompt: message.text,
+  });
+});
+```
+
+A **channel** scope is unaffected by `strictScope` — it still allows any thread within the channel. This is opt-in rather than the default so existing channel-membership-style behavior is preserved; enable it when you want reads confined to the exact thread.
 
 ## Approval control
 
@@ -164,6 +198,15 @@ createChatTools({
 ```
 
 Read tools (`fetchMessages`, `fetchThread`, `getChannelInfo`, …) and the `startTyping` indicator never require approval.
+
+<Callout>
+  `createChatTools` only marks a tool as needing approval — capturing the
+  decision, and (optionally) signing it so a resumed approval can't be forged,
+  is handled by the AI SDK itself. If you round-trip approvals through an
+  untrusted client and enable the AI SDK's `experimental_toolApprovalSecret`,
+  use a version of `ai` that includes the injective-payload signing fix
+  ([vercel/ai#17493](https://github.com/vercel/ai/pull/17493)).
+</Callout>
 
 ## Cherry-picking tools
 
@@ -260,6 +303,7 @@ type ChatToolsOptions = {
   preset?: ChatToolPreset | ChatToolPreset[];
   overrides?: Partial<Record<ChatToolName, ToolOverrides>>;
   scope?: ReadScope | false;
+  strictScope?: boolean;
 };
 
 type ChatToolPreset = "reader" | "messenger" | "moderator";
@@ -272,4 +316,5 @@ type ReadScope = string | { id: string };
 | `preset` | Preset (or array of presets) restricting which tools are returned. Omit to get every tool. |
 | `requireApproval` | `true` (default), `false`, or per-tool overrides. Read tools and `startTyping` are never gated. |
 | `overrides` | Per-tool customization of any AI SDK `tool()` property except `execute`, `inputSchema`, and `outputSchema`. |
-| `scope` | Conversation the read tools are confined to. Defaults to the conversation being handled. Pass a `Thread`, `Channel`, or `false` to read across every conversation the bot can see. |
+| `scope` | Conversation the read tools are confined to. Defaults to the conversation being handled. Pass a `Thread`, `Channel`, or `false` to read across every conversation the bot can see. Channel-level by default. |
+| `strictScope` | `false` (default). Set `true` to tighten a thread `scope` to that thread alone, rejecting sibling threads in its channel. A channel scope is unaffected. |

--- a/apps/docs/content/docs/ai/ai-sdk-tools.mdx
+++ b/apps/docs/content/docs/ai/ai-sdk-tools.mdx
@@ -152,7 +152,7 @@ This channel-level default is coarser than the per-thread ACLs on platforms like
 
 ### Tightening to a single thread
 
-Set `strictScope` to confine a **thread** scope to that thread and its parent channel only — sibling threads are then rejected. Recommended when the agent handles untrusted input on a per-thread-ACL platform:
+Set `strictScope` to confine a **thread** scope to that thread alone. Sibling threads and the parent channel are both rejected. Recommended when the agent handles untrusted input on a per-thread-ACL platform:
 
 ```typescript title="lib/bot.ts" lineNumbers
 bot.onNewMention(async (thread, message) => {
@@ -160,7 +160,7 @@ bot.onNewMention(async (thread, message) => {
     chat,
     preset: "reader",
     scope: thread,
-    strictScope: true, // sibling threads in the channel are rejected
+    strictScope: true, // sibling threads and the parent channel are rejected
   });
 
   const result = await generateText({
@@ -171,7 +171,9 @@ bot.onNewMention(async (thread, message) => {
 });
 ```
 
-A **channel** scope is unaffected by `strictScope` — it still allows any thread within the channel. This is opt-in rather than the default so existing channel-membership-style behavior is preserved; enable it when you want reads confined to the exact thread.
+Rejecting the parent channel matters most on the platforms this is aimed at, because a channel there is the widest read available. A GitHub channel is an entire repository, so a channel-level read would list every issue and pull request in it: broader than any sibling thread the option blocks.
+
+A **channel** scope is unaffected by `strictScope`. It still allows any thread within the channel, and the channel itself. This is opt-in rather than the default so existing channel-membership-style behavior is preserved; enable it when you want reads confined to the exact thread.
 
 ## Approval control
 
@@ -317,4 +319,4 @@ type ReadScope = string | { id: string };
 | `requireApproval` | `true` (default), `false`, or per-tool overrides. Read tools and `startTyping` are never gated. |
 | `overrides` | Per-tool customization of any AI SDK `tool()` property except `execute`, `inputSchema`, and `outputSchema`. |
 | `scope` | Conversation the read tools are confined to. Defaults to the conversation being handled. Pass a `Thread`, `Channel`, or `false` to read across every conversation the bot can see. Channel-level by default. |
-| `strictScope` | `false` (default). Set `true` to tighten a thread `scope` to that thread alone, rejecting sibling threads in its channel. A channel scope is unaffected. |
+| `strictScope` | `false` (default). Set `true` to tighten a thread `scope` to that thread alone, rejecting both sibling threads and the parent channel. A channel scope is unaffected. |

--- a/packages/chat/src/ai/index.test.ts
+++ b/packages/chat/src/ai/index.test.ts
@@ -15,7 +15,7 @@ const REQUIRES_CHAT_INSTANCE_REGEX = /requires a `chat` instance/;
 const NO_FETCH_CHANNEL_MESSAGES_REGEX =
   /does not support fetching channel messages/;
 const NO_LIST_THREADS_REGEX = /does not support listing threads/;
-const OUT_OF_SCOPE_REGEX = /reads are scoped to channel/;
+const OUT_OF_SCOPE_REGEX = /reads are scoped to/;
 const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
 
 // Minimal tool execution options stub used by every test below. Derived from
@@ -392,8 +392,54 @@ describe("createChatTools", () => {
       expect(mockAdapter.fetchMessages).not.toHaveBeenCalled();
     });
 
-    it("allows reading another thread in the scoped channel", async () => {
+    it("allows a sibling thread in the scoped channel by default", async () => {
       const tools = createChatTools({ chat, scope: CALLER_THREAD });
+      await tools.fetchMessages?.execute?.(
+        { threadId: "slack:C123:9999.0000", limit: 5, direction: "backward" },
+        TOOL_OPTIONS
+      );
+      expect(mockAdapter.fetchMessages).toHaveBeenCalled();
+    });
+
+    it("blocks a sibling thread when scoped to a single thread with strictScope", async () => {
+      const tools = createChatTools({
+        chat,
+        scope: CALLER_THREAD,
+        strictScope: true,
+      });
+      await expect(
+        tools.fetchMessages?.execute?.(
+          { threadId: "slack:C123:9999.0000", limit: 5, direction: "backward" },
+          TOOL_OPTIONS
+        )
+      ).rejects.toThrow(OUT_OF_SCOPE_REGEX);
+      expect(mockAdapter.fetchMessages).not.toHaveBeenCalled();
+    });
+
+    it("allows a sibling thread under strictScope when a channel is scoped", async () => {
+      const tools = createChatTools({
+        chat,
+        scope: "slack:C123",
+        strictScope: true,
+      });
+      await tools.fetchMessages?.execute?.(
+        { threadId: "slack:C123:9999.0000", limit: 5, direction: "backward" },
+        TOOL_OPTIONS
+      );
+      expect(mockAdapter.fetchMessages).toHaveBeenCalled();
+    });
+
+    it("allows channel-level reads when scoped to a thread", async () => {
+      const tools = createChatTools({ chat, scope: CALLER_THREAD });
+      await tools.fetchChannelMessages?.execute?.(
+        { channelId: "slack:C123", limit: 5, direction: "backward" },
+        TOOL_OPTIONS
+      );
+      expect(mockAdapter.fetchChannelMessages).toHaveBeenCalled();
+    });
+
+    it("allows sibling threads when scoped to the whole channel", async () => {
+      const tools = createChatTools({ chat, scope: "slack:C123" });
       await tools.fetchMessages?.execute?.(
         { threadId: "slack:C123:9999.0000", limit: 5, direction: "backward" },
         TOOL_OPTIONS
@@ -512,8 +558,8 @@ describe("createChatTools", () => {
         });
 
       const results = await Promise.all([
-        read(CALLER_THREAD, "slack:C123:5555.0000"),
-        read(OTHER_THREAD, "slack:C123:5555.0000"),
+        read(CALLER_THREAD, CALLER_THREAD),
+        read(OTHER_THREAD, CALLER_THREAD),
         read(CALLER_THREAD, OTHER_THREAD),
         read(OTHER_THREAD, OTHER_THREAD),
       ]);
@@ -592,13 +638,85 @@ describe("createChatTools", () => {
       expect(outcome).toBe("blocked");
     });
 
-    it("stays unscoped outside a handler when scope is omitted", async () => {
+    it("stays unscoped outside a handler when scope is omitted, but warns", async () => {
+      const warn = mockLogger.warn as ReturnType<typeof vi.fn>;
+      warn.mockClear();
       const tools = createChatTools({ chat });
       await tools.fetchMessages?.execute?.(
         { threadId: OTHER_THREAD, limit: 5, direction: "backward" },
         TOOL_OPTIONS
       );
       expect(mockAdapter.fetchMessages).toHaveBeenCalled();
+      expect(warn).toHaveBeenCalledTimes(1);
+      // A second unscoped read on the same guard must not warn again.
+      await tools.fetchMessages?.execute?.(
+        { threadId: OTHER_THREAD, limit: 5, direction: "backward" },
+        TOOL_OPTIONS
+      );
+      expect(warn).toHaveBeenCalledTimes(1);
+    });
+
+    it("scopes to the conversation, not the channel, across adapters", async () => {
+      // Discord collapses a thread id to `discord:guild:channel`, so sibling
+      // threads share a channel that the coarse gate alone would allow.
+      const discord = createMockAdapter("discord");
+      (
+        discord.channelIdFromThreadId as ReturnType<typeof vi.fn>
+      ).mockImplementation((id: string) => id.split(":").slice(0, 3).join(":"));
+      const discordChat = new Chat({
+        userName: "testbot",
+        adapters: { discord },
+        state: createMockState(),
+        logger: mockLogger,
+      });
+      await discordChat.initialize();
+
+      const tools = createChatTools({
+        chat: discordChat,
+        scope: "discord:g:c:t1",
+        strictScope: true,
+      });
+      // Sibling thread under the same parent channel is blocked.
+      await expect(
+        tools.fetchMessages?.execute?.(
+          { threadId: "discord:g:c:t2", limit: 5, direction: "backward" },
+          TOOL_OPTIONS
+        )
+      ).rejects.toThrow(OUT_OF_SCOPE_REGEX);
+      // The parent channel itself stays readable.
+      await tools.fetchChannelMessages?.execute?.(
+        { channelId: "discord:g:c", limit: 5, direction: "backward" },
+        TOOL_OPTIONS
+      );
+      expect(discord.fetchChannelMessages).toHaveBeenCalled();
+    });
+
+    it("scopes reads during member-joined dispatch", async () => {
+      let outcome = "not-run";
+      chat.onMemberJoinedChannel(async () => {
+        const tools = createChatTools({ chat });
+        try {
+          await tools.fetchMessages?.execute?.(
+            { threadId: OTHER_THREAD, limit: 5, direction: "backward" },
+            TOOL_OPTIONS
+          );
+          outcome = "allowed";
+        } catch {
+          outcome = "blocked";
+        }
+      });
+
+      chat.processMemberJoinedChannel(
+        {
+          adapter: mockAdapter,
+          channelId: "slack:C123",
+          userId: "U1",
+        },
+        undefined
+      );
+      await sleep(0);
+
+      expect(outcome).toBe("blocked");
     });
   });
 

--- a/packages/chat/src/ai/index.test.ts
+++ b/packages/chat/src/ai/index.test.ts
@@ -683,12 +683,28 @@ describe("createChatTools", () => {
           TOOL_OPTIONS
         )
       ).rejects.toThrow(OUT_OF_SCOPE_REGEX);
-      // The parent channel itself stays readable.
+      // The parent channel is rejected too: on a per-thread-ACL platform it is
+      // the widest read available, so allowing it would defeat the point.
+      await expect(
+        tools.fetchChannelMessages?.execute?.(
+          { channelId: "discord:g:c", limit: 5, direction: "backward" },
+          TOOL_OPTIONS
+        )
+      ).rejects.toThrow(OUT_OF_SCOPE_REGEX);
+      expect(discord.fetchChannelMessages).not.toHaveBeenCalled();
+    });
+
+    it("allows a channel-level read under strictScope when a channel is scoped", async () => {
+      const tools = createChatTools({
+        chat,
+        scope: "slack:C123",
+        strictScope: true,
+      });
       await tools.fetchChannelMessages?.execute?.(
-        { channelId: "discord:g:c", limit: 5, direction: "backward" },
+        { channelId: "slack:C123", limit: 5, direction: "backward" },
         TOOL_OPTIONS
       );
-      expect(discord.fetchChannelMessages).toHaveBeenCalled();
+      expect(mockAdapter.fetchChannelMessages).toHaveBeenCalled();
     });
 
     it("scopes reads during member-joined dispatch", async () => {

--- a/packages/chat/src/ai/index.ts
+++ b/packages/chat/src/ai/index.ts
@@ -208,9 +208,11 @@ export interface ChatToolsOptions {
    *
    * By default a read is in scope when it resolves to the same channel as the
    * scoped conversation, so a thread scope still permits reading sibling
-   * threads in that channel. Set `true` to reject sibling threads: a thread
-   * scope then confines reads to that thread and its parent channel only. A
-   * channel scope is unaffected; it still allows any thread within the channel.
+   * threads in that channel. Set `true` to confine a thread scope to that
+   * thread alone: sibling threads and the parent channel are both rejected,
+   * which matters on platforms where a channel is the widest read available
+   * (a GitHub channel is an entire repo). A channel scope is unaffected; it
+   * still allows any thread within the channel.
    *
    * @default false
    */

--- a/packages/chat/src/ai/index.ts
+++ b/packages/chat/src/ai/index.ts
@@ -181,11 +181,19 @@ export interface ChatToolsOptions {
    * Confine read tools to a single conversation, so a thread or channel id
    * the model supplies that resolves elsewhere is rejected.
    *
+   * Scoping is channel-level: a read is allowed when it resolves to the same
+   * channel as the scoped conversation, so a thread scope still permits sibling
+   * threads within that channel. Set {@link ChatToolsOptions.strictScope} to
+   * tighten a thread scope to that thread alone.
+   *
    * Defaults to the conversation being handled, so tools created inside a
    * handler are already confined to it. Set this when the agent runs outside
-   * a handler and still reads on a user's behalf.
+   * a handler and still reads on a user's behalf, or pass a channel id to read
+   * channel-wide.
    *
-   * Pass `false` to read across every conversation the bot can see.
+   * Pass `false` to read across every conversation the bot can see. When no
+   * scope resolves (outside a handler, no explicit scope), reads run
+   * workspace-wide and a warning is logged.
    *
    * @example
    * ```ts
@@ -195,6 +203,18 @@ export interface ChatToolsOptions {
    * ```
    */
   scope?: ReadScope | false;
+  /**
+   * Tighten `scope` from channel-level (default) to conversation-level.
+   *
+   * By default a read is in scope when it resolves to the same channel as the
+   * scoped conversation, so a thread scope still permits reading sibling
+   * threads in that channel. Set `true` to reject sibling threads: a thread
+   * scope then confines reads to that thread and its parent channel only. A
+   * channel scope is unaffected; it still allows any thread within the channel.
+   *
+   * @default false
+   */
+  strictScope?: boolean;
 }
 
 function resolveApproval(
@@ -281,6 +301,7 @@ export function createChatTools({
   preset,
   overrides,
   scope,
+  strictScope = false,
 }: ChatToolsOptions) {
   if (!chat) {
     throw new Error(
@@ -293,7 +314,7 @@ export function createChatTools({
   });
   const allowed = preset ? resolvePresetTools(preset) : null;
 
-  const guard = createScopeGuard(chat, scope);
+  const guard = createScopeGuard(chat, scope, strictScope);
 
   // Each entry is built lazily so a preset filter skips both the
   // `approval()` lookup and the underlying `tool({ ... })` (and its zod

--- a/packages/chat/src/ai/scope.ts
+++ b/packages/chat/src/ai/scope.ts
@@ -23,10 +23,19 @@ function channelOf(chat: ChatBinding, id: string): string {
  * The scope resolves per call: an explicit one wins, and a toolset built
  * without one inherits the conversation currently being handled. Returns
  * `undefined` only when the caller opted out with `scope: false`.
+ *
+ * By default a read is allowed when it resolves to the same channel as the
+ * scoped conversation, so a thread scope still permits sibling threads in its
+ * channel. Pass `strict` to confine a thread scope to that thread and its
+ * parent channel; a channel scope still allows any thread within it.
+ *
+ * When no scope resolves (no explicit scope and no conversation being handled,
+ * e.g. a cron job or queued work), reads run workspace-wide but warn once.
  */
 export function createScopeGuard(
   chat: ChatBinding,
-  scope: ReadScope | false | undefined
+  scope: ReadScope | false | undefined,
+  strict = false
 ): ScopeGuard | undefined {
   if (scope === false) {
     return;
@@ -37,16 +46,38 @@ export function createScopeGuard(
     explicit = typeof scope === "string" ? scope : scope.id;
   }
 
+  let warnedUnscoped = false;
+
   return (id: string) => {
     const active = explicit ?? activeConversation();
     if (!active) {
+      if (!warnedUnscoped) {
+        warnedUnscoped = true;
+        chat
+          .getLogger()
+          .warn(
+            `Agent read tool ran unscoped: "${id}" was read workspace-wide because no conversation is being handled and no \`scope\` was set. Pass \`scope\` to createChatTools to confine reads.`
+          );
+      }
       return;
     }
 
-    const channel = channelOf(chat, active);
-    if (channelOf(chat, id) !== channel) {
+    const activeChannel = channelOf(chat, active);
+    const targetChannel = channelOf(chat, id);
+
+    // Same channel is always required. In strict mode also require the exact
+    // scoped conversation, a channel-level read, or a channel-wide scope, so a
+    // sibling thread is rejected.
+    const sameChannel = targetChannel === activeChannel;
+    const scopeIsChannel = active === activeChannel;
+    const targetIsChannel = id === targetChannel;
+    const inScope =
+      sameChannel &&
+      (!strict || id === active || targetIsChannel || scopeIsChannel);
+
+    if (!inScope) {
       throw new Error(
-        `Tool call blocked: reads are scoped to channel "${channel}", but "${id}" resolves outside it.`
+        `Tool call blocked: reads are scoped to "${active}", but "${id}" resolves outside it.`
       );
     }
   };

--- a/packages/chat/src/ai/scope.ts
+++ b/packages/chat/src/ai/scope.ts
@@ -26,8 +26,9 @@ function channelOf(chat: ChatBinding, id: string): string {
  *
  * By default a read is allowed when it resolves to the same channel as the
  * scoped conversation, so a thread scope still permits sibling threads in its
- * channel. Pass `strict` to confine a thread scope to that thread and its
- * parent channel; a channel scope still allows any thread within it.
+ * channel. Pass `strict` to confine a thread scope to that thread alone,
+ * rejecting sibling threads and the parent channel; a channel scope is
+ * unaffected and still allows any thread within it.
  *
  * When no scope resolves (no explicit scope and no conversation being handled,
  * e.g. a cron job or queued work), reads run workspace-wide but warn once.
@@ -65,15 +66,15 @@ export function createScopeGuard(
     const activeChannel = channelOf(chat, active);
     const targetChannel = channelOf(chat, id);
 
-    // Same channel is always required. In strict mode also require the exact
-    // scoped conversation, a channel-level read, or a channel-wide scope, so a
-    // sibling thread is rejected.
+    // Same channel is always required. Under strict a thread scope additionally
+    // requires the exact scoped conversation, so both sibling threads and the
+    // parent channel are rejected: on per-thread-ACL platforms the channel is
+    // the widest read available (a GitHub channel is the whole repo), so
+    // allowing it would defeat the point of confining to one thread. A channel
+    // scope is unaffected and still permits anything within it.
     const sameChannel = targetChannel === activeChannel;
     const scopeIsChannel = active === activeChannel;
-    const targetIsChannel = id === targetChannel;
-    const inScope =
-      sameChannel &&
-      (!strict || id === active || targetIsChannel || scopeIsChannel);
+    const inScope = sameChannel && (!strict || scopeIsChannel || id === active);
 
     if (!inScope) {
       throw new Error(

--- a/packages/chat/src/chat.ts
+++ b/packages/chat/src/chat.ts
@@ -1050,23 +1050,29 @@ export class Chat<
       relatedChannel,
     };
 
-    let result: ModalResponse | undefined;
-    for (const { callbackIds, handler } of this.modalSubmitHandlers) {
-      if (callbackIds.length === 0 || callbackIds.includes(event.callbackId)) {
-        try {
-          const response = await handler(fullEvent);
-          if (response) {
-            result = response;
-            break;
+    const conversationId = relatedThread?.id ?? relatedChannel?.id;
+    const runHandlers = async (): Promise<ModalResponse | undefined> => {
+      for (const { callbackIds, handler } of this.modalSubmitHandlers) {
+        if (
+          callbackIds.length === 0 ||
+          callbackIds.includes(event.callbackId)
+        ) {
+          try {
+            const response = await handler(fullEvent);
+            if (response) {
+              return response;
+            }
+          } catch (err) {
+            this.logger.error("Modal submit handler error", {
+              error: err,
+              callbackId: event.callbackId,
+            });
           }
-        } catch (err) {
-          this.logger.error("Modal submit handler error", {
-            error: err,
-            callbackId: event.callbackId,
-          });
         }
       }
-    }
+      return;
+    };
+    const result = await runInConversation(conversationId, runHandlers);
 
     if (callbackUrl && result?.action !== "errors") {
       const task = postToCallbackUrl(callbackUrl, {
@@ -1117,14 +1123,18 @@ export class Chat<
         relatedChannel,
       };
 
-      for (const { callbackIds, handler } of this.modalCloseHandlers) {
-        if (
-          callbackIds.length === 0 ||
-          callbackIds.includes(event.callbackId)
-        ) {
-          await handler(fullEvent);
+      const conversationId = relatedThread?.id ?? relatedChannel?.id;
+      const runHandlers = async () => {
+        for (const { callbackIds, handler } of this.modalCloseHandlers) {
+          if (
+            callbackIds.length === 0 ||
+            callbackIds.includes(event.callbackId)
+          ) {
+            await handler(fullEvent);
+          }
         }
-      }
+      };
+      await runInConversation(conversationId, runHandlers);
     })().catch((err) => {
       this.logger.error("Modal close handler error", {
         error: err,
@@ -1165,11 +1175,11 @@ export class Chat<
     event: AssistantThreadStartedEvent,
     options?: WebhookOptions
   ): void {
-    const task = (async () => {
+    const task = runInConversation(event.threadId, async () => {
       for (const handler of this.assistantThreadStartedHandlers) {
         await handler(event);
       }
-    })().catch((err) => {
+    }).catch((err) => {
       this.logger.error("Assistant thread started handler error", {
         error: err,
         threadId: event.threadId,
@@ -1185,11 +1195,11 @@ export class Chat<
     event: AssistantContextChangedEvent,
     options?: WebhookOptions
   ): void {
-    const task = (async () => {
+    const task = runInConversation(event.threadId, async () => {
       for (const handler of this.assistantContextChangedHandlers) {
         await handler(event);
       }
-    })().catch((err) => {
+    }).catch((err) => {
       this.logger.error("Assistant context changed handler error", {
         error: err,
         threadId: event.threadId,
@@ -1205,11 +1215,11 @@ export class Chat<
     event: AppHomeOpenedEvent,
     options?: WebhookOptions
   ): void {
-    const task = (async () => {
+    const task = runInConversation(event.channelId, async () => {
       for (const handler of this.appHomeOpenedHandlers) {
         await handler(event);
       }
-    })().catch((err) => {
+    }).catch((err) => {
       this.logger.error("App home opened handler error", {
         error: err,
         userId: event.userId,
@@ -1225,11 +1235,11 @@ export class Chat<
     event: AppContextChangedEvent,
     options?: WebhookOptions
   ): void {
-    const task = (async () => {
+    const task = runInConversation(event.channelId, async () => {
       for (const handler of this.appContextChangedHandlers) {
         await handler(event);
       }
-    })().catch((err) => {
+    }).catch((err) => {
       this.logger.error("App context changed handler error", {
         error: err,
         userId: event.userId,
@@ -1245,11 +1255,11 @@ export class Chat<
     event: MemberJoinedChannelEvent,
     options?: WebhookOptions
   ): void {
-    const task = (async () => {
+    const task = runInConversation(event.channelId, async () => {
       for (const handler of this.memberJoinedChannelHandlers) {
         await handler(event);
       }
-    })().catch((err) => {
+    }).catch((err) => {
       this.logger.error("Member joined channel handler error", {
         error: err,
         channelId: event.channelId,

--- a/packages/chat/src/context.ts
+++ b/packages/chat/src/context.ts
@@ -6,9 +6,17 @@ const conversationStorage = new AsyncLocalStorage<string>();
  * Run `fn` with `threadId` marked as the conversation currently being handled.
  * Chat wraps handler dispatch in this so tools invoked inside a handler can
  * tell which conversation they are serving.
+ *
+ * An `undefined` id runs `fn` bare, with no active conversation, the same state
+ * as running outside a handler. This lets dispatch paths whose conversation id
+ * is optional (e.g. a modal with no related thread or channel) call this
+ * unconditionally.
  */
-export function runInConversation<T>(threadId: string, fn: () => T): T {
-  return conversationStorage.run(threadId, fn);
+export function runInConversation<T>(
+  threadId: string | undefined,
+  fn: () => T
+): T {
+  return threadId === undefined ? fn() : conversationStorage.run(threadId, fn);
 }
 
 /**


### PR DESCRIPTION
Follow-up hardening and updated docs for the agent read-tool scoping in `createChatTools`.

## What changed

- Wrap the remaining dispatch paths (modal submit/close, assistant-thread, assistant-context, app-home, app-context, member-joined) in `runInConversation` so read tools built inside those handlers inherit the active conversation.
- Log a warning when a read runs with no resolvable scope, instead of failing open silently.
- Keep scoping channel-level by default; add opt-in `strictScope: true` to confine a thread scope to that thread alone (rejects sibling threads on per-thread-ACL platforms like Discord and GitHub).
- Update the AI SDK tools docs to cover the channel-level default, what `scope` does and does not do, and the `strictScope` opt-in.