### PR TITLE
fix(teams,slack): follow-up hardening for html and url parsing

### DIFF
--- a/.changeset/slack-unfurl-url-bound.md
+++ b/.changeset/slack-unfurl-url-bound.md
@@ -1,0 +1,5 @@
+---
+"@chat-adapter/slack": patch
+---
+
+Bound the length of bracketed URLs parsed from message text in the link-unfurl fallback, avoiding a quadratic scan on adversarial input. Valid links are unaffected.

--- a/.changeset/teams-strip-html-tags.md
+++ b/.changeset/teams-strip-html-tags.md
@@ -1,0 +1,5 @@
+---
+"@chat-adapter/teams": patch
+---
+
+Harden Teams HTML-to-text conversion to strip tags until the output is stable, so nested or malformed markup can't leave a partial tag behind. `stripHtmlTags` is now shared across the format and Graph message converters.

--- a/packages/adapter-slack/src/index.test.ts
+++ b/packages/adapter-slack/src/index.test.ts
@@ -9926,6 +9926,42 @@ describe("link unfurl enrichment", () => {
     expect(msg.links[0].title).toBeUndefined();
   });
 
+  it("parses bracketed links from text and bounds their length", async () => {
+    const state = createMockState();
+    const chatInstance = createMockChatInstance({ state });
+    const adapter = createSlackAdapter({
+      botToken: "xoxb-test-token",
+      signingSecret: secret,
+      logger: mockLogger,
+    });
+    await adapter.initialize(chatInstance);
+
+    const overLong = `https://example.com/${"a".repeat(4000)}`;
+    const body = JSON.stringify({
+      type: "event_callback",
+      event: {
+        type: "message",
+        channel: "C123",
+        ts: "1234567890.123456",
+        text: `ok <https://example.com/x> and <${overLong}>`,
+        user: "U_USER",
+      },
+    });
+
+    const request = createWebhookRequest(body, secret);
+    await adapter.handleWebhook(request);
+
+    const factory = (chatInstance.processMessage as ReturnType<typeof vi.fn>)
+      .mock.calls[0][2] as () => Promise<{
+      links: Array<{ url: string }>;
+    }>;
+    const msg = await factory();
+
+    const urls = msg.links.map((l) => l.url);
+    expect(urls).toContain("https://example.com/x");
+    expect(urls).not.toContain(overLong);
+  });
+
   it("should match unfurl metadata with trailing slash differences", async () => {
     const state = createMockState();
     const chatInstance = createMockChatInstance({ state });

--- a/packages/adapter-slack/src/index.ts
+++ b/packages/adapter-slack/src/index.ts
@@ -183,6 +183,8 @@ interface SlackUnfurl {
 }
 const SLACK_MESSAGE_URL_PATTERN =
   /^https?:\/\/[^/]+\.slack\.com\/archives\/([A-Z0-9]+)\/p(\d+)(?:\?.*)?$/;
+// Bracketed URL in message text; length-bounded to keep the scan linear.
+const BRACKETED_URL_PATTERN = /<(https?:\/\/[^>]{1,2048})>/g;
 
 import type {
   SlackAdapterConfig,
@@ -3308,8 +3310,7 @@ export class SlackAdapter implements Adapter<SlackThreadId, unknown> {
 
     // Fallback: parse <url> and <url|label> from text
     if (urls.size === 0 && event.text) {
-      const urlPattern = /<(https?:\/\/[^>]{1,2048})>/g;
-      for (const match of event.text.matchAll(urlPattern)) {
+      for (const match of event.text.matchAll(BRACKETED_URL_PATTERN)) {
         const raw = match[1] as string;
         const pipeIdx = raw.indexOf("|");
         urls.add(pipeIdx >= 0 ? raw.slice(0, pipeIdx) : raw);

--- a/packages/adapter-slack/src/index.ts
+++ b/packages/adapter-slack/src/index.ts
@@ -3308,7 +3308,7 @@ export class SlackAdapter implements Adapter<SlackThreadId, unknown> {
 
     // Fallback: parse <url> and <url|label> from text
     if (urls.size === 0 && event.text) {
-      const urlPattern = /<(https?:\/\/[^>]+)>/g;
+      const urlPattern = /<(https?:\/\/[^>]{1,2048})>/g;
       for (const match of event.text.matchAll(urlPattern)) {
         const raw = match[1] as string;
         const pipeIdx = raw.indexOf("|");

--- a/packages/adapter-teams/src/format/index.test.ts
+++ b/packages/adapter-teams/src/format/index.test.ts
@@ -4,10 +4,13 @@ import {
   escapeTeamsText,
   formatTeamsMention,
   markdownToTeamsHtml,
+  stripHtmlTags,
   teamsHtmlToMarkdown,
   teamsMentionToPlainText,
   unescapeTeamsText,
 } from "./index";
+
+const HTML_TAG = /<[^>]+>/;
 
 describe("Teams format primitives", () => {
   it("escapes and unescapes Teams text", () => {
@@ -21,6 +24,13 @@ describe("Teams format primitives", () => {
     expect(teamsMentionToPlainText("<at>Ada &amp; Ben</at> hi")).toBe(
       "@Ada & Ben hi"
     );
+  });
+
+  it("strips tags and leaves no complete tag on nested input", () => {
+    expect(stripHtmlTags("<b>hi</b>")).toBe("hi");
+    expect(stripHtmlTags("a<img src=x>b")).toBe("ab");
+    expect(stripHtmlTags("plain")).toBe("plain");
+    expect(HTML_TAG.test(stripHtmlTags("<<script>>"))).toBe(false);
   });
 
   it("converts Teams HTML to Markdown-ish text", () => {

--- a/packages/adapter-teams/src/format/index.ts
+++ b/packages/adapter-teams/src/format/index.ts
@@ -1,4 +1,5 @@
 const HTML_ESCAPE_PATTERN = /[&<>"]/g;
+const HTML_TAG_PATTERN = /<[^>]+>/g;
 const MARKDOWN_LINK_PATTERN = /\[([^\]]+)\]\(([^)]+)\)/g;
 const TEAMS_MENTION_PATTERN = /<at\b[^>]*>(.*?)<\/at>/gis;
 
@@ -38,12 +39,12 @@ export function formatTeamsMention(name: string): string {
 
 export function teamsMentionToPlainText(text: string): string {
   return text.replace(TEAMS_MENTION_PATTERN, (_match, name: string) => {
-    return `@${unescapeTeamsText(stripTags(name).trim())}`;
+    return `@${unescapeTeamsText(stripHtmlTags(name).trim())}`;
   });
 }
 
 export function teamsHtmlToMarkdown(html: string): string {
-  return unescapeTeamsText(
+  const withoutTags = stripHtmlTags(
     teamsMentionToPlainText(html)
       .replace(/<strong\b[^>]*>(.*?)<\/strong>/gis, "**$1**")
       .replace(/<b\b[^>]*>(.*?)<\/b>/gis, "**$1**")
@@ -55,9 +56,8 @@ export function teamsHtmlToMarkdown(html: string): string {
       .replace(/<a\b[^>]*href=["']([^"']+)["'][^>]*>(.*?)<\/a>/gis, "[$2]($1)")
       .replace(/<br\s*\/?>/gi, "\n")
       .replace(/<\/p>\s*<p[^>]*>/gi, "\n\n")
-      .replace(/<[^>]+>/g, "")
-      .replace(/\u00a0/g, " ")
-  ).trim();
+  );
+  return unescapeTeamsText(withoutTags.replace(/\u00a0/g, " ")).trim();
 }
 
 export function markdownToTeamsHtml(markdown: string): string {
@@ -80,8 +80,14 @@ export function convertTeamsEmojiPlaceholders(text: string): string {
   return converted;
 }
 
-function stripTags(text: string): string {
-  return text.replace(/<[^>]+>/g, "");
+export function stripHtmlTags(text: string): string {
+  let current = text;
+  let previous: string;
+  do {
+    previous = current;
+    current = current.replace(HTML_TAG_PATTERN, "");
+  } while (current !== previous);
+  return current;
 }
 
 function safeLinkHref(href: string): boolean {

--- a/packages/adapter-teams/src/format/index.ts
+++ b/packages/adapter-teams/src/format/index.ts
@@ -1,5 +1,6 @@
 const HTML_ESCAPE_PATTERN = /[&<>"]/g;
-const HTML_TAG_PATTERN = /<[^>]+>/g;
+// Tag body length-bounded to keep the scan linear.
+const HTML_TAG_PATTERN = /<[^>]{1,2048}>/g;
 const MARKDOWN_LINK_PATTERN = /\[([^\]]+)\]\(([^)]+)\)/g;
 const TEAMS_MENTION_PATTERN = /<at\b[^>]*>(.*?)<\/at>/gis;
 

--- a/packages/adapter-teams/src/graph/messages.ts
+++ b/packages/adapter-teams/src/graph/messages.ts
@@ -1,3 +1,4 @@
+import { stripHtmlTags } from "../format";
 import { callTeamsGraphApi } from "./client";
 import type {
   TeamsGraphListOptions,
@@ -121,11 +122,13 @@ export function extractTextFromGraphMessage(message: GraphChatMessage): string {
   if (!content) {
     return "";
   }
-  return content
-    .replace(/<at\b[^>]*>(.*?)<\/at>/gis, "@$1")
-    .replace(/<br\s*\/?>/gi, "\n")
-    .replace(/<\/p>\s*<p[^>]*>/gi, "\n\n")
-    .replace(/<[^>]+>/g, "")
+  const withoutTags = stripHtmlTags(
+    content
+      .replace(/<at\b[^>]*>(.*?)<\/at>/gis, "@$1")
+      .replace(/<br\s*\/?>/gi, "\n")
+      .replace(/<\/p>\s*<p[^>]*>/gi, "\n\n")
+  );
+  return withoutTags
     .replace(/&nbsp;/g, " ")
     .replace(/&lt;/g, "<")
     .replace(/&gt;/g, ">")


### PR DESCRIPTION
Follow-up and hardening for two inbound parsers.

- **Teams** — HTML-to-text conversion now strips tags until the output is stable, so nested or malformed markup can't leave a partial tag behind. A shared `stripHtmlTags` helper backs both the format converter and the Graph message converter (was three inline single-pass regexes).
- **Slack** — the link-unfurl fallback bounds the length of bracketed URLs parsed from message text, avoiding a quadratic scan on adversarial input. Valid links are unaffected.

Two changesets (`@chat-adapter/teams`, `@chat-adapter/slack`); no public-type change. Independent of #774/#775.

🤖 Generated with [Claude Code](https://claude.com/claude-code)