### PR TITLE
docs: add cross-link card sections and page-level SEO metadata

### DIFF
--- a/apps/docs/app/[lang]/adapters/(detail)/community/[slug]/page.tsx
+++ b/apps/docs/app/[lang]/adapters/(detail)/community/[slug]/page.tsx
@@ -225,6 +225,7 @@ export const generateMetadata = async ({
       card: "summary_large_image",
     },
     alternates: {
+      canonical: `/adapters/community/${slug}`,
       types: {
         "text/markdown": `/adapters/community/${slug}.md`,
       },

--- a/apps/docs/app/[lang]/adapters/(detail)/official/[slug]/page.tsx
+++ b/apps/docs/app/[lang]/adapters/(detail)/official/[slug]/page.tsx
@@ -10,6 +10,7 @@ import type { AdapterFeatureValue } from "@/lib/adapter-features";
 import { getAdapterJsonLd } from "@/lib/geistdocs/adapter-jsonld";
 import { getAdapter } from "@/lib/geistdocs/adapter-readme";
 import { adaptersSource } from "@/lib/geistdocs/adapters-source";
+import { MoreAdapters } from "../../../components/more-adapters";
 
 interface AdapterFrontmatter {
   beta?: boolean;
@@ -103,6 +104,7 @@ const Page = async ({ params }: { params: Promise<PageParams> }) => {
             FeatureSupport: BoundFeatureSupport,
           })}
         />
+        <MoreAdapters page={page} />
       </DocsBody>
     </DocsPage>
   );
@@ -137,6 +139,7 @@ export const generateMetadata = async ({
       card: "summary_large_image",
     },
     alternates: {
+      canonical: `/adapters/official/${slug}`,
       types: {
         "text/markdown": `/adapters/official/${slug}.md`,
       },

--- a/apps/docs/app/[lang]/adapters/(detail)/vendor-official/[slug]/page.tsx
+++ b/apps/docs/app/[lang]/adapters/(detail)/vendor-official/[slug]/page.tsx
@@ -217,6 +217,7 @@ export const generateMetadata = async ({
       card: "summary_large_image",
     },
     alternates: {
+      canonical: `/adapters/vendor-official/${slug}`,
       types: {
         "text/markdown": `/adapters/vendor-official/${slug}.md`,
       },

--- a/apps/docs/app/[lang]/adapters/components/more-adapters.tsx
+++ b/apps/docs/app/[lang]/adapters/components/more-adapters.tsx
@@ -1,3 +1,4 @@
+import { Heading } from "fumadocs-ui/components/heading";
 import {
   type AdapterPage,
   adaptersSource,
@@ -55,8 +56,10 @@ export const MoreAdapters = ({ page }: { page: AdapterPage }) => {
   }
 
   return (
-    <section aria-labelledby="more-adapters-heading">
-      <h2 id="more-adapters-heading">More adapters</h2>
+    <section aria-labelledby="more-adapters">
+      <Heading as="h2" id="more-adapters">
+        More adapters
+      </Heading>
       <div className="not-prose grid gap-4 sm:grid-cols-2">
         {picks.map((adapter) => {
           const data = adapter.data as unknown as AdapterCardData;

--- a/apps/docs/app/[lang]/adapters/components/more-adapters.tsx
+++ b/apps/docs/app/[lang]/adapters/components/more-adapters.tsx
@@ -1,0 +1,77 @@
+import {
+  type AdapterPage,
+  adaptersSource,
+} from "@/lib/geistdocs/adapters-source";
+import { collectRuns, rotateAfter } from "@/lib/read-more";
+import { AdapterCard } from "./adapter-card";
+
+const CARD_COUNT = 4;
+const OFFICIAL_PREFIX = "/adapters/official/";
+
+interface AdapterCardData {
+  logo?: string;
+  packageName?: string;
+}
+
+/**
+ * Picks the official adapters to feature: same-type adapters first (the
+ * official meta.json separators split platform and state into their own
+ * runs), rotated after the current adapter, then the other official group.
+ * Vendor-official and community adapters are never included.
+ */
+const selectMoreAdapters = (page: AdapterPage): AdapterPage[] => {
+  const lang = page.locale;
+  const byUrl = new Map<string, AdapterPage>();
+  for (const candidate of adaptersSource.getPages(lang)) {
+    if (candidate.url.startsWith(OFFICIAL_PREFIX)) {
+      byUrl.set(candidate.url, candidate);
+    }
+  }
+
+  const runs = collectRuns(adaptersSource.getPageTree(lang)).filter((run) =>
+    run.some((url) => url.startsWith(OFFICIAL_PREFIX))
+  );
+  const sameType = runs.find((run) => run.includes(page.url)) ?? [];
+  const otherRuns = runs.filter((run) => run !== sameType).flat();
+
+  const selected: AdapterPage[] = [];
+  for (const url of [...rotateAfter(sameType, page.url), ...otherRuns]) {
+    if (selected.length >= CARD_COUNT) {
+      break;
+    }
+    const candidate = byUrl.get(url);
+    if (candidate && candidate.url !== page.url) {
+      selected.push(candidate);
+    }
+  }
+  return selected;
+};
+
+/** "More adapters" section rendered at the bottom of official adapter pages. */
+export const MoreAdapters = ({ page }: { page: AdapterPage }) => {
+  const picks = selectMoreAdapters(page);
+  if (picks.length === 0) {
+    return null;
+  }
+
+  return (
+    <section aria-labelledby="more-adapters-heading">
+      <h2 id="more-adapters-heading">More adapters</h2>
+      <div className="not-prose grid gap-4 sm:grid-cols-2">
+        {picks.map((adapter) => {
+          const data = adapter.data as unknown as AdapterCardData;
+          return (
+            <AdapterCard
+              description={adapter.data.description ?? ""}
+              href={adapter.url}
+              icon={data.logo}
+              key={adapter.url}
+              name={adapter.data.title}
+              packageName={data.packageName}
+            />
+          );
+        })}
+      </div>
+    </section>
+  );
+};

--- a/apps/docs/app/[lang]/docs/[[...slug]]/page.tsx
+++ b/apps/docs/app/[lang]/docs/[[...slug]]/page.tsx
@@ -1,6 +1,8 @@
 import { MobileDocsBar } from "@vercel/geistdocs/mobile-docs-bar";
 import { createDocsPage } from "@vercel/geistdocs/pages/docs";
 import type { Metadata } from "next";
+import type { ReactNode } from "react";
+import { ReadMore } from "@/components/custom/read-more";
 import { getMDXComponents } from "@/components/geistdocs/mdx-components";
 import { config } from "@/lib/geistdocs/config";
 import { getDocsJsonLd } from "@/lib/geistdocs/docs-jsonld";
@@ -8,9 +10,22 @@ import { geistdocsSource } from "@/lib/geistdocs/source";
 
 const docsPage = createDocsPage({
   config,
-  mdx: ({ link }) => getMDXComponents({ a: link }),
-  metadata: ({ metadata }): Metadata => ({
+  mdx: ({ link, page, source }) =>
+    getMDXComponents({
+      a: link,
+      wrapper: ({ children }: { children?: ReactNode }) => (
+        <>
+          {children}
+          <ReadMore page={page} source={source} />
+        </>
+      ),
+    }),
+  metadata: ({ metadata, page }): Metadata => ({
     ...metadata,
+    alternates: {
+      ...metadata.alternates,
+      canonical: page.url,
+    },
     openGraph: {
       ...metadata.openGraph,
       title: metadata.title ?? undefined,
@@ -33,13 +48,11 @@ const docsPage = createDocsPage({
     return (
       <>
         <MobileDocsBar toc={data.toc} />
-        {jsonLd ? (
-          <script
-            // biome-ignore lint/security/noDangerouslySetInnerHtml: static JSON-LD, not user input
-            dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
-            type="application/ld+json"
-          />
-        ) : null}
+        <script
+          // biome-ignore lint/security/noDangerouslySetInnerHtml: static JSON-LD, not user input
+          dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
+          type="application/ld+json"
+        />
         {/* biome-ignore lint/a11y/useAnchorContent: intentionally aria-hidden hint surfacing the markdown URL for AI/LLM crawlers, not for screen readers */}
         <a
           aria-hidden="true"

--- a/apps/docs/components/custom/read-more.tsx
+++ b/apps/docs/components/custom/read-more.tsx
@@ -1,0 +1,36 @@
+import type { GeistdocsSourceBundle } from "@vercel/geistdocs/source";
+import { Card, Cards } from "fumadocs-ui/components/card";
+import { type LoaderPage, selectReadMore } from "@/lib/read-more";
+
+interface ReadMoreProps {
+  page: LoaderPage;
+  source: GeistdocsSourceBundle;
+}
+
+/**
+ * "Read more" section rendered at the bottom of every docs page. Links are
+ * picked by `selectReadMore` from the page's `related` and `prerequisites`
+ * frontmatter, topped up with section siblings.
+ */
+export const ReadMore = ({ page, source }: ReadMoreProps) => {
+  const pages = selectReadMore(source.source, page);
+  if (pages.length === 0) {
+    return null;
+  }
+
+  return (
+    <section aria-labelledby="read-more-heading">
+      <h2 id="read-more-heading">Read more</h2>
+      <Cards>
+        {pages.map((related) => (
+          <Card
+            description={related.data.description}
+            href={related.url}
+            key={related.url}
+            title={related.data.title}
+          />
+        ))}
+      </Cards>
+    </section>
+  );
+};

--- a/apps/docs/components/custom/read-more.tsx
+++ b/apps/docs/components/custom/read-more.tsx
@@ -1,5 +1,6 @@
 import type { GeistdocsSourceBundle } from "@vercel/geistdocs/source";
 import { Card, Cards } from "fumadocs-ui/components/card";
+import { Heading } from "fumadocs-ui/components/heading";
 import { type LoaderPage, selectReadMore } from "@/lib/read-more";
 
 interface ReadMoreProps {
@@ -19,8 +20,10 @@ export const ReadMore = ({ page, source }: ReadMoreProps) => {
   }
 
   return (
-    <section aria-labelledby="read-more-heading">
-      <h2 id="read-more-heading">Read more</h2>
+    <section aria-labelledby="read-more">
+      <Heading as="h2" id="read-more">
+        Read more
+      </Heading>
       <Cards>
         {pages.map((related) => (
           <Card

--- a/apps/docs/content/docs/actions.mdx
+++ b/apps/docs/content/docs/actions.mdx
@@ -6,6 +6,7 @@ prerequisites:
   - /docs/cards
 related:
   - /docs/modals
+  - /docs/approvals
 ---
 
 Actions let you handle button clicks, dropdown selections, and other interactive events from [cards](/docs/cards). Register handlers with `onAction` to respond when users interact with your cards.

--- a/apps/docs/content/docs/ai/ai-sdk-tools.mdx
+++ b/apps/docs/content/docs/ai/ai-sdk-tools.mdx
@@ -9,6 +9,7 @@ related:
   - /docs/ai/to-ai-messages
   - /docs/streaming
   - /docs/conversation-history
+  - /docs/approvals
 ---
 
 `createChatTools` exposes Chat SDK operations as ready-to-use [AI SDK](https://ai-sdk.dev) tools so an agent can act inside the same workspaces your bot is connected to: read messages, post replies, send DMs, react, edit, delete, and manage thread subscriptions across every adapter you've registered.

--- a/apps/docs/content/docs/api/cards.mdx
+++ b/apps/docs/content/docs/api/cards.mdx
@@ -2,6 +2,9 @@
 title: Cards
 description: Rich card components for cross-platform interactive messages.
 type: reference
+related:
+  - /docs/cards
+  - /docs/actions
 ---
 
 Card components render natively on each platform — Block Kit on Slack, Adaptive Cards on Teams, embeds or components on Discord, and Google Chat Cards.

--- a/apps/docs/content/docs/api/channel.mdx
+++ b/apps/docs/content/docs/api/channel.mdx
@@ -2,6 +2,8 @@
 title: Channel
 description: Channel container that holds threads, with methods for listing, posting, and iteration.
 type: reference
+related:
+  - /docs/threads-messages-channels
 ---
 
 A `Channel` represents a channel or conversation container that holds threads. Both `Thread` and `Channel` extend the shared `Postable` interface, so they share common methods like `post()`, `state`, and `messages`.

--- a/apps/docs/content/docs/api/chat.mdx
+++ b/apps/docs/content/docs/api/chat.mdx
@@ -2,6 +2,9 @@
 title: Chat
 description: The main entry point for creating a multi-platform chat bot.
 type: reference
+related:
+  - /docs/usage
+  - /docs/handling-events
 ---
 
 The `Chat` class coordinates adapters, state, and event handlers. Create one instance and register handlers for different event types.

--- a/apps/docs/content/docs/api/markdown.mdx
+++ b/apps/docs/content/docs/api/markdown.mdx
@@ -2,6 +2,9 @@
 title: Markdown
 description: AST builder functions and utilities for programmatic message formatting.
 type: reference
+related:
+  - /docs/posting-messages
+  - /docs/emoji
 ---
 
 The SDK uses [mdast](https://github.com/syntax-tree/mdast) (Markdown AST) as the canonical format for message formatting. Each adapter converts the AST to the platform's native format.

--- a/apps/docs/content/docs/api/message.mdx
+++ b/apps/docs/content/docs/api/message.mdx
@@ -2,6 +2,10 @@
 title: Message
 description: Normalized message format with text, AST, author, and metadata.
 type: reference
+related:
+  - /docs/handling-events
+  - /docs/subject
+  - /docs/ai/to-ai-messages
 ---
 
 Incoming messages are normalized across all platforms into a consistent `Message` object.

--- a/apps/docs/content/docs/api/modals.mdx
+++ b/apps/docs/content/docs/api/modals.mdx
@@ -2,6 +2,8 @@
 title: Modals
 description: Modal form components for collecting user input.
 type: reference
+related:
+  - /docs/modals
 ---
 
 Modals display form dialogs that collect structured user input. Currently supported on Slack and Teams.

--- a/apps/docs/content/docs/api/postable-message.mdx
+++ b/apps/docs/content/docs/api/postable-message.mdx
@@ -2,6 +2,10 @@
 title: PostableMessage
 description: The union type accepted by thread.post() for sending messages.
 type: reference
+related:
+  - /docs/posting-messages
+  - /docs/streaming
+  - /docs/cards
 ---
 
 `PostableMessage` is the union of all message formats accepted by `thread.post()` and `sent.edit()`.

--- a/apps/docs/content/docs/api/thread.mdx
+++ b/apps/docs/content/docs/api/thread.mdx
@@ -2,6 +2,9 @@
 title: Thread
 description: Represents a conversation thread with methods for posting, subscribing, and state management.
 type: reference
+related:
+  - /docs/threads-messages-channels
+  - /docs/posting-messages
 ---
 
 A `Thread` is provided to your event handlers and represents a conversation thread on any platform. You can also create thread handles directly using `chat.thread()` or `chat.openDM()`.

--- a/apps/docs/content/docs/api/transcripts.mdx
+++ b/apps/docs/content/docs/api/transcripts.mdx
@@ -2,6 +2,8 @@
 title: Transcripts
 description: Cross-platform per-user transcript persistence — configuration, methods, and entry shape.
 type: reference
+related:
+  - /docs/conversation-history
 ---
 
 `bot.transcripts` provides per-user message persistence keyed by a stable cross-platform identifier. See the [Conversation history](/docs/conversation-history) guide for usage patterns.

--- a/apps/docs/content/docs/cards.mdx
+++ b/apps/docs/content/docs/cards.mdx
@@ -7,6 +7,8 @@ prerequisites:
 related:
   - /docs/actions
   - /docs/modals
+  - /docs/api/cards
+  - /docs/emoji
 ---
 
 Cards let you send structured, interactive messages that render natively on each platform — Block Kit on Slack, Adaptive Cards on Teams, Discord embeds or Components, and Google Chat Cards.

--- a/apps/docs/content/docs/concurrency.mdx
+++ b/apps/docs/content/docs/concurrency.mdx
@@ -7,6 +7,7 @@ prerequisites:
 related:
   - /docs/state-adapters
   - /docs/streaming
+  - /docs/error-handling
 ---
 
 When multiple messages arrive on the same thread while a handler is still processing, the SDK needs a strategy. By default, the incoming message is dropped. The `concurrency` option on `ChatConfig` lets you choose what happens instead.

--- a/apps/docs/content/docs/contributing/testing.mdx
+++ b/apps/docs/content/docs/contributing/testing.mdx
@@ -6,6 +6,7 @@ prerequisites:
   - /docs/contributing/building
 related:
   - /docs/adapters
+  - /docs/testing
 ---
 
 ## Testing philosophy

--- a/apps/docs/content/docs/create-chat-sdk.mdx
+++ b/apps/docs/content/docs/create-chat-sdk.mdx
@@ -1,6 +1,9 @@
 ---
 title: CLI
 description: Scaffold a Chat SDK bot app with a single command.
+related:
+  - /docs
+  - /docs/getting-started
 ---
 
 `create-chat-sdk` creates a minimal Next.js app for Chat SDK bots.

--- a/apps/docs/content/docs/emoji.mdx
+++ b/apps/docs/content/docs/emoji.mdx
@@ -2,6 +2,10 @@
 title: Emoji
 description: Type-safe, cross-platform emoji that automatically convert to each platform's format.
 type: reference
+related:
+  - /docs/posting-messages
+  - /docs/cards
+  - /docs/handling-events
 ---
 
 The `emoji` helper provides cross-platform emoji that automatically convert to the correct format for each platform. On Slack, emoji render as `:shortcode:` format. On other platforms, they render as Unicode characters.

--- a/apps/docs/content/docs/getting-started.mdx
+++ b/apps/docs/content/docs/getting-started.mdx
@@ -1,6 +1,11 @@
 ---
 title: Getting Started
 description: Pick a guide to start building with Chat SDK.
+related:
+  - /docs/usage
+  - /docs/platform-adapters
+  - /docs/vercel-connect
+  - /docs/create-chat-sdk
 ---
 
 ## Usage

--- a/apps/docs/content/docs/handling-events.mdx
+++ b/apps/docs/content/docs/handling-events.mdx
@@ -8,6 +8,7 @@ related:
   - /docs/slash-commands
   - /docs/actions
   - /docs/modals
+  - /docs/api/message
 ---
 
 Chat SDK uses an event-driven architecture. You register handlers for different event types, and the SDK routes incoming webhooks to the appropriate handler.

--- a/apps/docs/content/docs/index.mdx
+++ b/apps/docs/content/docs/index.mdx
@@ -2,6 +2,11 @@
 title: Introduction
 description: A unified SDK for building chat bots across Slack, Microsoft Teams, Google Chat, Discord, Telegram, and more.
 type: overview
+related:
+  - /docs/getting-started
+  - /docs/usage
+  - /docs/api
+  - /docs/ai
 ---
 
 Chat SDK is a TypeScript library for building chat bots that work across multiple platforms with a single codebase. Write your bot logic once and deploy it wherever you have an [adapter](/adapters).

--- a/apps/docs/content/docs/modals.mdx
+++ b/apps/docs/content/docs/modals.mdx
@@ -4,6 +4,10 @@ description: Collect structured user input through modal dialogs with text field
 type: guide
 prerequisites:
   - /docs/actions
+related:
+  - /docs/api/modals
+  - /docs/cards
+  - /docs/slash-commands
 ---
 
 Modals open form dialogs in response to button clicks or [slash commands](/docs/slash-commands). They support text inputs, dropdowns, radio buttons, and server-side validation. Currently supported on Slack and Teams.

--- a/apps/docs/content/docs/posting-messages.mdx
+++ b/apps/docs/content/docs/posting-messages.mdx
@@ -8,6 +8,8 @@ related:
   - /docs/cards
   - /docs/streaming
   - /docs/files
+  - /docs/api/postable-message
+  - /docs/threads-messages-channels
 ---
 
 `thread.post()` accepts several message formats, each suited to different use cases. Choose the format that best fits your content — from plain strings to structured AST to rich interactive cards.

--- a/apps/docs/content/docs/slash-commands.mdx
+++ b/apps/docs/content/docs/slash-commands.mdx
@@ -9,6 +9,7 @@ related:
   - /adapters/official/slack
   - /adapters/official/discord
   - /adapters/official/telegram
+  - /docs/ephemeral-messages
 ---
 
 Slash commands let users invoke your bot with `/command` syntax. Register handlers with `onSlashCommand` to respond.

--- a/apps/docs/content/docs/state-adapters.mdx
+++ b/apps/docs/content/docs/state-adapters.mdx
@@ -4,6 +4,10 @@ description: Pluggable state adapters for thread subscriptions, distributed lock
 type: overview
 prerequisites:
   - /docs/getting-started
+related:
+  - /docs/concurrency
+  - /docs/conversation-history
+  - /docs/testing
 ---
 
 State adapters handle persistent storage for thread subscriptions, distributed locks (to prevent duplicate processing), and caching. You must provide a state adapter when creating a `Chat` instance. Browse all available state adapters on the [Adapters](/adapters) page.

--- a/apps/docs/content/docs/streaming.mdx
+++ b/apps/docs/content/docs/streaming.mdx
@@ -4,6 +4,10 @@ description: Stream real-time text responses from AI models and other async sour
 type: guide
 prerequisites:
   - /docs/usage
+related:
+  - /docs/api/markdown
+  - /docs/concurrency
+  - /docs/ai
 ---
 
 Chat SDK accepts any `AsyncIterable<string>` as a message, enabling real-time streaming of AI responses and other incremental content to chat platforms. For platforms with native or structured streaming support, you can also stream `StreamChunk` objects for rich content like task progress cards and plan updates.

--- a/apps/docs/content/docs/threads-messages-channels.mdx
+++ b/apps/docs/content/docs/threads-messages-channels.mdx
@@ -7,6 +7,9 @@ prerequisites:
 related:
   - /docs/handling-events
   - /docs/posting-messages
+  - /docs/api/thread
+  - /docs/api/channel
+  - /docs/subject
 ---
 
 ## Threads

--- a/apps/docs/content/docs/usage.mdx
+++ b/apps/docs/content/docs/usage.mdx
@@ -8,6 +8,8 @@ related:
   - /docs/handling-events
   - /docs/adapters
   - /docs/state-adapters
+  - /docs/api/chat
+  - /docs/error-handling
 ---
 
 The `Chat` class is the main entry point for your bot. It coordinates adapters, routes events to your handlers, and manages thread state.

--- a/apps/docs/lib/geistdocs/docs-jsonld.ts
+++ b/apps/docs/lib/geistdocs/docs-jsonld.ts
@@ -8,9 +8,6 @@ const VERCEL_ORG = {
   url: "https://vercel.com",
 };
 
-/** Core docs pages that emit structured data for search and answer engines. */
-const JSON_LD_DOC_SLUGS = new Set(["getting-started", "streaming", "cards"]);
-
 interface DocsPage {
   data: {
     description?: string;
@@ -18,7 +15,6 @@ interface DocsPage {
     toc?: TableOfContents;
     type?: string;
   };
-  slugs: string[];
   url: string;
 }
 
@@ -96,16 +92,11 @@ const getTechArticleJsonLd = (
 });
 
 /**
- * Build JSON-LD for selected core documentation pages.
- * Guides (`type: guide`) emit `HowTo` with h2 sections as steps; hub pages use
- * `TechArticle`. Always includes a `BreadcrumbList`.
+ * Build JSON-LD for documentation pages.
+ * Guides (`type: guide`) emit `HowTo` with h2 sections as steps; other pages
+ * use `TechArticle`. Always includes a `BreadcrumbList`.
  */
 export const getDocsJsonLd = (page: DocsPage) => {
-  const slug = page.slugs.join("/");
-  if (!JSON_LD_DOC_SLUGS.has(slug)) {
-    return null;
-  }
-
   const pageUrl = getDocsPageUrl(page.url);
   const { description, type, toc } = page.data;
   const title = page.data.title ?? "Chat SDK";

--- a/apps/docs/lib/read-more.ts
+++ b/apps/docs/lib/read-more.ts
@@ -1,0 +1,118 @@
+import type {
+  GeistdocsSourceBundle,
+  GeistdocsSourcePageData,
+} from "@vercel/geistdocs/source";
+import { flattenTree, type Node, type Root } from "fumadocs-core/page-tree";
+
+export type DocsSource = GeistdocsSourceBundle["source"];
+export type LoaderPage = NonNullable<ReturnType<DocsSource["getPage"]>>;
+
+/**
+ * Loader pages with the geistdocs frontmatter fields (`related`,
+ * `prerequisites`, `internal`, ...) that the generic fumadocs loader type
+ * erases.
+ */
+export type DocsPage = Omit<LoaderPage, "data"> & {
+  data: LoaderPage["data"] & GeistdocsSourcePageData;
+};
+
+const CARD_COUNT = 4;
+
+/**
+ * Splits the page tree into "runs": contiguous groups of pages bounded by
+ * meta.json separators (e.g. `---Usage---`) or folder boundaries. Pages in
+ * the same run are treated as section siblings.
+ */
+export const collectRuns = (root: Root): string[][] => {
+  const runs: string[][] = [];
+  const walk = (children: Node[], indexUrl?: string) => {
+    let current: string[] = indexUrl === undefined ? [] : [indexUrl];
+    const closeRun = () => {
+      if (current.length > 0) {
+        runs.push(current);
+      }
+      current = [];
+    };
+    for (const node of children) {
+      if (node.type === "page") {
+        current.push(node.url);
+      } else if (node.type === "separator") {
+        closeRun();
+      } else {
+        walk(node.children, node.index?.url);
+      }
+    }
+    closeRun();
+  };
+  walk(root.children);
+  return runs;
+};
+
+/** Returns `urls` reordered to start after `currentUrl`, wrapping around. */
+export const rotateAfter = (urls: string[], currentUrl: string): string[] => {
+  const index = urls.indexOf(currentUrl);
+  if (index === -1) {
+    return urls;
+  }
+  return [...urls.slice(index + 1), ...urls.slice(0, index)];
+};
+
+/**
+ * Picks the pages to feature in a page's "Read more" section, in priority
+ * order: `related` frontmatter, then `prerequisites`, then section siblings
+ * (same meta.json run), then the rest of the page tree. Deterministic, and
+ * always fills all slots as long as enough pages exist.
+ */
+export const selectReadMore = (
+  source: DocsSource,
+  page: LoaderPage,
+  count = CARD_COUNT
+): DocsPage[] => {
+  const lang = page.locale;
+  const byUrl = new Map<string, DocsPage>();
+  for (const candidate of source.getPages(lang) as DocsPage[]) {
+    if (!candidate.data.internal) {
+      byUrl.set(candidate.url, candidate);
+    }
+  }
+
+  const selected: DocsPage[] = [];
+  const seen = new Set<string>([page.url]);
+  const add = (url: string) => {
+    const candidate = byUrl.get(url);
+    if (!candidate || seen.has(url) || selected.length >= count) {
+      return;
+    }
+    seen.add(url);
+    selected.push(candidate);
+  };
+
+  const data = page.data as DocsPage["data"];
+  const curated = [...(data.related ?? []), ...(data.prerequisites ?? [])];
+  for (const url of curated) {
+    if (
+      !byUrl.has(url) &&
+      url.startsWith("/docs") &&
+      process.env.NODE_ENV === "development"
+    ) {
+      // biome-ignore lint/suspicious/noConsole: dev-only authoring hint
+      console.warn(`read-more: ${page.url} references unknown page ${url}`);
+    }
+    add(url);
+  }
+
+  if (selected.length < count) {
+    const tree = source.getPageTree(lang);
+    const siblings =
+      collectRuns(tree).find((run) => run.includes(page.url)) ?? [];
+    for (const url of rotateAfter(siblings, page.url)) {
+      add(url);
+    }
+    const allUrls = flattenTree(tree.children).map((item) => item.url);
+    for (const url of rotateAfter(allUrls, page.url)) {
+      add(url);
+    }
+  }
+
+  return selected;
+};

--- a/packages/create-chat-sdk/docs/create-chat-sdk.mdx
+++ b/packages/create-chat-sdk/docs/create-chat-sdk.mdx
@@ -1,6 +1,9 @@
 ---
 title: CLI
 description: Scaffold a Chat SDK bot app with a single command.
+related:
+  - /docs
+  - /docs/getting-started
 ---
 
 `create-chat-sdk` creates a minimal Next.js app for Chat SDK bots.


### PR DESCRIPTION
Many docs pages are orphaned: nothing links to them apart from the sidebar, so readers and crawlers rarely find them. This PR gives every docs page a Read more section with four cards at the bottom of the article, above the prev/next footer.

Cards are picked deterministically in lib/read-more.ts: the page's related frontmatter first, then prerequisites, then siblings from the same sidebar section, then the rest of the page tree, so every page always fills all four slots. Card titles and descriptions come from the target page's own frontmatter, nothing is duplicated. The section is injected through the MDX wrapper slot in the docs route, so it applies to all pages without touching content.

To make the links topical rather than positional, 26 pages get related frontmatter additions. The 20 pages that no other page referenced (all ten api/ pages among them) now each have at least one inbound link, generally pairing guides with their API reference and back. The bundled copy of create-chat-sdk.mdx is synced to keep the byte-match test green.

Official adapter pages get the same treatment with a More adapters section: same-type adapters first (platform or state, using the catalog order), topped up from the other official group. Vendor-official and community adapters are never shown, and their pages don't render the section. It reuses AdapterCard, so logos and package names match the listing page.

Two small SEO fixes ride along. JSON-LD was allowlisted to three docs pages; the allowlist is gone, so all 45 now emit HowTo or TechArticle plus a BreadcrumbList. Docs and adapter detail pages also emit canonical URLs now, resolved against the existing metadataBase.

Verified against the production build: all 45 docs pages and all 19 official adapter pages render exactly four cards, no page is left unreferenced, canonicals and JSON-LD are present everywhere, and pnpm validate passes. Docs-only, so no changeset.