### PR TITLE
fix(slack): preserve pasted tables in message content

### DIFF
--- a/.changeset/fiery-parts-tap.md
+++ b/.changeset/fiery-parts-tap.md
@@ -1,0 +1,5 @@
+---
+"@chat-adapter/slack": patch
+---
+
+preserve pasted Slack tables in parsed message content

--- a/.changeset/fiery-parts-tap.md
+++ b/.changeset/fiery-parts-tap.md
@@ -2,4 +2,4 @@
 "@chat-adapter/slack": patch
 ---
 
-preserve pasted Slack tables in parsed message content
+preserve pasted Slack tables in parsed message content: `table` and `data_table` blocks become structured table nodes in `message.formatted` and tab-separated text in `message.text`. Table cells render mentions, channels, and links through the same mrkdwn converter as body text, unfurl and app attachments are excluded, date cells without a fallback are formatted from their timestamp, and tables pasted above the message text stay above it. Headerless pasted tables get an empty header row so GFM re-serialization doesn't promote the first data row to a header. `SlackEvent.blocks` is now typed with the exported `SlackMessageBlock` interface.

--- a/.changeset/tame-tables-align.md
+++ b/.changeset/tame-tables-align.md
@@ -1,0 +1,5 @@
+---
+"chat": patch
+---
+
+`toPlainText` keeps empty table cells so tab-separated columns stay aligned, and drops table rows with no content (such as placeholder header rows)

--- a/packages/adapter-slack/sample-messages.md
+++ b/packages/adapter-slack/sample-messages.md
@@ -65,3 +65,9 @@
   body: '{"token":"xAbCdEfGhIjKlMnOpQrStUvW","team_id":"T00FAKE00AA","api_app_id":"A00FAKEAPP01","event":{"type":"message","user":"USLACK","channel":"D00FAKEDM001","channel_type":"im","text":"<@U00FAKEUSER1> archived the channel <#C00FAKECHAN1>","ts":"1771460800.444100","event_ts":"1771460800.444100"},"type":"event_callback","event_id":"Ev0ASYSTEM01","event_time":1771460800}'
 }
 ```
+
+```log
+[chat-sdk:slack] Slack webhook raw body {
+  body: '{"token":"xAbCdEfGhIjKlMnOpQrStUvW","team_id":"T00FAKE00AA","context_team_id":"T00FAKE00AA","context_enterprise_id":null,"api_app_id":"A00FAKEAPP01","event":{"type":"message","user":"U00FAKEUSER1","ts":"1786120899.208429","client_msg_id":"8f1c2d3e-45a6-47b8-9c0d-1e2f3a4b5c6d","text":"Which devices support remote firmware upgrades?","team":"T00FAKE00AA","blocks":[{"type":"rich_text","block_id":"tblQ1","elements":[{"type":"rich_text_section","elements":[{"type":"text","text":"Which devices support remote firmware upgrades?"}]}]}],"attachments":[{"id":1,"fallback":"[no preview available]","blocks":[{"type":"table","block_id":"pasted1","rows":[[{"type":"rich_text","elements":[{"type":"rich_text_section","elements":[{"type":"text","text":"Manufacturer","style":{"bold":true}}]}]},{"type":"raw_text","text":"Identifier Listed"},{"type":"raw_text","text":"Units"}],[{"type":"raw_text","text":"Samsung"},{"type":"raw_text","text":"QB55C"},{"type":"raw_number","value":3}]]}]}],"channel":"C00FAKECHAN1","event_ts":"1786120899.208429","channel_type":"channel"},"type":"event_callback","event_id":"Ev0ATABLE001","event_time":1786120899,"authorizations":[{"enterprise_id":null,"team_id":"T00FAKE00AA","user_id":"U00FAKEBOT01","is_bot":true,"is_enterprise_install":false}],"is_ext_shared_channel":false}'
+}
+```

--- a/packages/adapter-slack/src/index.test.ts
+++ b/packages/adapter-slack/src/index.test.ts
@@ -1390,6 +1390,86 @@ describe("parseMessage", () => {
     expect(message.formatted.children).toHaveLength(1);
     expect(message.formatted.children[0]?.type).toBe("table");
   });
+
+  it("preserves inline rich text within table cells", () => {
+    const message = adapter.parseMessage({
+      type: "message",
+      user: "U123",
+      channel: "C456",
+      text: "",
+      ts: "1786120899.208429",
+      blocks: [
+        {
+          type: "table",
+          rows: [
+            [
+              {
+                type: "rich_text",
+                elements: [
+                  {
+                    type: "rich_text_quote",
+                    elements: [
+                      { type: "text", text: "See " },
+                      {
+                        type: "link",
+                        text: "details",
+                        url: "https://example.com",
+                      },
+                    ],
+                  },
+                ],
+              },
+            ],
+          ],
+        },
+      ],
+    });
+
+    expect(message.text).toBe("See details");
+  });
+
+  it("preserves rich text metadata within table cells", () => {
+    const message = adapter.parseMessage({
+      type: "message",
+      user: "U123",
+      channel: "C456",
+      text: "",
+      ts: "1786120899.208429",
+      blocks: [
+        {
+          type: "table",
+          rows: [
+            [
+              {
+                type: "rich_text",
+                elements: [
+                  {
+                    type: "rich_text_section",
+                    elements: [
+                      { type: "channel", channel_id: "C789" },
+                      { type: "text", text: " " },
+                      { type: "usergroup", usergroup_id: "S789" },
+                      { type: "text", text: " " },
+                      {
+                        type: "date",
+                        timestamp: 1_720_710_212,
+                        format: "{date_num}",
+                        fallback: "July 11",
+                      },
+                      { type: "text", text: " " },
+                      { type: "color", value: "#ff0000" },
+                    ],
+                  },
+                ],
+              },
+            ],
+          ],
+        },
+      ],
+    });
+
+    expect(message.text).toBe("<#C789> <!subteam^S789> July 11 #ff0000");
+  });
 });
 
 // ============================================================================

--- a/packages/adapter-slack/src/index.test.ts
+++ b/packages/adapter-slack/src/index.test.ts
@@ -21,6 +21,7 @@ import type {
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type {
   SlackAdapterConfig,
+  SlackEvent,
   SlackInstallation,
   SlackThreadId,
 } from "./index";
@@ -1279,6 +1280,115 @@ describe("parseMessage", () => {
 
     const fileMsg = adapter.parseMessage(createEvent("application/pdf"));
     expect(fileMsg.attachments?.[0].type).toBe("file");
+  });
+
+  it("preserves pasted table attachments as message content", async () => {
+    const event: SlackEvent = {
+      type: "message",
+      user: "U123",
+      username: "alice",
+      channel: "C456",
+      text: "Which devices support remote firmware upgrades?",
+      ts: "1786120899.208429",
+      attachments: [
+        {
+          fallback: "[no preview available]",
+          blocks: [
+            {
+              type: "table",
+              rows: [
+                [
+                  {
+                    type: "rich_text",
+                    elements: [
+                      {
+                        type: "rich_text_section",
+                        elements: [
+                          {
+                            type: "text",
+                            text: "Manufacturer",
+                            style: { bold: true },
+                          },
+                        ],
+                      },
+                    ],
+                  },
+                  { type: "raw_text", text: "Identifier Listed" },
+                  { type: "raw_text", text: "Units" },
+                ],
+                [
+                  { type: "raw_text", text: "Samsung" },
+                  { type: "raw_text", text: "QB55C" },
+                  { type: "raw_number", value: 3 },
+                ],
+              ],
+            },
+          ],
+        },
+      ],
+    };
+    const expected =
+      "Which devices support remote firmware upgrades?\n\n" +
+      "Manufacturer\tIdentifier Listed\tUnits\nSamsung\tQB55C\t3";
+    const sync = adapter.parseMessage(event);
+    const internals = adapter as unknown as {
+      parseSlackMessage(
+        value: SlackEvent,
+        threadId: string
+      ): Promise<Message<unknown>>;
+    };
+    const async = await internals.parseSlackMessage(
+      event,
+      "slack:C456:1786120899.208429"
+    );
+
+    for (const message of [sync, async]) {
+      expect(message.text).toBe(expected);
+      expect(message.attachments).toEqual([]);
+      expect(message.formatted.children[1]).toMatchObject({
+        type: "table",
+        children: [
+          {
+            type: "tableRow",
+            children: [
+              { type: "tableCell", children: [{ value: "Manufacturer" }] },
+              {
+                type: "tableCell",
+                children: [{ value: "Identifier Listed" }],
+              },
+              { type: "tableCell", children: [{ value: "Units" }] },
+            ],
+          },
+          {
+            type: "tableRow",
+            children: [
+              { type: "tableCell", children: [{ value: "Samsung" }] },
+              { type: "tableCell", children: [{ value: "QB55C" }] },
+              { type: "tableCell", children: [{ value: "3" }] },
+            ],
+          },
+        ],
+      });
+    }
+  });
+
+  it("preserves table-only messages and ignores malformed table blocks", () => {
+    const message = adapter.parseMessage({
+      type: "message",
+      user: "U123",
+      channel: "C456",
+      text: "",
+      ts: "1786120899.208429",
+      blocks: [
+        { type: "table", rows: [[{ type: "raw_text", text: "Visible" }]] },
+        { type: "table", rows: "invalid" },
+      ],
+      attachments: [{ blocks: [{ type: "table" }] }],
+    });
+
+    expect(message.text).toBe("Visible");
+    expect(message.formatted.children).toHaveLength(1);
+    expect(message.formatted.children[0]?.type).toBe("table");
   });
 });
 

--- a/packages/adapter-slack/src/index.test.ts
+++ b/packages/adapter-slack/src/index.test.ts
@@ -1426,6 +1426,31 @@ describe("parseMessage", () => {
     });
 
     expect(message.text).toBe("See details");
+    // The link URL survives in the AST as a real link node
+    expect(message.formatted.children[0]).toMatchObject({
+      type: "table",
+      children: [
+        // Headerless table: an empty header row is inserted so GFM doesn't
+        // promote the data row to a header
+        { type: "tableRow", children: [{ type: "tableCell", children: [] }] },
+        {
+          type: "tableRow",
+          children: [
+            {
+              type: "tableCell",
+              children: [
+                { type: "text", value: "See " },
+                {
+                  type: "link",
+                  url: "https://example.com",
+                  children: [{ type: "text", value: "details" }],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    });
   });
 
   it("preserves rich text metadata within table cells", () => {
@@ -1468,7 +1493,190 @@ describe("parseMessage", () => {
       ],
     });
 
-    expect(message.text).toBe("<#C789> <!subteam^S789> July 11 #ff0000");
+    // Cell tokens are rendered by the same mrkdwn converter as body text
+    expect(message.text).toBe("#C789 <!subteam^S789> July 11 #ff0000");
+  });
+
+  it("formats date cells from the timestamp when no fallback is present", () => {
+    const message = adapter.parseMessage({
+      type: "message",
+      user: "U123",
+      channel: "C456",
+      text: "",
+      ts: "1786120899.208429",
+      blocks: [
+        {
+          type: "table",
+          rows: [
+            [
+              {
+                type: "date",
+                timestamp: 1_720_710_212,
+                format: "{date_num}",
+              },
+            ],
+          ],
+        },
+      ],
+    });
+
+    expect(message.text).toBe("2024-07-11");
+    expect(message.text).not.toContain("{date_num}");
+  });
+
+  it("preserves empty and raw value cells so columns stay aligned", () => {
+    const message = adapter.parseMessage({
+      type: "message",
+      user: "U123",
+      channel: "C456",
+      text: "",
+      ts: "1786120899.208429",
+      blocks: [
+        {
+          type: "table",
+          rows: [
+            [
+              { type: "raw_text", text: "Samsung" },
+              { type: "raw_text", text: "" },
+              { type: "raw_number", value: 3 },
+            ],
+            [
+              { type: "raw_text", text: "LG" },
+              { type: "raw_boolean", value: true },
+              { type: "raw_number", value: "7" },
+            ],
+          ],
+        },
+      ],
+    });
+
+    expect(message.text).toBe("Samsung\t\t3\nLG\ttrue\t7");
+  });
+
+  it("parses data_table blocks with their header row intact", () => {
+    const message = adapter.parseMessage({
+      type: "message",
+      user: "U123",
+      channel: "C456",
+      text: "",
+      ts: "1786120899.208429",
+      blocks: [
+        {
+          type: "data_table",
+          caption: "Devices",
+          rows: [
+            [
+              { type: "raw_text", text: "Manufacturer" },
+              { type: "raw_text", text: "Units" },
+            ],
+            [
+              { type: "raw_text", text: "Samsung" },
+              { type: "raw_text", text: "3" },
+            ],
+          ],
+        },
+      ],
+    });
+
+    expect(message.text).toBe("Manufacturer\tUnits\nSamsung\t3");
+    // data_table rows always start with a header row; no placeholder is added
+    expect(message.formatted.children[0]).toMatchObject({
+      type: "table",
+      children: [
+        {
+          type: "tableRow",
+          children: [
+            { type: "tableCell", children: [{ value: "Manufacturer" }] },
+            { type: "tableCell", children: [{ value: "Units" }] },
+          ],
+        },
+        {
+          type: "tableRow",
+          children: [
+            { type: "tableCell", children: [{ value: "Samsung" }] },
+            { type: "tableCell", children: [{ value: "3" }] },
+          ],
+        },
+      ],
+    });
+  });
+
+  it("ignores tables in unfurl and app attachments", () => {
+    const tableBlock = {
+      type: "table",
+      rows: [[{ type: "raw_text", text: "Foreign" }]],
+    };
+    const message = adapter.parseMessage({
+      type: "message",
+      user: "U123",
+      channel: "C456",
+      text: "Check this out",
+      ts: "1786120899.208429",
+      attachments: [
+        { is_msg_unfurl: true, blocks: [tableBlock] },
+        { is_app_unfurl: true, blocks: [tableBlock] },
+        { from_url: "https://example.com", blocks: [tableBlock] },
+        { original_url: "https://example.com/page", blocks: [tableBlock] },
+      ],
+    });
+
+    expect(message.text).toBe("Check this out");
+    expect(message.formatted.children).toHaveLength(1);
+  });
+
+  it("keeps tables pasted above the message text above it", () => {
+    const message = adapter.parseMessage({
+      type: "message",
+      user: "U123",
+      channel: "C456",
+      text: "The table above shows Q1",
+      ts: "1786120899.208429",
+      blocks: [
+        {
+          type: "table",
+          rows: [[{ type: "raw_text", text: "Row" }]],
+        },
+        {
+          type: "rich_text",
+          elements: [
+            {
+              type: "rich_text_section",
+              elements: [{ type: "text", text: "The table above shows Q1" }],
+            },
+          ],
+        },
+      ],
+    });
+
+    expect(message.formatted.children[0]?.type).toBe("table");
+    expect(message.formatted.children[1]?.type).toBe("paragraph");
+    expect(message.text).toBe("Row\n\nThe table above shows Q1");
+  });
+
+  it("does not leave raw bot mention tokens in table cells", () => {
+    const message = adapter.parseMessage({
+      type: "message",
+      user: "U123",
+      channel: "C456",
+      text: "",
+      ts: "1786120899.208429",
+      blocks: [
+        {
+          type: "table",
+          rows: [
+            [
+              { type: "raw_text", text: "On call" },
+              { type: "user", user_id: "UBOT123" },
+            ],
+          ],
+        },
+      ],
+    });
+
+    // Raw <@UBOT123> would false-positive Chat core's Discord-format
+    // mention fallback; the converter rewrites it like body text
+    expect(message.text).toBe("On call\t@UBOT123");
+    expect(message.text).not.toContain("<@");
   });
 });
 

--- a/packages/adapter-slack/src/index.ts
+++ b/packages/adapter-slack/src/index.ts
@@ -304,15 +304,23 @@ export interface SlackThreadId {
 }
 
 interface SlackBlock {
+  channel_id?: string;
   elements?: SlackBlock[];
+  fallback?: string;
+  file_id?: string;
+  format?: string;
+  label?: string;
   name?: string;
   range?: string;
   rows?: unknown;
+  team_id?: string;
   text?: string;
+  timestamp?: number;
   type: string;
   url?: string;
   user_id?: string;
-  value?: number;
+  usergroup_id?: string;
+  value?: number | string;
 }
 
 type SlackTable = Extract<
@@ -343,20 +351,39 @@ function blocktext(value: unknown): string {
   if (block.type === "broadcast") {
     return block.range ? `@${block.range}` : "";
   }
+  if (block.type === "channel") {
+    return block.channel_id ? `<#${block.channel_id}>` : "";
+  }
+  if (block.type === "usergroup") {
+    return block.usergroup_id ? `<!subteam^${block.usergroup_id}>` : "";
+  }
+  if (block.type === "date") {
+    return block.fallback ?? block.format ?? "";
+  }
+  if (block.type === "color") {
+    return typeof block.value === "string" ? block.value : "";
+  }
+  if (block.type === "team") {
+    return block.team_id ?? "";
+  }
   if (typeof block.text === "string") {
     return block.text;
+  }
+  if (typeof block.label === "string") {
+    return block.label;
+  }
+  if (typeof block.url === "string") {
+    return block.url;
+  }
+  if (typeof block.file_id === "string") {
+    return block.file_id;
   }
   if (!Array.isArray(block.elements)) {
     return "";
   }
 
   const separator =
-    block.type === "rich_text" ||
-    block.type === "rich_text_list" ||
-    block.type === "rich_text_quote" ||
-    block.type === "rich_text_preformatted"
-      ? "\n"
-      : "";
+    block.type === "rich_text" || block.type === "rich_text_list" ? "\n" : "";
   return block.elements.map(blocktext).join(separator);
 }
 

--- a/packages/adapter-slack/src/index.ts
+++ b/packages/adapter-slack/src/index.ts
@@ -303,10 +303,106 @@ export interface SlackThreadId {
   threadTs: string;
 }
 
+interface SlackBlock {
+  elements?: SlackBlock[];
+  name?: string;
+  range?: string;
+  rows?: unknown;
+  text?: string;
+  type: string;
+  url?: string;
+  user_id?: string;
+  value?: number;
+}
+
+type SlackTable = Extract<
+  FormattedContent["children"][number],
+  { type: "table" }
+>;
+
+function blocktext(value: unknown): string {
+  if (!(typeof value === "object" && value !== null && "type" in value)) {
+    return "";
+  }
+
+  const block = value as SlackBlock;
+  if (block.type === "raw_number") {
+    return (
+      block.text ?? (typeof block.value === "number" ? String(block.value) : "")
+    );
+  }
+  if (block.type === "link") {
+    return block.text ?? block.url ?? "";
+  }
+  if (block.type === "emoji") {
+    return block.name ? `:${block.name}:` : "";
+  }
+  if (block.type === "user") {
+    return block.user_id ? `<@${block.user_id}>` : "";
+  }
+  if (block.type === "broadcast") {
+    return block.range ? `@${block.range}` : "";
+  }
+  if (typeof block.text === "string") {
+    return block.text;
+  }
+  if (!Array.isArray(block.elements)) {
+    return "";
+  }
+
+  const separator =
+    block.type === "rich_text" ||
+    block.type === "rich_text_list" ||
+    block.type === "rich_text_quote" ||
+    block.type === "rich_text_preformatted"
+      ? "\n"
+      : "";
+  return block.elements.map(blocktext).join(separator);
+}
+
+function table(block: SlackBlock): SlackTable | null {
+  if (!(block.type === "table" && Array.isArray(block.rows))) {
+    return null;
+  }
+
+  const children = block.rows.flatMap((row) => {
+    if (!(Array.isArray(row) && row.length > 0)) {
+      return [];
+    }
+    return [
+      {
+        type: "tableRow" as const,
+        children: row.map((cell) => ({
+          type: "tableCell" as const,
+          children: [{ type: "text" as const, value: blocktext(cell) }],
+        })),
+      },
+    ];
+  });
+
+  return children.length > 0 ? { type: "table", children } : null;
+}
+
+function tables(event: SlackEvent): SlackTable[] {
+  const blocks = [
+    ...(event.blocks ?? []),
+    ...(event.attachments ?? []).flatMap((attachment) =>
+      Array.isArray(attachment.blocks) ? attachment.blocks : []
+    ),
+  ];
+
+  return blocks.flatMap((block) => {
+    const parsed = table(block);
+    return parsed ? [parsed] : [];
+  });
+}
+
 /** Slack event payload (raw message format) */
 export interface SlackEvent {
   /** Legacy attachments (unfurl previews, app unfurls, etc.) */
   attachments?: Array<{
+    blocks?: SlackBlock[];
+    fallback?: string;
     from_url?: string;
     image_url?: string;
     is_msg_unfurl?: boolean;
@@ -319,17 +415,7 @@ export interface SlackEvent {
     title_link?: string;
   }>;
   /** Rich text blocks containing structured elements (links, mentions, etc.) */
-  blocks?: Array<{
-    type: string;
-    elements?: Array<{
-      type: string;
-      elements?: Array<{
-        type: string;
-        url?: string;
-        text?: string;
-      }>;
-    }>;
-  }>;
+  blocks?: SlackBlock[];
   bot_id?: string;
   channel?: string;
   /** Channel type: "channel", "group", "mpim", or "im" (DM) */
@@ -3549,12 +3635,13 @@ export class SlackAdapter implements Adapter<SlackThreadId, unknown> {
 
     // Resolve inline @mentions to display names
     const text = await this.resolveInlineMentions(rawText, skipSelfMention);
+    const formatted = this.content(event, text);
 
     return new Message({
       id: event.ts || "",
       threadId,
-      text: this.formatConverter.extractPlainText(text),
-      formatted: this.formatConverter.toAst(text),
+      text: toPlainText(formatted),
+      formatted,
       raw: event,
       author: {
         userId: event.user || event.bot_id || "unknown",
@@ -5430,6 +5517,7 @@ export class SlackAdapter implements Adapter<SlackThreadId, unknown> {
     const isMe = this.isMessageFromSelf(event);
 
     const text = event.text || "";
+    const formatted = this.content(event, text);
     // Without async lookup, fall back to user ID for human users
     const userName = event.username || event.user || "unknown";
     const fullName = event.username || event.user || "unknown";
@@ -5437,8 +5525,8 @@ export class SlackAdapter implements Adapter<SlackThreadId, unknown> {
     return new Message({
       id: event.ts || "",
       threadId,
-      text: this.formatConverter.extractPlainText(text),
-      formatted: this.formatConverter.toAst(text),
+      text: toPlainText(formatted),
+      formatted,
       raw: event,
       author: {
         userId: event.user || event.bot_id || "unknown",
@@ -5460,6 +5548,12 @@ export class SlackAdapter implements Adapter<SlackThreadId, unknown> {
       ),
       links: this.extractLinks(event),
     });
+  }
+
+  protected content(event: SlackEvent, text: string): FormattedContent {
+    const formatted = this.formatConverter.toAst(text);
+    formatted.children.push(...tables(event));
+    return formatted;
   }
 
   // =========================================================================

--- a/packages/adapter-slack/src/index.ts
+++ b/packages/adapter-slack/src/index.ts
@@ -67,7 +67,7 @@ import {
   type SlackAppContext,
   type SlackAppContextChangedEvent,
 } from "./agent-context";
-import { cardToBlockKit, cardToFallbackText } from "./cards";
+import { cardToBlockKit, cardToFallbackText, type SlackBlock } from "./cards";
 import type { EncryptedTokenData } from "./crypto";
 import {
   decodeKey,
@@ -303,135 +303,218 @@ export interface SlackThreadId {
   threadTs: string;
 }
 
-interface SlackBlock {
-  channel_id?: string;
-  elements?: SlackBlock[];
-  fallback?: string;
-  file_id?: string;
-  format?: string;
-  label?: string;
-  name?: string;
-  range?: string;
+/**
+ * Block inside a Slack message event (`event.blocks` or `attachment.blocks`).
+ * Extends the open Block Kit shape with the fields the parser reads directly;
+ * everything else stays reachable through the index signature.
+ */
+export interface SlackMessageBlock extends SlackBlock {
+  elements?: SlackMessageBlock[];
   rows?: unknown;
-  team_id?: string;
   text?: string;
-  timestamp?: number;
-  type: string;
   url?: string;
-  user_id?: string;
-  usergroup_id?: string;
-  value?: number | string;
 }
 
 type SlackTable = Extract<
   FormattedContent["children"][number],
   { type: "table" }
 >;
+type SlackTableRow = SlackTable["children"][number];
+type SlackTableCell = SlackTableRow["children"][number];
 
+/** Table extracted from a Slack table block, one mrkdwn string per cell. */
+interface SlackTableData {
+  /**
+   * True when the source rows carry no header styling. GFM tables always
+   * render their first row as a header, so headerless tables get an empty
+   * header row prepended instead of promoting the first data row.
+   */
+  headerless: boolean;
+  rows: string[][];
+}
+
+const TABLE_BLOCK_TYPES = new Set(["table", "data_table"]);
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+function str(value: unknown): string | undefined {
+  return typeof value === "string" ? value : undefined;
+}
+
+/**
+ * Flatten a table cell (or any rich text element inside one) to mrkdwn.
+ * Mentions, channels, and links are emitted as mrkdwn tokens so the format
+ * converter renders them the same way it renders body text.
+ */
 function blocktext(value: unknown): string {
-  if (!(typeof value === "object" && value !== null && "type" in value)) {
+  if (!(isRecord(value) && typeof value.type === "string")) {
     return "";
   }
 
-  const block = value as SlackBlock;
-  if (block.type === "raw_number") {
-    return (
-      block.text ?? (typeof block.value === "number" ? String(block.value) : "")
-    );
+  const text = str(value.text);
+  switch (value.type) {
+    case "link": {
+      const url = str(value.url);
+      if (!url) {
+        return text ?? "";
+      }
+      return text ? `<${url}|${text}>` : `<${url}>`;
+    }
+    case "emoji": {
+      const name = str(value.name);
+      return name ? `:${name}:` : "";
+    }
+    case "user": {
+      const userId = str(value.user_id);
+      return userId ? `<@${userId}>` : "";
+    }
+    case "broadcast": {
+      const range = str(value.range);
+      return range ? `@${range}` : "";
+    }
+    case "channel": {
+      const channelId = str(value.channel_id);
+      return channelId ? `<#${channelId}>` : "";
+    }
+    case "usergroup": {
+      const usergroupId = str(value.usergroup_id);
+      return usergroupId ? `<!subteam^${usergroupId}>` : "";
+    }
+    case "date": {
+      const fallback = str(value.fallback);
+      if (fallback) {
+        return fallback;
+      }
+      // Format the timestamp rather than leaking the raw format template
+      // (e.g. "{date_num}") when Slack omits the fallback.
+      return typeof value.timestamp === "number"
+        ? new Date(value.timestamp * 1000).toISOString().slice(0, 10)
+        : "";
+    }
+    case "color":
+      return str(value.value) ?? "";
+    case "team":
+      return str(value.team_id) ?? "";
+    default:
+      break;
   }
-  if (block.type === "link") {
-    return block.text ?? block.url ?? "";
+  if (text !== undefined) {
+    return text;
   }
-  if (block.type === "emoji") {
-    return block.name ? `:${block.name}:` : "";
+  const fallback = str(value.label) ?? str(value.url) ?? str(value.file_id);
+  if (fallback !== undefined) {
+    return fallback;
   }
-  if (block.type === "user") {
-    return block.user_id ? `<@${block.user_id}>` : "";
+  // Raw value cells (raw_number, raw_date, raw_currency, raw_percent,
+  // raw_boolean, …) carry a primitive value when text is absent.
+  if (
+    typeof value.value === "number" ||
+    typeof value.value === "string" ||
+    typeof value.value === "boolean"
+  ) {
+    return String(value.value);
   }
-  if (block.type === "broadcast") {
-    return block.range ? `@${block.range}` : "";
-  }
-  if (block.type === "channel") {
-    return block.channel_id ? `<#${block.channel_id}>` : "";
-  }
-  if (block.type === "usergroup") {
-    return block.usergroup_id ? `<!subteam^${block.usergroup_id}>` : "";
-  }
-  if (block.type === "date") {
-    return block.fallback ?? block.format ?? "";
-  }
-  if (block.type === "color") {
-    return typeof block.value === "string" ? block.value : "";
-  }
-  if (block.type === "team") {
-    return block.team_id ?? "";
-  }
-  if (typeof block.text === "string") {
-    return block.text;
-  }
-  if (typeof block.label === "string") {
-    return block.label;
-  }
-  if (typeof block.url === "string") {
-    return block.url;
-  }
-  if (typeof block.file_id === "string") {
-    return block.file_id;
-  }
-  if (!Array.isArray(block.elements)) {
+  if (!Array.isArray(value.elements)) {
     return "";
   }
 
   const separator =
-    block.type === "rich_text" || block.type === "rich_text_list" ? "\n" : "";
-  return block.elements.map(blocktext).join(separator);
+    value.type === "rich_text" || value.type === "rich_text_list" ? "\n" : "";
+  return value.elements.map(blocktext).join(separator);
 }
 
-function table(block: SlackBlock): SlackTable | null {
-  if (!(block.type === "table" && Array.isArray(block.rows))) {
+function hasBoldText(value: unknown): boolean {
+  if (!isRecord(value)) {
+    return false;
+  }
+  if (isRecord(value.style) && value.style.bold === true) {
+    return true;
+  }
+  return Array.isArray(value.elements) && value.elements.some(hasBoldText);
+}
+
+function tableData(block: SlackMessageBlock): SlackTableData | null {
+  if (!(TABLE_BLOCK_TYPES.has(block.type) && Array.isArray(block.rows))) {
     return null;
   }
 
-  const children = block.rows.flatMap((row) => {
-    if (!(Array.isArray(row) && row.length > 0)) {
-      return [];
-    }
-    return [
-      {
-        type: "tableRow" as const,
-        children: row.map((cell) => ({
-          type: "tableCell" as const,
-          children: [{ type: "text" as const, value: blocktext(cell) }],
-        })),
-      },
-    ];
-  });
+  const sourceRows = block.rows.filter(
+    (row): row is unknown[] => Array.isArray(row) && row.length > 0
+  );
+  if (sourceRows.length === 0) {
+    return null;
+  }
 
-  return children.length > 0 ? { type: "table", children } : null;
+  // data_table rows always start with a header row (the outbound renderer in
+  // blocks/index.ts relies on this); pasted `table` blocks mark headers only
+  // via bold cell styling.
+  const headerless = block.type === "table" && !sourceRows[0].some(hasBoldText);
+  return { headerless, rows: sourceRows.map((row) => row.map(blocktext)) };
 }
 
-function tables(event: SlackEvent): SlackTable[] {
-  const blocks = [
-    ...(event.blocks ?? []),
-    ...(event.attachments ?? []).flatMap((attachment) =>
-      Array.isArray(attachment.blocks) ? attachment.blocks : []
-    ),
-  ];
+interface SlackEventTables {
+  /** Tables that appear before any other block, rendered above the text. */
+  leading: SlackTableData[];
+  /** All remaining tables, rendered below the text. */
+  trailing: SlackTableData[];
+}
 
-  return blocks.flatMap((block) => {
-    const parsed = table(block);
-    return parsed ? [parsed] : [];
-  });
+/**
+ * Skip attachments that carry someone else's content (link unfurls, app
+ * unfurls) — their blocks must not be attributed to the message author.
+ */
+function isForeignAttachment(
+  attachment: NonNullable<SlackEvent["attachments"]>[number]
+): boolean {
+  return Boolean(
+    attachment.is_msg_unfurl ||
+      attachment.is_app_unfurl ||
+      attachment.from_url ||
+      attachment.original_url
+  );
+}
+
+/**
+ * Collect table blocks from the event, split by position. Slack flattens all
+ * rich text into `event.text`, so exact interleaving can't be reconstructed;
+ * tables pasted above the text at least stay above it.
+ */
+function eventTables(event: SlackEvent): SlackEventTables {
+  const blocks = event.blocks ?? [];
+  const firstContentIdx = blocks.findIndex(
+    (block) => !TABLE_BLOCK_TYPES.has(block.type)
+  );
+  const splitIdx = firstContentIdx === -1 ? blocks.length : firstContentIdx;
+
+  const parse = (list: SlackMessageBlock[]) =>
+    list.flatMap((block) => {
+      const parsed = tableData(block);
+      return parsed ? [parsed] : [];
+    });
+
+  const attachmentBlocks = (event.attachments ?? [])
+    .filter((attachment) => !isForeignAttachment(attachment))
+    .flatMap((attachment) =>
+      Array.isArray(attachment.blocks) ? attachment.blocks : []
+    );
+
+  return {
+    leading: parse(blocks.slice(0, splitIdx)),
+    trailing: [...parse(blocks.slice(splitIdx)), ...parse(attachmentBlocks)],
+  };
 }
 
 /** Slack event payload (raw message format) */
 export interface SlackEvent {
   /** Legacy attachments (unfurl previews, app unfurls, etc.) */
   attachments?: Array<{
-    blocks?: SlackBlock[];
+    blocks?: SlackMessageBlock[];
     fallback?: string;
     from_url?: string;
     image_url?: string;
+    is_app_unfurl?: boolean;
     is_msg_unfurl?: boolean;
     original_url?: string;
     service_icon?: string;
@@ -442,7 +525,7 @@ export interface SlackEvent {
     title_link?: string;
   }>;
   /** Rich text blocks containing structured elements (links, mentions, etc.) */
-  blocks?: SlackBlock[];
+  blocks?: SlackMessageBlock[];
   bot_id?: string;
   channel?: string;
   /** Channel type: "channel", "group", "mpim", or "im" (DM) */
@@ -3662,7 +3745,7 @@ export class SlackAdapter implements Adapter<SlackThreadId, unknown> {
 
     // Resolve inline @mentions to display names
     const text = await this.resolveInlineMentions(rawText, skipSelfMention);
-    const formatted = this.content(event, text);
+    const formatted = await this.resolvedContent(event, text, skipSelfMention);
 
     return new Message({
       id: event.ts || "",
@@ -5578,9 +5661,97 @@ export class SlackAdapter implements Adapter<SlackThreadId, unknown> {
   }
 
   protected content(event: SlackEvent, text: string): FormattedContent {
+    return this.assembleContent(text, eventTables(event));
+  }
+
+  /**
+   * Like `content`, but resolves user and channel mentions inside table
+   * cells the same way `resolveInlineMentions` resolves them in body text.
+   */
+  protected async resolvedContent(
+    event: SlackEvent,
+    text: string,
+    skipSelfMention: boolean
+  ): Promise<FormattedContent> {
+    const resolve = async (data: SlackTableData): Promise<SlackTableData> => ({
+      ...data,
+      rows: await Promise.all(
+        data.rows.map((row) =>
+          Promise.all(
+            row.map((cell) =>
+              cell ? this.resolveInlineMentions(cell, skipSelfMention) : cell
+            )
+          )
+        )
+      ),
+    });
+
+    const { leading, trailing } = eventTables(event);
+    return this.assembleContent(text, {
+      leading: await Promise.all(leading.map(resolve)),
+      trailing: await Promise.all(trailing.map(resolve)),
+    });
+  }
+
+  private assembleContent(
+    text: string,
+    tables: SlackEventTables
+  ): FormattedContent {
     const formatted = this.formatConverter.toAst(text);
-    formatted.children.push(...tables(event));
+    formatted.children.unshift(
+      ...tables.leading.map((data) => this.tableNode(data))
+    );
+    formatted.children.push(
+      ...tables.trailing.map((data) => this.tableNode(data))
+    );
     return formatted;
+  }
+
+  private tableNode(data: SlackTableData): SlackTable {
+    const rows: SlackTableRow[] = data.rows.map((row) => ({
+      type: "tableRow",
+      children: row.map((cell) => ({
+        type: "tableCell",
+        children: this.cellChildren(cell),
+      })),
+    }));
+    if (data.headerless) {
+      const width = Math.max(...data.rows.map((row) => row.length));
+      rows.unshift({
+        type: "tableRow",
+        children: Array.from({ length: width }, () => ({
+          type: "tableCell",
+          children: [],
+        })),
+      });
+    }
+    return { type: "table", children: rows };
+  }
+
+  /**
+   * Convert a cell's mrkdwn text to table cell (phrasing) content via the
+   * same format converter used for body text, so mentions, links, and emoji
+   * render consistently.
+   */
+  private cellChildren(cell: string): SlackTableCell["children"] {
+    if (!cell) {
+      return [];
+    }
+    const children: SlackTableCell["children"] = [];
+    for (const node of this.formatConverter.toAst(cell).children) {
+      if (children.length > 0) {
+        children.push({ type: "text", value: "\n" });
+      }
+      if (node.type === "paragraph") {
+        children.push(...node.children);
+      } else {
+        children.push({
+          type: "text",
+          value: toPlainText({ type: "root", children: [node] }),
+        });
+      }
+    }
+    return children;
   }
 
   // =========================================================================
@@ -6166,6 +6337,7 @@ export type {
 } from "./agent-context";
 // Re-export agent active-view context helpers for advanced use
 export { getAppContext, normalizeAppContextEntities } from "./agent-context";
+export type { SlackBlock } from "./cards";
 // Re-export card converter for advanced use
 export { cardToBlockKit, cardToFallbackText } from "./cards";
 export type { EncryptedTokenData } from "./crypto";

--- a/packages/chat/src/markdown.test.ts
+++ b/packages/chat/src/markdown.test.ts
@@ -246,6 +246,20 @@ describe("toPlainText", () => {
     expect(result).toBe("Name\tRole\nAda Lovelace\tEngineer");
   });
 
+  it("keeps empty table cells so columns stay aligned", () => {
+    const ast = parseMarkdown(
+      "| Name | Middle | Units |\n| --- | --- | --- |\n| Samsung |  | 3 |"
+    );
+    const result = toPlainText(ast);
+    expect(result).toBe("Name\tMiddle\tUnits\nSamsung\t\t3");
+  });
+
+  it("drops table rows with no content", () => {
+    const ast = parseMarkdown("|  |  |\n| --- | --- |\n| Samsung | 3 |");
+    const result = toPlainText(ast);
+    expect(result).toBe("Samsung\t3");
+  });
+
   it("handles empty AST", () => {
     const ast = root([]);
     const result = toPlainText(ast);

--- a/packages/chat/src/markdown.ts
+++ b/packages/chat/src/markdown.ts
@@ -323,15 +323,21 @@ function nodeValue(node: Content | Root): string | null {
   return null;
 }
 
-function childPlainText(node: Content | Root, separator: string): string {
+function childPlainText(
+  node: Content | Root,
+  separator: string,
+  keepEmpty = false
+): string {
   if (!("children" in node && Array.isArray(node.children))) {
     return "";
   }
 
-  return (node.children as (Content | Root)[])
-    .map((child) => plainTextNode(child))
-    .filter((text) => text.length > 0)
-    .join(separator);
+  const texts = (node.children as (Content | Root)[]).map((child) =>
+    plainTextNode(child)
+  );
+  return (keepEmpty ? texts : texts.filter((text) => text.length > 0)).join(
+    separator
+  );
 }
 
 function plainTextNode(node: Content | Root): string {
@@ -344,13 +350,21 @@ function plainTextNode(node: Content | Root): string {
     case "root":
       return childPlainText(node, "\n\n");
     case "list":
-    case "table":
       return childPlainText(node, "\n");
+    case "table": {
+      // Drop rows with no content (e.g. a placeholder header row) but keep
+      // rows that have any populated cell.
+      const rows = (node.children as Content[]).map((child) =>
+        plainTextNode(child)
+      );
+      return rows.filter((row) => row.trim().length > 0).join("\n");
+    }
     case "listItem":
     case "blockquote":
       return childPlainText(node, "\n");
     case "tableRow":
-      return childPlainText(node, "\t");
+      // Keep empty cells so columns stay aligned in the tab-separated output
+      return childPlainText(node, "\t", true);
     case "break":
       return "\n";
     case "thematicBreak":


### PR DESCRIPTION
## summary

- parse Slack table blocks from both top-level blocks and attachment blocks
- preserve pasted spreadsheet data in formatted mdast and plain message text
- support rich text, raw text, and numeric table cells
- ignore malformed table blocks without dropping valid content
- fixes #803

## test plan

- added coverage for pasted tables alongside regular message text
- added coverage for table-only messages and malformed blocks
- verified synchronous and asynchronous message parsing
- ran Slack adapter tests, integration tests, typecheck, builds, and formatting checks
