### PR TITLE
fix(discord): restore forwarded attachment downloads

### DIFF
--- a/.changeset/discord-forwarded-attachments.md
+++ b/.changeset/discord-forwarded-attachments.md
@@ -1,0 +1,5 @@
+---
+"@chat-adapter/discord": patch
+---
+
+Restore attachment downloads for forwarded Discord Gateway messages.

--- a/.changeset/discord-forwarded-attachments.md
+++ b/.changeset/discord-forwarded-attachments.md
@@ -2,4 +2,4 @@
 "@chat-adapter/discord": patch
 ---
 
-Restore attachment downloads for forwarded Discord Gateway messages.
+Restore attachment downloads across Discord inbound message paths.

--- a/packages/adapter-discord/src/index.test.ts
+++ b/packages/adapter-discord/src/index.test.ts
@@ -1055,6 +1055,7 @@ describe("parseMessage", () => {
     expect(message.attachments?.[0].mimeType).toBe("image/png");
     expect(message.attachments?.[0].width).toBe(800);
     expect(message.attachments?.[0].height).toBe(600);
+    expect(message.attachments?.[0].fetchData).toEqual(expect.any(Function));
   });
 
   it("handles different attachment types", () => {
@@ -3707,7 +3708,14 @@ describe("legacy gateway interactions", () => {
       channel: { isThread: () => false },
       createdAt: new Date("2021-01-01T00:00:00.000Z"),
       editedAt: null,
-      attachments: [],
+      attachments: [
+        {
+          contentType: "audio/ogg",
+          url: "https://cdn.discordapp.com/attachments/1/2/voice.ogg",
+          name: "voice.ogg",
+          size: 1234,
+        },
+      ],
     });
     await waitForGatewayHandlers();
 
@@ -3719,7 +3727,12 @@ describe("legacy gateway interactions", () => {
     expect(chat.handleIncomingMessage).toHaveBeenCalledWith(
       adapter,
       "discord:guild1:channel456:thread789",
-      expect.objectContaining({ isMention: true })
+      expect.objectContaining({
+        isMention: true,
+        attachments: [
+          expect.objectContaining({ fetchData: expect.any(Function) }),
+        ],
+      })
     );
   });
 

--- a/packages/adapter-discord/src/index.test.ts
+++ b/packages/adapter-discord/src/index.test.ts
@@ -3952,7 +3952,15 @@ describe("handleWebhook - forwarded gateway events", () => {
           bot: false,
         },
         mentions: [],
-        attachments: [],
+        attachments: [
+          {
+            id: "attachment123",
+            filename: "voice.ogg",
+            size: 1234,
+            url: "https://cdn.discordapp.com/attachments/1/2/voice.ogg",
+            content_type: "audio/ogg",
+          },
+        ],
       },
     });
 
@@ -3967,7 +3975,15 @@ describe("handleWebhook - forwarded gateway events", () => {
 
     const response = await adapter.handleWebhook(request);
     expect(response.status).toBe(200);
-    expect(chat.handleIncomingMessage).toHaveBeenCalled();
+    expect(chat.handleIncomingMessage).toHaveBeenCalledWith(
+      adapter,
+      expect.any(String),
+      expect.objectContaining({
+        attachments: [
+          expect.objectContaining({ fetchData: expect.any(Function) }),
+        ],
+      })
+    );
   });
 
   it("handles GATEWAY_MESSAGE_REACTION_ADD event", async () => {

--- a/packages/adapter-discord/src/index.ts
+++ b/packages/adapter-discord/src/index.ts
@@ -908,13 +908,15 @@ export class DiscordAdapter implements Adapter<DiscordThreadId, unknown> {
         dateSent: new Date(data.timestamp),
         edited: false,
       },
-      attachments: data.attachments.map((a) => ({
-        type: this.getAttachmentType(a.content_type),
-        url: a.url,
-        name: a.filename,
-        mimeType: a.content_type,
-        size: a.size,
-      })),
+      attachments: data.attachments.map((a) =>
+        this.rehydrateAttachment({
+          type: this.getAttachmentType(a.content_type),
+          url: a.url,
+          name: a.filename,
+          mimeType: a.content_type,
+          size: a.size,
+        })
+      ),
       raw: data,
       isMention: isMentioned,
     });

--- a/packages/adapter-discord/src/index.ts
+++ b/packages/adapter-discord/src/index.ts
@@ -1845,15 +1845,17 @@ export class DiscordAdapter implements Adapter<DiscordThreadId, unknown> {
           ? new Date(msg.edited_timestamp)
           : undefined,
       },
-      attachments: (msg.attachments || []).map((att) => ({
-        type: this.getAttachmentType(att.content_type),
-        url: att.url,
-        name: att.filename,
-        mimeType: att.content_type,
-        size: att.size,
-        width: att.width ?? undefined,
-        height: att.height ?? undefined,
-      })),
+      attachments: (msg.attachments || []).map((att) =>
+        this.rehydrateAttachment({
+          type: this.getAttachmentType(att.content_type),
+          url: att.url,
+          name: att.filename,
+          mimeType: att.content_type,
+          size: att.size,
+          width: att.width ?? undefined,
+          height: att.height ?? undefined,
+        })
+      ),
     });
   }
 
@@ -2421,13 +2423,15 @@ export class DiscordAdapter implements Adapter<DiscordThreadId, unknown> {
         edited: message.editedAt !== null,
         editedAt: message.editedAt ?? undefined,
       },
-      attachments: message.attachments.map((a) => ({
-        type: this.getAttachmentType(a.contentType),
-        url: a.url,
-        name: a.name,
-        mimeType: a.contentType ?? undefined,
-        size: a.size,
-      })),
+      attachments: message.attachments.map((a) =>
+        this.rehydrateAttachment({
+          type: this.getAttachmentType(a.contentType),
+          url: a.url,
+          name: a.name,
+          mimeType: a.contentType ?? undefined,
+          size: a.size,
+        })
+      ),
       raw: {
         id: message.id,
         channel_id: channelId,


### PR DESCRIPTION
## Summary

Discord inbound messages created attachment objects without `fetchData`, so consumers could not download audio or other attachments. The omission affected forwarded Gateway webhooks, REST and history parsing, and direct Discord.js Gateway messages.

Route attachments from all three inbound paths through the adapter's existing `rehydrateAttachment()` implementation. Existing parser and Gateway tests now assert that the resulting attachments are downloadable.

## Test plan

- `pnpm validate`
- `pnpm --filter @chat-adapter/discord test` — 278 tests passing
- `pnpm --filter @chat-adapter/discord typecheck`
- `pnpm --filter @chat-adapter/discord build`

## Checklist

- [x] All commits are signed and verified
- [x] All commits are signed off for the DCO (`git commit -s`)
- [x] `pnpm validate` passes
- [x] Changeset added
- [x] Documentation updated (N/A — no public API or configuration change)
