### PR TITLE
Add Vercel Connect support to Telegram

### DIFF
--- a/.changeset/telegram-connect-chat.md
+++ b/.changeset/telegram-connect-chat.md
@@ -1,0 +1,6 @@
+---
+"@chat-adapter/telegram": minor
+"create-chat-sdk": minor
+---
+
+Add outbound-only Vercel Connect authentication for Telegram while retaining native webhook verification or polling.

--- a/apps/docs/content/adapters/official/telegram.mdx
+++ b/apps/docs/content/adapters/official/telegram.mdx
@@ -105,6 +105,27 @@ curl -X POST "https://api.telegram.org/bot$TELEGRAM_BOT_TOKEN/setWebhook" \
   }'
 ```
 
+## Vercel Connect
+
+Use Vercel Connect for the outbound Telegram bot token:
+
+```typescript title="lib/bot.ts" lineNumbers
+import { createTelegramAdapter } from "@chat-adapter/telegram";
+import { connectTelegramAdapter } from "@vercel/connect/chat";
+
+const telegram = createTelegramAdapter({
+  ...connectTelegramAdapter("telegram/acme-telegram"),
+  secretToken: process.env.TELEGRAM_WEBHOOK_SECRET_TOKEN,
+});
+```
+
+<Callout type="info">
+  Connect does not forward Telegram webhooks. Keep
+  `TELEGRAM_WEBHOOK_SECRET_TOKEN` for native webhook verification, or use
+  polling mode without an inbound webhook. `TELEGRAM_BOT_TOKEN` is not needed
+  when using `connectTelegramAdapter`.
+</Callout>
+
 ## Configuration
 
 <TypeTable
@@ -115,8 +136,9 @@ curl -X POST "https://api.telegram.org/bot$TELEGRAM_BOT_TOKEN/setWebhook" \
         "Telegram user IDs allowed to trigger the adapter. Auto-detected from `TELEGRAM_ALLOWED_USER_IDS` (comma-separated). All users are allowed when omitted or empty.",
     },
     botToken: {
-      type: "string",
-      description: "Telegram bot token. Auto-detected from `TELEGRAM_BOT_TOKEN`.",
+      type: "string | (() => string | Promise<string>)",
+      description:
+        "Telegram bot token or resolver invoked for each Bot API request. Auto-detected from `TELEGRAM_BOT_TOKEN`.",
     },
     secretToken: {
       type: "string",

--- a/apps/docs/content/docs/create-chat-sdk.mdx
+++ b/apps/docs/content/docs/create-chat-sdk.mdx
@@ -103,13 +103,13 @@ When the [Discord adapter](/adapters/official/discord) is selected, the CLI also
 
 ## Vercel Connect
 
-[Vercel Connect](/docs/vercel-connect) supplies outbound credentials for the Slack, Discord, GitHub, Linear, and Notion adapters. Pass `--connect` — or choose **Vercel Connect** at the interactive auth-mode prompt — to scaffold Connect wiring for any selected adapter in that list. Notion webhooks remain direct and retain `NOTION_VERIFICATION_TOKEN`.
+[Vercel Connect](/docs/vercel-connect) supplies outbound credentials for the Slack, Discord, GitHub, Linear, Notion, and Telegram adapters. Pass `--connect` — or choose **Vercel Connect** at the interactive auth-mode prompt — to scaffold Connect wiring for any selected adapter in that list. Notion and Telegram webhooks remain direct and retain their native verification secrets.
 
 ```bash
 npm create chat-sdk@latest -- my-bot --adapter slack --connect -y
 ```
 
-The generated `src/lib/bot.ts` spreads the matching helper from `@vercel/connect/chat` into the adapter factory, `@vercel/connect` is added to dependencies, and `.env.example` lists each connector UID (for example `SLACK_CONNECTOR`). Native webhook verification secrets are retained for adapters such as Notion.
+The generated `src/lib/bot.ts` spreads the matching helper from `@vercel/connect/chat` into the adapter factory, `@vercel/connect` is added to dependencies, and `.env.example` lists each connector UID (for example `SLACK_CONNECTOR`). Native webhook verification secrets are retained for adapters such as Notion and Telegram.
 
 <Callout type="info">
   Vercel Connect provides `VERCEL_OIDC_TOKEN` at runtime. For local development, run `vercel link` then `vercel env pull` to populate it. Connect forwards inbound webhooks only to deployed URLs, so test webhook delivery against a Vercel deployment (such as a preview) rather than localhost.
@@ -123,7 +123,7 @@ The generated `src/lib/bot.ts` spreads the matching helper from `@vercel/connect
 | `-d, --description <text>` | Project description. |
 | `--adapter <values...>` | Platform or state adapters to include. |
 | `--vendor` | List only vendor-official adapters in the interactive prompt. |
-| `--connect` | Authenticate Slack, Discord, GitHub, Linear, and Notion adapters with Vercel Connect. |
+| `--connect` | Authenticate Slack, Discord, GitHub, Linear, Notion, and Telegram adapters with Vercel Connect. |
 | `--pm <manager>` | Package manager to use: `npm`, `yarn`, `pnpm`, or `bun`. |
 | `-y, --yes` | Skip prompts and accept defaults. |
 | `--interactive` | Always prompt, even when a coding agent environment is detected. |

--- a/apps/docs/content/docs/vercel-connect.mdx
+++ b/apps/docs/content/docs/vercel-connect.mdx
@@ -1,6 +1,6 @@
 ---
 title: Vercel Connect
-description: Authenticate Slack, Discord, GitHub, Linear, and Notion adapters with Vercel Connect — short-lived runtime tokens for outbound calls and OIDC-verified inbound webhooks where supported.
+description: Authenticate Slack, Discord, GitHub, Linear, Notion, and Telegram adapters with Vercel Connect — short-lived runtime tokens for outbound calls and OIDC-verified inbound webhooks where supported.
 type: overview
 related:
   - /docs/usage
@@ -9,6 +9,7 @@ related:
   - /adapters/official/github
   - /adapters/official/linear
   - /adapters/official/notion
+  - /adapters/official/telegram
 ---
 
 [Vercel Connect](https://vercel.com/docs/connect) lets your bot use a registered connector for adapter authentication instead of storing long-lived provider secrets. You register a connector once, link it to your project and environments, and your code requests scoped, short-lived tokens at runtime.
@@ -20,6 +21,7 @@ The `@vercel/connect/chat` subpath ships a helper per platform that you spread i
 - `connectGitHubAdapter`
 - `connectLinearAdapter`
 - `connectNotionAdapter`
+- `connectTelegramAdapter`
 
 Each helper wires outbound credentials; trigger-capable providers also wire
 inbound traffic:
@@ -48,14 +50,15 @@ pnpm add @vercel/connect
 | [GitHub](/adapters/official/github) | `connectGitHubAdapter` | `installationToken` |
 | [Linear](/adapters/official/linear) | `connectLinearAdapter` | `accessToken` |
 | [Notion](/adapters/official/notion) | `connectNotionAdapter` | `token` |
+| [Telegram](/adapters/official/telegram) | `connectTelegramAdapter` | `botToken` |
 
 Each helper accepts `(connector, params?, options?)`, where `params` is the [`getToken`](https://vercel.com/docs/connect/ts-sdk-reference) parameters minus `subject` (pinned to `{ type: "app" }`), letting you pass through `installationId`, `scopes`, or `validityBufferMs`.
 
 ## Set up a connector
 
 The trigger-forwarding steps below apply to Slack, Discord, GitHub, and Linear.
-For Notion, create and attach the connector without triggers, then configure the
-webhook subscription directly in Notion.
+For Notion and Telegram, create and attach the connector without triggers, then
+use native webhook verification or polling.
 
 1. Create a connector for the provider in the [Vercel dashboard](https://vercel.com/d?to=%2F%5Bteam%5D%2F~%2Fconnect) or with the CLI, enabling trigger forwarding so inbound webhooks reach your project:
 
@@ -168,6 +171,23 @@ createNotionAdapter({
 webhook subscription directly in Notion and retain
 `NOTION_VERIFICATION_TOKEN` for native HMAC verification. Omit
 `NOTION_TOKEN` when using the helper.
+
+### Telegram
+
+```typescript title="lib/bot.ts" lineNumbers
+import { createTelegramAdapter } from "@chat-adapter/telegram";
+import { connectTelegramAdapter } from "@vercel/connect/chat";
+
+createTelegramAdapter({
+  ...connectTelegramAdapter("telegram/acme-telegram"),
+  secretToken: process.env.TELEGRAM_WEBHOOK_SECRET_TOKEN,
+});
+```
+
+`connectTelegramAdapter` supplies only the outbound `botToken`; it does not
+include a `webhookVerifier`. Connect does not forward Telegram triggers, so
+retain `TELEGRAM_WEBHOOK_SECRET_TOKEN` for native webhook verification or use
+polling mode. Omit `TELEGRAM_BOT_TOKEN` when using the helper.
 
 ## Custom webhook verification
 

--- a/apps/docs/content/docs/vercel-connect.mdx
+++ b/apps/docs/content/docs/vercel-connect.mdx
@@ -185,9 +185,10 @@ createTelegramAdapter({
 ```
 
 `connectTelegramAdapter` supplies only the outbound `botToken`; it does not
-include a `webhookVerifier`. Connect does not forward Telegram triggers, so
-retain `TELEGRAM_WEBHOOK_SECRET_TOKEN` for native webhook verification or use
-polling mode. Omit `TELEGRAM_BOT_TOKEN` when using the helper.
+include a `webhookVerifier`. The adapter derives webhook deduplication scope
+from Telegram's stable bot identity, not the rotating credential. Retain
+`TELEGRAM_WEBHOOK_SECRET_TOKEN` for native webhook verification or use polling
+mode. Omit `TELEGRAM_BOT_TOKEN` when using the helper.
 
 ## Custom webhook verification
 

--- a/packages/adapter-telegram/AGENTS.md
+++ b/packages/adapter-telegram/AGENTS.md
@@ -65,8 +65,11 @@ Replay tests live in
 Main exports from `src/index.ts`:
 
 - `createTelegramAdapter(config?)` — primary factory. Auto-detects
-  `TELEGRAM_BOT_TOKEN`, `TELEGRAM_WEBHOOK_SECRET`, and the optional
+  `TELEGRAM_BOT_TOKEN`, `TELEGRAM_WEBHOOK_SECRET_TOKEN`, and the optional
   `TELEGRAM_BOT_USERNAME` (used for mention detection in groups).
+- `botToken` accepts a static string or async resolver and is resolved for each
+  Telegram Bot API or file-download request. This supports outbound-only
+  Vercel Connect authentication while native webhooks keep `secretToken`.
 - `TelegramAdapter` class — implements `Adapter<TelegramThreadId,
   unknown>`. Public methods: `handleWebhook`, `postMessage`,
   `editMessage`, `deleteMessage`, `addReaction`, `removeReaction`,

--- a/packages/adapter-telegram/AGENTS.md
+++ b/packages/adapter-telegram/AGENTS.md
@@ -71,7 +71,8 @@ Main exports from `src/index.ts`:
   Telegram Bot API or file-download request. This supports outbound-only
   Vercel Connect authentication while native webhooks keep `secretToken`.
   Webhook deduplication is scoped with the stable bot ID returned by `getMe`,
-  never the potentially rotating token.
+  never the potentially rotating token. Failed startup identity lookups retry
+  lazily on later verified webhooks.
 - `TelegramAdapter` class — implements `Adapter<TelegramThreadId,
   unknown>`. Public methods: `handleWebhook`, `postMessage`,
   `editMessage`, `deleteMessage`, `addReaction`, `removeReaction`,

--- a/packages/adapter-telegram/AGENTS.md
+++ b/packages/adapter-telegram/AGENTS.md
@@ -70,6 +70,8 @@ Main exports from `src/index.ts`:
 - `botToken` accepts a static string or async resolver and is resolved for each
   Telegram Bot API or file-download request. This supports outbound-only
   Vercel Connect authentication while native webhooks keep `secretToken`.
+  Webhook deduplication is scoped with the stable bot ID returned by `getMe`,
+  never the potentially rotating token.
 - `TelegramAdapter` class — implements `Adapter<TelegramThreadId,
   unknown>`. Public methods: `handleWebhook`, `postMessage`,
   `editMessage`, `deleteMessage`, `addReaction`, `removeReaction`,

--- a/packages/adapter-telegram/README.md
+++ b/packages/adapter-telegram/README.md
@@ -47,6 +47,26 @@ bot.onNewMention(async (thread, message) => {
 });
 ```
 
+## Vercel Connect
+
+Use `connectTelegramAdapter` to resolve the outbound bot token from Vercel
+Connect:
+
+```typescript
+import { createTelegramAdapter } from "@chat-adapter/telegram";
+import { connectTelegramAdapter } from "@vercel/connect/chat";
+
+const telegram = createTelegramAdapter({
+  ...connectTelegramAdapter("telegram/acme-telegram"),
+  secretToken: process.env.TELEGRAM_WEBHOOK_SECRET_TOKEN,
+});
+```
+
+Connect does not forward Telegram webhooks. Keep
+`TELEGRAM_WEBHOOK_SECRET_TOKEN` when using webhook mode, or use polling mode
+without an inbound webhook. `TELEGRAM_BOT_TOKEN` is not needed when using the
+Connect helper.
+
 ## Webhook route
 
 ```typescript

--- a/packages/adapter-telegram/README.md
+++ b/packages/adapter-telegram/README.md
@@ -66,7 +66,8 @@ Connect does not forward Telegram webhooks. Keep
 `TELEGRAM_WEBHOOK_SECRET_TOKEN` when using webhook mode, or use polling mode
 without an inbound webhook. `TELEGRAM_BOT_TOKEN` is not needed when using the
 Connect helper. The adapter derives webhook deduplication scope from Telegram's
-stable bot identity, so token rotation does not split update claims.
+stable bot identity, so token rotation does not split update claims. If bot
+identity lookup fails at startup, the next verified webhook retries it.
 
 ## Webhook route
 

--- a/packages/adapter-telegram/README.md
+++ b/packages/adapter-telegram/README.md
@@ -65,7 +65,8 @@ const telegram = createTelegramAdapter({
 Connect does not forward Telegram webhooks. Keep
 `TELEGRAM_WEBHOOK_SECRET_TOKEN` when using webhook mode, or use polling mode
 without an inbound webhook. `TELEGRAM_BOT_TOKEN` is not needed when using the
-Connect helper.
+Connect helper. The adapter derives webhook deduplication scope from Telegram's
+stable bot identity, so token rotation does not split update claims.
 
 ## Webhook route
 

--- a/packages/adapter-telegram/src/index.test.ts
+++ b/packages/adapter-telegram/src/index.test.ts
@@ -393,7 +393,7 @@ describe("bot token resolver", () => {
     ]);
   });
 
-  it("scopes webhook deduplication with the resolved bot token", async () => {
+  it("scopes webhook deduplication with the stable bot identity", async () => {
     const botToken = vi.fn().mockResolvedValue("resolved-token");
     mockFetch.mockResolvedValue(
       telegramOk({
@@ -432,12 +432,55 @@ describe("bot token resolver", () => {
       })
     );
 
-    const scope = createHash("sha256").update("resolved-token").digest("hex");
+    const scope = createHash("sha256").update("999").digest("hex");
     expect(state.setIfNotExists).toHaveBeenCalledWith(
       `telegram:webhook-update:${scope}:1`,
       true,
       86_400_000
     );
+  });
+
+  it("keeps the webhook scope stable across token rotation and instances", async () => {
+    mockFetch.mockResolvedValue(
+      telegramOk({
+        id: 999,
+        is_bot: true,
+        first_name: "Bot",
+        username: "mybot",
+      })
+    );
+    const state = createMockState();
+    const adapters = ["rotated-token-a", "rotated-token-b"].map((token) =>
+      createTelegramAdapter({
+        botToken: async () => token,
+        mode: "webhook",
+        logger: mockLogger,
+        secretToken: "secret",
+        userName: "mybot",
+      })
+    );
+    const chats = adapters.map(() =>
+      createMockChatInstance({ logger: mockLogger, state, userName: "mybot" })
+    );
+    await Promise.all(
+      adapters.map((adapter, index) => adapter.initialize(chats[index]))
+    );
+
+    const request = () =>
+      new Request("https://example.com/webhook", {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          "x-telegram-bot-api-secret-token": "secret",
+        },
+        body: JSON.stringify({ update_id: 1 }),
+      });
+    await Promise.all(
+      adapters.map((adapter) => adapter.handleWebhook(request()))
+    );
+
+    const keys = state.setIfNotExists.mock.calls.map(([key]) => key);
+    expect(new Set(keys).size).toBe(1);
   });
 });
 
@@ -534,13 +577,15 @@ describe("TelegramAdapter", () => {
   });
 
   it("deduplicates sequential and concurrent webhook updates", async () => {
-    mockFetch.mockResolvedValue(
-      telegramOk({
-        id: 999,
-        is_bot: true,
-        first_name: "Bot",
-        username: "mybot",
-      })
+    mockFetch.mockImplementation(() =>
+      Promise.resolve(
+        telegramOk({
+          id: 999,
+          is_bot: true,
+          first_name: "Bot",
+          username: "mybot",
+        })
+      )
     );
 
     const state = createMockState();
@@ -637,7 +682,7 @@ describe("TelegramAdapter", () => {
 
     expect(chat.processMessage).toHaveBeenCalledTimes(3);
     expect(state.setIfNotExists).toHaveBeenCalledTimes(2);
-    const scope = createHash("sha256").update("token").digest("hex");
+    const scope = createHash("sha256").update("999").digest("hex");
     expect(state.setIfNotExists).toHaveBeenCalledWith(
       `telegram:webhook-update:${scope}:1`,
       true,
@@ -685,14 +730,16 @@ describe("TelegramAdapter", () => {
     expect(state.setIfNotExists).not.toHaveBeenCalled();
   });
 
-  it("scopes webhook update claims by bot token", async () => {
-    mockFetch.mockResolvedValue(
-      telegramOk({
-        id: 999,
-        is_bot: true,
-        first_name: "Bot",
-        username: "mybot",
-      })
+  it("scopes webhook update claims by bot identity", async () => {
+    mockFetch.mockImplementation((url) =>
+      Promise.resolve(
+        telegramOk({
+          id: String(url).includes("token-a") ? 100 : 200,
+          is_bot: true,
+          first_name: "Bot",
+          username: "mybot",
+        })
+      )
     );
 
     const state = createMockState();

--- a/packages/adapter-telegram/src/index.test.ts
+++ b/packages/adapter-telegram/src/index.test.ts
@@ -196,6 +196,14 @@ describe("createTelegramAdapter", () => {
     expect(adapter).toBeInstanceOf(TelegramAdapter);
     expect(adapter.name).toBe("telegram");
   });
+
+  it("accepts an async bot token resolver", () => {
+    const adapter = createTelegramAdapter({
+      botToken: async () => "resolved-token",
+      logger: mockLogger,
+    });
+    expect(adapter).toBeInstanceOf(TelegramAdapter);
+  });
 });
 
 describe("constructor env var resolution", () => {
@@ -299,6 +307,137 @@ describe("constructor env var resolution", () => {
       userName: "config-name",
     });
     expect(adapter.userName).toBe("config-name");
+  });
+});
+
+describe("bot token resolver", () => {
+  it("resolves a fresh token for each Bot API request", async () => {
+    const botToken = vi
+      .fn()
+      .mockResolvedValueOnce("telegram-token-1")
+      .mockResolvedValueOnce("telegram-token-2");
+    mockFetch.mockImplementation(() =>
+      Promise.resolve(
+        telegramOk({
+          id: 123,
+          is_bot: true,
+          first_name: "Test Bot",
+          username: "test_bot",
+        })
+      )
+    );
+    const adapter = createTelegramAdapter({
+      botToken,
+      mode: "webhook",
+      logger: mockLogger,
+    });
+
+    const telegramFetch = (
+      adapter as unknown as {
+        telegramFetch<TResult>(method: string): Promise<TResult>;
+      }
+    ).telegramFetch.bind(adapter);
+    await telegramFetch("getMe");
+    await telegramFetch("getMe");
+
+    expect(botToken).toHaveBeenCalledTimes(2);
+    expect(mockFetch.mock.calls.map(([url]) => String(url))).toEqual([
+      "https://api.telegram.org/bottelegram-token-1/getMe",
+      "https://api.telegram.org/bottelegram-token-2/getMe",
+    ]);
+  });
+
+  it("rejects an empty resolved token before calling Telegram", async () => {
+    const adapter = createTelegramAdapter({
+      botToken: async () => "",
+      mode: "webhook",
+      logger: mockLogger,
+    });
+
+    await expect(
+      (
+        adapter as unknown as {
+          telegramFetch<TResult>(method: string): Promise<TResult>;
+        }
+      ).telegramFetch("getMe")
+    ).rejects.toThrow(AuthenticationError);
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it("resolves the token again when downloading a file", async () => {
+    const botToken = vi
+      .fn()
+      .mockResolvedValueOnce("telegram-api-token")
+      .mockResolvedValueOnce("telegram-file-token");
+    mockFetch
+      .mockResolvedValueOnce(
+        telegramOk({ file_id: "file-1", file_path: "documents/file.txt" })
+      )
+      .mockResolvedValueOnce(new Response("contents"));
+    const adapter = createTelegramAdapter({
+      botToken,
+      mode: "webhook",
+      logger: mockLogger,
+    });
+
+    await (
+      adapter as unknown as {
+        downloadFile(fileId: string): Promise<Buffer>;
+      }
+    ).downloadFile("file-1");
+
+    expect(botToken).toHaveBeenCalledTimes(2);
+    expect(mockFetch.mock.calls.map(([url]) => String(url))).toEqual([
+      "https://api.telegram.org/bottelegram-api-token/getFile",
+      "https://api.telegram.org/file/bottelegram-file-token/documents/file.txt",
+    ]);
+  });
+
+  it("scopes webhook deduplication with the resolved bot token", async () => {
+    const botToken = vi.fn().mockResolvedValue("resolved-token");
+    mockFetch.mockResolvedValue(
+      telegramOk({
+        id: 999,
+        is_bot: true,
+        first_name: "Bot",
+        username: "mybot",
+      })
+    );
+    const state = createMockState();
+    const chat = createMockChatInstance({
+      logger: mockLogger,
+      state,
+      userName: "mybot",
+    });
+    const adapter = createTelegramAdapter({
+      botToken,
+      mode: "webhook",
+      logger: mockLogger,
+      secretToken: "secret",
+      userName: "mybot",
+    });
+    await adapter.initialize(chat);
+
+    await adapter.handleWebhook(
+      new Request("https://example.com/webhook", {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          "x-telegram-bot-api-secret-token": "secret",
+        },
+        body: JSON.stringify({
+          update_id: 1,
+          message: sampleMessage(),
+        }),
+      })
+    );
+
+    const scope = createHash("sha256").update("resolved-token").digest("hex");
+    expect(state.setIfNotExists).toHaveBeenCalledWith(
+      `telegram:webhook-update:${scope}:1`,
+      true,
+      86_400_000
+    );
   });
 });
 

--- a/packages/adapter-telegram/src/index.test.ts
+++ b/packages/adapter-telegram/src/index.test.ts
@@ -482,6 +482,55 @@ describe("bot token resolver", () => {
     const keys = state.setIfNotExists.mock.calls.map(([key]) => key);
     expect(new Set(keys).size).toBe(1);
   });
+
+  it("retries bot identity resolution on a later webhook", async () => {
+    const botToken = vi.fn().mockResolvedValue("resolved-token");
+    mockFetch
+      .mockRejectedValueOnce(new Error("temporary getMe failure"))
+      .mockResolvedValueOnce(
+        telegramOk({
+          id: 999,
+          is_bot: true,
+          first_name: "Bot",
+          username: "mybot",
+        })
+      );
+    const state = createMockState();
+    const chat = createMockChatInstance({
+      logger: mockLogger,
+      state,
+      userName: "mybot",
+    });
+    const adapter = createTelegramAdapter({
+      botToken,
+      mode: "webhook",
+      logger: mockLogger,
+      secretToken: "secret",
+      userName: "mybot",
+    });
+    await adapter.initialize(chat);
+
+    const request = (updateId: number) =>
+      new Request("https://example.com/webhook", {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          "x-telegram-bot-api-secret-token": "secret",
+        },
+        body: JSON.stringify({ update_id: updateId }),
+      });
+    expect((await adapter.handleWebhook(request(1))).status).toBe(200);
+    expect((await adapter.handleWebhook(request(2))).status).toBe(200);
+
+    const scope = createHash("sha256").update("999").digest("hex");
+    expect(state.setIfNotExists).toHaveBeenCalledWith(
+      `telegram:webhook-update:${scope}:1`,
+      true,
+      86_400_000
+    );
+    expect(botToken).toHaveBeenCalledTimes(2);
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+  });
 });
 
 // ============================================================================

--- a/packages/adapter-telegram/src/index.ts
+++ b/packages/adapter-telegram/src/index.ts
@@ -277,6 +277,7 @@ export class TelegramAdapter
   protected readonly staticBotToken?: string;
   protected readonly apiBaseUrl: string;
   protected readonly secretToken?: string;
+  private botIdentityPromise: Promise<void> | null = null;
   private webhookScope?: string;
   private warnedNoVerification = false;
   protected readonly logger: Logger;
@@ -370,6 +371,32 @@ export class TelegramAdapter
     return botToken;
   }
 
+  protected async ensureBotIdentity(): Promise<void> {
+    if (this.webhookScope) {
+      return;
+    }
+    if (!this.botIdentityPromise) {
+      this.botIdentityPromise = this.telegramFetch<TelegramUser>("getMe")
+        .then((me) => {
+          this._botUserId = String(me.id);
+          this.webhookScope = createHash("sha256")
+            .update(this._botUserId)
+            .digest("hex");
+          if (!this.hasExplicitUserName && me.username) {
+            this._userName = this.normalizeUserName(me.username);
+          }
+          this.logger.info("Telegram bot identity resolved", {
+            botUserId: this._botUserId,
+            userName: this._userName,
+          });
+        })
+        .finally(() => {
+          this.botIdentityPromise = null;
+        });
+    }
+    await this.botIdentityPromise;
+  }
+
   async initialize(chat: ChatInstance): Promise<void> {
     this.chat = chat;
 
@@ -383,19 +410,7 @@ export class TelegramAdapter
     }
 
     try {
-      const me = await this.telegramFetch<TelegramUser>("getMe");
-      this._botUserId = String(me.id);
-      this.webhookScope = createHash("sha256")
-        .update(this._botUserId)
-        .digest("hex");
-      if (!this.hasExplicitUserName && me.username) {
-        this._userName = this.normalizeUserName(me.username);
-      }
-
-      this.logger.info("Telegram adapter initialized", {
-        botUserId: this._botUserId,
-        userName: this._userName,
-      });
+      await this.ensureBotIdentity();
     } catch (error) {
       this.logger.warn("Failed to fetch Telegram bot identity", {
         error: String(error),
@@ -491,11 +506,20 @@ export class TelegramAdapter
     }
 
     if (this.secretToken && Number.isInteger(update.update_id)) {
-      const webhookScope = this.webhookScope;
+      let webhookScope = this.webhookScope;
       if (!webhookScope) {
-        this.logger.warn(
-          "Telegram webhook update could not be scoped before bot identity resolution"
-        );
+        try {
+          await this.ensureBotIdentity();
+          webhookScope = this.webhookScope;
+        } catch (error) {
+          this.logger.warn(
+            "Telegram webhook update could not resolve bot identity",
+            { error: String(error) }
+          );
+          return new Response("Service unavailable", { status: 503 });
+        }
+      }
+      if (!webhookScope) {
         return new Response("Service unavailable", { status: 503 });
       }
       try {

--- a/packages/adapter-telegram/src/index.ts
+++ b/packages/adapter-telegram/src/index.ts
@@ -130,6 +130,16 @@ const TELEGRAM_MAX_POLLING_LIMIT = 100;
 const TELEGRAM_MIN_POLLING_LIMIT = 1;
 const TELEGRAM_MIN_POLLING_TIMEOUT_SECONDS = 0;
 const TELEGRAM_MAX_POLLING_TIMEOUT_SECONDS = 300;
+
+function normalizeBotTokenProvider(
+  botToken: string | (() => string | Promise<string>)
+): () => Promise<string> {
+  if (typeof botToken === "function") {
+    return async () => await botToken();
+  }
+  return () => Promise.resolve(botToken);
+}
+
 interface TelegramMessageAuthor {
   fullName: string;
   isBot: boolean | "unknown";
@@ -263,10 +273,11 @@ export class TelegramAdapter
   readonly persistThreadHistory = true;
 
   protected readonly allowedUserIds?: Set<string>;
-  protected readonly botToken: string;
+  protected readonly botTokenProvider: () => Promise<string>;
+  protected readonly staticBotToken?: string;
   protected readonly apiBaseUrl: string;
   protected readonly secretToken?: string;
-  private readonly webhookScope: string;
+  private webhookScope?: string;
   private warnedNoVerification = false;
   protected readonly logger: Logger;
   protected readonly formatConverter = new TelegramFormatConverter();
@@ -315,8 +326,11 @@ export class TelegramAdapter
       );
     }
 
-    this.botToken = botToken;
-    this.webhookScope = createHash("sha256").update(botToken).digest("hex");
+    this.botTokenProvider = normalizeBotTokenProvider(botToken);
+    this.staticBotToken = typeof botToken === "string" ? botToken : undefined;
+    this.webhookScope = this.staticBotToken
+      ? createHash("sha256").update(this.staticBotToken).digest("hex")
+      : undefined;
     this.apiBaseUrl = trimTrailingSlashes(
       config.apiUrl ??
         config.apiBaseUrl ??
@@ -347,6 +361,18 @@ export class TelegramAdapter
         `Invalid mode: ${this.mode}. Expected "auto", "webhook", or "polling".`
       );
     }
+  }
+
+  protected async resolveBotToken(): Promise<string> {
+    const botToken = await this.botTokenProvider();
+    if (!botToken) {
+      throw new AuthenticationError(
+        "telegram",
+        "Telegram bot token resolver returned an empty token. Check TELEGRAM_BOT_TOKEN or the Vercel Connect connector."
+      );
+    }
+    this.webhookScope ??= createHash("sha256").update(botToken).digest("hex");
+    return botToken;
   }
 
   async initialize(chat: ChatInstance): Promise<void> {
@@ -467,11 +493,18 @@ export class TelegramAdapter
     }
 
     if (this.secretToken && Number.isInteger(update.update_id)) {
+      const webhookScope = this.webhookScope;
+      if (!webhookScope) {
+        this.logger.warn(
+          "Telegram webhook update could not be scoped before bot token resolution"
+        );
+        return new Response("Service unavailable", { status: 503 });
+      }
       try {
         const claimed = await this.chat
           .getState()
           .setIfNotExists(
-            `${this.name}:webhook-update:${this.webhookScope}:${update.update_id}`,
+            `${this.name}:webhook-update:${webhookScope}:${update.update_id}`,
             true,
             TELEGRAM_WEBHOOK_UPDATE_TTL_MS
           );
@@ -2018,7 +2051,8 @@ export class TelegramAdapter
       throw new ResourceNotFoundError("telegram", "file", fileId);
     }
 
-    const fileUrl = `${this.apiBaseUrl}/file/bot${this.botToken}/${file.file_path}`;
+    const botToken = this.staticBotToken ?? (await this.resolveBotToken());
+    const fileUrl = `${this.apiBaseUrl}/file/bot${botToken}/${file.file_path}`;
 
     let response: Response;
     try {
@@ -3087,7 +3121,8 @@ export class TelegramAdapter
       signal?: AbortSignal;
     }
   ): Promise<TResult> {
-    const url = `${this.apiBaseUrl}/bot${this.botToken}/${method}`;
+    const botToken = this.staticBotToken ?? (await this.resolveBotToken());
+    const url = `${this.apiBaseUrl}/bot${botToken}/${method}`;
 
     let response: Response;
     try {

--- a/packages/adapter-telegram/src/index.ts
+++ b/packages/adapter-telegram/src/index.ts
@@ -325,12 +325,8 @@ export class TelegramAdapter
         "botToken is required. Set TELEGRAM_BOT_TOKEN or provide it in config."
       );
     }
-
     this.botTokenProvider = normalizeBotTokenProvider(botToken);
     this.staticBotToken = typeof botToken === "string" ? botToken : undefined;
-    this.webhookScope = this.staticBotToken
-      ? createHash("sha256").update(this.staticBotToken).digest("hex")
-      : undefined;
     this.apiBaseUrl = trimTrailingSlashes(
       config.apiUrl ??
         config.apiBaseUrl ??
@@ -371,7 +367,6 @@ export class TelegramAdapter
         "Telegram bot token resolver returned an empty token. Check TELEGRAM_BOT_TOKEN or the Vercel Connect connector."
       );
     }
-    this.webhookScope ??= createHash("sha256").update(botToken).digest("hex");
     return botToken;
   }
 
@@ -390,6 +385,9 @@ export class TelegramAdapter
     try {
       const me = await this.telegramFetch<TelegramUser>("getMe");
       this._botUserId = String(me.id);
+      this.webhookScope = createHash("sha256")
+        .update(this._botUserId)
+        .digest("hex");
       if (!this.hasExplicitUserName && me.username) {
         this._userName = this.normalizeUserName(me.username);
       }
@@ -496,7 +494,7 @@ export class TelegramAdapter
       const webhookScope = this.webhookScope;
       if (!webhookScope) {
         this.logger.warn(
-          "Telegram webhook update could not be scoped before bot token resolution"
+          "Telegram webhook update could not be scoped before bot identity resolution"
         );
         return new Response("Service unavailable", { status: 503 });
       }

--- a/packages/adapter-telegram/src/types.ts
+++ b/packages/adapter-telegram/src/types.ts
@@ -14,8 +14,8 @@ export interface TelegramAdapterConfig {
   apiBaseUrl?: string;
   /** Override the Telegram API base URL. Alias for apiBaseUrl — apiUrl takes precedence if both are set. Defaults to TELEGRAM_API_BASE_URL env var. */
   apiUrl?: string;
-  /** Telegram bot token from BotFather. Defaults to TELEGRAM_BOT_TOKEN env var. */
-  botToken?: string;
+  /** Telegram bot token from BotFather, or a resolver invoked for each Bot API request. Defaults to TELEGRAM_BOT_TOKEN env var. */
+  botToken?: string | (() => string | Promise<string>);
   /** Logger instance for error reporting. Defaults to ConsoleLogger. */
   logger?: Logger;
   /** Optional long-polling configuration for getUpdates flow. */

--- a/packages/create-chat-sdk/README.md
+++ b/packages/create-chat-sdk/README.md
@@ -39,13 +39,13 @@ When the CLI detects a coding agent environment, it announces the detection and 
 
 ## Vercel Connect
 
-The Slack, Discord, GitHub, Linear, and Notion adapters can use [Vercel Connect](https://chat-sdk.dev/docs/vercel-connect) for outbound credentials. Pass `--connect`, or choose **Vercel Connect** at the interactive auth-mode prompt:
+The Slack, Discord, GitHub, Linear, Notion, and Telegram adapters can use [Vercel Connect](https://chat-sdk.dev/docs/vercel-connect) for outbound credentials. Pass `--connect`, or choose **Vercel Connect** at the interactive auth-mode prompt:
 
 ```bash
 npm create chat-sdk@latest -- my-bot --adapter slack --connect -y
 ```
 
-The generated bot spreads the matching helper from `@vercel/connect/chat` into the adapter factory, adds `@vercel/connect` to dependencies, and lists each connector UID (such as `SLACK_CONNECTOR`) in `.env.example`. Native webhook verification secrets are retained for adapters such as Notion.
+The generated bot spreads the matching helper from `@vercel/connect/chat` into the adapter factory, adds `@vercel/connect` to dependencies, and lists each connector UID (such as `SLACK_CONNECTOR`) in `.env.example`. Native webhook verification secrets are retained for adapters such as Notion and Telegram.
 
 ## Options
 
@@ -60,8 +60,8 @@ Options:
   --adapter <values...>     platform or state adapters to include
   --vendor                  list vendor-official adapters in the interactive
                             prompt
-  --connect                 authenticate Slack, Discord, GitHub, Linear, and
-                            Notion adapters with Vercel Connect
+  --connect                 authenticate Slack, Discord, GitHub, Linear,
+                            Notion, and Telegram adapters with Vercel Connect
   --pm <manager>            package manager to use (npm, yarn, pnpm, bun)
   -y, --yes                 skip prompts and accept defaults
   --interactive             always prompt, even when a coding agent

--- a/packages/create-chat-sdk/docs/create-chat-sdk.mdx
+++ b/packages/create-chat-sdk/docs/create-chat-sdk.mdx
@@ -103,13 +103,13 @@ When the [Discord adapter](/adapters/official/discord) is selected, the CLI also
 
 ## Vercel Connect
 
-[Vercel Connect](/docs/vercel-connect) supplies outbound credentials for the Slack, Discord, GitHub, Linear, and Notion adapters. Pass `--connect` — or choose **Vercel Connect** at the interactive auth-mode prompt — to scaffold Connect wiring for any selected adapter in that list. Notion webhooks remain direct and retain `NOTION_VERIFICATION_TOKEN`.
+[Vercel Connect](/docs/vercel-connect) supplies outbound credentials for the Slack, Discord, GitHub, Linear, Notion, and Telegram adapters. Pass `--connect` — or choose **Vercel Connect** at the interactive auth-mode prompt — to scaffold Connect wiring for any selected adapter in that list. Notion and Telegram webhooks remain direct and retain their native verification secrets.
 
 ```bash
 npm create chat-sdk@latest -- my-bot --adapter slack --connect -y
 ```
 
-The generated `src/lib/bot.ts` spreads the matching helper from `@vercel/connect/chat` into the adapter factory, `@vercel/connect` is added to dependencies, and `.env.example` lists each connector UID (for example `SLACK_CONNECTOR`). Native webhook verification secrets are retained for adapters such as Notion.
+The generated `src/lib/bot.ts` spreads the matching helper from `@vercel/connect/chat` into the adapter factory, `@vercel/connect` is added to dependencies, and `.env.example` lists each connector UID (for example `SLACK_CONNECTOR`). Native webhook verification secrets are retained for adapters such as Notion and Telegram.
 
 <Callout type="info">
   Vercel Connect provides `VERCEL_OIDC_TOKEN` at runtime. For local development, run `vercel link` then `vercel env pull` to populate it. Connect forwards inbound webhooks only to deployed URLs, so test webhook delivery against a Vercel deployment (such as a preview) rather than localhost.
@@ -123,7 +123,7 @@ The generated `src/lib/bot.ts` spreads the matching helper from `@vercel/connect
 | `-d, --description <text>` | Project description. |
 | `--adapter <values...>` | Platform or state adapters to include. |
 | `--vendor` | List only vendor-official adapters in the interactive prompt. |
-| `--connect` | Authenticate Slack, Discord, GitHub, Linear, and Notion adapters with Vercel Connect. |
+| `--connect` | Authenticate Slack, Discord, GitHub, Linear, Notion, and Telegram adapters with Vercel Connect. |
 | `--pm <manager>` | Package manager to use: `npm`, `yarn`, `pnpm`, or `bun`. |
 | `-y, --yes` | Skip prompts and accept defaults. |
 | `--interactive` | Always prompt, even when a coding agent environment is detected. |

--- a/packages/create-chat-sdk/src/catalog/scaffold-spec.ts
+++ b/packages/create-chat-sdk/src/catalog/scaffold-spec.ts
@@ -81,7 +81,7 @@ export interface AdapterConnectSpec {
 export interface CliScaffoldSpec {
   /**
    * Vercel Connect code-generation policy. Present only for adapters that
-   * support Connect (Slack, Discord, GitHub, Linear, Notion).
+   * support Connect (Slack, Discord, GitHub, Linear, Notion, Telegram).
    */
   connect?: AdapterConnectSpec;
   /**
@@ -322,6 +322,17 @@ export const CLI_SCAFFOLD_SPEC = {
     },
   },
   telegram: {
+    connect: {
+      connectorEnvVar: "TELEGRAM_CONNECTOR",
+      extraEnv: [
+        {
+          description: "Native Telegram webhook secret token",
+          key: "TELEGRAM_WEBHOOK_SECRET_TOKEN",
+        },
+      ],
+      helper: "connectTelegramAdapter",
+      inbound: "native",
+    },
     invocation: { kind: "zero-arg" },
   },
   twilio: {

--- a/packages/create-chat-sdk/src/cli/e2e.test.ts
+++ b/packages/create-chat-sdk/src/cli/e2e.test.ts
@@ -198,6 +198,49 @@ describe("CLI Vercel Connect mode", () => {
     );
     expect(readme).not.toContain("Enable Connect trigger forwarding");
   });
+
+  it("scaffolds Telegram with Connect tokens and native webhooks", async () => {
+    process.exitCode = undefined;
+    const program = createProgram();
+    await program.parseAsync([
+      "node",
+      "create-chat-sdk",
+      "connect-telegram-bot",
+      "--adapter",
+      "telegram",
+      "memory",
+      "--connect",
+      "-yq",
+      "--skip-install",
+      "--no-git",
+    ]);
+
+    expect(process.exitCode).toBeUndefined();
+
+    const botTs = readProjectFile("connect-telegram-bot", "src/lib/bot.ts");
+    expect(botTs).toContain(
+      'import { connectTelegramAdapter } from "@vercel/connect/chat";'
+    );
+    expect(botTs).toContain(
+      '...connectTelegramAdapter(requireEnv("TELEGRAM_CONNECTOR")),'
+    );
+
+    const packageJson = JSON.parse(
+      readProjectFile("connect-telegram-bot", "package.json")
+    ) as { dependencies?: Record<string, string> };
+    expect(packageJson.dependencies?.["@vercel/connect"]).toBe("latest");
+
+    const envExample = readProjectFile("connect-telegram-bot", ".env.example");
+    expect(envExample).toContain("TELEGRAM_CONNECTOR=");
+    expect(envExample).toContain("TELEGRAM_WEBHOOK_SECRET_TOKEN=");
+    expect(envExample).not.toContain("TELEGRAM_BOT_TOKEN=");
+
+    const readme = readProjectFile("connect-telegram-bot", "README.md");
+    expect(readme).toContain(
+      "Configure native webhook subscriptions for Telegram"
+    );
+    expect(readme).not.toContain("Enable Connect trigger forwarding");
+  });
 });
 
 describe("CLI agent mode", () => {

--- a/packages/create-chat-sdk/src/cli/program.ts
+++ b/packages/create-chat-sdk/src/cli/program.ts
@@ -71,7 +71,7 @@ export function createProgram(): Command {
     )
     .option(
       "--connect",
-      "authenticate Slack, Discord, GitHub, Linear, and Notion adapters with Vercel Connect"
+      "authenticate Slack, Discord, GitHub, Linear, Notion, and Telegram adapters with Vercel Connect"
     )
     .option(
       "--pm <manager>",

--- a/packages/create-chat-sdk/src/generators/generators.test.ts
+++ b/packages/create-chat-sdk/src/generators/generators.test.ts
@@ -159,11 +159,36 @@ describe("Vercel Connect generation", () => {
     expect(readme).not.toContain("Enable Connect trigger forwarding");
   });
 
+  it("scaffolds Telegram with Connect tokens and native webhook verification", () => {
+    const botTs = generateBotTs(connectConfig(["telegram"]));
+    expect(botTs).toContain(
+      'import { connectTelegramAdapter } from "@vercel/connect/chat";'
+    );
+    expect(botTs).toContain("telegram: createTelegramAdapter({");
+    expect(botTs).toContain(
+      '...connectTelegramAdapter(requireEnv("TELEGRAM_CONNECTOR")),'
+    );
+
+    const envExample = generateEnvExample(connectConfig(["telegram"]));
+    expect(envExample).toContain("TELEGRAM_CONNECTOR=");
+    expect(envExample).toContain("TELEGRAM_WEBHOOK_SECRET_TOKEN=");
+    expect(envExample).not.toContain("TELEGRAM_BOT_TOKEN=");
+
+    const readme = generateReadme(connectConfig(["telegram"]));
+    expect(readme).toContain("outbound credentials for Telegram");
+    expect(readme).toContain(
+      "Configure native webhook subscriptions for Telegram"
+    );
+    expect(readme).not.toContain("Enable Connect trigger forwarding");
+  });
+
   it("documents mixed Connect trigger and native webhook modes", () => {
-    const readme = generateReadme(connectConfig(["slack", "notion"]));
+    const readme = generateReadme(
+      connectConfig(["slack", "notion", "telegram"])
+    );
     expect(readme).toContain("Enable Connect trigger forwarding for Slack");
     expect(readme).toContain(
-      "Configure native webhook subscriptions for Notion"
+      "Configure native webhook subscriptions for Notion, Telegram"
     );
   });
 
@@ -184,16 +209,23 @@ describe("Vercel Connect generation", () => {
 
   it("imports every selected Connect helper, sorted", () => {
     const result = generateBotTs(
-      connectConfig(["slack", "discord", "github", "linear", "notion"])
+      connectConfig([
+        "slack",
+        "discord",
+        "github",
+        "linear",
+        "notion",
+        "telegram",
+      ])
     );
     expect(result).toContain(
-      'import { connectDiscordAdapter, connectGitHubAdapter, connectLinearAdapter, connectNotionAdapter, connectSlackAdapter } from "@vercel/connect/chat";'
+      'import { connectDiscordAdapter, connectGitHubAdapter, connectLinearAdapter, connectNotionAdapter, connectSlackAdapter, connectTelegramAdapter } from "@vercel/connect/chat";'
     );
   });
 
   it("leaves non-Connect adapters on their native factory calls", () => {
-    const result = generateBotTs(connectConfig(["slack", "telegram"]));
-    expect(result).toContain("telegram: createTelegramAdapter(),");
+    const result = generateBotTs(connectConfig(["slack", "gchat"]));
+    expect(result).toContain("gchat: createGoogleChatAdapter(),");
     expect(result).toContain("slack: createSlackAdapter({");
   });
 
@@ -214,7 +246,7 @@ describe("Vercel Connect generation", () => {
   it("does not add @vercel/connect without a Connect-capable adapter", () => {
     const result = generatePackageJson(
       { dependencies: {} },
-      { ...makeConfig(["telegram"]), useConnect: true }
+      { ...makeConfig(["gchat"]), useConnect: true }
     );
     expect(result.dependencies?.["@vercel/connect"]).toBeUndefined();
   });
@@ -242,7 +274,7 @@ describe("Vercel Connect generation", () => {
 
   it("omits the README Connect section without a Connect-capable adapter", () => {
     const result = generateReadme({
-      ...makeConfig(["telegram"]),
+      ...makeConfig(["gchat"]),
       useConnect: true,
     });
     expect(result).not.toContain("Authentication (Vercel Connect)");

--- a/packages/create-chat-sdk/src/prompts/flow.test.ts
+++ b/packages/create-chat-sdk/src/prompts/flow.test.ts
@@ -239,7 +239,7 @@ describe("runPrompts", () => {
 
   it("does not prompt for auth mode without a Connect-capable adapter", async () => {
     vi.mocked(text).mockResolvedValueOnce("my-bot").mockResolvedValueOnce("");
-    vi.mocked(multiselect).mockResolvedValueOnce(["telegram"]);
+    vi.mocked(multiselect).mockResolvedValueOnce(["gchat"]);
     vi.mocked(select).mockResolvedValueOnce("memory");
     vi.mocked(confirm).mockResolvedValueOnce(true);
 
@@ -266,7 +266,7 @@ describe("runPrompts", () => {
       connect: true,
       name: "my-bot",
       quiet: false,
-      selectedAdapters: ["telegram", "memory"],
+      selectedAdapters: ["gchat", "memory"],
       yes: true,
     });
 

--- a/packages/create-chat-sdk/src/prompts/flow.ts
+++ b/packages/create-chat-sdk/src/prompts/flow.ts
@@ -146,7 +146,7 @@ export async function runPrompts(
     useConnect = connectCapable;
     if (!(connectCapable || inputs.quiet)) {
       log.warning(
-        "Ignoring --connect: Vercel Connect supports only the Slack, Discord, GitHub, Linear, and Notion adapters."
+        "Ignoring --connect: Vercel Connect supports only the Slack, Discord, GitHub, Linear, Notion, and Telegram adapters."
       );
     }
   } else if (!(inputs.yes || flaggedSelection) && connectCapable) {

--- a/packages/create-chat-sdk/src/types.ts
+++ b/packages/create-chat-sdk/src/types.ts
@@ -45,7 +45,8 @@ export interface ProjectConfig extends AdapterSelection {
   shouldInstall: boolean;
   /**
    * Authenticate Connect-capable adapters (Slack, Discord, GitHub, Linear,
-   * Notion) with Vercel Connect for outbound credentials. Defaults to `false`.
+   * Notion, Telegram) with Vercel Connect for outbound credentials. Defaults
+   * to `false`.
    */
   useConnect?: boolean;
 }


### PR DESCRIPTION
Adds function-backed Telegram bot-token resolution so the adapter can use short-lived Vercel Connect credentials for every Bot API and file-download request. Static tokens retain their existing synchronous behavior, while native Telegram webhook verification or polling remains unchanged.

```ts
import { createTelegramAdapter } from "@chat-adapter/telegram";
import { connectTelegramAdapter } from "@vercel/connect/chat";

createTelegramAdapter({
  ...connectTelegramAdapter("telegram/acme-telegram"),
  secretToken: process.env.TELEGRAM_WEBHOOK_SECRET_TOKEN,
});
```

`create-chat-sdk` now recognizes Telegram as Connect-capable, preserves `TELEGRAM_WEBHOOK_SECRET_TOKEN`, and emits native-webhook guidance:

```bash
npm create chat-sdk@latest -- my-bot --adapter telegram memory --connect -y
```

This PR is stacked on the Notion Connect work in #812. Validated with the Telegram adapter suite (251 tests), create-chat-sdk suite (211 tests), package type checks/builds, and repository lint/format checks.