### PR TITLE
Add Vercel Connect support to Discord

### DIFF
--- a/.changeset/chatty-discord-connect.md
+++ b/.changeset/chatty-discord-connect.md
@@ -1,0 +1,7 @@
+---
+"@chat-adapter/discord": minor
+"chat": minor
+"create-chat-sdk": minor
+---
+
+Add Vercel Connect credential resolvers and custom webhook verification to the Discord adapter, with `create-chat-sdk --connect` scaffolding for Discord bots.

--- a/apps/docs/content/adapters/official/discord.mdx
+++ b/apps/docs/content/adapters/official/discord.mdx
@@ -82,8 +82,9 @@ bot.onNewMention(async (thread, message) => {
 <TypeTable
   type={{
     botToken: {
-      type: "string",
-      description: "Discord bot token. Auto-detected from `DISCORD_BOT_TOKEN`.",
+      type: "string | (() => string | Promise<string>)",
+      description:
+        "Discord bot token or resolver invoked per API call. Auto-detected from `DISCORD_BOT_TOKEN`.",
     },
     publicKey: {
       type: "string",
@@ -91,9 +92,14 @@ bot.onNewMention(async (thread, message) => {
         "Application public key. Auto-detected from `DISCORD_PUBLIC_KEY`.",
     },
     applicationId: {
-      type: "string",
+      type: "string | (() => string | Promise<string>)",
       description:
-        "Discord application ID. Auto-detected from `DISCORD_APPLICATION_ID`.",
+        "Discord application ID or resolver. Auto-detected from `DISCORD_APPLICATION_ID`.",
+    },
+    webhookVerifier: {
+      type: "(request: Request, body: string) => unknown | Promise<unknown>",
+      description:
+        "Custom webhook verifier used instead of Discord's Ed25519 public key.",
     },
     contentFormat: {
       type: "DiscordContentFormat",
@@ -127,7 +133,8 @@ bot.onNewMention(async (thread, message) => {
   }}
 />
 
-`botToken`, `publicKey`, and `applicationId` are required.
+`botToken` and `applicationId` are required. Provide either `publicKey` or
+`webhookVerifier`.
 
 ## Components cards
 

--- a/apps/docs/content/docs/create-chat-sdk.mdx
+++ b/apps/docs/content/docs/create-chat-sdk.mdx
@@ -100,7 +100,7 @@ When the [Discord adapter](/adapters/official/discord) is selected, the CLI also
 
 ## Vercel Connect
 
-[Vercel Connect](/docs/vercel-connect) lets the Slack, GitHub, and Linear adapters authenticate with a connector instead of stored provider secrets. Pass `--connect` — or choose **Vercel Connect** at the interactive auth-mode prompt — to scaffold Connect wiring for any selected Slack, GitHub, or Linear adapter:
+[Vercel Connect](/docs/vercel-connect) lets the Slack, Discord, GitHub, and Linear adapters authenticate with a connector instead of stored provider secrets. Pass `--connect` — or choose **Vercel Connect** at the interactive auth-mode prompt — to scaffold Connect wiring for any selected Slack, Discord, GitHub, or Linear adapter:
 
 ```bash
 npm create chat-sdk@latest -- my-bot --adapter slack --connect -y
@@ -120,7 +120,7 @@ The generated `src/lib/bot.ts` spreads the matching helper from `@vercel/connect
 | `-d, --description <text>` | Project description. |
 | `--adapter <values...>` | Platform or state adapters to include. |
 | `--vendor` | List only vendor-official adapters in the interactive prompt. |
-| `--connect` | Authenticate Slack, GitHub, and Linear adapters with Vercel Connect. |
+| `--connect` | Authenticate Slack, Discord, GitHub, and Linear adapters with Vercel Connect. |
 | `--pm <manager>` | Package manager to use: `npm`, `yarn`, `pnpm`, or `bun`. |
 | `-y, --yes` | Skip prompts and accept defaults. |
 | `--interactive` | Always prompt, even when a coding agent environment is detected. |

--- a/apps/docs/content/docs/vercel-connect.mdx
+++ b/apps/docs/content/docs/vercel-connect.mdx
@@ -1,10 +1,11 @@
 ---
 title: Vercel Connect
-description: Authenticate Slack, GitHub, and Linear adapters with Vercel Connect — short-lived runtime tokens for outbound calls and OIDC-verified inbound webhooks, with no stored provider secrets.
+description: Authenticate Slack, Discord, GitHub, and Linear adapters with Vercel Connect — short-lived runtime tokens for outbound calls and OIDC-verified inbound webhooks, with no stored provider secrets.
 type: overview
 related:
   - /docs/usage
   - /adapters/official/slack
+  - /adapters/official/discord
   - /adapters/official/github
   - /adapters/official/linear
 ---
@@ -14,6 +15,7 @@ related:
 The `@vercel/connect/chat` subpath ships a helper per platform that you spread into the matching `create*Adapter` factory:
 
 - `connectSlackAdapter`
+- `connectDiscordAdapter`
 - `connectGitHubAdapter`
 - `connectLinearAdapter`
 
@@ -39,6 +41,7 @@ pnpm add @vercel/connect
 | Adapter | Helper | Outbound field |
 |---------|--------|----------------|
 | [Slack](/adapters/official/slack) | `connectSlackAdapter` | `botToken` |
+| [Discord](/adapters/official/discord) | `connectDiscordAdapter` | `botToken`, `applicationId` |
 | [GitHub](/adapters/official/github) | `connectGitHubAdapter` | `installationToken` |
 | [Linear](/adapters/official/linear) | `connectLinearAdapter` | `accessToken` |
 
@@ -89,6 +92,22 @@ export const bot = new Chat({
 ```
 
 Replace `slack/acme-slack` with your connector UID from the Connect dashboard or `vercel connect list`. Omit `signingSecret` / `SLACK_SIGNING_SECRET` when using the helper — the OIDC `webhookVerifier` is the freshness boundary.
+
+### Discord
+
+```typescript title="lib/bot.ts" lineNumbers
+import { createDiscordAdapter } from "@chat-adapter/discord";
+import { connectDiscordAdapter } from "@vercel/connect/chat";
+
+createDiscordAdapter({
+  ...connectDiscordAdapter("discord/acme-discord"),
+});
+```
+
+The helper resolves `botToken` and `applicationId` from one Connect token
+response. Omit `DISCORD_BOT_TOKEN`, `DISCORD_PUBLIC_KEY`, and
+`DISCORD_APPLICATION_ID` — Connect OIDC verification replaces Discord's
+Ed25519 public-key check for trigger-forwarded interactions.
 
 ### GitHub
 

--- a/packages/adapter-discord/README.md
+++ b/packages/adapter-discord/README.md
@@ -221,9 +221,10 @@ All options are auto-detected from environment variables when not provided.
 
 | Option | Required | Description |
 |--------|----------|-------------|
-| `botToken` | No* | Discord bot token. Auto-detected from `DISCORD_BOT_TOKEN` |
+| `botToken` | No* | Discord bot token or async resolver. Auto-detected from `DISCORD_BOT_TOKEN` |
 | `publicKey` | No* | Application public key. Auto-detected from `DISCORD_PUBLIC_KEY` |
-| `applicationId` | No* | Discord application ID. Auto-detected from `DISCORD_APPLICATION_ID` |
+| `applicationId` | No* | Discord application ID or async resolver. Auto-detected from `DISCORD_APPLICATION_ID` |
+| `webhookVerifier` | No | Custom webhook verifier that replaces Discord's Ed25519 `publicKey` verification |
 | `contentFormat` | No | Render Chat SDK cards as `DiscordContentFormat.Embeds` or `DiscordContentFormat.ComponentsV2`. Defaults to `DiscordContentFormat.Embeds` |
 | `mentionRoleIds` | No | Array of role IDs that trigger mention handlers. Auto-detected from `DISCORD_MENTION_ROLE_IDS` (comma-separated) |
 | `respondToChannelIds` | No | Parent channel IDs whose non-bot messages, including messages in child threads, trigger mention handlers without an @mention. Top-level messages use the adapter's normal per-message Discord thread. Auto-detected from `DISCORD_RESPOND_TO_CHANNEL_IDS` (comma-separated). Defaults to `[]` |
@@ -232,7 +233,25 @@ All options are auto-detected from environment variables when not provided.
 | `apiUrl` | No | Override the Discord API base URL. Auto-detected from `DISCORD_API_URL` |
 | `logger` | No | Logger instance (defaults to `ConsoleLogger("info")`) |
 
-*`botToken`, `publicKey`, and `applicationId` are required — either via config or env vars.
+*`botToken` and `applicationId` are required via config or env vars. Provide either `publicKey` or `webhookVerifier` for inbound webhook verification.
+
+### Vercel Connect
+
+Use `connectDiscordAdapter` to resolve the bot token and application ID from a
+Vercel Connect Discord connector and verify trigger-forwarded interactions with
+Vercel OIDC:
+
+```typescript
+import { createDiscordAdapter } from "@chat-adapter/discord";
+import { connectDiscordAdapter } from "@vercel/connect/chat";
+
+const discord = createDiscordAdapter({
+  ...connectDiscordAdapter("discord/acme-discord"),
+});
+```
+
+No `DISCORD_BOT_TOKEN`, `DISCORD_PUBLIC_KEY`, or `DISCORD_APPLICATION_ID` is
+needed in this mode.
 
 ## Discord thread channel names
 

--- a/packages/adapter-discord/src/index.test.ts
+++ b/packages/adapter-discord/src/index.test.ts
@@ -143,8 +143,48 @@ describe("constructor env var resolution", () => {
 
   it("should throw when publicKey is missing and env var not set", () => {
     expect(() => new DiscordAdapter({ botToken: "test" })).toThrow(
-      "publicKey is required"
+      "publicKey or webhookVerifier is required"
     );
+  });
+
+  it("accepts resolver credentials with a custom webhook verifier", async () => {
+    const botToken = vi.fn().mockResolvedValue("resolved-token");
+    const applicationId = vi.fn().mockResolvedValue("resolved-app-id");
+    const adapter = new DiscordAdapter({
+      botToken,
+      applicationId,
+      webhookVerifier: () => true,
+      logger: mockLogger,
+    });
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          id: "user-id",
+          username: "test-user",
+          global_name: "Test User",
+        }),
+        { status: 200, headers: { "Content-Type": "application/json" } }
+      )
+    );
+
+    try {
+      await adapter.initialize(createMockChatInstance());
+      await adapter.getUser("user-id");
+
+      expect(adapter.botUserId).toBe("resolved-app-id");
+      expect(applicationId).toHaveBeenCalledTimes(1);
+      expect(botToken).toHaveBeenCalledTimes(1);
+      expect(fetchSpy).toHaveBeenCalledWith(
+        "https://discord.com/api/v10/users/user-id",
+        expect.objectContaining({
+          headers: expect.objectContaining({
+            Authorization: "Bot resolved-token",
+          }),
+        })
+      );
+    } finally {
+      fetchSpy.mockRestore();
+    }
   });
 
   it("should throw when applicationId is missing and env var not set", () => {
@@ -355,6 +395,66 @@ describe("handleWebhook - signature verification", () => {
 
     const response = await adapter.handleWebhook(request);
     expect(response.status).toBe(200);
+  });
+});
+
+describe("handleWebhook - custom webhook verifier", () => {
+  it("uses the custom verifier without Discord signature headers", async () => {
+    const verifier = vi.fn().mockResolvedValue(true);
+    const adapter = createDiscordAdapter({
+      botToken: "test-token",
+      applicationId: async () => "test-app-id",
+      webhookVerifier: verifier,
+      logger: mockLogger,
+    });
+    const body = JSON.stringify({ type: InteractionType.Ping });
+    const request = new Request("https://example.com/webhook", {
+      method: "POST",
+      headers: { authorization: "Bearer connect-token" },
+      body,
+    });
+
+    const response = await adapter.handleWebhook(request);
+
+    expect(response.status).toBe(200);
+    expect(verifier).toHaveBeenCalledWith(request, body);
+    expect(adapter.botUserId).toBe("test-app-id");
+  });
+
+  it("rejects requests when the custom verifier returns a falsy value", async () => {
+    const adapter = createDiscordAdapter({
+      botToken: "test-token",
+      applicationId: "test-app-id",
+      webhookVerifier: () => false,
+      logger: mockLogger,
+    });
+    const request = new Request("https://example.com/webhook", {
+      method: "POST",
+      body: JSON.stringify({ type: InteractionType.Ping }),
+    });
+
+    const response = await adapter.handleWebhook(request);
+
+    expect(response.status).toBe(401);
+  });
+
+  it("rejects requests when the custom verifier throws", async () => {
+    const adapter = createDiscordAdapter({
+      botToken: "test-token",
+      applicationId: "test-app-id",
+      webhookVerifier: () => {
+        throw new Error("invalid OIDC token");
+      },
+      logger: mockLogger,
+    });
+    const request = new Request("https://example.com/webhook", {
+      method: "POST",
+      body: JSON.stringify({ type: InteractionType.Ping }),
+    });
+
+    const response = await adapter.handleWebhook(request);
+
+    expect(response.status).toBe(401);
   });
 });
 
@@ -747,6 +847,57 @@ describe("handleWebhook - APPLICATION_COMMAND", () => {
         expect.objectContaining({
           method: "PATCH",
         })
+      );
+    } finally {
+      fetchSpy.mockRestore();
+    }
+  });
+
+  it("uses a resolved application ID for interaction webhook responses", async () => {
+    const applicationId = vi.fn().mockResolvedValue("resolved-app-id");
+    const resolverAdapter = createDiscordAdapter({
+      botToken: "test-token",
+      applicationId,
+      webhookVerifier: () => true,
+      logger: mockLogger,
+    });
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(JSON.stringify({ id: "msg123" }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      })
+    );
+
+    try {
+      await resolverAdapter.initialize(createMockChatInstance());
+      await (
+        resolverAdapter as unknown as {
+          postSlashCommandResponse: (
+            context: {
+              channelId: string;
+              initialResponseSent: boolean;
+              interactionToken: string;
+            },
+            threadId: string,
+            payload: { content: string },
+            files: []
+          ) => Promise<unknown>;
+        }
+      ).postSlashCommandResponse(
+        {
+          channelId: "discord:guild123:channel456",
+          initialResponseSent: false,
+          interactionToken: "interaction-token",
+        },
+        "discord:guild123:channel456",
+        { content: "Pong!" },
+        []
+      );
+
+      expect(applicationId).toHaveBeenCalledTimes(1);
+      expect(fetchSpy).toHaveBeenCalledWith(
+        "https://discord.com/api/v10/webhooks/resolved-app-id/interaction-token/messages/@original",
+        expect.objectContaining({ method: "PATCH" })
       );
     } finally {
       fetchSpy.mockRestore();
@@ -3917,6 +4068,35 @@ describe("handleWebhook - forwarded gateway events", () => {
 
     const response = await adapter.handleWebhook(request);
     expect(response.status).toBe(200);
+  });
+
+  it("validates forwarded events with resolved credentials", async () => {
+    const botToken = vi.fn().mockResolvedValue("resolved-token");
+    const applicationId = vi.fn().mockResolvedValue("resolved-app-id");
+    const resolverAdapter = createDiscordAdapter({
+      botToken,
+      applicationId,
+      webhookVerifier: () => true,
+      logger: mockLogger,
+    });
+    const request = new Request("https://example.com/webhook", {
+      method: "POST",
+      headers: {
+        "x-discord-gateway-token": "resolved-token",
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({
+        type: "GATEWAY_UNKNOWN_EVENT",
+        timestamp: Date.now(),
+        data: {},
+      }),
+    });
+
+    const response = await resolverAdapter.handleWebhook(request);
+
+    expect(response.status).toBe(200);
+    expect(botToken).toHaveBeenCalledTimes(1);
+    expect(applicationId).toHaveBeenCalledTimes(1);
   });
 
   it("returns 400 for invalid JSON in forwarded events", async () => {

--- a/packages/adapter-discord/src/index.ts
+++ b/packages/adapter-discord/src/index.ts
@@ -2,7 +2,8 @@
  * Discord adapter for chat-sdk.
  *
  * Uses Discord's HTTP Interactions API (not Gateway WebSocket) for
- * serverless compatibility. Webhook signature verification uses Ed25519.
+ * serverless compatibility. Webhooks use Ed25519 verification by default,
+ * or a custom verifier for services such as Vercel Connect.
  */
 
 import { AsyncLocalStorage } from "node:async_hooks";
@@ -90,6 +91,7 @@ import {
   type DiscordSlashCommandContext,
   type DiscordThreadId,
   type DiscordUser,
+  type DiscordWebhookVerifier,
   InteractionResponseType,
 } from "./types";
 
@@ -111,15 +113,26 @@ interface DiscordFileUpload {
   mimeType?: string;
 }
 
+function normalizeCredentialProvider(
+  value: string | (() => string | Promise<string>)
+): () => Promise<string> {
+  if (typeof value === "function") {
+    return async () => await value();
+  }
+  return () => Promise.resolve(value);
+}
+
 export class DiscordAdapter implements Adapter<DiscordThreadId, unknown> {
   readonly name = "discord";
   readonly userName: string;
-  readonly botUserId?: string;
 
   protected readonly apiBaseUrl: string;
-  protected readonly botToken: string;
-  protected readonly publicKey: string;
-  protected readonly applicationId: string;
+  protected readonly botTokenProvider: () => Promise<string>;
+  protected readonly applicationIdProvider: () => Promise<string>;
+  protected readonly publicKey?: string;
+  protected readonly webhookVerifier?: DiscordWebhookVerifier;
+  protected resolvedApplicationId?: string;
+  protected pendingApplicationId?: Promise<string>;
   protected readonly mentionRoleIds: string[];
   protected readonly contentFormat: DiscordContentFormat;
   protected readonly respondToChannelIds: string[];
@@ -136,6 +149,20 @@ export class DiscordAdapter implements Adapter<DiscordThreadId, unknown> {
   >();
   protected static readonly THREAD_PARENT_CACHE_TTL = 5 * 60 * 1000;
 
+  get botUserId(): string | undefined {
+    return this.resolvedApplicationId;
+  }
+
+  protected get applicationId(): string {
+    if (!this.resolvedApplicationId) {
+      throw new ValidationError(
+        "discord",
+        "applicationId has not been resolved. Ensure chat.initialize() has completed."
+      );
+    }
+    return this.resolvedApplicationId;
+  }
+
   constructor(config: DiscordAdapterConfig = {}) {
     const botToken = config.botToken ?? process.env.DISCORD_BOT_TOKEN;
     if (!botToken) {
@@ -144,11 +171,14 @@ export class DiscordAdapter implements Adapter<DiscordThreadId, unknown> {
         "botToken is required. Set DISCORD_BOT_TOKEN or provide it in config."
       );
     }
-    const publicKey = config.publicKey ?? process.env.DISCORD_PUBLIC_KEY;
-    if (!publicKey) {
+    const webhookVerifier = config.webhookVerifier;
+    const publicKey = webhookVerifier
+      ? undefined
+      : (config.publicKey ?? process.env.DISCORD_PUBLIC_KEY);
+    if (!(publicKey || webhookVerifier)) {
       throw new ValidationError(
         "discord",
-        "publicKey is required. Set DISCORD_PUBLIC_KEY or provide it in config."
+        "publicKey or webhookVerifier is required. Set DISCORD_PUBLIC_KEY, provide publicKey in config, or provide a webhookVerifier."
       );
     }
     const applicationId =
@@ -162,9 +192,12 @@ export class DiscordAdapter implements Adapter<DiscordThreadId, unknown> {
 
     this.apiBaseUrl =
       config.apiUrl ?? process.env.DISCORD_API_URL ?? DISCORD_API_BASE;
-    this.botToken = botToken;
-    this.publicKey = publicKey.trim().toLowerCase();
-    this.applicationId = applicationId;
+    this.botTokenProvider = normalizeCredentialProvider(botToken);
+    this.applicationIdProvider = normalizeCredentialProvider(applicationId);
+    this.resolvedApplicationId =
+      typeof applicationId === "string" ? applicationId : undefined;
+    this.publicKey = publicKey?.trim().toLowerCase();
+    this.webhookVerifier = webhookVerifier;
     this.mentionRoleIds =
       config.mentionRoleIds ??
       (process.env.DISCORD_MENTION_ROLE_IDS
@@ -189,14 +222,13 @@ export class DiscordAdapter implements Adapter<DiscordThreadId, unknown> {
           )
         : []);
     this.respondToGlobalMentions = config.respondToGlobalMentions ?? false;
-    this.botUserId = applicationId; // Discord app ID is the bot's user ID
     this.contentFormat = contentFormat;
     this.interactionFlags = config.interactionFlags;
     this.logger = config.logger ?? new ConsoleLogger("info").child("discord");
     this.userName = config.userName ?? "bot";
 
     // Validate public key format
-    if (!HEX_64_PATTERN.test(this.publicKey)) {
+    if (this.publicKey && !HEX_64_PATTERN.test(this.publicKey)) {
       this.logger.error("Invalid Discord public key format", {
         length: this.publicKey.length,
         isHex: HEX_PATTERN.test(this.publicKey),
@@ -205,8 +237,43 @@ export class DiscordAdapter implements Adapter<DiscordThreadId, unknown> {
   }
 
   async initialize(chat: ChatInstance): Promise<void> {
+    await this.resolveApplicationId();
     this.chat = chat;
     this.logger.info("Discord adapter initialized");
+  }
+
+  protected async resolveBotToken(): Promise<string> {
+    const botToken = await this.botTokenProvider();
+    if (!botToken) {
+      throw new ValidationError(
+        "discord",
+        "botToken resolver returned an empty token."
+      );
+    }
+    return botToken;
+  }
+
+  protected async resolveApplicationId(): Promise<string> {
+    if (this.resolvedApplicationId) {
+      return this.resolvedApplicationId;
+    }
+    if (!this.pendingApplicationId) {
+      this.pendingApplicationId = this.applicationIdProvider()
+        .then((applicationId) => {
+          if (!applicationId) {
+            throw new ValidationError(
+              "discord",
+              "applicationId resolver returned an empty application ID."
+            );
+          }
+          this.resolvedApplicationId = applicationId;
+          return applicationId;
+        })
+        .finally(() => {
+          this.pendingApplicationId = undefined;
+        });
+    }
+    return this.pendingApplicationId;
   }
 
   async getUser(userId: string): Promise<UserInfo | null> {
@@ -243,7 +310,11 @@ export class DiscordAdapter implements Adapter<DiscordThreadId, unknown> {
     // Check if this is a forwarded Gateway event (uses bot token for auth)
     const gatewayToken = request.headers.get("x-discord-gateway-token");
     if (gatewayToken) {
-      if (gatewayToken !== this.botToken) {
+      const [, botToken] = await Promise.all([
+        this.resolveApplicationId(),
+        this.resolveBotToken(),
+      ]);
+      if (gatewayToken !== botToken) {
         this.logger.warn("Invalid gateway token");
         return new Response("Invalid gateway token", { status: 401 });
       }
@@ -256,6 +327,8 @@ export class DiscordAdapter implements Adapter<DiscordThreadId, unknown> {
       }
     }
 
+    await this.resolveApplicationId();
+
     this.logger.info("Discord webhook received", {
       bodyLength: body.length,
       bodyBytesLength: bodyBytes.length,
@@ -263,20 +336,35 @@ export class DiscordAdapter implements Adapter<DiscordThreadId, unknown> {
       hasTimestamp: !!request.headers.get("x-signature-timestamp"),
     });
 
-    // Verify Ed25519 signature using raw bytes
-    const signature = request.headers.get("x-signature-ed25519");
-    const timestamp = request.headers.get("x-signature-timestamp");
-
-    const signatureValid = await this.verifySignature(
-      bodyBytes,
-      signature,
-      timestamp
-    );
-    if (!signatureValid) {
-      this.logger.warn("Discord signature verification failed, returning 401");
-      return new Response("Invalid signature", { status: 401 });
+    if (this.webhookVerifier) {
+      let verified: unknown;
+      try {
+        verified = await this.webhookVerifier(request, body);
+      } catch (error) {
+        this.logger.warn("Discord webhook verifier rejected the request", {
+          error,
+        });
+        return new Response("Invalid signature", { status: 401 });
+      }
+      if (!verified) {
+        return new Response("Invalid signature", { status: 401 });
+      }
+    } else {
+      const signature = request.headers.get("x-signature-ed25519");
+      const timestamp = request.headers.get("x-signature-timestamp");
+      const signatureValid = await this.verifySignature(
+        bodyBytes,
+        signature,
+        timestamp
+      );
+      if (!signatureValid) {
+        this.logger.warn(
+          "Discord signature verification failed, returning 401"
+        );
+        return new Response("Invalid signature", { status: 401 });
+      }
+      this.logger.info("Discord signature verification passed");
     }
-    this.logger.info("Discord signature verification passed");
 
     let interaction: DiscordInteraction;
     try {
@@ -339,6 +427,9 @@ export class DiscordAdapter implements Adapter<DiscordThreadId, unknown> {
     signature: string | null,
     timestamp: string | null
   ): Promise<boolean> {
+    if (!this.publicKey) {
+      return false;
+    }
     if (!(signature && timestamp)) {
       this.logger.warn(
         "Discord signature verification failed: missing headers",
@@ -1348,6 +1439,7 @@ export class DiscordAdapter implements Adapter<DiscordThreadId, unknown> {
     payload: DiscordMessagePayload,
     files: DiscordFileUpload[]
   ): Promise<RawMessage<unknown>> {
+    const botToken = await this.resolveBotToken();
     const formData = new FormData();
 
     // Add JSON payload
@@ -1376,7 +1468,7 @@ export class DiscordAdapter implements Adapter<DiscordThreadId, unknown> {
       {
         method: "POST",
         headers: {
-          Authorization: `Bot ${this.botToken}`,
+          Authorization: `Bot ${botToken}`,
         },
         body: formData,
       }
@@ -1924,9 +2016,10 @@ export class DiscordAdapter implements Adapter<DiscordThreadId, unknown> {
     method: string,
     body?: unknown
   ): Promise<Response> {
+    const botToken = await this.resolveBotToken();
     const url = `${this.apiBaseUrl}${path}`;
     const headers: Record<string, string> = {
-      Authorization: `Bot ${this.botToken}`,
+      Authorization: `Bot ${botToken}`,
     };
 
     if (body) {
@@ -2110,7 +2203,7 @@ export class DiscordAdapter implements Adapter<DiscordThreadId, unknown> {
 
     try {
       // Login to Discord
-      await client.login(this.botToken);
+      await client.login(await this.resolveBotToken());
 
       // Wait for either: duration timeout OR abort signal
       await new Promise<void>((resolve) => {
@@ -2312,6 +2405,7 @@ export class DiscordAdapter implements Adapter<DiscordThreadId, unknown> {
     event: DiscordForwardedEvent
   ): Promise<void> {
     try {
+      const botToken = await this.resolveBotToken();
       this.logger.debug("Forwarding Gateway event to webhook", {
         type: event.type,
         webhookUrl,
@@ -2321,7 +2415,7 @@ export class DiscordAdapter implements Adapter<DiscordThreadId, unknown> {
         method: "POST",
         headers: {
           "Content-Type": "application/json",
-          "x-discord-gateway-token": this.botToken,
+          "x-discord-gateway-token": botToken,
         },
         body: JSON.stringify(event),
       });
@@ -2902,6 +2996,7 @@ export type {
   DiscordMessageFlags,
   DiscordMessageFlagValue,
   DiscordThreadId,
+  DiscordWebhookVerifier,
 } from "./types";
 export {
   DiscordComponentType,

--- a/packages/adapter-discord/src/types.ts
+++ b/packages/adapter-discord/src/types.ts
@@ -20,13 +20,24 @@ export enum DiscordContentFormat {
   Embeds = "embeds",
 }
 
+/**
+ * Custom webhook verifier used in place of Discord's Ed25519 public key.
+ *
+ * Receives the incoming request and its raw body. Return a truthy value
+ * to accept the request; throw or return a falsy value to reject it.
+ */
+export type DiscordWebhookVerifier = (
+  request: Request,
+  body: string
+) => Promise<unknown> | unknown;
+
 export interface DiscordAdapterConfig {
   /** Override the Discord API base URL. Defaults to DISCORD_API_URL env var or "https://discord.com/api/v10". */
   apiUrl?: string;
-  /** Discord application ID. Defaults to DISCORD_APPLICATION_ID env var. */
-  applicationId?: string;
-  /** Discord bot token. Defaults to DISCORD_BOT_TOKEN env var. */
-  botToken?: string;
+  /** Discord application ID or resolver. Defaults to DISCORD_APPLICATION_ID env var. */
+  applicationId?: string | (() => string | Promise<string>);
+  /** Discord bot token or resolver invoked per API call. Defaults to DISCORD_BOT_TOKEN env var. */
+  botToken?: string | (() => string | Promise<string>);
   /** Render Discord card content as embeds or Components v2. Defaults to DiscordContentFormat.Embeds. */
   contentFormat?: DiscordContentFormat;
   /** Return interaction flags for the initial deferred slash command response. */
@@ -45,6 +56,8 @@ export interface DiscordAdapterConfig {
   respondToGlobalMentions?: boolean;
   /** Override bot username (optional) */
   userName?: string;
+  /** Custom webhook verifier used instead of Discord's Ed25519 public key. */
+  webhookVerifier?: DiscordWebhookVerifier;
 }
 
 /**

--- a/packages/create-chat-sdk/README.md
+++ b/packages/create-chat-sdk/README.md
@@ -39,7 +39,7 @@ When the CLI detects a coding agent environment, it announces the detection and 
 
 ## Vercel Connect
 
-The Slack, GitHub, and Linear adapters can authenticate with [Vercel Connect](https://chat-sdk.dev/docs/vercel-connect) instead of stored provider secrets. Pass `--connect`, or choose **Vercel Connect** at the interactive auth-mode prompt:
+The Slack, Discord, GitHub, and Linear adapters can authenticate with [Vercel Connect](https://chat-sdk.dev/docs/vercel-connect) instead of stored provider secrets. Pass `--connect`, or choose **Vercel Connect** at the interactive auth-mode prompt:
 
 ```bash
 npm create chat-sdk@latest -- my-bot --adapter slack --connect -y
@@ -60,8 +60,8 @@ Options:
   --adapter <values...>     platform or state adapters to include
   --vendor                  list vendor-official adapters in the interactive
                             prompt
-  --connect                 authenticate Slack, GitHub, and Linear adapters
-                            with Vercel Connect
+  --connect                 authenticate Slack, Discord, GitHub, and Linear
+                            adapters with Vercel Connect
   --pm <manager>            package manager to use (npm, yarn, pnpm, bun)
   -y, --yes                 skip prompts and accept defaults
   --interactive             always prompt, even when a coding agent

--- a/packages/create-chat-sdk/docs/create-chat-sdk.mdx
+++ b/packages/create-chat-sdk/docs/create-chat-sdk.mdx
@@ -100,7 +100,7 @@ When the [Discord adapter](/adapters/official/discord) is selected, the CLI also
 
 ## Vercel Connect
 
-[Vercel Connect](/docs/vercel-connect) lets the Slack, GitHub, and Linear adapters authenticate with a connector instead of stored provider secrets. Pass `--connect` — or choose **Vercel Connect** at the interactive auth-mode prompt — to scaffold Connect wiring for any selected Slack, GitHub, or Linear adapter:
+[Vercel Connect](/docs/vercel-connect) lets the Slack, Discord, GitHub, and Linear adapters authenticate with a connector instead of stored provider secrets. Pass `--connect` — or choose **Vercel Connect** at the interactive auth-mode prompt — to scaffold Connect wiring for any selected Slack, Discord, GitHub, or Linear adapter:
 
 ```bash
 npm create chat-sdk@latest -- my-bot --adapter slack --connect -y
@@ -120,7 +120,7 @@ The generated `src/lib/bot.ts` spreads the matching helper from `@vercel/connect
 | `-d, --description <text>` | Project description. |
 | `--adapter <values...>` | Platform or state adapters to include. |
 | `--vendor` | List only vendor-official adapters in the interactive prompt. |
-| `--connect` | Authenticate Slack, GitHub, and Linear adapters with Vercel Connect. |
+| `--connect` | Authenticate Slack, Discord, GitHub, and Linear adapters with Vercel Connect. |
 | `--pm <manager>` | Package manager to use: `npm`, `yarn`, `pnpm`, or `bun`. |
 | `-y, --yes` | Skip prompts and accept defaults. |
 | `--interactive` | Always prompt, even when a coding agent environment is detected. |

--- a/packages/create-chat-sdk/src/catalog/scaffold-spec.ts
+++ b/packages/create-chat-sdk/src/catalog/scaffold-spec.ts
@@ -75,7 +75,7 @@ export interface AdapterConnectSpec {
 export interface CliScaffoldSpec {
   /**
    * Vercel Connect code-generation policy. Present only for adapters that
-   * support Connect (Slack, GitHub, Linear).
+   * support Connect (Slack, Discord, GitHub, Linear).
    */
   connect?: AdapterConnectSpec;
   /**
@@ -146,6 +146,10 @@ export const CLI_SCAFFOLD_SPEC = {
     },
   },
   discord: {
+    connect: {
+      connectorEnvVar: "DISCORD_CONNECTOR",
+      helper: "connectDiscordAdapter",
+    },
     invocation: { kind: "zero-arg" },
     serverExternalPackages: [
       "discord.js",

--- a/packages/create-chat-sdk/src/cli/e2e.test.ts
+++ b/packages/create-chat-sdk/src/cli/e2e.test.ts
@@ -116,6 +116,45 @@ describe("CLI Vercel Connect mode", () => {
     expect(envExample).toContain("SLACK_CONNECTOR=");
     expect(envExample).not.toContain("SLACK_SIGNING_SECRET=");
   });
+
+  it("scaffolds Discord with Vercel Connect when --connect is passed", async () => {
+    process.exitCode = undefined;
+    const program = createProgram();
+    await program.parseAsync([
+      "node",
+      "create-chat-sdk",
+      "connect-discord-bot",
+      "--adapter",
+      "discord",
+      "memory",
+      "--connect",
+      "-yq",
+      "--skip-install",
+      "--no-git",
+    ]);
+
+    expect(process.exitCode).toBeUndefined();
+
+    const botTs = readProjectFile("connect-discord-bot", "src/lib/bot.ts");
+    expect(botTs).toContain(
+      'import { connectDiscordAdapter } from "@vercel/connect/chat";'
+    );
+    expect(botTs).toContain(
+      '...connectDiscordAdapter(requireEnv("DISCORD_CONNECTOR")),'
+    );
+
+    const packageJson = JSON.parse(
+      readProjectFile("connect-discord-bot", "package.json")
+    ) as { dependencies?: Record<string, string> };
+    expect(packageJson.dependencies?.["@vercel/connect"]).toBe("latest");
+
+    const envExample = readProjectFile("connect-discord-bot", ".env.example");
+    expect(envExample).toContain("DISCORD_CONNECTOR=");
+    expect(envExample).toContain("CRON_SECRET=");
+    expect(envExample).not.toContain("DISCORD_BOT_TOKEN=");
+    expect(envExample).not.toContain("DISCORD_PUBLIC_KEY=");
+    expect(envExample).not.toContain("DISCORD_APPLICATION_ID=");
+  });
 });
 
 describe("CLI agent mode", () => {

--- a/packages/create-chat-sdk/src/cli/program.ts
+++ b/packages/create-chat-sdk/src/cli/program.ts
@@ -71,7 +71,7 @@ export function createProgram(): Command {
     )
     .option(
       "--connect",
-      "authenticate Slack, GitHub, and Linear adapters with Vercel Connect"
+      "authenticate Slack, Discord, GitHub, and Linear adapters with Vercel Connect"
     )
     .option(
       "--pm <manager>",

--- a/packages/create-chat-sdk/src/generators/generators.test.ts
+++ b/packages/create-chat-sdk/src/generators/generators.test.ts
@@ -113,6 +113,29 @@ describe("Vercel Connect generation", () => {
     );
   });
 
+  it("scaffolds Discord with Connect credentials instead of native secrets", () => {
+    const botTs = generateBotTs(connectConfig(["discord"]));
+    expect(botTs).toContain(
+      'import { connectDiscordAdapter } from "@vercel/connect/chat";'
+    );
+    expect(botTs).toContain("discord: createDiscordAdapter({");
+    expect(botTs).toContain(
+      '...connectDiscordAdapter(requireEnv("DISCORD_CONNECTOR")),'
+    );
+
+    const envExample = generateEnvExample(connectConfig(["discord"]));
+    expect(envExample).toContain("DISCORD_CONNECTOR=");
+    expect(envExample).toContain("CRON_SECRET=");
+    expect(envExample).not.toContain("DISCORD_BOT_TOKEN=");
+    expect(envExample).not.toContain("DISCORD_PUBLIC_KEY=");
+    expect(envExample).not.toContain("DISCORD_APPLICATION_ID=");
+
+    const readme = generateReadme(connectConfig(["discord"]));
+    expect(readme).toContain("authenticates Discord with");
+    expect(readme).toContain("DISCORD_CONNECTOR");
+    expect(readme).toContain("Discord Gateway (cron)");
+  });
+
   it("fails loudly on a missing connector via requireEnv", () => {
     const result = generateBotTs(connectConfig(["slack"]));
     expect(result).toContain("const requireEnv = (name: string): string =>");
@@ -129,15 +152,17 @@ describe("Vercel Connect generation", () => {
   });
 
   it("imports every selected Connect helper, sorted", () => {
-    const result = generateBotTs(connectConfig(["slack", "github", "linear"]));
+    const result = generateBotTs(
+      connectConfig(["slack", "discord", "github", "linear"])
+    );
     expect(result).toContain(
-      'import { connectGitHubAdapter, connectLinearAdapter, connectSlackAdapter } from "@vercel/connect/chat";'
+      'import { connectDiscordAdapter, connectGitHubAdapter, connectLinearAdapter, connectSlackAdapter } from "@vercel/connect/chat";'
     );
   });
 
   it("leaves non-Connect adapters on their native factory calls", () => {
-    const result = generateBotTs(connectConfig(["slack", "discord"]));
-    expect(result).toContain("discord: createDiscordAdapter(),");
+    const result = generateBotTs(connectConfig(["slack", "telegram"]));
+    expect(result).toContain("telegram: createTelegramAdapter(),");
     expect(result).toContain("slack: createSlackAdapter({");
   });
 
@@ -158,7 +183,7 @@ describe("Vercel Connect generation", () => {
   it("does not add @vercel/connect without a Connect-capable adapter", () => {
     const result = generatePackageJson(
       { dependencies: {} },
-      { ...makeConfig(["discord"]), useConnect: true }
+      { ...makeConfig(["telegram"]), useConnect: true }
     );
     expect(result.dependencies?.["@vercel/connect"]).toBeUndefined();
   });
@@ -186,7 +211,7 @@ describe("Vercel Connect generation", () => {
 
   it("omits the README Connect section without a Connect-capable adapter", () => {
     const result = generateReadme({
-      ...makeConfig(["discord"]),
+      ...makeConfig(["telegram"]),
       useConnect: true,
     });
     expect(result).not.toContain("Authentication (Vercel Connect)");

--- a/packages/create-chat-sdk/src/prompts/flow.test.ts
+++ b/packages/create-chat-sdk/src/prompts/flow.test.ts
@@ -205,7 +205,7 @@ describe("runPrompts", () => {
 
   it("prompts for auth mode and applies Vercel Connect when chosen", async () => {
     vi.mocked(text).mockResolvedValueOnce("my-bot").mockResolvedValueOnce("");
-    vi.mocked(multiselect).mockResolvedValueOnce(["slack"]);
+    vi.mocked(multiselect).mockResolvedValueOnce(["discord"]);
     vi.mocked(select)
       .mockResolvedValueOnce("memory")
       .mockResolvedValueOnce("connect");
@@ -239,7 +239,7 @@ describe("runPrompts", () => {
 
   it("does not prompt for auth mode without a Connect-capable adapter", async () => {
     vi.mocked(text).mockResolvedValueOnce("my-bot").mockResolvedValueOnce("");
-    vi.mocked(multiselect).mockResolvedValueOnce(["discord"]);
+    vi.mocked(multiselect).mockResolvedValueOnce(["telegram"]);
     vi.mocked(select).mockResolvedValueOnce("memory");
     vi.mocked(confirm).mockResolvedValueOnce(true);
 
@@ -254,7 +254,7 @@ describe("runPrompts", () => {
       connect: true,
       name: "my-bot",
       quiet: true,
-      selectedAdapters: ["slack", "memory"],
+      selectedAdapters: ["discord", "memory"],
       yes: true,
     });
 
@@ -266,7 +266,7 @@ describe("runPrompts", () => {
       connect: true,
       name: "my-bot",
       quiet: false,
-      selectedAdapters: ["discord", "memory"],
+      selectedAdapters: ["telegram", "memory"],
       yes: true,
     });
 

--- a/packages/create-chat-sdk/src/prompts/flow.ts
+++ b/packages/create-chat-sdk/src/prompts/flow.ts
@@ -146,7 +146,7 @@ export async function runPrompts(
     useConnect = connectCapable;
     if (!(connectCapable || inputs.quiet)) {
       log.warning(
-        "Ignoring --connect: Vercel Connect supports only the Slack, GitHub, and Linear adapters."
+        "Ignoring --connect: Vercel Connect supports only the Slack, Discord, GitHub, and Linear adapters."
       );
     }
   } else if (!(inputs.yes || flaggedSelection) && connectCapable) {

--- a/packages/create-chat-sdk/src/types.ts
+++ b/packages/create-chat-sdk/src/types.ts
@@ -44,8 +44,9 @@ export interface ProjectConfig extends AdapterSelection {
    */
   shouldInstall: boolean;
   /**
-   * Authenticate Connect-capable adapters (Slack, GitHub, Linear) with Vercel
-   * Connect instead of native provider secrets. Defaults to `false`.
+   * Authenticate Connect-capable adapters (Slack, Discord, GitHub, Linear)
+   * with Vercel Connect instead of native provider secrets. Defaults to
+   * `false`.
    */
   useConnect?: boolean;
 }


### PR DESCRIPTION
Adds function-backed Discord bot token and application ID resolvers, plus custom webhook verification for Vercel Connect trigger-forwarded interactions. Native Discord Ed25519 verification remains the default when no custom verifier is configured.

```ts
import { createDiscordAdapter } from "@chat-adapter/discord";
import { connectDiscordAdapter } from "@vercel/connect/chat";

createDiscordAdapter({
  ...connectDiscordAdapter("discord/acme-discord"),
});
```

`create-chat-sdk` now recognizes Discord as Connect-capable, generates `DISCORD_CONNECTOR` instead of native credential variables, and preserves `CRON_SECRET` for Gateway forwarding:

```bash
npm create chat-sdk@latest -- my-bot --adapter discord memory --connect -y
```

Validated with the Discord adapter suite (284 tests), create-chat-sdk suite (206 tests), package type checks/builds, and repository lint/format checks.