### PR TITLE
fix(gchat): bind add-on webhook verification to a configured identity

### DIFF
--- a/.changeset/neat-bugs-invent.md
+++ b/.changeset/neat-bugs-invent.md
@@ -1,0 +1,5 @@
+---
+"@chat-adapter/gchat": minor
+---
+
+Bind Workspace Add-on webhook verification to a specific identity with the new `workspaceAddOnServiceAccountEmail` option, replacing a pattern match on the add-on service account email. Workspace Add-on Chat apps must set it; standalone Chat apps are unaffected.

--- a/apps/docs/content/adapters/official/gchat.mdx
+++ b/apps/docs/content/adapters/official/gchat.mdx
@@ -118,6 +118,11 @@ bot.onNewMention(async (thread, message) => {
       description:
         "Public URL of the webhook endpoint. Required for routing button click actions to your app, and used as an accepted JWT audience for direct webhooks when the Chat app's authentication audience is set to 'HTTP endpoint URL'.",
     },
+    workspaceAddOnServiceAccountEmail: {
+      type: "string",
+      description:
+        "Your own service-{projectNumber}@gcp-sa-gsuiteaddons.iam.gserviceaccount.com identity. Required to accept Workspace Add-on Chat app webhooks, which are signed by an add-on identity rather than chat@system.gserviceaccount.com. Without it, add-on tokens are rejected.",
+    },
     impersonateUser: {
       type: "string",
       description:
@@ -212,10 +217,14 @@ If you only configure a direct-webhook verifier, incoming Pub/Sub-shaped request
 | -------------------------------------------------------------------------------------------------------- | ----------------------------------------- | -------------------------------------------------------------------------- | ------------------------------------------------------------------ |
 | Standalone Chat app, **Authentication audience: Project number** (in Chat API config)                   | self-signed JWT, `aud` = project number   | `chat@system.gserviceaccount.com` (its own X.509 certs)                    | `googleChatProjectNumber`                                          |
 | Standalone Chat app, **Authentication audience: HTTP endpoint URL**                                      | Google OIDC ID token, `aud` = endpoint URL | Google (`email`: `chat@system.gserviceaccount.com`)                        | `endpointUrl`                                                      |
-| **Workspace Add-on Chat app** (built via Google Workspace Marketplace SDK; the audience is hardcoded)    | Google OIDC ID token, `aud` = endpoint URL | Google (`email`: `service-{projectNumber}@gcp-sa-gsuiteaddons.iam.gserviceaccount.com`) | `endpointUrl`                                                      |
+| **Workspace Add-on Chat app** (built via Google Workspace Marketplace SDK; the audience is hardcoded)    | Google OIDC ID token, `aud` = endpoint URL | Google (`email`: `service-{projectNumber}@gcp-sa-gsuiteaddons.iam.gserviceaccount.com`) | `endpointUrl` **and** `workspaceAddOnServiceAccountEmail`          |
 | Mixed across envs / not sure                                                                             | varies                                    | varies                                                                     | both `googleChatProjectNumber` and `endpointUrl`                   |
 
 The two token types are verified differently, matching [Google's reference implementation](https://developers.google.com/workspace/chat/verify-requests-from-chat): endpoint-URL tokens are standard OIDC ID tokens checked against Google's public certs plus the Chat service-account `email` claim; project-number tokens are self-signed by `chat@system.gserviceaccount.com` and checked against that service account's own X.509 certificates. When both `googleChatProjectNumber` and `endpointUrl` are set, either token type is accepted. If you don't know which mode your app uses, look at an incoming token: an `email` claim containing `gcp-sa-gsuiteaddons` means it's a Workspace Add-on (URL audience).
+
+<Callout type="warn">
+Every Workspace Add-on project produces an `email` of the same `service-{projectNumber}@gcp-sa-gsuiteaddons` shape, so that shape identifies "some add-on", not *your* add-on. Set `workspaceAddOnServiceAccountEmail` to your own project's address and the adapter compares it exactly. Leave it unset and add-on tokens are rejected with HTTP 401, rather than accepting any add-on that happens to point at your endpoint URL. Standalone Chat apps signing as `chat@system.gserviceaccount.com` are unaffected.
+</Callout>
 
 <Callout type="info">
 Workspace Add-on Chat apps don't expose an "Authentication audience" radio; their token `aud` is always the endpoint URL. Set `endpointUrl` for these.

--- a/packages/adapter-gchat/README.md
+++ b/packages/adapter-gchat/README.md
@@ -181,6 +181,7 @@ Most options are auto-detected from environment variables when not provided.
 | `pubsubAudience` | No† | Expected JWT audience for Pub/Sub webhook verification. Auto-detected from `GOOGLE_CHAT_PUBSUB_AUDIENCE` |
 | `googleChatProjectNumber` | No† | GCP project number for direct webhook JWT verification when the Chat app's authentication audience is "Project number". Auto-detected from `GOOGLE_CHAT_PROJECT_NUMBER` |
 | `endpointUrl` | No† | Public webhook URL for button click routing and direct webhook JWT verification when the Chat app's authentication audience is "HTTP endpoint URL". Must be passed in config |
+| `workspaceAddOnServiceAccountEmail` | No‡ | Your own `service-{projectNumber}@gcp-sa-gsuiteaddons.iam.gserviceaccount.com` identity. Required to accept Workspace Add-on Chat app webhooks. Auto-detected from `GOOGLE_CHAT_WORKSPACE_ADDON_SERVICE_ACCOUNT_EMAIL` |
 | `disableSignatureVerification` | No† | Disable JWT verification entirely (development only). Auto-detected from `GOOGLE_CHAT_DISABLE_SIGNATURE_VERIFICATION=true` |
 | `impersonateUser` | No | User email for domain-wide delegation. Auto-detected from `GOOGLE_CHAT_IMPERSONATE_USER` |
 | `auth` | No | Custom auth object (advanced) |
@@ -190,6 +191,8 @@ Most options are auto-detected from environment variables when not provided.
 *Either `credentials`, `GOOGLE_CHAT_CREDENTIALS` env var, `useApplicationDefaultCredentials`, or `GOOGLE_CHAT_USE_ADC=true` is required.
 
 †One of `googleChatProjectNumber`, `endpointUrl`, `pubsubAudience`, or `disableSignatureVerification: true` is required — the constructor throws otherwise. Configure the verifier(s) for each transport you actually receive; requests of a shape whose verifier is unconfigured are rejected with HTTP 401.
+
+‡Only Workspace Add-on Chat apps need this. Their webhooks are signed by an add-on service identity rather than `chat@system.gserviceaccount.com`, and every add-on project shares the same `service-{projectNumber}@gcp-sa-gsuiteaddons` email shape — so the identity is only meaningful compared exactly. Without it, add-on tokens are rejected with HTTP 401 rather than trusted by shape. Standalone Chat apps are unaffected.
 
 ## Environment variables
 
@@ -203,6 +206,8 @@ GOOGLE_CHAT_IMPERSONATE_USER=admin@yourdomain.com
 # Webhook verification — at least one verifier or the explicit opt-out is required
 GOOGLE_CHAT_PROJECT_NUMBER=123456789          # Direct webhooks with project-number audience
 GOOGLE_CHAT_PUBSUB_AUDIENCE=https://your-domain.com/api/webhooks/gchat  # For Pub/Sub JWT verification
+# Workspace Add-on Chat apps only — your own add-on service identity
+GOOGLE_CHAT_WORKSPACE_ADDON_SERVICE_ACCOUNT_EMAIL=service-123456789@gcp-sa-gsuiteaddons.iam.gserviceaccount.com
 # GOOGLE_CHAT_DISABLE_SIGNATURE_VERIFICATION=true  # Escape hatch for local dev only
 
 # Optional: override the Google Chat API base URL
@@ -216,7 +221,7 @@ The adapter supports JWT verification for both webhook types. When configured, t
 Verification is required. The constructor throws `ValidationError` unless one of the following is set:
 
 - `googleChatProjectNumber` (or `GOOGLE_CHAT_PROJECT_NUMBER`) — direct webhooks when the Chat app's authentication audience is "Project number"
-- `endpointUrl` — direct webhooks when the Chat app's authentication audience is "HTTP endpoint URL"; also required for routing card button clicks in HTTP endpoint apps
+- `endpointUrl` — direct webhooks when the Chat app's authentication audience is "HTTP endpoint URL"; also required for routing card button clicks in HTTP endpoint apps. Workspace Add-on Chat apps additionally need `workspaceAddOnServiceAccountEmail`, since their tokens are signed by an add-on identity instead of `chat@system.gserviceaccount.com`
 - `pubsubAudience` (or `GOOGLE_CHAT_PUBSUB_AUDIENCE`) — Pub/Sub push deliveries
 - `disableSignatureVerification: true` (or `GOOGLE_CHAT_DISABLE_SIGNATURE_VERIFICATION=true`) — explicit opt-out, intended for local development only
 

--- a/packages/adapter-gchat/src/index.test.ts
+++ b/packages/adapter-gchat/src/index.test.ts
@@ -145,6 +145,7 @@ async function createInitializedAdapter(opts?: {
   endpointUrl?: string;
   googleChatProjectNumber?: string;
   pubsubAudience?: string;
+  workspaceAddOnServiceAccountEmail?: string;
 }) {
   const adapter = createGoogleChatAdapter({
     credentials: TEST_CREDENTIALS,
@@ -154,6 +155,7 @@ async function createInitializedAdapter(opts?: {
     endpointUrl: opts?.endpointUrl,
     googleChatProjectNumber: opts?.googleChatProjectNumber,
     pubsubAudience: opts?.pubsubAudience,
+    workspaceAddOnServiceAccountEmail: opts?.workspaceAddOnServiceAccountEmail,
   });
   const mockState = createMockStateAdapter();
   const mockChat = createMockChatInstance({ state: mockState });
@@ -2954,33 +2956,116 @@ describe("GoogleChatAdapter", () => {
       });
     });
 
-    it("should allow direct webhook with Workspace Add-on service account email when endpointUrl is configured", async () => {
+    async function addOnWebhook(
+      tokenEmail: string,
+      workspaceAddOnServiceAccountEmail?: string
+    ) {
       verifyIdTokenSpy.mockResolvedValue({
         getPayload: () => ({
           iss: "https://accounts.google.com",
           aud: "https://example.com/webhook",
-          email:
-            "service-123456789@gcp-sa-gsuiteaddons.iam.gserviceaccount.com",
+          email: tokenEmail,
           email_verified: true,
         }),
       });
 
       const { adapter } = await createInitializedAdapter({
         endpointUrl: "https://example.com/webhook",
+        workspaceAddOnServiceAccountEmail,
       });
 
-      const event = makeMessageEvent({ messageText: "Hello" });
       const request = new Request("https://example.com/webhook", {
         method: "POST",
         headers: {
           "content-type": "application/json",
           authorization: "Bearer valid-google-jwt",
         },
-        body: JSON.stringify(event),
+        body: JSON.stringify(makeMessageEvent({ messageText: "Hello" })),
       });
 
-      const response = await adapter.handleWebhook(request);
+      return adapter.handleWebhook(request);
+    }
+
+    it("should allow a Workspace Add-on token matching the configured service account", async () => {
+      const response = await addOnWebhook(
+        "service-111@gcp-sa-gsuiteaddons.iam.gserviceaccount.com",
+        "service-111@gcp-sa-gsuiteaddons.iam.gserviceaccount.com"
+      );
       expect(response.status).toBe(200);
+    });
+
+    it("should reject a Workspace Add-on token from a different project", async () => {
+      // The generic `service-<number>@gcp-sa-gsuiteaddons` shape matches every
+      // Workspace Add-on project, so an attacker's own add-on must not pass.
+      const response = await addOnWebhook(
+        "service-999@gcp-sa-gsuiteaddons.iam.gserviceaccount.com",
+        "service-111@gcp-sa-gsuiteaddons.iam.gserviceaccount.com"
+      );
+      expect(response.status).toBe(401);
+    });
+
+    it("should reject a Workspace Add-on token when no service account is configured", async () => {
+      const response = await addOnWebhook(
+        "service-111@gcp-sa-gsuiteaddons.iam.gserviceaccount.com"
+      );
+      expect(response.status).toBe(401);
+    });
+
+    it("should still allow the Chat system service account without add-on config", async () => {
+      const response = await addOnWebhook("chat@system.gserviceaccount.com");
+      expect(response.status).toBe(200);
+    });
+
+    it.each([
+      [
+        "a suffixed lookalike domain",
+        "service-111@gcp-sa-gsuiteaddons.iam.gserviceaccount.com.evil.test",
+      ],
+      [
+        "a prefixed lookalike domain",
+        "service-111@evil.test/gcp-sa-gsuiteaddons.iam.gserviceaccount.com",
+      ],
+      [
+        "an uppercase variant",
+        "SERVICE-111@GCP-SA-GSUITEADDONS.IAM.GSERVICEACCOUNT.COM",
+      ],
+      [
+        "trailing whitespace",
+        "service-111@gcp-sa-gsuiteaddons.iam.gserviceaccount.com ",
+      ],
+    ])("should reject %s of the configured add-on identity", async (_, email) => {
+      const response = await addOnWebhook(
+        email,
+        "service-111@gcp-sa-gsuiteaddons.iam.gserviceaccount.com"
+      );
+      expect(response.status).toBe(401);
+    });
+
+    it("should reject the configured add-on identity when email_verified is false", async () => {
+      verifyIdTokenSpy.mockResolvedValue({
+        getPayload: () => ({
+          iss: "https://accounts.google.com",
+          aud: "https://example.com/webhook",
+          email: "service-111@gcp-sa-gsuiteaddons.iam.gserviceaccount.com",
+          email_verified: false,
+        }),
+      });
+      const { adapter } = await createInitializedAdapter({
+        endpointUrl: "https://example.com/webhook",
+        workspaceAddOnServiceAccountEmail:
+          "service-111@gcp-sa-gsuiteaddons.iam.gserviceaccount.com",
+      });
+      const response = await adapter.handleWebhook(
+        new Request("https://example.com/webhook", {
+          method: "POST",
+          headers: {
+            "content-type": "application/json",
+            authorization: "Bearer valid-google-jwt",
+          },
+          body: JSON.stringify(makeMessageEvent({ messageText: "Hello" })),
+        })
+      );
+      expect(response.status).toBe(401);
     });
 
     it("should reject endpointUrl direct webhook when token email is not Google Chat", async () => {

--- a/packages/adapter-gchat/src/index.ts
+++ b/packages/adapter-gchat/src/index.ts
@@ -251,6 +251,8 @@ export class GoogleChatAdapter implements Adapter<GoogleChatThreadId, unknown> {
   protected readonly googleChatProjectNumber?: string;
   /** Expected audience for Pub/Sub push message JWT verification */
   protected readonly pubsubAudience?: string;
+  /** Exact service account identity of this app's Workspace Add-on, if any */
+  protected readonly workspaceAddOnServiceAccountEmail?: string;
   /** Explicit opt-in to skip JWT verification (fail-open). */
   protected readonly disableSignatureVerification: boolean;
   /** OAuth2 client for verifying Google-signed JWTs */
@@ -277,6 +279,9 @@ export class GoogleChatAdapter implements Adapter<GoogleChatThreadId, unknown> {
       config.googleChatProjectNumber ?? process.env.GOOGLE_CHAT_PROJECT_NUMBER;
     this.pubsubAudience =
       config.pubsubAudience ?? process.env.GOOGLE_CHAT_PUBSUB_AUDIENCE;
+    this.workspaceAddOnServiceAccountEmail =
+      config.workspaceAddOnServiceAccountEmail ??
+      process.env.GOOGLE_CHAT_WORKSPACE_ADDON_SERVICE_ACCOUNT_EMAIL;
     this.disableSignatureVerification =
       config.disableSignatureVerification ??
       process.env.GOOGLE_CHAT_DISABLE_SIGNATURE_VERIFICATION === "true";
@@ -713,19 +718,35 @@ export class GoogleChatAdapter implements Adapter<GoogleChatThreadId, unknown> {
    * Google OIDC ID tokens, so anyone can mint one with `aud` set to our
    * public endpoint URL — the token is only trustworthy if it was issued
    * to Google Chat itself: `email` must be the Chat system service
-   * account (or the Workspace Add-on service identity) and verified.
+   * account (or this app's own Workspace Add-on identity) and verified.
+   *
+   * Add-on identities are compared exactly, never by shape. Every Workspace
+   * Add-on project produces a `service-{projectNumber}@gcp-sa-gsuiteaddons`
+   * email, so matching the pattern alone would accept an attacker's own
+   * add-on pointed at our public endpoint. When no add-on identity is
+   * configured, add-on tokens are rejected rather than trusted by shape.
    */
   private validateEndpointUrlTokenPayload(payload: {
     email?: string;
     email_verified?: boolean;
   }): boolean {
-    return (
-      payload.email_verified === true &&
-      (payload.email === GOOGLE_CHAT_SERVICE_ACCOUNT_EMAIL ||
-        GOOGLE_WORKSPACE_ADD_ON_SERVICE_ACCOUNT_PATTERN.test(
-          payload.email ?? ""
-        ))
-    );
+    if (payload.email_verified !== true || !payload.email) {
+      return false;
+    }
+    if (payload.email === GOOGLE_CHAT_SERVICE_ACCOUNT_EMAIL) {
+      return true;
+    }
+    if (!GOOGLE_WORKSPACE_ADD_ON_SERVICE_ACCOUNT_PATTERN.test(payload.email)) {
+      return false;
+    }
+    if (!this.workspaceAddOnServiceAccountEmail) {
+      this.logger.warn(
+        "Rejected a Workspace Add-on token because no add-on identity is configured. Set `workspaceAddOnServiceAccountEmail` (or GOOGLE_CHAT_WORKSPACE_ADDON_SERVICE_ACCOUNT_EMAIL) to your own service-{projectNumber}@gcp-sa-gsuiteaddons.iam.gserviceaccount.com address.",
+        { email: payload.email }
+      );
+      return false;
+    }
+    return payload.email === this.workspaceAddOnServiceAccountEmail;
   }
 
   private async getChatIssuerCerts(): Promise<Record<string, string>> {

--- a/packages/adapter-gchat/src/types.ts
+++ b/packages/adapter-gchat/src/types.ts
@@ -78,6 +78,20 @@ export interface GoogleChatAdapterBaseConfig {
   pubsubTopic?: string;
   /** Override bot username (optional) */
   userName?: string;
+  /**
+   * Service account identity of your Workspace Add-on Chat app, in the form
+   * `service-{projectNumber}@gcp-sa-gsuiteaddons.iam.gserviceaccount.com`,
+   * where `projectNumber` is your own Google Cloud project number.
+   *
+   * Workspace Add-on Chat apps sign endpoint-URL webhooks with this identity
+   * instead of `chat@system.gserviceaccount.com`. Every add-on project shares
+   * the same email shape, so the identity is only meaningful compared exactly:
+   * without this option the adapter rejects add-on tokens rather than trusting
+   * any project's add-on. Ordinary Chat apps are unaffected.
+   *
+   * Defaults to GOOGLE_CHAT_WORKSPACE_ADDON_SERVICE_ACCOUNT_EMAIL env var.
+   */
+  workspaceAddOnServiceAccountEmail?: string;
 }
 
 /** Config using service account credentials (JSON key file) */

--- a/packages/chat/src/adapters/index.ts
+++ b/packages/chat/src/adapters/index.ts
@@ -362,6 +362,10 @@ export const ADAPTERS = {
           "Audience used for Workspace Events push verification."
         ),
         env(
+          "GOOGLE_CHAT_WORKSPACE_ADDON_SERVICE_ACCOUNT_EMAIL",
+          "Your Workspace Add-on service account identity. Required to accept add-on webhooks."
+        ),
+        env(
           "GOOGLE_CHAT_DISABLE_SIGNATURE_VERIFICATION",
           "Set to true to disable signature verification for local fixtures."
         ),


### PR DESCRIPTION
## summary

endpoint-URL webhook verification accepted any `email` claim matching the generic Workspace Add-on shape:

```ts
/^service-\d+@gcp-sa-gsuiteaddons\.iam\.gserviceaccount\.com$/
```

the `\d+` is a GCP project number, and service agents are `service-{PROJECT_NUMBER}@gcp-sa-{SERVICE}...` for the project that owns them. so that shape identifies "some Workspace Add-on", not *this* app's add-on, and it was the only thing standing between a public endpoint URL and a verified request. the method's own doc comment already stated the correct invariant, that the token is only trustworthy if it was issued to Google Chat itself

adds `workspaceAddOnServiceAccountEmail` (env `GOOGLE_CHAT_WORKSPACE_ADDON_SERVICE_ACCOUNT_EMAIL`) and compares add-on identities exactly. when it is unset, add-on-shaped tokens are rejected rather than trusted by shape, with a log naming the option to set

`chat@system.gserviceaccount.com` is untouched, so standalone Chat apps behave exactly as before. the project-number and Pub/Sub paths were already bound to exact identities and are unchanged

### behavior

| token `email` | before | after |
| --- | --- | --- |
| `chat@system.gserviceaccount.com` | accept | accept |
| add-on shape, matches configured identity | accept | accept |
| add-on shape, different project | accept | **reject** |
| add-on shape, option unset | accept | **reject** |

<details>
<summary>why not reject at construction</summary>

refusing to initialize when the option is absent would be the stricter-looking choice, but the adapter cannot tell Workspace Add-on mode from config alone, it only sees `endpointUrl`. throwing there would break every ordinary endpoint-URL Chat app. rejecting add-on-shaped tokens at verification is the precise equivalent without the collateral

</details>

## test plan

- an add-on token matching the configured identity is accepted
- an add-on token from a different project is rejected, the case the generic shape allowed
- an add-on token is rejected when no identity is configured
- `chat@system.gserviceaccount.com` is still accepted with no add-on config
- suffixed and prefixed lookalike domains, an uppercase variant, and trailing whitespace are all rejected
- a matching identity with `email_verified: false` is rejected

the two rejection cases above returned 200 before this change and 401 after

