### PR TITLE
Update CODEOWNERS to require @vercel/chat-sdk approval

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,4 @@
-/packages/ @vercel/chat-sdk
+* @vercel/chat-sdk
 
 **/*.md
 


### PR DESCRIPTION
Update CODEOWNERS to require @vercel/chat-sdk approval, except for MD changes
