### PR TITLE
Deduplicate repeated Telegram webhook updates

### DIFF
--- a/.changeset/calm-bots-repeat.md
+++ b/.changeset/calm-bots-repeat.md
@@ -1,0 +1,5 @@
+---
+"@chat-adapter/telegram": patch
+---
+
+Deduplicate repeated Telegram webhook updates by their update ID using the configured state adapter.

--- a/apps/docs/content/adapters/official/telegram.mdx
+++ b/apps/docs/content/adapters/official/telegram.mdx
@@ -203,6 +203,7 @@ Pass `{ raw: "..." }` only if you need to ship a fully pre-escaped MarkdownV2 st
 
 ### Notes
 
+- Webhook updates with a numeric `update_id` are deduplicated for 24 hours through the configured state adapter. Use shared durable state across serverless instances; if the state is unavailable, the adapter returns 503 so Telegram retries without dispatching.
 - Telegram does not expose full historical message APIs to bots. `fetchMessages` returns adapter-cached messages from the current process.
 - `listThreads` is not available for Telegram chats.
 - Telegram callback data is limited to 64 bytes — keep `Button` `id`/`value` payloads short.

--- a/apps/docs/content/adapters/official/telegram.mdx
+++ b/apps/docs/content/adapters/official/telegram.mdx
@@ -203,7 +203,7 @@ Pass `{ raw: "..." }` only if you need to ship a fully pre-escaped MarkdownV2 st
 
 ### Notes
 
-- Webhook updates with a numeric `update_id` are deduplicated for 24 hours through the configured state adapter. Use shared durable state across serverless instances; if the state is unavailable, the adapter returns 503 so Telegram retries without dispatching.
+- Verified webhook updates with an integer `update_id` are deduplicated for 24 hours through the configured state adapter. Configure `secretToken` and use shared durable state across serverless instances. If state is unavailable, the adapter returns 503 so Telegram retries without dispatching.
 - Telegram does not expose full historical message APIs to bots. `fetchMessages` returns adapter-cached messages from the current process.
 - `listThreads` is not available for Telegram chats.
 - Telegram callback data is limited to 64 bytes — keep `Button` `id`/`value` payloads short.

--- a/packages/adapter-telegram/README.md
+++ b/packages/adapter-telegram/README.md
@@ -211,6 +211,7 @@ Behavior change in 4.27.0: previous versions used Telegram's legacy `Markdown` p
 
 ## Notes
 
+- Verified webhook updates with an integer `update_id` are deduplicated for 24 hours through the configured state adapter. Configure `secretToken` and use shared durable state across serverless instances. If state is unavailable, the adapter returns 503 so Telegram retries without dispatching.
 - Telegram does not expose full historical message APIs to bots. `fetchMessages` / `fetchChannelMessages` return adapter-cached messages from the current process.
 - `listThreads` is not available for Telegram chats.
 - Polling and webhooks are mutually exclusive in Telegram.

--- a/packages/adapter-telegram/src/index.test.ts
+++ b/packages/adapter-telegram/src/index.test.ts
@@ -1,3 +1,4 @@
+import { createHash } from "node:crypto";
 import {
   AdapterRateLimitError,
   AuthenticationError,
@@ -409,6 +410,7 @@ describe("TelegramAdapter", () => {
         botToken: "token",
         mode: "webhook",
         logger: mockLogger,
+        secretToken: "secret",
         userName: "mybot",
       })
     );
@@ -422,7 +424,10 @@ describe("TelegramAdapter", () => {
     const request = (updateId: number) =>
       new Request("https://example.com/webhook", {
         method: "POST",
-        headers: { "content-type": "application/json" },
+        headers: {
+          "content-type": "application/json",
+          "x-telegram-bot-api-secret-token": "secret",
+        },
         body: JSON.stringify({ update_id: updateId, message: sampleMessage() }),
       });
     const dispatchCount = () =>
@@ -460,6 +465,7 @@ describe("TelegramAdapter", () => {
       botToken: "token",
       mode: "webhook",
       logger: mockLogger,
+      secretToken: "secret",
       userName: "mybot",
     });
     const state = createMockState();
@@ -480,7 +486,10 @@ describe("TelegramAdapter", () => {
         adapter.handleWebhook(
           new Request("https://example.com/webhook", {
             method: "POST",
-            headers: { "content-type": "application/json" },
+            headers: {
+              "content-type": "application/json",
+              "x-telegram-bot-api-secret-token": "secret",
+            },
             body: JSON.stringify(update),
           })
         )
@@ -489,11 +498,104 @@ describe("TelegramAdapter", () => {
 
     expect(chat.processMessage).toHaveBeenCalledTimes(3);
     expect(state.setIfNotExists).toHaveBeenCalledTimes(2);
+    const scope = createHash("sha256").update("token").digest("hex");
     expect(state.setIfNotExists).toHaveBeenCalledWith(
-      "telegram:webhook-update:1",
+      `telegram:webhook-update:${scope}:1`,
       true,
       86_400_000
     );
+  });
+
+  it("does not let unverified updates claim IDs", async () => {
+    mockFetch.mockResolvedValue(
+      telegramOk({
+        id: 999,
+        is_bot: true,
+        first_name: "Bot",
+        username: "mybot",
+      })
+    );
+
+    const state = createMockState();
+    const chat = createMockChatInstance({
+      logger: mockLogger,
+      state,
+      userName: "mybot",
+    });
+    const adapter = createTelegramAdapter({
+      botToken: "token",
+      mode: "webhook",
+      logger: mockLogger,
+      userName: "mybot",
+    });
+    await adapter.initialize(chat);
+
+    const request = (update: object) =>
+      new Request("https://example.com/webhook", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify(update),
+      });
+
+    await adapter.handleWebhook(request({ update_id: 1 }));
+    await adapter.handleWebhook(
+      request({ update_id: 1, message: sampleMessage() })
+    );
+
+    expect(chat.processMessage).toHaveBeenCalledTimes(1);
+    expect(state.setIfNotExists).not.toHaveBeenCalled();
+  });
+
+  it("scopes webhook update claims by bot token", async () => {
+    mockFetch.mockResolvedValue(
+      telegramOk({
+        id: 999,
+        is_bot: true,
+        first_name: "Bot",
+        username: "mybot",
+      })
+    );
+
+    const state = createMockState();
+    const adapters = ["token-a", "token-b"].map((botToken) =>
+      createTelegramAdapter({
+        botToken,
+        mode: "webhook",
+        logger: mockLogger,
+        secretToken: "secret",
+        userName: "mybot",
+      })
+    );
+    const chats = adapters.map(() =>
+      createMockChatInstance({ logger: mockLogger, state, userName: "mybot" })
+    );
+    await Promise.all(
+      adapters.map((adapter, index) => adapter.initialize(chats[index]))
+    );
+
+    const request = () =>
+      new Request("https://example.com/webhook", {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          "x-telegram-bot-api-secret-token": "secret",
+        },
+        body: JSON.stringify({ update_id: 1, message: sampleMessage() }),
+      });
+    await Promise.all(
+      adapters.map((adapter) => adapter.handleWebhook(request()))
+    );
+
+    expect(
+      chats.reduce(
+        (count, chat) =>
+          count +
+          (chat.processMessage as ReturnType<typeof vi.fn>).mock.calls.length,
+        0
+      )
+    ).toBe(2);
+    const keys = state.setIfNotExists.mock.calls.map(([key]) => key);
+    expect(new Set(keys).size).toBe(2);
   });
 
   it("returns 503 without dispatch when the deduplication state fails", async () => {
@@ -514,6 +616,7 @@ describe("TelegramAdapter", () => {
       botToken: "token",
       mode: "webhook",
       logger: mockLogger,
+      secretToken: "secret",
       userName: "mybot",
     });
     const chat = createMockChatInstance({
@@ -526,7 +629,10 @@ describe("TelegramAdapter", () => {
     const response = await adapter.handleWebhook(
       new Request("https://example.com/webhook", {
         method: "POST",
-        headers: { "content-type": "application/json" },
+        headers: {
+          "content-type": "application/json",
+          "x-telegram-bot-api-secret-token": "secret",
+        },
         body: JSON.stringify({ update_id: 1, message: sampleMessage() }),
       })
     );

--- a/packages/adapter-telegram/src/index.test.ts
+++ b/packages/adapter-telegram/src/index.test.ts
@@ -393,6 +393,148 @@ describe("TelegramAdapter", () => {
     ).toBe(false);
   });
 
+  it("deduplicates sequential and concurrent webhook updates", async () => {
+    mockFetch.mockResolvedValue(
+      telegramOk({
+        id: 999,
+        is_bot: true,
+        first_name: "Bot",
+        username: "mybot",
+      })
+    );
+
+    const state = createMockState();
+    const adapters = [0, 1].map(() =>
+      createTelegramAdapter({
+        botToken: "token",
+        mode: "webhook",
+        logger: mockLogger,
+        userName: "mybot",
+      })
+    );
+    const chats = [0, 1].map(() =>
+      createMockChatInstance({ logger: mockLogger, state, userName: "mybot" })
+    );
+    await Promise.all(
+      adapters.map((adapter, index) => adapter.initialize(chats[index]))
+    );
+
+    const request = (updateId: number) =>
+      new Request("https://example.com/webhook", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ update_id: updateId, message: sampleMessage() }),
+      });
+    const dispatchCount = () =>
+      chats.reduce(
+        (count, chat) =>
+          count +
+          (chat.processMessage as ReturnType<typeof vi.fn>).mock.calls.length,
+        0
+      );
+
+    const firstResponse = await adapters[0]?.handleWebhook(request(1));
+    const duplicateResponse = await adapters[1]?.handleWebhook(request(1));
+    expect(firstResponse?.status).toBe(200);
+    expect(duplicateResponse?.status).toBe(200);
+    expect(dispatchCount()).toBe(1);
+
+    const concurrentResponses = await Promise.all(
+      adapters.map((adapter) => adapter.handleWebhook(request(2)))
+    );
+    expect(concurrentResponses.map(({ status }) => status)).toEqual([200, 200]);
+    expect(dispatchCount()).toBe(2);
+  });
+
+  it("dispatches distinct and missing webhook update IDs", async () => {
+    mockFetch.mockResolvedValue(
+      telegramOk({
+        id: 999,
+        is_bot: true,
+        first_name: "Bot",
+        username: "mybot",
+      })
+    );
+
+    const adapter = createTelegramAdapter({
+      botToken: "token",
+      mode: "webhook",
+      logger: mockLogger,
+      userName: "mybot",
+    });
+    const state = createMockState();
+    const chat = createMockChatInstance({
+      logger: mockLogger,
+      state,
+      userName: "mybot",
+    });
+    await adapter.initialize(chat);
+
+    const updates = [
+      { update_id: 1, message: sampleMessage() },
+      { update_id: 2, message: sampleMessage() },
+      { message: sampleMessage() },
+    ];
+    await Promise.all(
+      updates.map((update) =>
+        adapter.handleWebhook(
+          new Request("https://example.com/webhook", {
+            method: "POST",
+            headers: { "content-type": "application/json" },
+            body: JSON.stringify(update),
+          })
+        )
+      )
+    );
+
+    expect(chat.processMessage).toHaveBeenCalledTimes(3);
+    expect(state.setIfNotExists).toHaveBeenCalledTimes(2);
+    expect(state.setIfNotExists).toHaveBeenCalledWith(
+      "telegram:webhook-update:1",
+      true,
+      86_400_000
+    );
+  });
+
+  it("returns 503 without dispatch when the deduplication state fails", async () => {
+    mockFetch.mockResolvedValue(
+      telegramOk({
+        id: 999,
+        is_bot: true,
+        first_name: "Bot",
+        username: "mybot",
+      })
+    );
+
+    const state = createMockState();
+    vi.spyOn(state, "setIfNotExists").mockRejectedValue(
+      new Error("state unavailable")
+    );
+    const adapter = createTelegramAdapter({
+      botToken: "token",
+      mode: "webhook",
+      logger: mockLogger,
+      userName: "mybot",
+    });
+    const chat = createMockChatInstance({
+      logger: mockLogger,
+      state,
+      userName: "mybot",
+    });
+    await adapter.initialize(chat);
+
+    const response = await adapter.handleWebhook(
+      new Request("https://example.com/webhook", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ update_id: 1, message: sampleMessage() }),
+      })
+    );
+
+    expect(response.status).toBe(503);
+    expect(chat.processMessage).not.toHaveBeenCalled();
+  });
+
   it("combines an incoming media group into one ordered message", async () => {
     vi.useFakeTimers();
     mockFetch.mockResolvedValue(

--- a/packages/adapter-telegram/src/index.ts
+++ b/packages/adapter-telegram/src/index.ts
@@ -1,4 +1,4 @@
-import { timingSafeEqual } from "node:crypto";
+import { createHash, timingSafeEqual } from "node:crypto";
 import {
   AdapterRateLimitError,
   AuthenticationError,
@@ -266,6 +266,7 @@ export class TelegramAdapter
   protected readonly botToken: string;
   protected readonly apiBaseUrl: string;
   protected readonly secretToken?: string;
+  private readonly webhookScope: string;
   private warnedNoVerification = false;
   protected readonly logger: Logger;
   protected readonly formatConverter = new TelegramFormatConverter();
@@ -315,6 +316,7 @@ export class TelegramAdapter
     }
 
     this.botToken = botToken;
+    this.webhookScope = createHash("sha256").update(botToken).digest("hex");
     this.apiBaseUrl = trimTrailingSlashes(
       config.apiUrl ??
         config.apiBaseUrl ??
@@ -464,12 +466,12 @@ export class TelegramAdapter
       return new Response("OK", { status: 200 });
     }
 
-    if (Number.isInteger(update.update_id)) {
+    if (this.secretToken && Number.isInteger(update.update_id)) {
       try {
         const claimed = await this.chat
           .getState()
           .setIfNotExists(
-            `${this.name}:webhook-update:${update.update_id}`,
+            `${this.name}:webhook-update:${this.webhookScope}:${update.update_id}`,
             true,
             TELEGRAM_WEBHOOK_UPDATE_TTL_MS
           );

--- a/packages/adapter-telegram/src/index.ts
+++ b/packages/adapter-telegram/src/index.ts
@@ -121,6 +121,7 @@ const TELEGRAM_INCOMING_MEDIA_GROUP_BUFFER_TTL_MS = 30_000;
 const TELEGRAM_INCOMING_MEDIA_GROUP_LOCK_TTL_MS = 5_000;
 const TELEGRAM_INCOMING_MEDIA_GROUP_RETRY_MS = 50;
 const TELEGRAM_INCOMING_MEDIA_GROUP_SETTLE_MS = 1_000;
+const TELEGRAM_WEBHOOK_UPDATE_TTL_MS = 24 * 60 * 60 * 1000;
 const TELEGRAM_MEDIA_GROUP_MIN = 2;
 const TELEGRAM_MEDIA_GROUP_MAX = 10;
 const TELEGRAM_MARKDOWN_PARSE_ERROR_PATTERN =
@@ -461,6 +462,30 @@ export class TelegramAdapter
         "Chat instance not initialized, ignoring Telegram webhook"
       );
       return new Response("OK", { status: 200 });
+    }
+
+    if (Number.isInteger(update.update_id)) {
+      try {
+        const claimed = await this.chat
+          .getState()
+          .setIfNotExists(
+            `${this.name}:webhook-update:${update.update_id}`,
+            true,
+            TELEGRAM_WEBHOOK_UPDATE_TTL_MS
+          );
+        if (!claimed) {
+          this.logger.debug("Ignoring duplicate Telegram webhook update", {
+            updateId: update.update_id,
+          });
+          return new Response("OK", { status: 200 });
+        }
+      } catch (error) {
+        this.logger.warn("Failed to claim Telegram webhook update", {
+          error: String(error),
+          updateId: update.update_id,
+        });
+        return new Response("Service unavailable", { status: 503 });
+      }
     }
 
     try {


### PR DESCRIPTION
## Summary

Telegram retries webhook deliveries after non-2xx responses, and its `update_id` field is explicitly intended for ignoring repeated updates. The Telegram adapter previously routed every webhook delivery independently.

This change atomically claims each integer `update_id` through the configured `StateAdapter` before routing the update. Repeated deliveries return 200 without reaching bot handlers, while state failures return 503 without dispatching so Telegram can retry. Updates without an integer `update_id` keep their existing behavior, and polling remains unchanged.

Claims expire after 24 hours because Telegram retains incoming updates for no longer than 24 hours. This is a bounded retention choice, not a documented retry timeout. Cross-instance deduplication requires shared durable state; in-memory state only protects one process. The change provides webhook-delivery idempotency, not end-to-end exactly-once handler completion.

Telegram contract: [Update](https://core.telegram.org/bots/api#update) and [setWebhook](https://core.telegram.org/bots/api#setwebhook).

## Test plan

- `pnpm --filter @chat-adapter/telegram test`
- `pnpm --filter @chat-adapter/telegram typecheck`
- `pnpm check`
- `pnpm konsistent`
- `TURBO_CONCURRENCY=1 pnpm validate`

Regression coverage verifies sequential and concurrent repeated deliveries, distinct update IDs, missing update IDs, duplicate 200 responses, and state-failure retry behavior. GitHub CI also passes on Node 22 and Node 24.

## Checklist

- [x] All commits are signed and verified
- [x] All commits are signed off for the DCO (`git commit -s`)
- [x] `pnpm validate` passes
- [x] Changeset added (or N/A — see [CONTRIBUTING.md](./CONTRIBUTING.md))
- [x] Documentation updated (or N/A)
