### PR TITLE
fix(discord): route thread starter message operations correctly

### DIFF
--- a/.changeset/light-badgers-see.md
+++ b/.changeset/light-badgers-see.md
@@ -1,0 +1,5 @@
+---
+"@chat-adapter/discord": patch
+---
+
+fix edits, deletes, and reactions on Discord thread starter messages

--- a/.changeset/light-badgers-see.md
+++ b/.changeset/light-badgers-see.md
@@ -3,3 +3,7 @@
 ---
 
 fix edits, deletes, and reactions on Discord thread starter messages
+
+Operations on a thread's starter message now try the thread first and fall back to the parent channel when Discord reports the message as unknown. Threads on a text channel keep their starter message in the parent channel, so those operations used to fail; forum and media posts keep theirs in the thread and are unaffected.
+
+Note that deleting a text-channel thread's starter message now deletes the message, which Discord cascades into deleting the thread.

--- a/packages/adapter-discord/src/index.test.ts
+++ b/packages/adapter-discord/src/index.test.ts
@@ -2215,6 +2215,113 @@ describe("removeReaction", () => {
   });
 });
 
+describe("thread starter message routing", () => {
+  const adapter = createDiscordAdapter({
+    botToken: "test-token",
+    publicKey: testPublicKey,
+    applicationId: "test-app-id",
+    logger: mockLogger,
+  });
+
+  it("routes text-channel starter operations to the parent channel", async () => {
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockImplementation(() =>
+      Promise.resolve(
+        Response.json({
+          id: "starter123",
+          channel_id: "channel456",
+          content: "updated",
+        })
+      )
+    );
+
+    try {
+      const threadId = "discord:guild1:channel456:starter123";
+      await adapter.editMessage(threadId, "starter123", "updated");
+      await adapter.deleteMessage(threadId, "starter123");
+      await adapter.addReaction(threadId, "starter123", "heart");
+      await adapter.removeReaction(threadId, "starter123", "heart");
+
+      expect(
+        fetchSpy.mock.calls
+          .filter(([input]) =>
+            String(input).startsWith("https://discord.com/api/v10/")
+          )
+          .map(([input, init]) => [String(input), init?.method])
+      ).toEqual([
+        [
+          "https://discord.com/api/v10/channels/channel456/messages/starter123",
+          "PATCH",
+        ],
+        [
+          "https://discord.com/api/v10/channels/channel456/messages/starter123",
+          "DELETE",
+        ],
+        [
+          "https://discord.com/api/v10/channels/channel456/messages/starter123/reactions/%E2%9D%A4%EF%B8%8F/@me",
+          "PUT",
+        ],
+        [
+          "https://discord.com/api/v10/channels/channel456/messages/starter123/reactions/%E2%9D%A4%EF%B8%8F/@me",
+          "DELETE",
+        ],
+      ]);
+    } finally {
+      fetchSpy.mockRestore();
+    }
+  });
+
+  it("retries a forum starter against the thread on unknown message", async () => {
+    const fetchSpy = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(
+        Response.json(
+          { code: 10_008, message: "Unknown Message" },
+          { status: 404 }
+        )
+      )
+      .mockResolvedValueOnce(new Response(null, { status: 204 }));
+
+    try {
+      await adapter.addReaction(
+        "discord:guild1:forum456:starter123",
+        "starter123",
+        "heart"
+      );
+
+      expect(fetchSpy.mock.calls.map(([input]) => String(input))).toEqual([
+        "https://discord.com/api/v10/channels/forum456/messages/starter123/reactions/%E2%9D%A4%EF%B8%8F/@me",
+        "https://discord.com/api/v10/channels/starter123/messages/starter123/reactions/%E2%9D%A4%EF%B8%8F/@me",
+      ]);
+    } finally {
+      fetchSpy.mockRestore();
+    }
+  });
+
+  it("does not retry other Discord errors", async () => {
+    const fetchSpy = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValue(
+        Response.json(
+          { code: 50_013, message: "Missing Permissions" },
+          { status: 403 }
+        )
+      );
+
+    try {
+      await expect(
+        adapter.addReaction(
+          "discord:guild1:channel456:starter123",
+          "starter123",
+          "heart"
+        )
+      ).rejects.toThrow("50013");
+      expect(fetchSpy).toHaveBeenCalledTimes(1);
+    } finally {
+      fetchSpy.mockRestore();
+    }
+  });
+});
+
 // ============================================================================
 // normalizeDiscordEmoji Tests
 // ============================================================================

--- a/packages/adapter-discord/src/index.test.ts
+++ b/packages/adapter-discord/src/index.test.ts
@@ -4,7 +4,7 @@
 
 import { generateKeyPairSync, sign } from "node:crypto";
 import { EventEmitter } from "node:events";
-import { ValidationError } from "@chat-adapter/shared";
+import { NetworkError, ValidationError } from "@chat-adapter/shared";
 import {
   createMockChatInstance,
   mockLogger,
@@ -2223,19 +2223,35 @@ describe("thread starter message routing", () => {
     logger: mockLogger,
   });
 
-  it("routes text-channel starter operations to the parent channel", async () => {
-    const fetchSpy = vi.spyOn(globalThis, "fetch").mockImplementation(() =>
-      Promise.resolve(
-        Response.json({
-          id: "starter123",
-          channel_id: "channel456",
-          content: "updated",
-        })
-      )
-    );
+  it("routes forum starter operations to the thread", async () => {
+    const fetchSpy = vi
+      .spyOn(globalThis, "fetch")
+      .mockImplementation((input) => {
+        // Forum and media channels contain no messages, so Discord rejects
+        // message routes against them with a channel type error, not 10008.
+        if (String(input).includes("/channels/forum456/")) {
+          return Promise.resolve(
+            Response.json(
+              {
+                code: 50_024,
+                message: "Cannot execute action on this channel type",
+              },
+              { status: 400 }
+            )
+          );
+        }
+
+        return Promise.resolve(
+          Response.json({
+            id: "starter123",
+            channel_id: "starter123",
+            content: "updated",
+          })
+        );
+      });
 
     try {
-      const threadId = "discord:guild1:channel456:starter123";
+      const threadId = "discord:guild1:forum456:starter123";
       await adapter.editMessage(threadId, "starter123", "updated");
       await adapter.deleteMessage(threadId, "starter123");
       await adapter.addReaction(threadId, "starter123", "heart");
@@ -2249,19 +2265,19 @@ describe("thread starter message routing", () => {
           .map(([input, init]) => [String(input), init?.method])
       ).toEqual([
         [
-          "https://discord.com/api/v10/channels/channel456/messages/starter123",
+          "https://discord.com/api/v10/channels/starter123/messages/starter123",
           "PATCH",
         ],
         [
-          "https://discord.com/api/v10/channels/channel456/messages/starter123",
+          "https://discord.com/api/v10/channels/starter123/messages/starter123",
           "DELETE",
         ],
         [
-          "https://discord.com/api/v10/channels/channel456/messages/starter123/reactions/%E2%9D%A4%EF%B8%8F/@me",
+          "https://discord.com/api/v10/channels/starter123/messages/starter123/reactions/%E2%9D%A4%EF%B8%8F/@me",
           "PUT",
         ],
         [
-          "https://discord.com/api/v10/channels/channel456/messages/starter123/reactions/%E2%9D%A4%EF%B8%8F/@me",
+          "https://discord.com/api/v10/channels/starter123/messages/starter123/reactions/%E2%9D%A4%EF%B8%8F/@me",
           "DELETE",
         ],
       ]);
@@ -2270,27 +2286,58 @@ describe("thread starter message routing", () => {
     }
   });
 
-  it("retries a forum starter against the thread on unknown message", async () => {
+  it("falls back to the parent channel for a text-channel starter", async () => {
     const fetchSpy = vi
       .spyOn(globalThis, "fetch")
-      .mockResolvedValueOnce(
-        Response.json(
-          { code: 10_008, message: "Unknown Message" },
-          { status: 404 }
-        )
-      )
-      .mockResolvedValueOnce(new Response(null, { status: 204 }));
+      .mockImplementation((input) => {
+        // A text-channel thread's starter message lives in the parent
+        // channel, so the thread itself reports it as unknown.
+        if (String(input).includes("/channels/starter123/")) {
+          return Promise.resolve(
+            Response.json(
+              { code: 10_008, message: "Unknown Message" },
+              { status: 404 }
+            )
+          );
+        }
+
+        return Promise.resolve(
+          Response.json({
+            id: "starter123",
+            channel_id: "channel456",
+            content: "updated",
+          })
+        );
+      });
 
     try {
-      await adapter.addReaction(
-        "discord:guild1:forum456:starter123",
-        "starter123",
-        "heart"
-      );
+      const threadId = "discord:guild1:channel456:starter123";
+      await adapter.editMessage(threadId, "starter123", "updated");
+      await adapter.addReaction(threadId, "starter123", "heart");
 
-      expect(fetchSpy.mock.calls.map(([input]) => String(input))).toEqual([
-        "https://discord.com/api/v10/channels/forum456/messages/starter123/reactions/%E2%9D%A4%EF%B8%8F/@me",
-        "https://discord.com/api/v10/channels/starter123/messages/starter123/reactions/%E2%9D%A4%EF%B8%8F/@me",
+      expect(
+        fetchSpy.mock.calls
+          .filter(([input]) =>
+            String(input).startsWith("https://discord.com/api/v10/")
+          )
+          .map(([input, init]) => [String(input), init?.method])
+      ).toEqual([
+        [
+          "https://discord.com/api/v10/channels/starter123/messages/starter123",
+          "PATCH",
+        ],
+        [
+          "https://discord.com/api/v10/channels/channel456/messages/starter123",
+          "PATCH",
+        ],
+        [
+          "https://discord.com/api/v10/channels/starter123/messages/starter123/reactions/%E2%9D%A4%EF%B8%8F/@me",
+          "PUT",
+        ],
+        [
+          "https://discord.com/api/v10/channels/channel456/messages/starter123/reactions/%E2%9D%A4%EF%B8%8F/@me",
+          "PUT",
+        ],
       ]);
     } finally {
       fetchSpy.mockRestore();
@@ -5422,57 +5469,81 @@ describe("createDiscordThread 160004 recovery", () => {
   });
 
   it("should recover when Discord returns 160004 (thread already exists)", async () => {
-    const { NetworkError } = await import("@chat-adapter/shared");
-
-    const spy = vi
-      .spyOn(adapter as any, "discordFetch")
-      .mockRejectedValue(
-        new NetworkError(
-          "discord",
-          'Discord API error: 400 {"code": 160004, "message": "A thread has already been created for this message"}'
-        )
-      );
-
-    const result = await (adapter as any).createDiscordThread(
-      "channel123",
-      "msg456"
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      Response.json(
+        {
+          code: 160_004,
+          message: "A thread has already been created for this message",
+        },
+        { status: 400 }
+      )
     );
 
-    expect(result.id).toBe("msg456");
-    expect(result.name).toContain("Thread ");
+    try {
+      const result = await (adapter as any).createDiscordThread(
+        "channel123",
+        "msg456"
+      );
 
-    spy.mockRestore();
+      expect(result.id).toBe("msg456");
+      expect(result.name).toContain("Thread ");
+    } finally {
+      fetchSpy.mockRestore();
+    }
+  });
+
+  it("should not recover when 160004 only appears elsewhere in the body", async () => {
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      Response.json(
+        {
+          code: 429,
+          message: "You are being rate limited.",
+          retry_after: 160_004,
+        },
+        { status: 429 }
+      )
+    );
+
+    try {
+      await expect(
+        (adapter as any).createDiscordThread("channel123", "msg456")
+      ).rejects.toThrow(NetworkError);
+    } finally {
+      fetchSpy.mockRestore();
+    }
   });
 
   it("should propagate non-160004 NetworkErrors", async () => {
-    const { NetworkError } = await import("@chat-adapter/shared");
-
-    const spy = vi
-      .spyOn(adapter as any, "discordFetch")
-      .mockRejectedValue(
-        new NetworkError(
-          "discord",
-          'Discord API error: 403 {"code": 50001, "message": "Missing Access"}'
+    const fetchSpy = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValue(
+        Response.json(
+          { code: 50_001, message: "Missing Access" },
+          { status: 403 }
         )
       );
 
-    await expect(
-      (adapter as any).createDiscordThread("channel123", "msg456")
-    ).rejects.toThrow(NetworkError);
-
-    spy.mockRestore();
+    try {
+      await expect(
+        (adapter as any).createDiscordThread("channel123", "msg456")
+      ).rejects.toThrow(NetworkError);
+    } finally {
+      fetchSpy.mockRestore();
+    }
   });
 
   it("should propagate non-NetworkError errors", async () => {
-    const spy = vi
-      .spyOn(adapter as any, "discordFetch")
+    const fetchSpy = vi
+      .spyOn(globalThis, "fetch")
       .mockRejectedValue(new Error("Connection failed"));
 
-    await expect(
-      (adapter as any).createDiscordThread("channel123", "msg456")
-    ).rejects.toThrow("Connection failed");
-
-    spy.mockRestore();
+    try {
+      await expect(
+        (adapter as any).createDiscordThread("channel123", "msg456")
+      ).rejects.toThrow("Connection failed");
+    } finally {
+      fetchSpy.mockRestore();
+    }
   });
 });
 

--- a/packages/adapter-discord/src/index.ts
+++ b/packages/adapter-discord/src/index.ts
@@ -97,8 +97,38 @@ import {
 
 const DISCORD_API_BASE = "https://discord.com/api/v10";
 const DISCORD_MAX_CONTENT_LENGTH = 2000;
+const DISCORD_UNKNOWN_MESSAGE = 10_008;
 const HEX_64_PATTERN = /^[0-9a-f]{64}$/;
 const HEX_PATTERN = /^[0-9a-f]+$/;
+
+class DiscordApiError extends Error {
+  readonly code?: number;
+  readonly status: number;
+
+  constructor(status: number, body: string) {
+    super(body);
+    this.name = "DiscordApiError";
+    this.status = status;
+    this.code = parseDiscordErrorCode(body);
+  }
+}
+
+function parseDiscordErrorCode(body: string): number | undefined {
+  try {
+    const data: unknown = JSON.parse(body);
+    if (
+      typeof data === "object" &&
+      data !== null &&
+      "code" in data &&
+      typeof data.code === "number"
+    ) {
+      return data.code;
+    }
+  } catch {
+    return undefined;
+  }
+  return undefined;
+}
 
 interface GatewayCommandOption {
   name: string;
@@ -1577,25 +1607,26 @@ export class DiscordAdapter implements Adapter<DiscordThreadId, unknown> {
     messageId: string,
     message: AdapterPostableMessage
   ): Promise<RawMessage<unknown>> {
-    const { channelId, threadId: discordThreadId } =
-      this.decodeThreadId(threadId);
-    // Use thread channel ID if in a thread, otherwise use channel ID
-    const targetChannelId = discordThreadId || channelId;
-
     const { payload } = this.buildMessagePayload(message, {
       clearContentForCard: true,
     });
 
-    this.logger.debug("Discord API: PATCH message", {
-      channelId: targetChannelId,
+    const response = await this.withMessageChannel(
+      threadId,
       messageId,
-      contentLength: payload.content?.length || 0,
-    });
+      async (channelId) => {
+        this.logger.debug("Discord API: PATCH message", {
+          channelId,
+          messageId,
+          contentLength: payload.content?.length || 0,
+        });
 
-    const response = await this.discordFetch(
-      `/channels/${targetChannelId}/messages/${messageId}`,
-      "PATCH",
-      payload
+        return this.discordFetch(
+          `/channels/${channelId}/messages/${messageId}`,
+          "PATCH",
+          payload
+        );
+      }
     );
 
     const result = (await response.json()) as APIMessage;
@@ -1615,21 +1646,72 @@ export class DiscordAdapter implements Adapter<DiscordThreadId, unknown> {
    * Delete a Discord message.
    */
   async deleteMessage(threadId: string, messageId: string): Promise<void> {
+    await this.withMessageChannel(threadId, messageId, async (channelId) => {
+      this.logger.debug("Discord API: DELETE message", {
+        channelId,
+        messageId,
+      });
+
+      return this.discordFetch(
+        `/channels/${channelId}/messages/${messageId}`,
+        "DELETE"
+      );
+    });
+
+    this.logger.debug("Discord API: DELETE message response", { ok: true });
+  }
+
+  protected async withMessageChannel<T>(
+    threadId: string,
+    messageId: string,
+    operation: (channelId: string) => Promise<T>
+  ): Promise<T> {
     const { channelId, threadId: discordThreadId } =
       this.decodeThreadId(threadId);
     const targetChannelId = discordThreadId || channelId;
 
-    this.logger.debug("Discord API: DELETE message", {
-      channelId: targetChannelId,
-      messageId,
+    if (!(discordThreadId && discordThreadId === messageId)) {
+      return operation(targetChannelId);
+    }
+
+    try {
+      return await operation(channelId);
+    } catch (error) {
+      if (
+        !(
+          error instanceof NetworkError &&
+          error.originalError instanceof DiscordApiError &&
+          error.originalError.code === DISCORD_UNKNOWN_MESSAGE
+        )
+      ) {
+        throw error;
+      }
+      return operation(discordThreadId);
+    }
+  }
+
+  protected async withReaction(
+    threadId: string,
+    messageId: string,
+    emoji: EmojiValue | string,
+    method: "DELETE" | "PUT"
+  ): Promise<void> {
+    const emojiEncoded = this.encodeEmoji(emoji);
+
+    await this.withMessageChannel(threadId, messageId, async (channelId) => {
+      this.logger.debug(`Discord API: ${method} reaction`, {
+        channelId,
+        messageId,
+        emoji: emojiEncoded,
+      });
+
+      return this.discordFetch(
+        `/channels/${channelId}/messages/${messageId}/reactions/${emojiEncoded}/@me`,
+        method
+      );
     });
 
-    await this.discordFetch(
-      `/channels/${targetChannelId}/messages/${messageId}`,
-      "DELETE"
-    );
-
-    this.logger.debug("Discord API: DELETE message response", { ok: true });
+    this.logger.debug(`Discord API: ${method} reaction response`, { ok: true });
   }
 
   /**
@@ -1640,23 +1722,7 @@ export class DiscordAdapter implements Adapter<DiscordThreadId, unknown> {
     messageId: string,
     emoji: EmojiValue | string
   ): Promise<void> {
-    const { channelId, threadId: discordThreadId } =
-      this.decodeThreadId(threadId);
-    const targetChannelId = discordThreadId || channelId;
-    const emojiEncoded = this.encodeEmoji(emoji);
-
-    this.logger.debug("Discord API: PUT reaction", {
-      channelId: targetChannelId,
-      messageId,
-      emoji: emojiEncoded,
-    });
-
-    await this.discordFetch(
-      `/channels/${targetChannelId}/messages/${messageId}/reactions/${emojiEncoded}/@me`,
-      "PUT"
-    );
-
-    this.logger.debug("Discord API: PUT reaction response", { ok: true });
+    await this.withReaction(threadId, messageId, emoji, "PUT");
   }
 
   /**
@@ -1667,23 +1733,7 @@ export class DiscordAdapter implements Adapter<DiscordThreadId, unknown> {
     messageId: string,
     emoji: EmojiValue | string
   ): Promise<void> {
-    const { channelId, threadId: discordThreadId } =
-      this.decodeThreadId(threadId);
-    const targetChannelId = discordThreadId || channelId;
-    const emojiEncoded = this.encodeEmoji(emoji);
-
-    this.logger.debug("Discord API: DELETE reaction", {
-      channelId: targetChannelId,
-      messageId,
-      emoji: emojiEncoded,
-    });
-
-    await this.discordFetch(
-      `/channels/${targetChannelId}/messages/${messageId}/reactions/${emojiEncoded}/@me`,
-      "DELETE"
-    );
-
-    this.logger.debug("Discord API: DELETE reaction response", { ok: true });
+    await this.withReaction(threadId, messageId, emoji, "DELETE");
   }
 
   /**
@@ -2046,7 +2096,8 @@ export class DiscordAdapter implements Adapter<DiscordThreadId, unknown> {
       });
       throw new NetworkError(
         "discord",
-        `Discord API error: ${response.status} ${errorText}`
+        `Discord API error: ${response.status} ${errorText}`,
+        new DiscordApiError(response.status, errorText)
       );
     }
 

--- a/packages/adapter-discord/src/index.ts
+++ b/packages/adapter-discord/src/index.ts
@@ -98,6 +98,7 @@ import {
 const DISCORD_API_BASE = "https://discord.com/api/v10";
 const DISCORD_MAX_CONTENT_LENGTH = 2000;
 const DISCORD_UNKNOWN_MESSAGE = 10_008;
+const DISCORD_THREAD_ALREADY_CREATED = 160_004;
 const HEX_64_PATTERN = /^[0-9a-f]{64}$/;
 const HEX_PATTERN = /^[0-9a-f]+$/;
 
@@ -1437,9 +1438,8 @@ export class DiscordAdapter implements Adapter<DiscordThreadId, unknown> {
       // Recover by using the existing thread (its ID equals the parent message ID).
       if (
         error instanceof NetworkError &&
-        typeof error.message === "string" &&
-        error.message.includes('"code"') &&
-        error.message.includes("160004")
+        error.originalError instanceof DiscordApiError &&
+        error.originalError.code === DISCORD_THREAD_ALREADY_CREATED
       ) {
         this.logger.debug(
           "Thread already exists for message, reusing existing thread",
@@ -1674,8 +1674,15 @@ export class DiscordAdapter implements Adapter<DiscordThreadId, unknown> {
       return operation(targetChannelId);
     }
 
+    // A thread whose ID equals the message ID is a starter message, and where
+    // that message lives depends on the parent channel. Forum and media posts
+    // keep it inside the thread; threads on a text channel keep it in the
+    // parent channel. Try the thread first and fall back to the parent on
+    // "Unknown Message". Forum channels reject message routes with a channel
+    // type error rather than 10008, so probing them first would not be
+    // recoverable.
     try {
-      return await operation(channelId);
+      return await operation(discordThreadId);
     } catch (error) {
       if (
         !(
@@ -1686,7 +1693,7 @@ export class DiscordAdapter implements Adapter<DiscordThreadId, unknown> {
       ) {
         throw error;
       }
-      return operation(discordThreadId);
+      return operation(channelId);
     }
   }
 


### PR DESCRIPTION
## summary

- route edits, deletes, and reactions on text channel thread starters through the parent channel
- retry against the thread channel only when Discord returns unknown message, preserving forum and media post behavior
- preserve Discord API error codes so fallback behavior is limited to error `10008`
- add regression coverage for parent routing, forum fallback, and unrelated Discord errors
- fixes #809