### PR TITLE
fix(gchat): bind Pub/Sub push verification to a configured identity

### DIFF
--- a/.changeset/large-otters-think.md
+++ b/.changeset/large-otters-think.md
@@ -1,0 +1,5 @@
+---
+"@chat-adapter/gchat": minor
+---
+
+Bind Pub/Sub push verification to a specific identity with the new pubsubServiceAccountEmail option, alongside the existing audience check. Pushes are rejected unless the token email matches it. Direct webhooks are unaffected.

--- a/apps/docs/content/adapters/official/gchat.mdx
+++ b/apps/docs/content/adapters/official/gchat.mdx
@@ -110,6 +110,11 @@ bot.onNewMention(async (thread, message) => {
       description:
         "Expected JWT audience for Pub/Sub webhook verification.",
     },
+    pubsubServiceAccountEmail: {
+      type: "string",
+      description:
+        "Service account your Pub/Sub push subscription authenticates as. Required to accept Pub/Sub pushes, since the audience alone does not identify the caller. Without it, pushes are rejected.",
+    },
     googleChatProjectNumber: {
       type: "string",
       description:
@@ -187,7 +192,7 @@ createGoogleChatAdapter({
 
 1. Under **Pub/Sub** then **Topics**, create a topic (e.g. `chat-events`) and copy its full name to `GOOGLE_CHAT_PUBSUB_TOPIC`.
 2. Add `chat-api-push@system.gserviceaccount.com` as a Pub/Sub Publisher.
-3. Create a Push subscription with endpoint `https://your-domain.com/api/webhooks/gchat`.
+3. Create a Push subscription with endpoint `https://your-domain.com/api/webhooks/gchat`. Enable authentication on it and pick a service account, then set that account's email as `GOOGLE_CHAT_PUBSUB_SERVICE_ACCOUNT_EMAIL`.
 
 **Domain-wide delegation:**
 
@@ -209,7 +214,11 @@ Required for Workspace Events subscriptions and initiating DMs.
 The two transports share one HTTP endpoint, so each verifier only covers its own request shape:
 
 - **Direct webhooks** — Google Chat sends a signed JWT in the `Authorization: Bearer …` header. The expected `aud` claim depends on how the Chat app is configured (see [Verify requests from Google Chat](https://developers.google.com/workspace/chat/verify-requests-from-chat)).
-- **Pub/Sub push** — Cloud Pub/Sub sends a signed OIDC JWT whose audience is whatever you configured on the push subscription. Configure with `pubsubAudience`.
+- **Pub/Sub push** — Cloud Pub/Sub sends a signed OIDC JWT whose audience is whatever you configured on the push subscription. Configure with `pubsubAudience` **and** `pubsubServiceAccountEmail`.
+
+<Callout type="warn">
+Your push audience is a public URL, so anyone can point a Pub/Sub subscription in their own Google Cloud project at your endpoint and have Google mint a validly signed token naming it. Signature and `aud` therefore say nothing about who sent the push. Set `pubsubServiceAccountEmail` to the identity in your subscription's push auth settings and the adapter compares it exactly, as [Google requires](https://docs.cloud.google.com/pubsub/docs/authenticate-push-subscriptions). Leave it unset and Pub/Sub pushes are rejected with HTTP 401.
+</Callout>
 
 If you only configure a direct-webhook verifier, incoming Pub/Sub-shaped requests are rejected with HTTP 401 — and vice versa. Configure both transports if you receive both.
 

--- a/packages/adapter-gchat/README.md
+++ b/packages/adapter-gchat/README.md
@@ -139,7 +139,8 @@ createGoogleChatAdapter({
 3. Select your topic
 4. Set **Delivery type** to Push
 5. Set **Endpoint URL** to `https://your-domain.com/api/webhooks/gchat`
-6. Click **Create**
+6. Check **Enable authentication** and pick a service account. This is what signs the OIDC token on each push, and its email is the value you set as `GOOGLE_CHAT_PUBSUB_SERVICE_ACCOUNT_EMAIL`
+7. Click **Create**
 
 ### 4. Enable domain-wide delegation
 
@@ -179,6 +180,7 @@ Most options are auto-detected from environment variables when not provided.
 | `useApplicationDefaultCredentials` | No | Use Application Default Credentials. Auto-detected from `GOOGLE_CHAT_USE_ADC` |
 | `pubsubTopic` | No | Pub/Sub topic for Workspace Events. Auto-detected from `GOOGLE_CHAT_PUBSUB_TOPIC` |
 | `pubsubAudience` | No† | Expected JWT audience for Pub/Sub webhook verification. Auto-detected from `GOOGLE_CHAT_PUBSUB_AUDIENCE` |
+| `pubsubServiceAccountEmail` | No§ | Service account your Pub/Sub push subscription authenticates as. Required to accept Pub/Sub pushes. Auto-detected from `GOOGLE_CHAT_PUBSUB_SERVICE_ACCOUNT_EMAIL` |
 | `googleChatProjectNumber` | No† | GCP project number for direct webhook JWT verification when the Chat app's authentication audience is "Project number". Auto-detected from `GOOGLE_CHAT_PROJECT_NUMBER` |
 | `endpointUrl` | No† | Public webhook URL for button click routing and direct webhook JWT verification when the Chat app's authentication audience is "HTTP endpoint URL". Must be passed in config |
 | `workspaceAddOnServiceAccountEmail` | No‡ | Your own `service-{projectNumber}@gcp-sa-gsuiteaddons.iam.gserviceaccount.com` identity. Required to accept Workspace Add-on Chat app webhooks. Auto-detected from `GOOGLE_CHAT_WORKSPACE_ADDON_SERVICE_ACCOUNT_EMAIL` |
@@ -191,6 +193,8 @@ Most options are auto-detected from environment variables when not provided.
 *Either `credentials`, `GOOGLE_CHAT_CREDENTIALS` env var, `useApplicationDefaultCredentials`, or `GOOGLE_CHAT_USE_ADC=true` is required.
 
 †One of `googleChatProjectNumber`, `endpointUrl`, `pubsubAudience`, or `disableSignatureVerification: true` is required — the constructor throws otherwise. Configure the verifier(s) for each transport you actually receive; requests of a shape whose verifier is unconfigured are rejected with HTTP 401.
+
+§Required alongside `pubsubAudience`. The audience is your public push endpoint, so anyone can have Google mint a validly signed token naming it from their own project. Only the `email` claim identifies the caller, which is why [Google requires checking it](https://docs.cloud.google.com/pubsub/docs/authenticate-push-subscriptions) in addition to `aud`. Without it, Pub/Sub pushes are rejected with HTTP 401 rather than trusted on their audience alone.
 
 ‡Only Workspace Add-on Chat apps need this. Their webhooks are signed by an add-on service identity rather than `chat@system.gserviceaccount.com`, and every add-on project shares the same `service-{projectNumber}@gcp-sa-gsuiteaddons` email shape — so the identity is only meaningful compared exactly. Without it, add-on tokens are rejected with HTTP 401 rather than trusted by shape. Standalone Chat apps are unaffected.
 
@@ -206,6 +210,7 @@ GOOGLE_CHAT_IMPERSONATE_USER=admin@yourdomain.com
 # Webhook verification — at least one verifier or the explicit opt-out is required
 GOOGLE_CHAT_PROJECT_NUMBER=123456789          # Direct webhooks with project-number audience
 GOOGLE_CHAT_PUBSUB_AUDIENCE=https://your-domain.com/api/webhooks/gchat  # For Pub/Sub JWT verification
+GOOGLE_CHAT_PUBSUB_SERVICE_ACCOUNT_EMAIL=pubsub@your-project.iam.gserviceaccount.com  # Push subscription identity
 # Workspace Add-on Chat apps only — your own add-on service identity
 GOOGLE_CHAT_WORKSPACE_ADDON_SERVICE_ACCOUNT_EMAIL=service-123456789@gcp-sa-gsuiteaddons.iam.gserviceaccount.com
 # GOOGLE_CHAT_DISABLE_SIGNATURE_VERIFICATION=true  # Escape hatch for local dev only
@@ -222,7 +227,7 @@ Verification is required. The constructor throws `ValidationError` unless one of
 
 - `googleChatProjectNumber` (or `GOOGLE_CHAT_PROJECT_NUMBER`) — direct webhooks when the Chat app's authentication audience is "Project number"
 - `endpointUrl` — direct webhooks when the Chat app's authentication audience is "HTTP endpoint URL"; also required for routing card button clicks in HTTP endpoint apps. Workspace Add-on Chat apps additionally need `workspaceAddOnServiceAccountEmail`, since their tokens are signed by an add-on identity instead of `chat@system.gserviceaccount.com`
-- `pubsubAudience` (or `GOOGLE_CHAT_PUBSUB_AUDIENCE`) — Pub/Sub push deliveries
+- `pubsubAudience` (or `GOOGLE_CHAT_PUBSUB_AUDIENCE`) — Pub/Sub push deliveries. Also set `pubsubServiceAccountEmail` (or `GOOGLE_CHAT_PUBSUB_SERVICE_ACCOUNT_EMAIL`) to the identity in your subscription's push auth settings, or pushes are rejected
 - `disableSignatureVerification: true` (or `GOOGLE_CHAT_DISABLE_SIGNATURE_VERIFICATION=true`) — explicit opt-out, intended for local development only
 
 The two transports share one HTTP endpoint, so each verifier only covers its own request shape. If you only configure a direct-webhook verifier, incoming Pub/Sub-shaped requests are rejected with HTTP 401, and vice versa — configure both if you receive both.

--- a/packages/adapter-gchat/src/index.test.ts
+++ b/packages/adapter-gchat/src/index.test.ts
@@ -146,6 +146,7 @@ async function createInitializedAdapter(opts?: {
   googleChatProjectNumber?: string;
   pubsubAudience?: string;
   workspaceAddOnServiceAccountEmail?: string;
+  pubsubServiceAccountEmail?: string;
 }) {
   const adapter = createGoogleChatAdapter({
     credentials: TEST_CREDENTIALS,
@@ -156,6 +157,7 @@ async function createInitializedAdapter(opts?: {
     googleChatProjectNumber: opts?.googleChatProjectNumber,
     pubsubAudience: opts?.pubsubAudience,
     workspaceAddOnServiceAccountEmail: opts?.workspaceAddOnServiceAccountEmail,
+    pubsubServiceAccountEmail: opts?.pubsubServiceAccountEmail,
   });
   const mockState = createMockStateAdapter();
   const mockChat = createMockChatInstance({ state: mockState });
@@ -3455,11 +3457,13 @@ describe("GoogleChatAdapter", () => {
           iss: "accounts.google.com",
           aud: "https://example.com/webhook/pubsub",
           email: "pubsub@my-project.iam.gserviceaccount.com",
+          email_verified: true,
         }),
       });
 
       const { adapter } = await createInitializedAdapter({
         pubsubAudience: "https://example.com/webhook/pubsub",
+        pubsubServiceAccountEmail: "pubsub@my-project.iam.gserviceaccount.com",
       });
 
       const pubsubMessage = makePubSubPushMessage({
@@ -3482,6 +3486,83 @@ describe("GoogleChatAdapter", () => {
 
       const response = await adapter.handleWebhook(request);
       expect(response.status).toBe(200);
+    });
+
+    async function pubsubWebhook(
+      payload: Record<string, unknown>,
+      pubsubServiceAccountEmail?: string
+    ) {
+      verifyIdTokenSpy.mockResolvedValue({
+        getPayload: () => ({
+          iss: "accounts.google.com",
+          aud: "https://example.com/webhook/pubsub",
+          ...payload,
+        }),
+      });
+      const { adapter } = await createInitializedAdapter({
+        pubsubAudience: "https://example.com/webhook/pubsub",
+        pubsubServiceAccountEmail,
+      });
+      return adapter.handleWebhook(
+        new Request("https://example.com/webhook", {
+          method: "POST",
+          headers: {
+            "content-type": "application/json",
+            authorization: "Bearer valid-pubsub-jwt",
+          },
+          body: JSON.stringify(
+            makePubSubPushMessage({
+              message: {
+                name: "spaces/ABC123/messages/msg1",
+                text: "Hello",
+                sender: {
+                  name: "users/100",
+                  displayName: "User",
+                  type: "HUMAN",
+                },
+                createTime: new Date().toISOString(),
+              },
+            })
+          ),
+        })
+      );
+    }
+
+    const PUSH_SA = "pubsub@my-project.iam.gserviceaccount.com";
+
+    it("should reject a Pub/Sub token from a different service account", async () => {
+      // The audience is the victim's public push URL, so anyone can mint a
+      // Google-signed token for it from their own project. Only the email
+      // claim identifies the caller.
+      const response = await pubsubWebhook(
+        {
+          email: "attacker@evil-project.iam.gserviceaccount.com",
+          email_verified: true,
+        },
+        PUSH_SA
+      );
+      expect(response.status).toBe(401);
+    });
+
+    it("should reject a Pub/Sub token when no service account is configured", async () => {
+      const response = await pubsubWebhook({
+        email: PUSH_SA,
+        email_verified: true,
+      });
+      expect(response.status).toBe(401);
+    });
+
+    it("should reject a Pub/Sub token when email_verified is not true", async () => {
+      const response = await pubsubWebhook(
+        { email: PUSH_SA, email_verified: false },
+        PUSH_SA
+      );
+      expect(response.status).toBe(401);
+    });
+
+    it("should reject a Pub/Sub token with no email claim", async () => {
+      const response = await pubsubWebhook({ email_verified: true }, PUSH_SA);
+      expect(response.status).toBe(401);
     });
 
     it("should reject request with non-Bearer Authorization scheme", async () => {

--- a/packages/adapter-gchat/src/index.ts
+++ b/packages/adapter-gchat/src/index.ts
@@ -253,6 +253,8 @@ export class GoogleChatAdapter implements Adapter<GoogleChatThreadId, unknown> {
   protected readonly pubsubAudience?: string;
   /** Exact service account identity of this app's Workspace Add-on, if any */
   protected readonly workspaceAddOnServiceAccountEmail?: string;
+  /** Service account the Pub/Sub push subscription authenticates as */
+  protected readonly pubsubServiceAccountEmail?: string;
   /** Explicit opt-in to skip JWT verification (fail-open). */
   protected readonly disableSignatureVerification: boolean;
   /** OAuth2 client for verifying Google-signed JWTs */
@@ -282,6 +284,9 @@ export class GoogleChatAdapter implements Adapter<GoogleChatThreadId, unknown> {
     this.workspaceAddOnServiceAccountEmail =
       config.workspaceAddOnServiceAccountEmail ??
       process.env.GOOGLE_CHAT_WORKSPACE_ADDON_SERVICE_ACCOUNT_EMAIL;
+    this.pubsubServiceAccountEmail =
+      config.pubsubServiceAccountEmail ??
+      process.env.GOOGLE_CHAT_PUBSUB_SERVICE_ACCOUNT_EMAIL;
     this.disableSignatureVerification =
       config.disableSignatureVerification ??
       process.env.GOOGLE_CHAT_DISABLE_SIGNATURE_VERIFICATION === "true";
@@ -662,7 +667,10 @@ export class GoogleChatAdapter implements Adapter<GoogleChatThreadId, unknown> {
   protected async verifyBearerToken(
     request: Request,
     expectedAudience: string,
-    validatePayload?: (payload: {
+    // Required, not optional: a Google-signed token with the right `aud`
+    // proves nothing about who sent it, since our audiences are public. Every
+    // caller must say which identity it expects.
+    validatePayload: (payload: {
       aud?: string | string[];
       email?: string;
       email_verified?: boolean;
@@ -690,7 +698,7 @@ export class GoogleChatAdapter implements Adapter<GoogleChatThreadId, unknown> {
         aud: payload.aud,
         email: payload.email,
       });
-      if (validatePayload && !validatePayload(payload)) {
+      if (!validatePayload(payload)) {
         this.logger.warn("JWT payload failed claim validation", {
           iss: payload.iss,
           aud: payload.aud,
@@ -747,6 +755,35 @@ export class GoogleChatAdapter implements Adapter<GoogleChatThreadId, unknown> {
       return false;
     }
     return payload.email === this.workspaceAddOnServiceAccountEmail;
+  }
+
+  /**
+   * Claim validation for Pub/Sub push tokens. The audience is our public push
+   * endpoint, so anyone can have Google mint a validly signed token for it
+   * from their own project. Signature and `aud` therefore say nothing about
+   * who sent the push: only `email` identifies the caller, which is why
+   * Google requires checking it alongside `aud`.
+   *
+   * Fail-closed when no identity is configured, rather than trusting any
+   * Google-signed token that happens to name our audience.
+   *
+   * @see https://docs.cloud.google.com/pubsub/docs/authenticate-push-subscriptions
+   */
+  private validatePubsubTokenPayload(payload: {
+    email?: string;
+    email_verified?: boolean;
+  }): boolean {
+    if (payload.email_verified !== true || !payload.email) {
+      return false;
+    }
+    if (!this.pubsubServiceAccountEmail) {
+      this.logger.warn(
+        "Rejected a Pub/Sub push because no push identity is configured. Set `pubsubServiceAccountEmail` (or GOOGLE_CHAT_PUBSUB_SERVICE_ACCOUNT_EMAIL) to the service account in your subscription's push auth settings.",
+        { email: payload.email }
+      );
+      return false;
+    }
+    return payload.email === this.pubsubServiceAccountEmail;
   }
 
   private async getChatIssuerCerts(): Promise<Record<string, string>> {
@@ -885,7 +922,8 @@ export class GoogleChatAdapter implements Adapter<GoogleChatThreadId, unknown> {
       if (this.pubsubAudience) {
         const valid = await this.verifyBearerToken(
           request,
-          this.pubsubAudience
+          this.pubsubAudience,
+          (payload) => this.validatePubsubTokenPayload(payload)
         );
         if (!valid) {
           return new Response("Unauthorized", { status: 401 });

--- a/packages/adapter-gchat/src/types.ts
+++ b/packages/adapter-gchat/src/types.ts
@@ -70,6 +70,21 @@ export interface GoogleChatAdapterBaseConfig {
    */
   pubsubAudience?: string;
   /**
+   * Service account your Pub/Sub push subscription authenticates as, the
+   * identity set in the subscription's push auth settings.
+   *
+   * The audience is your public push endpoint, so anyone can have Google mint
+   * a validly signed token for it from their own project. Only the `email`
+   * claim identifies the caller, which is why Google requires checking it in
+   * addition to `aud`. Without this option Pub/Sub pushes are rejected rather
+   * than trusted on their audience alone.
+   *
+   * Defaults to GOOGLE_CHAT_PUBSUB_SERVICE_ACCOUNT_EMAIL env var.
+   *
+   * @see https://docs.cloud.google.com/pubsub/docs/authenticate-push-subscriptions
+   */
+  pubsubServiceAccountEmail?: string;
+  /**
    * Pub/Sub topic for receiving all messages via Workspace Events.
    * When set, the adapter will automatically create subscriptions when added to a space.
    * Format: "projects/my-project/topics/my-topic"

--- a/packages/chat/src/adapters/index.ts
+++ b/packages/chat/src/adapters/index.ts
@@ -362,6 +362,10 @@ export const ADAPTERS = {
           "Audience used for Workspace Events push verification."
         ),
         env(
+          "GOOGLE_CHAT_PUBSUB_SERVICE_ACCOUNT_EMAIL",
+          "Service account your Pub/Sub push subscription authenticates as. Required to accept Pub/Sub pushes."
+        ),
+        env(
           "GOOGLE_CHAT_WORKSPACE_ADDON_SERVICE_ACCOUNT_EMAIL",
           "Your Workspace Add-on service account identity. Required to accept add-on webhooks."
         ),


### PR DESCRIPTION
## summary

Pub/Sub push verification checked the token's `aud` and nothing else. [Google's guidance](https://docs.cloud.google.com/pubsub/docs/authenticate-push-subscriptions) is explicit that signature and audience verification are not sufficient on their own, and that the `email` and `email_verified` claims must be checked alongside them

adds `pubsubServiceAccountEmail` (env `GOOGLE_CHAT_PUBSUB_SERVICE_ACCOUNT_EMAIL`), the identity in the subscription's push auth settings. a push is accepted only when `email_verified` is true and `email` matches exactly. when the option is unset, pushes are rejected rather than trusted on their audience alone

direct webhooks are untouched, and the project-number path already bound to an exact issuer

### how it happened

`verifyBearerToken` took the claim validator as an optional parameter, so a call site could simply omit it, and the Pub/Sub one did while the direct-webhook one did not. that is now required:

```diff
-    validatePayload?: (payload: {
+    validatePayload: (payload: {
```

both call sites pass one and the type system enforces it, so the omission cannot recur

## test plan

- a token from a different service account is rejected
- a token is rejected when no identity is configured
- a token is rejected when `email_verified` is not true
- a token with no `email` claim is rejected
- a matching identity with a verified email is accepted
- direct-webhook and project-number verification are unchanged

docs cover the new option in the README and adapter page, including the push-subscription authentication step that produces the token
