### PR TITLE
feat(chat): preserve replied-to message context

### DIFF
--- a/.changeset/calm-messages-reply.md
+++ b/.changeset/calm-messages-reply.md
@@ -1,0 +1,6 @@
+---
+"@chat-adapter/telegram": minor
+"chat": minor
+---
+
+Preserve normalized replied-to message context and populate it from Telegram replies.

--- a/apps/docs/content/docs/api/message.mdx
+++ b/apps/docs/content/docs/api/message.mdx
@@ -46,6 +46,10 @@ import { Message } from "chat";
       description: 'File attachments.',
       type: 'Attachment[]',
     },
+    replyTo: {
+      description: 'The normalized message this message replies to, when provided by the adapter.',
+      type: 'Message | undefined',
+    },
     links: {
       description: 'Links found in the message, with optional preview metadata.',
       type: 'LinkPreview[]',

--- a/apps/docs/content/docs/threads-messages-channels.mdx
+++ b/apps/docs/content/docs/threads-messages-channels.mdx
@@ -166,6 +166,7 @@ Incoming messages are normalized across platforms into a consistent format:
 | `author` | `Author` | Message author info |
 | `metadata` | `MessageMetadata` | Timestamps and edit status |
 | `attachments` | `Attachment[]` (optional) | File attachments |
+| `replyTo` | `Message` (optional) | Normalized message this message replies to, when provided by the adapter |
 | `isMention` | `boolean` (optional) | Whether the bot was @-mentioned |
 
 ### Author

--- a/packages/adapter-telegram/src/index.test.ts
+++ b/packages/adapter-telegram/src/index.test.ts
@@ -3343,6 +3343,41 @@ describe("TelegramAdapter", () => {
     expect(forward.nextCursor).toBe("123:2");
   });
 
+  it("parses replied-to message context", () => {
+    const adapter = createTelegramAdapter({
+      botToken: "token",
+      mode: "webhook",
+      logger: mockLogger,
+      userName: "mybot",
+    });
+    const parsed = adapter.parseMessage(
+      sampleMessage({
+        message_id: 12,
+        text: "reply",
+        reply_to_message: sampleMessage({
+          message_id: 11,
+          text: "original",
+          date: 1735689500,
+          from: {
+            id: 789,
+            is_bot: false,
+            first_name: "Original",
+            username: "original",
+          },
+        }),
+      })
+    );
+
+    expect(parsed.replyTo).toBeInstanceOf(Message);
+    expect(parsed.replyTo?.id).toBe("123:11");
+    expect(parsed.replyTo?.threadId).toBe("telegram:123");
+    expect(parsed.replyTo?.text).toBe("original");
+    expect(parsed.replyTo?.author.userName).toBe("original");
+    expect(parsed.replyTo?.metadata.dateSent).toEqual(
+      new Date(1735689500 * 1000)
+    );
+  });
+
   it("decodes structured callback payloads into action id and value", async () => {
     mockFetch
       .mockResolvedValueOnce(

--- a/packages/adapter-telegram/src/index.test.ts
+++ b/packages/adapter-telegram/src/index.test.ts
@@ -443,6 +443,10 @@ describe("TelegramAdapter", () => {
         media_group_id: "meal-album",
         text: undefined,
         caption: "/analyze both pieces",
+        reply_to_message: sampleMessage({
+          message_id: 40,
+          text: "original meal",
+        }),
         photo: [
           {
             file_id: "photo-1",
@@ -487,12 +491,14 @@ describe("TelegramAdapter", () => {
       {
         attachments: Array<{ fetchMetadata?: { fileId?: string } }>;
         id: string;
+        replyTo?: Message;
         text: string;
       },
     ];
     expect(threadId).toBe("telegram:123");
     expect(parsedMessage.id).toBe("123:42");
     expect(parsedMessage.text).toBe("/analyze both pieces");
+    expect(parsedMessage.replyTo?.text).toBe("original meal");
     expect(
       parsedMessage.attachments.map(
         (attachment) => attachment.fetchMetadata?.fileId

--- a/packages/adapter-telegram/src/index.ts
+++ b/packages/adapter-telegram/src/index.ts
@@ -763,6 +763,7 @@ export class TelegramAdapter
         author: latestMessage.author,
         metadata: latestMessage.metadata,
         attachments: parsedMessages.flatMap((message) => message.attachments),
+        replyTo: parsedMessages.find((message) => message.replyTo)?.replyTo,
         isMention: parsedMessages.some((message) => message.isMention),
         links: parsedMessages.flatMap((message) => message.links),
       });

--- a/packages/adapter-telegram/src/index.ts
+++ b/packages/adapter-telegram/src/index.ts
@@ -1842,6 +1842,9 @@ export class TelegramAdapter
             : undefined,
       },
       attachments: this.extractAttachments(raw),
+      replyTo: raw.reply_to_message
+        ? this.parseTelegramMessage(raw.reply_to_message, threadId)
+        : undefined,
       isMention: this.isBotMentioned(raw, plainText),
     });
 

--- a/packages/adapter-telegram/src/types.ts
+++ b/packages/adapter-telegram/src/types.ts
@@ -446,6 +446,7 @@ export interface TelegramMessage {
   message_id: number;
   message_thread_id?: number;
   photo?: TelegramPhotoSize[];
+  reply_to_message?: TelegramMessage;
   rich_message?: TelegramRichMessage;
   sender_chat?: TelegramChat;
   sticker?: TelegramFile & { emoji?: string };

--- a/packages/chat/src/chat.test.ts
+++ b/packages/chat/src/chat.test.ts
@@ -12,6 +12,7 @@ import { Chat } from "./chat";
 import { getEmoji } from "./emoji";
 import { LockError } from "./errors";
 import { jsx } from "./jsx-runtime";
+import { Message } from "./message";
 import {
   createMockAdapter,
   createMockState,
@@ -3767,6 +3768,13 @@ describe("Chat", () => {
         ...att,
         fetchData: mockFetchData,
       }));
+      const mockSubject = {
+        type: "issue",
+        id: "ENG-1",
+        title: "Original message subject",
+        raw: {},
+      };
+      adapter.fetchSubject = vi.fn().mockResolvedValue(mockSubject);
 
       const queueChat = new Chat({
         userName: "testbot",
@@ -3781,9 +3789,15 @@ describe("Chat", () => {
       );
 
       const receivedAttachments: unknown[] = [];
+      let receivedReplyTo: Message | undefined;
+      let receivedReplyToSubject: unknown;
       queueChat.onNewMention(
         vi.fn().mockImplementation(async (_thread, message) => {
           receivedAttachments.push(message.attachments);
+          if (message.replyTo) {
+            receivedReplyTo = message.replyTo;
+            receivedReplyToSubject = await message.replyTo.subject;
+          }
         })
       );
 
@@ -3800,6 +3814,17 @@ describe("Chat", () => {
             fetchData: () => Promise.resolve(Buffer.from("original")),
           },
         ],
+        replyTo: createTestMessage("msg-original", "Original", {
+          raw: { reply: true },
+          attachments: [
+            {
+              type: "file" as const,
+              name: "reply.pdf",
+              fetchMetadata: { url: "https://example.com/reply.pdf" },
+              fetchData: () => Promise.resolve(Buffer.from("original")),
+            },
+          ],
+        }),
       });
 
       await queueChat.handleIncomingMessage(
@@ -3833,6 +3858,10 @@ describe("Chat", () => {
       ) as { fetchData?: () => Promise<Buffer> }[];
       expect(queuedAttachments).toBeDefined();
       expect(queuedAttachments[0].fetchData).toBe(mockFetchData);
+      expect(receivedReplyTo).toBeInstanceOf(Message);
+      expect(receivedReplyTo?.attachments[0]?.fetchData).toBe(mockFetchData);
+      expect(receivedReplyToSubject).toEqual(mockSubject);
+      expect(adapter.fetchSubject).toHaveBeenCalledWith({ reply: true });
     });
 
     it("should skip rehydration for attachments that already have fetchData", async () => {

--- a/packages/chat/src/chat.ts
+++ b/packages/chat/src/chat.ts
@@ -2930,51 +2930,48 @@ export class Chat<
     raw: Message | Record<string, unknown>,
     adapter?: Adapter
   ): Message {
-    if (raw instanceof Message) {
-      if (adapter) {
-        setMessageAdapter(raw, adapter);
-      }
-      return raw;
-    }
-    // After JSON roundtrip, Message.toJSON() was called during stringify,
-    // so the shape matches SerializedMessage
-    const obj = raw as Record<string, unknown>;
     let msg: Message;
-    if (obj._type === "chat:Message") {
-      msg = Message.fromJSON(obj as unknown as SerializedMessage);
+    if (raw instanceof Message) {
+      msg = raw;
     } else {
-      // Fallback: plain object that wasn't serialized via toJSON (e.g., in-memory state)
-      // Reconstruct with defensive defaults
-      const metadata = obj.metadata as Record<string, unknown>;
-      const dateSent = metadata.dateSent;
-      const editedAt = metadata.editedAt;
-      msg = new Message({
-        id: obj.id as string,
-        threadId: obj.threadId as string,
-        text: obj.text as string,
-        formatted: obj.formatted as FormattedContent,
-        raw: obj.raw,
-        author: obj.author as Author,
-        metadata: {
-          dateSent:
-            dateSent instanceof Date ? dateSent : new Date(dateSent as string),
-          edited: metadata.edited as boolean,
-          editedAt: editedAt
-            ? new Date(
-                editedAt instanceof Date
-                  ? editedAt.toISOString()
-                  : (editedAt as string)
-              )
-            : undefined,
-        },
-        attachments: (obj.attachments as Attachment[]) ?? [],
-        isMention: obj.isMention as boolean | undefined,
-        links: (obj.links as LinkPreview[] | undefined) ?? [],
-      });
-    }
-
-    if (adapter) {
-      setMessageAdapter(msg, adapter);
+      // After JSON roundtrip, Message.toJSON() was called during stringify,
+      // so the shape matches SerializedMessage
+      const obj = raw as Record<string, unknown>;
+      if (obj._type === "chat:Message") {
+        msg = Message.fromJSON(obj as unknown as SerializedMessage);
+      } else {
+        // Fallback: plain object that wasn't serialized via toJSON (e.g., in-memory state)
+        // Reconstruct with defensive defaults
+        const metadata = obj.metadata as Record<string, unknown>;
+        const dateSent = metadata.dateSent;
+        const editedAt = metadata.editedAt;
+        msg = new Message({
+          id: obj.id as string,
+          threadId: obj.threadId as string,
+          text: obj.text as string,
+          formatted: obj.formatted as FormattedContent,
+          raw: obj.raw,
+          author: obj.author as Author,
+          metadata: {
+            dateSent:
+              dateSent instanceof Date
+                ? dateSent
+                : new Date(dateSent as string),
+            edited: metadata.edited as boolean,
+            editedAt: editedAt
+              ? new Date(
+                  editedAt instanceof Date
+                    ? editedAt.toISOString()
+                    : (editedAt as string)
+                )
+              : undefined,
+          },
+          attachments: (obj.attachments as Attachment[]) ?? [],
+          replyTo: obj.replyTo as Message | undefined,
+          isMention: obj.isMention as boolean | undefined,
+          links: (obj.links as LinkPreview[] | undefined) ?? [],
+        });
+      }
     }
 
     const rehydrate = adapter?.rehydrateAttachment?.bind(adapter);
@@ -2982,6 +2979,14 @@ export class Chat<
       msg.attachments = msg.attachments.map((att) =>
         att.fetchData ? att : rehydrate(att)
       );
+    }
+
+    if (msg.replyTo) {
+      msg.replyTo = this.rehydrateMessage(msg.replyTo, adapter);
+    }
+
+    if (adapter) {
+      setMessageAdapter(msg, adapter);
     }
 
     return msg;

--- a/packages/chat/src/message.ts
+++ b/packages/chat/src/message.ts
@@ -18,6 +18,9 @@ const adapterMap = new WeakMap<Message, Adapter>();
 
 export function setMessageAdapter(message: Message, adapter: Adapter): void {
   adapterMap.set(message, adapter);
+  if (message.replyTo) {
+    setMessageAdapter(message.replyTo, adapter);
+  }
 }
 
 /**
@@ -41,6 +44,8 @@ export interface MessageData<TRawMessage = unknown> {
   metadata: MessageMetadata;
   /** Platform-specific raw payload (escape hatch) */
   raw: TRawMessage;
+  /** Message this message replies to */
+  replyTo?: Message<TRawMessage>;
   /** Plain text content (all formatting stripped) */
   text: string;
   /** Thread this message belongs to */
@@ -88,6 +93,7 @@ export interface SerializedMessage {
     editedAt?: string; // ISO string
   };
   raw: unknown;
+  replyTo?: SerializedMessage;
   text: string;
   threadId: string;
 }
@@ -136,6 +142,8 @@ export class Message<TRawMessage = unknown> {
   metadata: MessageMetadata;
   /** Attachments */
   attachments: Attachment[];
+  /** Message this message replies to */
+  replyTo?: Message<TRawMessage>;
 
   /**
    * Whether the bot is @-mentioned in this message.
@@ -193,6 +201,7 @@ export class Message<TRawMessage = unknown> {
     this.author = data.author;
     this.metadata = data.metadata;
     this.attachments = data.attachments;
+    this.replyTo = data.replyTo;
     this.isMention = data.isMention;
     this.links = data.links ?? [];
   }
@@ -238,6 +247,7 @@ export class Message<TRawMessage = unknown> {
         height: att.height,
         fetchMetadata: att.fetchMetadata,
       })),
+      replyTo: this.replyTo?.toJSON(),
       isMention: this.isMention,
       links:
         this.links.length > 0
@@ -274,6 +284,9 @@ export class Message<TRawMessage = unknown> {
           : undefined,
       },
       attachments: json.attachments,
+      replyTo: json.replyTo
+        ? Message.fromJSON<TRawMessage>(json.replyTo)
+        : undefined,
       isMention: json.isMention,
       links: json.links,
     });

--- a/packages/chat/src/serialization.test.ts
+++ b/packages/chat/src/serialization.test.ts
@@ -610,6 +610,49 @@ describe("Serialization", () => {
       // fetchMessage is not preserved across serialization
       expect(restored.links[0]?.fetchMessage).toBeUndefined();
     });
+
+    it("should round-trip replied-to message context", () => {
+      const replyTo = createTestMessage("msg-original", "Original message", {
+        raw: { platformId: "original-1" },
+        author: {
+          userId: "U456",
+          userName: "original-author",
+          fullName: "Original Author",
+          isBot: false,
+          isMe: false,
+        },
+        metadata: {
+          dateSent: new Date("2024-01-14T10:30:00.000Z"),
+          edited: false,
+        },
+        attachments: [
+          {
+            type: "file",
+            name: "original.pdf",
+            fetchMetadata: { fileId: "file-1" },
+          },
+        ],
+      });
+      const original = createTestMessage("msg-reply", "Reply", { replyTo });
+
+      const restored = Message.fromJSON(original.toJSON());
+
+      expect(restored.replyTo).toBeInstanceOf(Message);
+      expect(restored.replyTo?.id).toBe("msg-original");
+      expect(restored.replyTo?.text).toBe("Original message");
+      expect(restored.replyTo?.author.userName).toBe("original-author");
+      expect(restored.replyTo?.raw).toEqual({ platformId: "original-1" });
+      expect(restored.replyTo?.metadata.dateSent).toEqual(
+        new Date("2024-01-14T10:30:00.000Z")
+      );
+      expect(restored.replyTo?.attachments).toEqual([
+        {
+          type: "file",
+          name: "original.pdf",
+          fetchMetadata: { fileId: "file-1" },
+        },
+      ]);
+    });
   });
 
   describe("chat.reviver()", () => {

--- a/packages/chat/src/thread-history.test.ts
+++ b/packages/chat/src/thread-history.test.ts
@@ -57,8 +57,10 @@ describe("ThreadHistoryCache", () => {
     expect(messages[2].id).toBe("m5");
   });
 
-  it("should strip raw field on storage", async () => {
-    const msg = createTestMessage("m1", "Hello");
+  it("should strip raw fields on storage", async () => {
+    const replyTo = createTestMessage("m0", "Original");
+    replyTo.raw = { secret: "reply data" };
+    const msg = createTestMessage("m1", "Hello", { replyTo });
     msg.raw = { secret: "data", nested: { deep: true } };
 
     await cache.append("thread-1", msg);
@@ -67,9 +69,11 @@ describe("ThreadHistoryCache", () => {
     const appendedValue = (
       state.appendToList as ReturnType<typeof import("vitest").vi.fn>
     ).mock.calls[0][1] as {
+      replyTo?: { raw: unknown };
       raw: unknown;
     };
     expect(appendedValue.raw).toBeNull();
+    expect(appendedValue.replyTo?.raw).toBeNull();
   });
 
   it("should return empty array for unknown thread", async () => {

--- a/packages/chat/src/thread-history.ts
+++ b/packages/chat/src/thread-history.ts
@@ -51,9 +51,15 @@ export class ThreadHistoryCache {
   async append(threadId: string, message: Message): Promise<void> {
     const key = `${KEY_PREFIX}${threadId}`;
 
-    // Serialize with raw nulled out to save storage
+    // Omit raw payloads to keep history storage bounded.
     const serialized = message.toJSON();
-    serialized.raw = null;
+    for (
+      let current: SerializedMessage | undefined = serialized;
+      current;
+      current = current.replyTo
+    ) {
+      current.raw = null;
+    }
 
     await this.state.appendToList(key, serialized, {
       maxLength: this.maxMessages,

--- a/packages/chat/src/thread.test.ts
+++ b/packages/chat/src/thread.test.ts
@@ -2410,7 +2410,8 @@ describe("ThreadImpl", () => {
     });
 
     it("should wrap a Message as a SentMessage with same fields", () => {
-      const msg = createTestMessage("msg-1", "Hello world");
+      const replyTo = createTestMessage("msg-0", "Original message");
+      const msg = createTestMessage("msg-1", "Hello world", { replyTo });
 
       const sent = thread.createSentMessageFromMessage(msg);
 
@@ -2420,6 +2421,7 @@ describe("ThreadImpl", () => {
       expect(sent.author).toBe(msg.author);
       expect(sent.metadata).toBe(msg.metadata);
       expect(sent.attachments).toBe(msg.attachments);
+      expect(sent.replyTo).toBe(replyTo);
     });
 
     it("should provide edit capability", async () => {

--- a/packages/chat/src/thread.ts
+++ b/packages/chat/src/thread.ts
@@ -1039,6 +1039,7 @@ export class ThreadImpl<TState = Record<string, unknown>>
       author: message.author,
       metadata: message.metadata,
       attachments: message.attachments,
+      replyTo: message.replyTo,
       links: message.links,
       isMention: message.isMention,
 


### PR DESCRIPTION
## Summary

- add optional, normalized `Message.replyTo` context that survives JSON and workflow serialization, queue rehydration, thread history, and `SentMessage` reconstruction
- populate it from Telegram's `reply_to_message`, including combined media groups, so handlers don't need raw Telegram payloads
- keep the core contract adapter-neutral while Telegram owns only its platform mapping, allowing other adapters to populate it when they receive full replied-to messages

## Test plan

- `TURBO_CONCURRENCY=2 pnpm validate`

## Checklist

- [x] All commits are signed and verified
- [x] All commits are signed off for the DCO (`git commit -s`)
- [x] `pnpm validate` passes
- [x] Changeset added (or N/A — see [CONTRIBUTING.md](./CONTRIBUTING.md))
- [x] Documentation updated (or N/A)
