### PR TITLE
Add Vercel Connect support to Notion

### DIFF
--- a/.changeset/notion-connect-chat.md
+++ b/.changeset/notion-connect-chat.md
@@ -1,0 +1,6 @@
+---
+"@chat-adapter/notion": minor
+"create-chat-sdk": minor
+---
+
+Add outbound-only Vercel Connect authentication for Notion while retaining native webhook verification and scaffolding.

--- a/apps/docs/content/adapters/official/notion.mdx
+++ b/apps/docs/content/adapters/official/notion.mdx
@@ -88,6 +88,26 @@ export async function POST(request: Request): Promise<Response> {
 }
 ```
 
+## Vercel Connect
+
+Use Vercel Connect for the outbound Notion access token:
+
+```typescript title="lib/bot.ts" lineNumbers
+import { createNotionAdapter } from "@chat-adapter/notion";
+import { connectNotionAdapter } from "@vercel/connect/chat";
+
+const notion = createNotionAdapter({
+  ...connectNotionAdapter("notion/acme-notion"),
+  verificationToken: process.env.NOTION_VERIFICATION_TOKEN,
+});
+```
+
+<Callout type="info">
+  Connect does not forward Notion webhooks. Configure the subscription directly
+  in Notion and retain `NOTION_VERIFICATION_TOKEN` for native HMAC verification.
+  `NOTION_TOKEN` is not needed when using `connectNotionAdapter`.
+</Callout>
+
 ## Connection setup
 
 The adapter targets a **single workspace** via an [access-token connection](https://developers.notion.com/docs/getting-started).
@@ -137,9 +157,9 @@ Event-id dedupe is **best-effort**: in-memory plus state-backed when a Chat stat
 <TypeTable
   type={{
     token: {
-      type: "string",
+      type: "string | (() => string | Promise<string>)",
       description:
-        "Connection access token. Auto-detected from `NOTION_TOKEN`.",
+        "Connection access token or resolver invoked per API request. Auto-detected from `NOTION_TOKEN`.",
     },
     verificationToken: {
       type: "string",

--- a/apps/docs/content/docs/create-chat-sdk.mdx
+++ b/apps/docs/content/docs/create-chat-sdk.mdx
@@ -103,13 +103,13 @@ When the [Discord adapter](/adapters/official/discord) is selected, the CLI also
 
 ## Vercel Connect
 
-[Vercel Connect](/docs/vercel-connect) lets the Slack, Discord, GitHub, and Linear adapters authenticate with a connector instead of stored provider secrets. Pass `--connect` — or choose **Vercel Connect** at the interactive auth-mode prompt — to scaffold Connect wiring for any selected Slack, Discord, GitHub, or Linear adapter:
+[Vercel Connect](/docs/vercel-connect) supplies outbound credentials for the Slack, Discord, GitHub, Linear, and Notion adapters. Pass `--connect` — or choose **Vercel Connect** at the interactive auth-mode prompt — to scaffold Connect wiring for any selected adapter in that list. Notion webhooks remain direct and retain `NOTION_VERIFICATION_TOKEN`.
 
 ```bash
 npm create chat-sdk@latest -- my-bot --adapter slack --connect -y
 ```
 
-The generated `src/lib/bot.ts` spreads the matching helper from `@vercel/connect/chat` into the adapter factory, `@vercel/connect` is added to dependencies, and `.env.example` lists each connector UID (for example `SLACK_CONNECTOR`) in place of native secrets.
+The generated `src/lib/bot.ts` spreads the matching helper from `@vercel/connect/chat` into the adapter factory, `@vercel/connect` is added to dependencies, and `.env.example` lists each connector UID (for example `SLACK_CONNECTOR`). Native webhook verification secrets are retained for adapters such as Notion.
 
 <Callout type="info">
   Vercel Connect provides `VERCEL_OIDC_TOKEN` at runtime. For local development, run `vercel link` then `vercel env pull` to populate it. Connect forwards inbound webhooks only to deployed URLs, so test webhook delivery against a Vercel deployment (such as a preview) rather than localhost.
@@ -123,7 +123,7 @@ The generated `src/lib/bot.ts` spreads the matching helper from `@vercel/connect
 | `-d, --description <text>` | Project description. |
 | `--adapter <values...>` | Platform or state adapters to include. |
 | `--vendor` | List only vendor-official adapters in the interactive prompt. |
-| `--connect` | Authenticate Slack, Discord, GitHub, and Linear adapters with Vercel Connect. |
+| `--connect` | Authenticate Slack, Discord, GitHub, Linear, and Notion adapters with Vercel Connect. |
 | `--pm <manager>` | Package manager to use: `npm`, `yarn`, `pnpm`, or `bun`. |
 | `-y, --yes` | Skip prompts and accept defaults. |
 | `--interactive` | Always prompt, even when a coding agent environment is detected. |

--- a/apps/docs/content/docs/vercel-connect.mdx
+++ b/apps/docs/content/docs/vercel-connect.mdx
@@ -1,6 +1,6 @@
 ---
 title: Vercel Connect
-description: Authenticate Slack, Discord, GitHub, and Linear adapters with Vercel Connect — short-lived runtime tokens for outbound calls and OIDC-verified inbound webhooks, with no stored provider secrets.
+description: Authenticate Slack, Discord, GitHub, Linear, and Notion adapters with Vercel Connect — short-lived runtime tokens for outbound calls and OIDC-verified inbound webhooks where supported.
 type: overview
 related:
   - /docs/usage
@@ -8,6 +8,7 @@ related:
   - /adapters/official/discord
   - /adapters/official/github
   - /adapters/official/linear
+  - /adapters/official/notion
 ---
 
 [Vercel Connect](https://vercel.com/docs/connect) lets your bot use a registered connector for adapter authentication instead of storing long-lived provider secrets. You register a connector once, link it to your project and environments, and your code requests scoped, short-lived tokens at runtime.
@@ -18,11 +19,13 @@ The `@vercel/connect/chat` subpath ships a helper per platform that you spread i
 - `connectDiscordAdapter`
 - `connectGitHubAdapter`
 - `connectLinearAdapter`
+- `connectNotionAdapter`
 
-Each helper wires both directions of traffic:
+Each helper wires outbound credentials; trigger-capable providers also wire
+inbound traffic:
 
 - **Outbound** (your bot calls the provider API) — a function-form token field that resolves a fresh, short-lived token per call via `getToken`.
-- **Inbound** (the provider calls your bot) — a `webhookVerifier` that validates the Vercel OIDC token Connect attaches to [trigger-forwarded](https://vercel.com/docs/connect/concepts/triggers) webhooks, replacing the provider's native signature check.
+- **Inbound** (the provider calls your bot) — trigger-capable helpers include a `webhookVerifier` that validates the Vercel OIDC token Connect attaches to [trigger-forwarded](https://vercel.com/docs/connect/concepts/triggers) webhooks, replacing the provider's native signature check.
 
 <Callout type="info">
   Vercel Connect is in beta. Features and behavior, including available connectors and trigger forwarding, may change before general availability.
@@ -44,10 +47,15 @@ pnpm add @vercel/connect
 | [Discord](/adapters/official/discord) | `connectDiscordAdapter` | `botToken`, `applicationId` |
 | [GitHub](/adapters/official/github) | `connectGitHubAdapter` | `installationToken` |
 | [Linear](/adapters/official/linear) | `connectLinearAdapter` | `accessToken` |
+| [Notion](/adapters/official/notion) | `connectNotionAdapter` | `token` |
 
 Each helper accepts `(connector, params?, options?)`, where `params` is the [`getToken`](https://vercel.com/docs/connect/ts-sdk-reference) parameters minus `subject` (pinned to `{ type: "app" }`), letting you pass through `installationId`, `scopes`, or `validityBufferMs`.
 
 ## Set up a connector
+
+The trigger-forwarding steps below apply to Slack, Discord, GitHub, and Linear.
+For Notion, create and attach the connector without triggers, then configure the
+webhook subscription directly in Notion.
 
 1. Create a connector for the provider in the [Vercel dashboard](https://vercel.com/d?to=%2F%5Bteam%5D%2F~%2Fconnect) or with the CLI, enabling trigger forwarding so inbound webhooks reach your project:
 
@@ -143,9 +151,27 @@ await linear.withInstallation("org-id", async () => {
 });
 ```
 
+### Notion
+
+```typescript title="lib/bot.ts" lineNumbers
+import { createNotionAdapter } from "@chat-adapter/notion";
+import { connectNotionAdapter } from "@vercel/connect/chat";
+
+createNotionAdapter({
+  ...connectNotionAdapter("notion/acme-notion"),
+  verificationToken: process.env.NOTION_VERIFICATION_TOKEN,
+});
+```
+
+`connectNotionAdapter` supplies only the outbound `token`; it does not include a
+`webhookVerifier`. Connect does not forward Notion triggers, so configure the
+webhook subscription directly in Notion and retain
+`NOTION_VERIFICATION_TOKEN` for native HMAC verification. Omit
+`NOTION_TOKEN` when using the helper.
+
 ## Custom webhook verification
 
-Each helper attaches a default verifier that matches the deployment's project and environment automatically (`projectId` defaults to `VERCEL_PROJECT_ID`, `environment` to `VERCEL_TARGET_ENV` then `VERCEL_ENV`), so production, preview, and development each accept only their own tokens. Verification fails closed — if those values are absent, every request is rejected, and the issuer is pinned to `https://oidc.vercel.com`.
+Each trigger-capable helper attaches a default verifier that matches the deployment's project and environment automatically (`projectId` defaults to `VERCEL_PROJECT_ID`, `environment` to `VERCEL_TARGET_ENV` then `VERCEL_ENV`), so production, preview, and development each accept only their own tokens. Verification fails closed — if those values are absent, every request is rejected, and the issuer is pinned to `https://oidc.vercel.com`.
 
 To add constraints (for example to accept multiple environments), build a verifier with `createConnectWebhookVerifier` and override the field:
 

--- a/packages/adapter-notion/AGENTS.md
+++ b/packages/adapter-notion/AGENTS.md
@@ -12,6 +12,8 @@ monorepo-wide build, lint, and release rules — read it first.
 - Webhooks (`comment.created`) with `X-Notion-Signature` HMAC verification
   and a one-time `verification_token` handshake
 - Comments REST API (create / update / delete / list / retrieve)
+- Outbound Vercel Connect authentication via an async `token` resolver;
+  inbound webhooks remain direct and use native Notion HMAC verification
 - Outbound files via File Uploads API (`single_part` binary + `external_url`
   for public URLs). `external_url` imports are polled until `uploaded` before
   attach (default `[0, 5000, 10000]` — immediate recheck then 5s/10s; override
@@ -43,6 +45,8 @@ packages/adapter-notion/
 ## Public surface
 
 - `createNotionAdapter(config?)` / `NotionAdapter` / `NotionAdapterConfig`
+- `token` accepts a static string or async resolver and is resolved for every
+  Notion API request
 - Env: `NOTION_TOKEN`, `NOTION_VERIFICATION_TOKEN`, optional
   `NOTION_BOT_USERNAME`, `NOTION_VERSION`, `NOTION_MENTION_MODE`,
   `NOTION_KEYWORDS`

--- a/packages/adapter-notion/README.md
+++ b/packages/adapter-notion/README.md
@@ -47,6 +47,25 @@ bot.onNewMention(async (thread, message) => {
 });
 ```
 
+## Vercel Connect
+
+Use `connectNotionAdapter` to resolve the outbound Notion access token from
+Vercel Connect:
+
+```typescript
+import { createNotionAdapter } from "@chat-adapter/notion";
+import { connectNotionAdapter } from "@vercel/connect/chat";
+
+const notion = createNotionAdapter({
+  ...connectNotionAdapter("notion/acme-notion"),
+  verificationToken: process.env.NOTION_VERIFICATION_TOKEN,
+});
+```
+
+Connect does not forward Notion webhooks. Configure the webhook subscription
+directly in Notion and keep `NOTION_VERIFICATION_TOKEN` for native HMAC
+verification. `NOTION_TOKEN` is not needed when using the Connect helper.
+
 ## AI Coding Agents
 
 If you use an AI coding agent such as OpenAI Codex, Claude Code, or Cursor, install the Chat SDK skill so it knows the SDK APIs, adapter patterns, and project conventions before writing code.

--- a/packages/adapter-notion/src/index.test.ts
+++ b/packages/adapter-notion/src/index.test.ts
@@ -133,6 +133,13 @@ describe("createNotionAdapter", () => {
     expect(adapter.userName).toBe("notion-bot");
   });
 
+  it("accepts an async token resolver", () => {
+    const adapter = createTestAdapter({
+      token: async () => TOKEN,
+    });
+    expect(adapter.name).toBe("notion");
+  });
+
   it("throws ValidationError when token missing", () => {
     expect(() =>
       createNotionAdapter({ verificationToken: VERIFICATION_TOKEN })
@@ -192,6 +199,40 @@ describe("createNotionAdapter", () => {
     expect(
       (adapter as NotionAdapter & { mentionMode: string }).mentionMode
     ).toBe("mention");
+  });
+});
+
+describe("token resolver initialization", () => {
+  it("uses the resolved token to load the bot identity", async () => {
+    const token = vi.fn().mockResolvedValue("notion-connect-token");
+    const fetchMock = vi.fn().mockResolvedValue(
+      Response.json({
+        object: "user",
+        id: BOT_USER_ID,
+        name: "Docs Bot",
+        avatar_url: null,
+        type: "bot",
+        bot: { workspace_id: "ws-1", workspace_name: "Acme" },
+      })
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    try {
+      const adapter = createTestAdapter({ token });
+      await adapter.initialize(createMockChatInstance() as never);
+
+      expect(token).toHaveBeenCalledTimes(1);
+      expect(fetchMock).toHaveBeenCalledWith(
+        "https://api.notion.test/v1/users/me",
+        expect.objectContaining({
+          headers: expect.objectContaining({
+            Authorization: "Bearer notion-connect-token",
+          }),
+        })
+      );
+    } finally {
+      vi.unstubAllGlobals();
+    }
   });
 });
 
@@ -807,6 +848,37 @@ describe("postMessage / editMessage / deleteMessage", () => {
     });
   });
 
+  it("resolves a fresh token for each API request", async () => {
+    fetchMock.mockImplementation(() =>
+      Promise.resolve(Response.json(fixtureComment()))
+    );
+    const token = vi
+      .fn()
+      .mockResolvedValueOnce("notion-token-1")
+      .mockResolvedValueOnce("notion-token-2");
+    const adapter = createTestAdapter({ token });
+
+    await adapter.postMessage(`notion:${PAGE_ID}`, "first");
+    await adapter.postMessage(`notion:${PAGE_ID}`, "second");
+
+    expect(token).toHaveBeenCalledTimes(2);
+    expect(
+      fetchMock.mock.calls.map(([, init]) => {
+        const headers = (init as RequestInit).headers as Record<string, string>;
+        return headers.Authorization;
+      })
+    ).toEqual(["Bearer notion-token-1", "Bearer notion-token-2"]);
+  });
+
+  it("rejects an empty resolved token before calling Notion", async () => {
+    const adapter = createTestAdapter({ token: async () => "" });
+
+    await expect(
+      adapter.postMessage(`notion:${PAGE_ID}`, "hello")
+    ).rejects.toThrow("token resolver returned an empty token");
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
   it("replies with discussion_id", async () => {
     fetchMock.mockResolvedValue(Response.json(fixtureComment()));
     const adapter = createTestAdapter();
@@ -877,6 +949,10 @@ describe("postMessage / editMessage / deleteMessage", () => {
 
   it("retries on 429 Retry-After then succeeds", async () => {
     vi.useFakeTimers();
+    const token = vi
+      .fn()
+      .mockResolvedValueOnce("notion-token-1")
+      .mockResolvedValueOnce("notion-token-2");
     fetchMock
       .mockResolvedValueOnce(
         new Response("rate limited", {
@@ -886,12 +962,19 @@ describe("postMessage / editMessage / deleteMessage", () => {
       )
       .mockResolvedValueOnce(Response.json(fixtureComment()));
 
-    const adapter = createTestAdapter();
+    const adapter = createTestAdapter({ token });
     const promise = adapter.postMessage(`notion:${PAGE_ID}`, "hi");
     await vi.advanceTimersByTimeAsync(1100);
     const result = await promise;
     expect(result.id).toBe(COMMENT_ID);
     expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(token).toHaveBeenCalledTimes(2);
+    expect(
+      fetchMock.mock.calls.map(([, init]) => {
+        const headers = (init as RequestInit).headers as Record<string, string>;
+        return headers.Authorization;
+      })
+    ).toEqual(["Bearer notion-token-1", "Bearer notion-token-2"]);
     vi.useRealTimers();
   });
 
@@ -919,6 +1002,11 @@ describe("postMessage / editMessage / deleteMessage", () => {
   });
 
   it("uploads a file and attaches it on postMessage", async () => {
+    const token = vi
+      .fn()
+      .mockResolvedValueOnce("notion-create-token")
+      .mockResolvedValueOnce("notion-upload-token")
+      .mockResolvedValueOnce("notion-comment-token");
     fetchMock.mockImplementation((url: string, init?: RequestInit) => {
       const path = String(url);
       if (path.endsWith("/file_uploads") && init?.method === "POST") {
@@ -952,7 +1040,7 @@ describe("postMessage / editMessage / deleteMessage", () => {
       return Promise.resolve(new Response("unexpected", { status: 500 }));
     });
 
-    const adapter = createTestAdapter();
+    const adapter = createTestAdapter({ token });
     await adapter.postMessage(`notion:${PAGE_ID}`, {
       markdown: "hi",
       files: [
@@ -977,6 +1065,17 @@ describe("postMessage / editMessage / deleteMessage", () => {
     ]);
     expect(body.markdown).toContain("hi");
     expect(body.markdown).not.toContain("a.png");
+    expect(token).toHaveBeenCalledTimes(3);
+    expect(
+      fetchMock.mock.calls.map(([, init]) => {
+        const headers = (init as RequestInit).headers as Record<string, string>;
+        return headers.Authorization;
+      })
+    ).toEqual([
+      "Bearer notion-create-token",
+      "Bearer notion-upload-token",
+      "Bearer notion-comment-token",
+    ]);
   });
 
   it("attaches first 3 files and links the 4th on overflow", async () => {

--- a/packages/adapter-notion/src/index.ts
+++ b/packages/adapter-notion/src/index.ts
@@ -109,6 +109,15 @@ function parseKeywords(value: string | undefined): string[] | undefined {
   return keywords.length > 0 ? keywords : undefined;
 }
 
+function normalizeTokenProvider(
+  token: string | (() => string | Promise<string>)
+): () => Promise<string> {
+  if (typeof token === "function") {
+    return async () => await token();
+  }
+  return () => Promise.resolve(token);
+}
+
 export { NotionFormatConverter } from "./markdown";
 export type {
   NotionAdapterConfig,
@@ -173,7 +182,7 @@ export class NotionAdapter
   readonly userName: string;
   readonly lockScope = "thread" as const;
 
-  protected readonly token: string;
+  protected readonly tokenProvider: () => Promise<string>;
   /**
    * HMAC key from the webhook verification handshake.
    * Optional at construct time so the one-time `verification_token` POST can be
@@ -222,7 +231,7 @@ export class NotionAdapter
     }
 
     this.logger = config.logger ?? new ConsoleLogger("info").child("notion");
-    this.token = token;
+    this.tokenProvider = normalizeTokenProvider(token);
     this.verificationToken = verificationToken;
     this.notionVersion =
       config.notionVersion ??
@@ -249,6 +258,17 @@ export class NotionAdapter
         "NOTION_VERIFICATION_TOKEN is not set. The adapter will accept Notion's one-time verification_token handshake and log it, but all signed webhook events will return 401 until you set the token."
       );
     }
+  }
+
+  protected async resolveToken(): Promise<string> {
+    const token = await this.tokenProvider();
+    if (!token) {
+      throw new AuthenticationError(
+        "notion",
+        "Notion API token resolver returned an empty token. Check NOTION_TOKEN or the Vercel Connect connector."
+      );
+    }
+    return token;
   }
 
   async initialize(chat: ChatInstance): Promise<void> {
@@ -1140,11 +1160,12 @@ export class NotionAdapter
     let attempt = 0;
     for (;;) {
       await this.rateLimiter.acquire();
+      const token = await this.resolveToken();
       const url = path.startsWith("http") ? path : `${this.apiBaseUrl}${path}`;
       const response = await fetch(url, {
         method: init.method ?? "GET",
         headers: {
-          Authorization: `Bearer ${this.token}`,
+          Authorization: `Bearer ${token}`,
           "Notion-Version": this.notionVersion,
           "Content-Type": "application/json",
         },
@@ -1289,13 +1310,14 @@ export class NotionAdapter
     let attempt = 0;
     for (;;) {
       await this.rateLimiter.acquire();
+      const token = await this.resolveToken();
       const url = `${this.apiBaseUrl}${path}`;
       const formData = new FormData();
       formData.append("file", blob, filename);
       const response = await fetch(url, {
         method: "POST",
         headers: {
-          Authorization: `Bearer ${this.token}`,
+          Authorization: `Bearer ${token}`,
           "Notion-Version": this.notionVersion,
         },
         body: formData,
@@ -1352,7 +1374,7 @@ export class NotionAdapter
     if (response.status === 401) {
       throw new AuthenticationError(
         "notion",
-        "Notion API authentication failed — check NOTION_TOKEN"
+        "Notion API authentication failed — check NOTION_TOKEN or the Vercel Connect connector"
       );
     }
 

--- a/packages/adapter-notion/src/types.ts
+++ b/packages/adapter-notion/src/types.ts
@@ -61,10 +61,11 @@ export interface NotionAdapterConfig {
    */
   streamingEditIntervalMs?: number;
   /**
-   * Connection access token (Bearer token).
+   * Connection access token (Bearer token), or a resolver invoked for each
+   * Notion API request.
    * Defaults to `NOTION_TOKEN`.
    */
-  token?: string;
+  token?: string | (() => string | Promise<string>);
   /**
    * Bot display name override.
    * Defaults to `NOTION_BOT_USERNAME` or `"notion-bot"`.

--- a/packages/create-chat-sdk/README.md
+++ b/packages/create-chat-sdk/README.md
@@ -39,13 +39,13 @@ When the CLI detects a coding agent environment, it announces the detection and 
 
 ## Vercel Connect
 
-The Slack, Discord, GitHub, and Linear adapters can authenticate with [Vercel Connect](https://chat-sdk.dev/docs/vercel-connect) instead of stored provider secrets. Pass `--connect`, or choose **Vercel Connect** at the interactive auth-mode prompt:
+The Slack, Discord, GitHub, Linear, and Notion adapters can use [Vercel Connect](https://chat-sdk.dev/docs/vercel-connect) for outbound credentials. Pass `--connect`, or choose **Vercel Connect** at the interactive auth-mode prompt:
 
 ```bash
 npm create chat-sdk@latest -- my-bot --adapter slack --connect -y
 ```
 
-The generated bot spreads the matching helper from `@vercel/connect/chat` into the adapter factory, adds `@vercel/connect` to dependencies, and lists each connector UID (such as `SLACK_CONNECTOR`) in `.env.example` instead of native secrets.
+The generated bot spreads the matching helper from `@vercel/connect/chat` into the adapter factory, adds `@vercel/connect` to dependencies, and lists each connector UID (such as `SLACK_CONNECTOR`) in `.env.example`. Native webhook verification secrets are retained for adapters such as Notion.
 
 ## Options
 
@@ -60,8 +60,8 @@ Options:
   --adapter <values...>     platform or state adapters to include
   --vendor                  list vendor-official adapters in the interactive
                             prompt
-  --connect                 authenticate Slack, Discord, GitHub, and Linear
-                            adapters with Vercel Connect
+  --connect                 authenticate Slack, Discord, GitHub, Linear, and
+                            Notion adapters with Vercel Connect
   --pm <manager>            package manager to use (npm, yarn, pnpm, bun)
   -y, --yes                 skip prompts and accept defaults
   --interactive             always prompt, even when a coding agent

--- a/packages/create-chat-sdk/docs/create-chat-sdk.mdx
+++ b/packages/create-chat-sdk/docs/create-chat-sdk.mdx
@@ -103,13 +103,13 @@ When the [Discord adapter](/adapters/official/discord) is selected, the CLI also
 
 ## Vercel Connect
 
-[Vercel Connect](/docs/vercel-connect) lets the Slack, Discord, GitHub, and Linear adapters authenticate with a connector instead of stored provider secrets. Pass `--connect` — or choose **Vercel Connect** at the interactive auth-mode prompt — to scaffold Connect wiring for any selected Slack, Discord, GitHub, or Linear adapter:
+[Vercel Connect](/docs/vercel-connect) supplies outbound credentials for the Slack, Discord, GitHub, Linear, and Notion adapters. Pass `--connect` — or choose **Vercel Connect** at the interactive auth-mode prompt — to scaffold Connect wiring for any selected adapter in that list. Notion webhooks remain direct and retain `NOTION_VERIFICATION_TOKEN`.
 
 ```bash
 npm create chat-sdk@latest -- my-bot --adapter slack --connect -y
 ```
 
-The generated `src/lib/bot.ts` spreads the matching helper from `@vercel/connect/chat` into the adapter factory, `@vercel/connect` is added to dependencies, and `.env.example` lists each connector UID (for example `SLACK_CONNECTOR`) in place of native secrets.
+The generated `src/lib/bot.ts` spreads the matching helper from `@vercel/connect/chat` into the adapter factory, `@vercel/connect` is added to dependencies, and `.env.example` lists each connector UID (for example `SLACK_CONNECTOR`). Native webhook verification secrets are retained for adapters such as Notion.
 
 <Callout type="info">
   Vercel Connect provides `VERCEL_OIDC_TOKEN` at runtime. For local development, run `vercel link` then `vercel env pull` to populate it. Connect forwards inbound webhooks only to deployed URLs, so test webhook delivery against a Vercel deployment (such as a preview) rather than localhost.
@@ -123,7 +123,7 @@ The generated `src/lib/bot.ts` spreads the matching helper from `@vercel/connect
 | `-d, --description <text>` | Project description. |
 | `--adapter <values...>` | Platform or state adapters to include. |
 | `--vendor` | List only vendor-official adapters in the interactive prompt. |
-| `--connect` | Authenticate Slack, Discord, GitHub, and Linear adapters with Vercel Connect. |
+| `--connect` | Authenticate Slack, Discord, GitHub, Linear, and Notion adapters with Vercel Connect. |
 | `--pm <manager>` | Package manager to use: `npm`, `yarn`, `pnpm`, or `bun`. |
 | `-y, --yes` | Skip prompts and accept defaults. |
 | `--interactive` | Always prompt, even when a coding agent environment is detected. |

--- a/packages/create-chat-sdk/src/catalog/scaffold-spec.ts
+++ b/packages/create-chat-sdk/src/catalog/scaffold-spec.ts
@@ -58,7 +58,8 @@ export interface ConnectEnvVar {
  * When the user opts into Connect (`--connect` or the interactive auth-mode
  * prompt), the generated bot spreads the matching helper from
  * `@vercel/connect/chat` into the adapter factory and reads the connector UID
- * from `connectorEnvVar`, replacing the adapter's native provider secrets.
+ * from `connectorEnvVar`, replacing outbound provider credentials. Native
+ * webhook verification variables can remain in `extraEnv`.
  */
 export interface AdapterConnectSpec {
   /** Environment variable holding the Vercel Connect connector UID. */
@@ -67,6 +68,11 @@ export interface AdapterConnectSpec {
   extraEnv?: readonly ConnectEnvVar[];
   /** Helper exported from `@vercel/connect/chat`, e.g. `connectSlackAdapter`. */
   helper: string;
+  /**
+   * How inbound webhooks reach the generated app. Defaults to Connect trigger
+   * forwarding; use `native` when Connect supplies outbound credentials only.
+   */
+  inbound?: "connect-triggers" | "native";
 }
 
 /**
@@ -75,7 +81,7 @@ export interface AdapterConnectSpec {
 export interface CliScaffoldSpec {
   /**
    * Vercel Connect code-generation policy. Present only for adapters that
-   * support Connect (Slack, Discord, GitHub, Linear).
+   * support Connect (Slack, Discord, GitHub, Linear, Notion).
    */
   connect?: AdapterConnectSpec;
   /**
@@ -249,6 +255,18 @@ export const CLI_SCAFFOLD_SPEC = {
     invocation: { kind: "zero-arg" },
   },
   notion: {
+    connect: {
+      connectorEnvVar: "NOTION_CONNECTOR",
+      extraEnv: [
+        {
+          description:
+            "Webhook HMAC key from the Notion subscription verification handshake",
+          key: "NOTION_VERIFICATION_TOKEN",
+        },
+      ],
+      helper: "connectNotionAdapter",
+      inbound: "native",
+    },
     invocation: { kind: "zero-arg" },
   },
   novu: {

--- a/packages/create-chat-sdk/src/cli/e2e.test.ts
+++ b/packages/create-chat-sdk/src/cli/e2e.test.ts
@@ -155,6 +155,49 @@ describe("CLI Vercel Connect mode", () => {
     expect(envExample).not.toContain("DISCORD_PUBLIC_KEY=");
     expect(envExample).not.toContain("DISCORD_APPLICATION_ID=");
   });
+
+  it("scaffolds Notion with Connect tokens and native webhooks", async () => {
+    process.exitCode = undefined;
+    const program = createProgram();
+    await program.parseAsync([
+      "node",
+      "create-chat-sdk",
+      "connect-notion-bot",
+      "--adapter",
+      "notion",
+      "memory",
+      "--connect",
+      "-yq",
+      "--skip-install",
+      "--no-git",
+    ]);
+
+    expect(process.exitCode).toBeUndefined();
+
+    const botTs = readProjectFile("connect-notion-bot", "src/lib/bot.ts");
+    expect(botTs).toContain(
+      'import { connectNotionAdapter } from "@vercel/connect/chat";'
+    );
+    expect(botTs).toContain(
+      '...connectNotionAdapter(requireEnv("NOTION_CONNECTOR")),'
+    );
+
+    const packageJson = JSON.parse(
+      readProjectFile("connect-notion-bot", "package.json")
+    ) as { dependencies?: Record<string, string> };
+    expect(packageJson.dependencies?.["@vercel/connect"]).toBe("latest");
+
+    const envExample = readProjectFile("connect-notion-bot", ".env.example");
+    expect(envExample).toContain("NOTION_CONNECTOR=");
+    expect(envExample).toContain("NOTION_VERIFICATION_TOKEN=");
+    expect(envExample).not.toContain("NOTION_TOKEN=");
+
+    const readme = readProjectFile("connect-notion-bot", "README.md");
+    expect(readme).toContain(
+      "Configure native webhook subscriptions for Notion"
+    );
+    expect(readme).not.toContain("Enable Connect trigger forwarding");
+  });
 });
 
 describe("CLI agent mode", () => {

--- a/packages/create-chat-sdk/src/cli/program.ts
+++ b/packages/create-chat-sdk/src/cli/program.ts
@@ -71,7 +71,7 @@ export function createProgram(): Command {
     )
     .option(
       "--connect",
-      "authenticate Slack, Discord, GitHub, and Linear adapters with Vercel Connect"
+      "authenticate Slack, Discord, GitHub, Linear, and Notion adapters with Vercel Connect"
     )
     .option(
       "--pm <manager>",

--- a/packages/create-chat-sdk/src/generators/env-example.ts
+++ b/packages/create-chat-sdk/src/generators/env-example.ts
@@ -119,10 +119,17 @@ const connectNoteLines = (config: ProjectConfig): string[] => {
   if (!usesConnect(config)) {
     return [];
   }
+  const usesNativeWebhooks = config.platformAdapters.some(
+    (adapter) => getAdapterConnectSpec(adapter.slug)?.inbound === "native"
+  );
   return [
     "# Vercel Connect",
-    "# Adapters marked (Vercel Connect) below authenticate with a connector",
-    "# instead of stored secrets. Vercel injects VERCEL_OIDC_TOKEN at runtime;",
+    "# Adapters marked (Vercel Connect) below use a connector for outbound API",
+    "# credentials.",
+    ...(usesNativeWebhooks
+      ? ["# Native webhook adapters still require verification secrets below."]
+      : []),
+    "# Vercel injects VERCEL_OIDC_TOKEN at runtime;",
     "# for local development run `vercel env pull` to populate it. Set each",
     "# connector UID below (or in your Vercel project's environment variables).",
     "",

--- a/packages/create-chat-sdk/src/generators/generators.test.ts
+++ b/packages/create-chat-sdk/src/generators/generators.test.ts
@@ -131,9 +131,40 @@ describe("Vercel Connect generation", () => {
     expect(envExample).not.toContain("DISCORD_APPLICATION_ID=");
 
     const readme = generateReadme(connectConfig(["discord"]));
-    expect(readme).toContain("authenticates Discord with");
+    expect(readme).toContain("outbound credentials for Discord");
     expect(readme).toContain("DISCORD_CONNECTOR");
     expect(readme).toContain("Discord Gateway (cron)");
+  });
+
+  it("scaffolds Notion with Connect tokens and native webhook verification", () => {
+    const botTs = generateBotTs(connectConfig(["notion"]));
+    expect(botTs).toContain(
+      'import { connectNotionAdapter } from "@vercel/connect/chat";'
+    );
+    expect(botTs).toContain("notion: createNotionAdapter({");
+    expect(botTs).toContain(
+      '...connectNotionAdapter(requireEnv("NOTION_CONNECTOR")),'
+    );
+
+    const envExample = generateEnvExample(connectConfig(["notion"]));
+    expect(envExample).toContain("NOTION_CONNECTOR=");
+    expect(envExample).toContain("NOTION_VERIFICATION_TOKEN=");
+    expect(envExample).not.toContain("NOTION_TOKEN=");
+
+    const readme = generateReadme(connectConfig(["notion"]));
+    expect(readme).toContain("outbound credentials for Notion");
+    expect(readme).toContain(
+      "Configure native webhook subscriptions for Notion"
+    );
+    expect(readme).not.toContain("Enable Connect trigger forwarding");
+  });
+
+  it("documents mixed Connect trigger and native webhook modes", () => {
+    const readme = generateReadme(connectConfig(["slack", "notion"]));
+    expect(readme).toContain("Enable Connect trigger forwarding for Slack");
+    expect(readme).toContain(
+      "Configure native webhook subscriptions for Notion"
+    );
   });
 
   it("fails loudly on a missing connector via requireEnv", () => {
@@ -153,10 +184,10 @@ describe("Vercel Connect generation", () => {
 
   it("imports every selected Connect helper, sorted", () => {
     const result = generateBotTs(
-      connectConfig(["slack", "discord", "github", "linear"])
+      connectConfig(["slack", "discord", "github", "linear", "notion"])
     );
     expect(result).toContain(
-      'import { connectDiscordAdapter, connectGitHubAdapter, connectLinearAdapter, connectSlackAdapter } from "@vercel/connect/chat";'
+      'import { connectDiscordAdapter, connectGitHubAdapter, connectLinearAdapter, connectNotionAdapter, connectSlackAdapter } from "@vercel/connect/chat";'
     );
   });
 

--- a/packages/create-chat-sdk/src/generators/readme.ts
+++ b/packages/create-chat-sdk/src/generators/readme.ts
@@ -17,26 +17,55 @@ const connectSection = (config: ProjectConfig): string => {
     return "";
   }
   const names = connectAdapters.map((entry) => entry.adapter.name).join(", ");
+  const triggerNames = connectAdapters
+    .filter((entry) => entry.connect.inbound !== "native")
+    .map((entry) => entry.adapter.name)
+    .join(", ");
+  const nativeNames = connectAdapters
+    .filter((entry) => entry.connect.inbound === "native")
+    .map((entry) => entry.adapter.name)
+    .join(", ");
   const exampleVar = first.connect.connectorEnvVar;
   const lines = [
     "## Authentication (Vercel Connect)",
     "",
-    `This project authenticates ${names} with [Vercel Connect](https://chat-sdk.dev/docs/vercel-connect) instead of stored provider secrets.`,
+    `This project uses [Vercel Connect](https://chat-sdk.dev/docs/vercel-connect) for outbound credentials for ${names}.`,
     "",
-    "1. Create a connector for each provider in the [Vercel dashboard](https://vercel.com/d?to=%2F%5Bteam%5D%2F~%2Fconnect) and link it to this project, enabling trigger forwarding so inbound webhooks reach your deployment.",
-    "2. Pull the runtime OIDC token for local development:",
+    "1. Create a connector for each provider in the [Vercel dashboard](https://vercel.com/d?to=%2F%5Bteam%5D%2F~%2Fconnect) and link it to this project.",
+  ];
+  let step = 2;
+  if (triggerNames) {
+    lines.push(
+      `${step}. Enable Connect trigger forwarding for ${triggerNames} so inbound webhooks reach your deployment.`
+    );
+    step += 1;
+  }
+  if (nativeNames) {
+    lines.push(
+      `${step}. Configure native webhook subscriptions for ${nativeNames}; Connect supplies outbound credentials but does not forward those webhooks.`
+    );
+    step += 1;
+  }
+  lines.push(
+    `${step}. Pull the runtime OIDC token for local development:`,
     "",
     "```bash",
     "vercel link",
     "vercel env pull .env.local",
     "```",
     "",
-    `3. Set each connector UID (for example \`${exampleVar}\`) in your environment.`,
+    `${step + 1}. Set each connector UID (for example \`${exampleVar}\`) and any listed native webhook verification secrets in your environment.`,
     "",
-    "> Vercel Connect forwards inbound webhooks only to deployed URLs, so test webhook delivery against a Vercel deployment (such as a preview) rather than localhost.",
-    "",
-    "",
-  ];
+    ""
+  );
+  if (triggerNames) {
+    lines.splice(
+      -2,
+      0,
+      "> Vercel Connect forwards inbound webhooks only to deployed URLs, so test trigger delivery against a Vercel deployment (such as a preview) rather than localhost.",
+      ""
+    );
+  }
   return lines.join("\n");
 };
 

--- a/packages/create-chat-sdk/src/prompts/flow.test.ts
+++ b/packages/create-chat-sdk/src/prompts/flow.test.ts
@@ -254,7 +254,7 @@ describe("runPrompts", () => {
       connect: true,
       name: "my-bot",
       quiet: true,
-      selectedAdapters: ["discord", "memory"],
+      selectedAdapters: ["notion", "memory"],
       yes: true,
     });
 

--- a/packages/create-chat-sdk/src/prompts/flow.ts
+++ b/packages/create-chat-sdk/src/prompts/flow.ts
@@ -146,7 +146,7 @@ export async function runPrompts(
     useConnect = connectCapable;
     if (!(connectCapable || inputs.quiet)) {
       log.warning(
-        "Ignoring --connect: Vercel Connect supports only the Slack, Discord, GitHub, and Linear adapters."
+        "Ignoring --connect: Vercel Connect supports only the Slack, Discord, GitHub, Linear, and Notion adapters."
       );
     }
   } else if (!(inputs.yes || flaggedSelection) && connectCapable) {

--- a/packages/create-chat-sdk/src/types.ts
+++ b/packages/create-chat-sdk/src/types.ts
@@ -44,9 +44,8 @@ export interface ProjectConfig extends AdapterSelection {
    */
   shouldInstall: boolean;
   /**
-   * Authenticate Connect-capable adapters (Slack, Discord, GitHub, Linear)
-   * with Vercel Connect instead of native provider secrets. Defaults to
-   * `false`.
+   * Authenticate Connect-capable adapters (Slack, Discord, GitHub, Linear,
+   * Notion) with Vercel Connect for outbound credentials. Defaults to `false`.
    */
   useConnect?: boolean;
 }


### PR DESCRIPTION
Adds function-backed Notion access-token resolution so the adapter can use short-lived Vercel Connect credentials for every API request, retry, and multipart upload. Direct Notion webhooks continue to use `NOTION_VERIFICATION_TOKEN` and native HMAC verification because Connect does not forward Notion triggers.

```ts
import { createNotionAdapter } from "@chat-adapter/notion";
import { connectNotionAdapter } from "@vercel/connect/chat";

createNotionAdapter({
  ...connectNotionAdapter("notion/acme-notion"),
  verificationToken: process.env.NOTION_VERIFICATION_TOKEN,
});
```

`create-chat-sdk` now recognizes Notion as Connect-capable, preserves the native webhook verification token, and emits direct-webhook guidance:

```bash
npm create chat-sdk@latest -- my-bot --adapter notion memory --connect -y
```

Validated with the Notion adapter suite (71 tests), create-chat-sdk suite (209 tests), package type checks/builds, and repository lint/format checks.