### PR TITLE
fix(docs): remove hardcoded bg-background from CodePreview pre element

### DIFF
--- a/apps/docs/app/[lang]/(home)/components/get-started-section.tsx
+++ b/apps/docs/app/[lang]/(home)/components/get-started-section.tsx
@@ -50,7 +50,7 @@ const CodePreview = async ({ code }: { code: string }) => {
 
   return (
     <pre
-      className="overflow-hidden bg-background p-3 text-xs leading-relaxed"
+      className="overflow-hidden p-3 text-xs leading-relaxed"
       style={{ "--sdm-bg": "#fff", ...preStyle } as CSSProperties}
     >
       <code className="grid min-w-max">

--- a/apps/docs/app/[lang]/(home)/components/get-started-section.tsx
+++ b/apps/docs/app/[lang]/(home)/components/get-started-section.tsx
@@ -143,7 +143,7 @@ export const GetStartedSection = ({ data }: { data: Template[] }) => (
           </p>
           <div
             className={cn(
-              "mt-4 -mr-8 -mb-8 ml-4 aspect-video -rotate-3 overflow-hidden rounded-md border",
+              "mt-4 -mr-8 -mb-8 ml-4 aspect-video -rotate-3 overflow-hidden rounded-md border bg-background",
               "transition-transform duration-300 group-hover:-rotate-1 group-hover:scale-105"
             )}
           >


### PR DESCRIPTION
## Problem

On the GetStarted cards in the home page, the `<pre>` inside `CodePreview` had `bg-background` hardcoded. When hovering a card (`hover:bg-muted/40`), the code block retained its own opaque background, so the hover tint only showed through around the text — the dark/muted fill appeared clipped to the text container rather than filling the whole rotated card.

## Fix

Removed `bg-background` from the `<pre>` element so it inherits the parent card's background. The default state is unchanged since the card itself already has `bg-background`.