### PR TITLE
feat(chat): add message reply support

### DIFF
--- a/.changeset/light-mails-scream.md
+++ b/.changeset/light-mails-scream.md
@@ -1,0 +1,6 @@
+---
+"@chat-adapter/whatsapp": minor
+"chat": minor
+---
+
+add native message replies with WhatsApp contextual reply support

--- a/apps/docs/content/adapters/official/whatsapp.mdx
+++ b/apps/docs/content/adapters/official/whatsapp.mdx
@@ -9,6 +9,7 @@ tagline: Connect to WhatsApp Business Cloud for customer messaging and automated
 beta: true
 features:
   postMessage: yes
+  messageReplies: yes
   editMessage: no
   deleteMessage: no
   fileUploads:
@@ -174,6 +175,22 @@ Card elements are automatically converted to WhatsApp interactive messages:
 - **Max body text** — 1024 characters.
 
 When a card with reply buttons also contains link buttons, each link button is appended to the interactive message body as a `Label: url` line, since WhatsApp reply buttons cannot open URLs.
+
+### Contextual replies
+
+Use `thread.reply()` to quote a specific message in WhatsApp:
+
+```typescript
+bot.onNewMessage(async (thread, message) => {
+  await thread.reply(message, {
+    markdown: "I can help with that.",
+  });
+});
+```
+
+You can pass either a `Message` or a message ID as the target. Text, cards, files, and buffered streams are supported. When one logical reply produces multiple WhatsApp messages, only the first message includes the contextual reference.
+
+WhatsApp does not display the quoted bubble when the target was deleted or moved to long-term storage, when the reply is a template message, or for some media replies on KaiOS. Reaction messages cannot be contextual replies. See [Meta's contextual replies documentation](https://developers.facebook.com/documentation/business-messaging/whatsapp/messages/contextual-replies/).
 
 ### Link buttons (CTA URL)
 

--- a/apps/docs/content/adapters/official/whatsapp.mdx
+++ b/apps/docs/content/adapters/official/whatsapp.mdx
@@ -9,7 +9,9 @@ tagline: Connect to WhatsApp Business Cloud for customer messaging and automated
 beta: true
 features:
   postMessage: yes
-  messageReplies: yes
+  messageReplies:
+    status: partial
+    label: Outbound only
   editMessage: no
   deleteMessage: no
   fileUploads:
@@ -189,6 +191,8 @@ bot.onNewMessage(async (thread, message) => {
 ```
 
 You can pass either a `Message` or a message ID as the target. Text, cards, files, and buffered streams are supported. When one logical reply produces multiple WhatsApp messages, only the first message includes the contextual reference.
+
+Replies are outbound only. When a user quote-replies to one of your messages, the adapter does not yet surface what they quoted, so `message.replyTo` is `undefined` on inbound WhatsApp messages.
 
 WhatsApp does not display the quoted bubble when the target was deleted or moved to long-term storage, when the reply is a template message, or for some media replies on KaiOS. Reaction messages cannot be contextual replies. See [Meta's contextual replies documentation](https://developers.facebook.com/documentation/business-messaging/whatsapp/messages/contextual-replies/).
 

--- a/apps/docs/content/docs/api/thread.mdx
+++ b/apps/docs/content/docs/api/thread.mdx
@@ -75,6 +75,22 @@ await thread.post(new StreamingPlan(stream, { groupTasks: "plan" }));
 
 See [Posting Messages](/docs/posting-messages) for details on each format.
 
+## reply
+
+Post a message with a native reference to another message.
+
+```typescript
+await thread.reply(message, {
+  markdown: "Thanks, I can help with that.",
+});
+```
+
+**Parameters:** `target: string | Message`, `message: string | PostableMessage | CardJSXElement`
+
+**Returns:** `Promise<SentMessage>`
+
+The target `Message` must belong to the same thread. Streams are buffered before sending. Adapters without native message reply support throw `NotImplementedError`.
+
 ## postEphemeral
 
 Post a message visible only to a specific user.

--- a/apps/docs/content/docs/api/thread.mdx
+++ b/apps/docs/content/docs/api/thread.mdx
@@ -85,11 +85,13 @@ await thread.reply(message, {
 });
 ```
 
-**Parameters:** `target: string | Message`, `message: string | PostableMessage | CardJSXElement`
+**Parameters:** `target: string | Message`, `message: string | AdapterPostableMessage | AsyncIterable<string | StreamChunk | StreamEvent> | CardJSXElement`
 
 **Returns:** `Promise<SentMessage>`
 
-The target `Message` must belong to the same thread. Streams are buffered before sending. Adapters without native message reply support throw `NotImplementedError`.
+The target `Message` must belong to the same thread. Streams are buffered before sending. Unlike `post()`, `reply()` does not accept `Plan` or `StreamingPlan`. Adapters without native message reply support throw `NotImplementedError`.
+
+Prefer passing the `Message` over its ID. The `Message` is checked against this thread and carried through to `SentMessage.replyTo` and cached thread history. A bare ID is only resolved to a `Message` when the thread already holds it in `recentMessages`; otherwise the reply is still sent, but `replyTo` is left undefined.
 
 ## postEphemeral
 

--- a/apps/docs/content/docs/posting-messages.mdx
+++ b/apps/docs/content/docs/posting-messages.mdx
@@ -36,6 +36,22 @@ await thread.post({
 
 Under the hood, the SDK parses the markdown into an mdast AST, then each adapter handles it natively or converts it to the platform's format.
 
+## Reply to a message
+
+Use `thread.reply()` when the platform should preserve a native reference to a specific message:
+
+```typescript title="lib/bot.ts" lineNumbers
+bot.onNewMessage(async (thread, message) => {
+  await thread.reply(message, {
+    markdown: "Thanks, I can help with that.",
+  });
+});
+```
+
+The target can be a `Message` from the same thread or its message ID. Replies accept the same plain text, markdown, AST, card, file, and stream formats as regular messages. Streams are buffered before the reply is sent.
+
+Adapters without native message replies throw `NotImplementedError`. See the [adapter feature matrix](/docs/platform-adapters) for support.
+
 ## AST builders
 
 For programmatic control over message formatting, use the mdast AST builder functions exported from `chat`. This is the recommended approach for most use cases — it gives you fine-grained control without the overhead of card rendering.

--- a/apps/docs/lib/adapter-features.ts
+++ b/apps/docs/lib/adapter-features.ts
@@ -24,6 +24,7 @@ export const PLATFORM_FEATURE_CATEGORIES: AdapterFeatureCategory[] = [
     label: "Messaging",
     features: [
       { key: "postMessage", label: "Post message" },
+      { key: "messageReplies", label: "Message replies" },
       { key: "editMessage", label: "Edit message" },
       { key: "deleteMessage", label: "Delete message" },
       { key: "fileUploads", label: "File uploads" },

--- a/packages/adapter-whatsapp/AGENTS.md
+++ b/packages/adapter-whatsapp/AGENTS.md
@@ -70,7 +70,7 @@ Main exports from `src/index.ts`:
   `WHATSAPP_PHONE_NUMBER_ID`, `WHATSAPP_VERIFY_TOKEN`, and the
   optional `WHATSAPP_WABA_ID` (used for cross-number reads).
 - `WhatsAppAdapter` class — implements `Adapter<WhatsAppThreadId,
-  unknown>`. Public methods: `handleWebhook`, `postMessage`,
+  unknown>`. Public methods: `handleWebhook`, `postMessage`, `reply`,
   `editMessage`, `deleteMessage`, `addReaction`, `removeReaction`,
   `startTyping`, `markRead`, `fetchThread`, `fetchMessages`,
   `fetchSingleMessage`, `fetchChannelInfo`, `postChannelMessage`,

--- a/packages/adapter-whatsapp/src/index.test.ts
+++ b/packages/adapter-whatsapp/src/index.test.ts
@@ -834,6 +834,72 @@ describe("postMessage", () => {
   });
 });
 
+describe("reply", () => {
+  let fetchSpy: MockInstance;
+
+  beforeEach(() => {
+    fetchSpy = vi.spyOn(global, "fetch").mockImplementation(() =>
+      Promise.resolve(
+        new Response(JSON.stringify({ messages: [{ id: "wamid.sent123" }] }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        })
+      )
+    );
+  });
+
+  afterEach(() => {
+    fetchSpy.mockRestore();
+  });
+
+  it("adds contextual reply data to text messages", async () => {
+    const adapter = createTestAdapter();
+
+    await adapter.reply("whatsapp:123456789:15551234567", "wamid.original", {
+      markdown: "Hello there",
+    });
+
+    const [, init] = fetchSpy.mock.calls[0];
+    const sent = JSON.parse(init?.body as string);
+    expect(sent.context).toEqual({ message_id: "wamid.original" });
+  });
+
+  it("adds contextual reply data only to the first split message", async () => {
+    const adapter = createTestAdapter();
+
+    await adapter.reply("whatsapp:123456789:15551234567", "wamid.original", {
+      markdown: "a".repeat(5000),
+    });
+
+    const first = JSON.parse(fetchSpy.mock.calls[0][1]?.body as string);
+    const second = JSON.parse(fetchSpy.mock.calls[1][1]?.body as string);
+    expect(first.context).toEqual({ message_id: "wamid.original" });
+    expect(second).not.toHaveProperty("context");
+  });
+
+  it("adds contextual reply data to interactive cards", async () => {
+    const adapter = createTestAdapter();
+
+    await adapter.reply("whatsapp:123456789:15551234567", "wamid.original", {
+      card: {
+        type: "card",
+        title: "Approve?",
+        children: [
+          {
+            type: "actions",
+            children: [{ type: "button", id: "yes", label: "Yes" }],
+          },
+        ],
+      },
+    });
+
+    const [, init] = fetchSpy.mock.calls[0];
+    const sent = JSON.parse(init?.body as string);
+    expect(sent.type).toBe("interactive");
+    expect(sent.context).toEqual({ message_id: "wamid.original" });
+  });
+});
+
 // ---------------------------------------------------------------------------
 // postMessage - file uploads
 // ---------------------------------------------------------------------------
@@ -1024,6 +1090,31 @@ describe("postMessage - file uploads", () => {
     expect((first.document as { caption: string }).caption).toBe("Two files");
     expect((second.document as { caption?: string }).caption).toBeUndefined();
     expect(result.id).toBe("wamid.msg2");
+  });
+
+  it("adds reply context only to the first media message", async () => {
+    const adapter = createTestAdapter();
+
+    await adapter.reply(THREAD_ID, "wamid.original", {
+      markdown: "Two files",
+      files: [
+        {
+          data: Buffer.from("a"),
+          filename: "first.pdf",
+          mimeType: "application/pdf",
+        },
+        {
+          data: Buffer.from("b"),
+          filename: "second.pdf",
+          mimeType: "application/pdf",
+        },
+      ],
+    });
+
+    const first = parseMessageBody(0);
+    const second = parseMessageBody(1);
+    expect(first.context).toEqual({ message_id: "wamid.original" });
+    expect(second).not.toHaveProperty("context");
   });
 
   it("attachment with HTTPS url uses link passthrough without upload", async () => {

--- a/packages/adapter-whatsapp/src/index.ts
+++ b/packages/adapter-whatsapp/src/index.ts
@@ -900,6 +900,14 @@ export class WhatsAppAdapter
     threadId: string,
     message: AdapterPostableMessage
   ): Promise<RawMessage<WhatsAppRawMessage>> {
+    return this.send(threadId, message);
+  }
+
+  protected async send(
+    threadId: string,
+    message: AdapterPostableMessage,
+    replyId?: string
+  ): Promise<RawMessage<WhatsAppRawMessage>> {
     const { userWaId } = this.decodeThreadId(threadId);
     const files = extractFiles(message);
     const attachments = extractPostableAttachments(message);
@@ -909,7 +917,13 @@ export class WhatsAppAdapter
     ];
 
     if (mediaItems.length > 0) {
-      return this.postMessageWithMedia(threadId, userWaId, message, mediaItems);
+      return this.postMessageWithMedia(
+        threadId,
+        userWaId,
+        message,
+        mediaItems,
+        replyId
+      );
     }
 
     // Check if this is a card with interactive buttons
@@ -925,13 +939,19 @@ export class WhatsAppAdapter
           )
         ) as WhatsAppInteractiveMessage;
 
-        return this.sendInteractiveMessage(threadId, userWaId, interactive);
+        return this.sendInteractiveMessage(
+          threadId,
+          userWaId,
+          interactive,
+          replyId
+        );
       }
 
       return this.sendTextMessage(
         threadId,
         userWaId,
-        convertEmojiPlaceholders(result.text, "whatsapp")
+        convertEmojiPlaceholders(result.text, "whatsapp"),
+        replyId
       );
     }
 
@@ -941,7 +961,15 @@ export class WhatsAppAdapter
       "whatsapp"
     );
 
-    return this.sendTextMessage(threadId, userWaId, body);
+    return this.sendTextMessage(threadId, userWaId, body, replyId);
+  }
+
+  async reply(
+    threadId: string,
+    messageId: string,
+    message: AdapterPostableMessage
+  ): Promise<RawMessage<WhatsAppRawMessage>> {
+    return this.send(threadId, message, messageId);
   }
 
   /**
@@ -951,8 +979,10 @@ export class WhatsAppAdapter
     threadId: string,
     userWaId: string,
     message: AdapterPostableMessage,
-    mediaItems: Array<FileUpload | Attachment>
+    mediaItems: Array<FileUpload | Attachment>,
+    replyId?: string
   ): Promise<RawMessage<WhatsAppRawMessage>> {
+    let remainingId = replyId;
     const card = extractCard(message);
     // cta_url promotion is disabled alongside media: the text fallback
     // captions the media in a single send, whereas an interactive
@@ -994,7 +1024,8 @@ export class WhatsAppAdapter
         !firstMedia?.captionEligible);
 
     if (useSeparateText) {
-      await this.sendTextMessage(threadId, userWaId, text);
+      await this.sendTextMessage(threadId, userWaId, text, remainingId);
+      remainingId = undefined;
     }
 
     let result: RawMessage<WhatsAppRawMessage> | undefined;
@@ -1014,8 +1045,10 @@ export class WhatsAppAdapter
         media.type,
         media.payload,
         caption,
-        media.filename
+        media.filename,
+        remainingId
       );
+      remainingId = undefined;
     }
 
     if (cardResult) {
@@ -1030,14 +1063,18 @@ export class WhatsAppAdapter
         result = await this.sendInteractiveMessage(
           threadId,
           userWaId,
-          interactive
+          interactive,
+          remainingId
         );
+        remainingId = undefined;
       } else if (text.length === 0) {
         result = await this.sendTextMessage(
           threadId,
           userWaId,
-          convertEmojiPlaceholders(cardResult.text, "whatsapp")
+          convertEmojiPlaceholders(cardResult.text, "whatsapp"),
+          remainingId
         );
+        remainingId = undefined;
       }
     }
 
@@ -1064,7 +1101,8 @@ export class WhatsAppAdapter
   protected async sendSingleTextMessage(
     threadId: string,
     to: string,
-    text: string
+    text: string,
+    replyId?: string
   ): Promise<RawMessage<WhatsAppRawMessage>> {
     const response = await this.graphApiRequest<WhatsAppSendResponse>(
       `/${this.phoneNumberId}/messages`,
@@ -1072,6 +1110,7 @@ export class WhatsAppAdapter
         messaging_product: "whatsapp",
         recipient_type: "individual",
         to,
+        ...(replyId ? { context: { message_id: replyId } } : {}),
         type: "text",
         text: { preview_url: false, body: text },
       }
@@ -1107,13 +1146,19 @@ export class WhatsAppAdapter
   protected async sendTextMessage(
     threadId: string,
     to: string,
-    text: string
+    text: string,
+    replyId?: string
   ): Promise<RawMessage<WhatsAppRawMessage>> {
     const chunks = this.splitMessage(text);
     let result: RawMessage<WhatsAppRawMessage> | undefined;
 
-    for (const chunk of chunks) {
-      result = await this.sendSingleTextMessage(threadId, to, chunk);
+    for (const [index, chunk] of chunks.entries()) {
+      result = await this.sendSingleTextMessage(
+        threadId,
+        to,
+        chunk,
+        index === 0 ? replyId : undefined
+      );
     }
 
     return result as RawMessage<WhatsAppRawMessage>;
@@ -1125,7 +1170,8 @@ export class WhatsAppAdapter
   protected async sendInteractiveMessage(
     threadId: string,
     to: string,
-    interactive: WhatsAppInteractiveMessage
+    interactive: WhatsAppInteractiveMessage,
+    replyId?: string
   ): Promise<RawMessage<WhatsAppRawMessage>> {
     const response = await this.graphApiRequest<WhatsAppSendResponse>(
       `/${this.phoneNumberId}/messages`,
@@ -1133,6 +1179,7 @@ export class WhatsAppAdapter
         messaging_product: "whatsapp",
         recipient_type: "individual",
         to,
+        ...(replyId ? { context: { message_id: replyId } } : {}),
         type: "interactive",
         interactive,
       }
@@ -1601,7 +1648,8 @@ export class WhatsAppAdapter
     type: WhatsAppMediaType,
     payload: { id?: string; link?: string },
     caption?: string,
-    filename?: string
+    filename?: string,
+    replyId?: string
   ): Promise<RawMessage<WhatsAppRawMessage>> {
     const mediaObject: Record<string, string> = {};
 
@@ -1627,6 +1675,7 @@ export class WhatsAppAdapter
         messaging_product: "whatsapp",
         recipient_type: "individual",
         to,
+        ...(replyId ? { context: { message_id: replyId } } : {}),
         type,
         [type]: mediaObject,
       }

--- a/packages/chat/src/thread.test.ts
+++ b/packages/chat/src/thread.test.ts
@@ -2824,6 +2824,57 @@ describe("ThreadImpl", () => {
         { markdown: "Hello world" }
       );
     });
+
+    it("falls back to a space when a stream produces no text", async () => {
+      mockAdapter.reply = vi.fn().mockResolvedValue({
+        id: "reply-1",
+        threadId: "slack:C123:1234.5678",
+        raw: {},
+      });
+      const stream = (async function* () {
+        yield { type: "tool-call", toolName: "search" };
+        yield { type: "finish-step" };
+      })();
+
+      await thread.reply("original", stream);
+
+      expect(mockAdapter.reply).toHaveBeenCalledWith(
+        "slack:C123:1234.5678",
+        "original",
+        { markdown: " " }
+      );
+    });
+
+    it("resolves a message id against messages the thread knows", async () => {
+      mockAdapter.reply = vi.fn().mockResolvedValue({
+        id: "reply-1",
+        threadId: "slack:C123:1234.5678",
+        raw: {},
+      });
+      const original = createTestMessage("original", "Question");
+      thread.recentMessages = [original];
+
+      const result = await thread.reply("original", "Answer");
+
+      expect(result.replyTo).toBe(original);
+    });
+
+    it("leaves replyTo undefined for an unknown message id", async () => {
+      mockAdapter.reply = vi.fn().mockResolvedValue({
+        id: "reply-1",
+        threadId: "slack:C123:1234.5678",
+        raw: {},
+      });
+
+      const result = await thread.reply("not-in-memory", "Answer");
+
+      expect(mockAdapter.reply).toHaveBeenCalledWith(
+        "slack:C123:1234.5678",
+        "not-in-memory",
+        "Answer"
+      );
+      expect(result.replyTo).toBeUndefined();
+    });
   });
 
   describe("schedule()", () => {

--- a/packages/chat/src/thread.test.ts
+++ b/packages/chat/src/thread.test.ts
@@ -2720,6 +2720,112 @@ describe("ThreadImpl", () => {
     });
   });
 
+  describe("reply()", () => {
+    let mockAdapter: Adapter;
+    let mockState: ReturnType<typeof createMockState>;
+    let thread: ThreadImpl;
+
+    beforeEach(() => {
+      mockAdapter = createMockAdapter();
+      mockState = createMockState();
+      thread = new ThreadImpl({
+        id: "slack:C123:1234.5678",
+        adapter: mockAdapter,
+        channelId: "C123",
+        stateAdapter: mockState,
+      });
+    });
+
+    it("throws when the adapter does not support replies", async () => {
+      await expect(thread.reply("original", "Hello")).rejects.toThrow(
+        NotImplementedError
+      );
+    });
+
+    it("delegates a message id and content to the adapter", async () => {
+      mockAdapter.reply = vi.fn().mockResolvedValue({
+        id: "reply-1",
+        threadId: "slack:C123:1234.5678",
+        raw: {},
+      });
+
+      const result = await thread.reply("original", { markdown: "Hello" });
+
+      expect(mockAdapter.reply).toHaveBeenCalledWith(
+        "slack:C123:1234.5678",
+        "original",
+        { markdown: "Hello" }
+      );
+      expect(result.id).toBe("reply-1");
+    });
+
+    it("accepts a Message and preserves it on the result", async () => {
+      mockAdapter.reply = vi.fn().mockResolvedValue({
+        id: "reply-1",
+        threadId: "slack:C123:1234.5678",
+        raw: {},
+      });
+      const original = createTestMessage("original", "Question");
+
+      const result = await thread.reply(original, "Answer");
+
+      expect(mockAdapter.reply).toHaveBeenCalledWith(
+        "slack:C123:1234.5678",
+        "original",
+        "Answer"
+      );
+      expect(result.replyTo).toBe(original);
+    });
+
+    it("rejects a Message from another thread", async () => {
+      mockAdapter.reply = vi.fn();
+      const original = createTestMessage("original", "Question", {
+        threadId: "slack:C999:9999.0000",
+      });
+
+      await expect(thread.reply(original, "Answer")).rejects.toThrow(
+        "Cannot reply to a message from another thread"
+      );
+      expect(mockAdapter.reply).not.toHaveBeenCalled();
+    });
+
+    it("converts JSX cards before delegating", async () => {
+      mockAdapter.reply = vi.fn().mockResolvedValue({
+        id: "reply-1",
+        threadId: "slack:C123:1234.5678",
+        raw: {},
+      });
+
+      await thread.reply("original", Card({ title: "Answer" }));
+
+      expect(mockAdapter.reply).toHaveBeenCalledWith(
+        "slack:C123:1234.5678",
+        "original",
+        expect.objectContaining({ type: "card", title: "Answer" })
+      );
+    });
+
+    it("buffers streams into one markdown reply", async () => {
+      mockAdapter.reply = vi.fn().mockResolvedValue({
+        id: "reply-1",
+        threadId: "slack:C123:1234.5678",
+        raw: {},
+      });
+      const stream = (async function* () {
+        yield "Hello ";
+        yield "world";
+      })();
+
+      await thread.reply("original", stream);
+
+      expect(mockAdapter.reply).toHaveBeenCalledWith(
+        "slack:C123:1234.5678",
+        "original",
+        { markdown: "Hello world" }
+      );
+    });
+  });
+
   describe("schedule()", () => {
     let mockAdapter: Adapter;
     let mockState: ReturnType<typeof createMockState>;

--- a/packages/chat/src/thread.ts
+++ b/packages/chat/src/thread.ts
@@ -550,7 +550,10 @@ export class ThreadImpl<TState = Record<string, unknown>>
       );
     }
 
-    if (target instanceof Message && target.threadId !== this.id) {
+    const targetMessage =
+      target instanceof Message ? target : this.findKnownMessage(target);
+
+    if (targetMessage && targetMessage.threadId !== this.id) {
       throw new Error("Cannot reply to a message from another thread");
     }
 
@@ -564,7 +567,10 @@ export class ThreadImpl<TState = Record<string, unknown>>
           markdown += chunk.text;
         }
       }
-      postable = { markdown };
+      // A stream can finish without producing text (tool calls only, or just
+      // task_update/plan_update chunks). Platforms reject empty message bodies,
+      // so fall back to a single space like fallbackStream does.
+      postable = { markdown: markdown.trim() ? markdown : " " };
     } else if (isJSX(message)) {
       const card = toCardElement(message);
       if (!card) {
@@ -582,7 +588,7 @@ export class ThreadImpl<TState = Record<string, unknown>>
       rawMessage.id,
       postable,
       rawMessage.threadId,
-      target instanceof Message ? target : undefined
+      targetMessage
     );
 
     if (this._threadHistory) {
@@ -590,6 +596,18 @@ export class ThreadImpl<TState = Record<string, unknown>>
     }
 
     return result;
+  }
+
+  /**
+   * Resolve a message id against the messages this thread already holds in
+   * memory. Deliberately does not fetch: callers that need `replyTo` populated
+   * for certain should pass the `Message` itself.
+   */
+  private findKnownMessage(messageId: string): Message | undefined {
+    if (this._currentMessage?.id === messageId) {
+      return this._currentMessage;
+    }
+    return this._recentMessages.find((m) => m.id === messageId);
   }
 
   private async processCallbackUrls(

--- a/packages/chat/src/thread.ts
+++ b/packages/chat/src/thread.ts
@@ -536,6 +536,62 @@ export class ThreadImpl<TState = Record<string, unknown>>
     return null;
   }
 
+  async reply(
+    target: string | Message,
+    message:
+      | AdapterPostableMessage
+      | AsyncIterable<string | StreamChunk | StreamEvent>
+      | ChatElement
+  ): Promise<SentMessage> {
+    if (!this.adapter.reply) {
+      throw new NotImplementedError(
+        "Message replies are not supported by this adapter",
+        "replies"
+      );
+    }
+
+    if (target instanceof Message && target.threadId !== this.id) {
+      throw new Error("Cannot reply to a message from another thread");
+    }
+
+    let postable: AdapterPostableMessage;
+    if (isAsyncIterable(message)) {
+      let markdown = "";
+      for await (const chunk of fromFullStream(message)) {
+        if (typeof chunk === "string") {
+          markdown += chunk;
+        } else if (chunk.type === "markdown_text") {
+          markdown += chunk.text;
+        }
+      }
+      postable = { markdown };
+    } else if (isJSX(message)) {
+      const card = toCardElement(message);
+      if (!card) {
+        throw new Error("Invalid JSX element: must be a Card element");
+      }
+      postable = card;
+    } else {
+      postable = message as AdapterPostableMessage;
+    }
+
+    postable = await this.processCallbackUrls(postable);
+    const targetId = typeof target === "string" ? target : target.id;
+    const rawMessage = await this.adapter.reply(this.id, targetId, postable);
+    const result = this.createSentMessage(
+      rawMessage.id,
+      postable,
+      rawMessage.threadId,
+      target instanceof Message ? target : undefined
+    );
+
+    if (this._threadHistory) {
+      await this._threadHistory.append(this.id, new Message(result));
+    }
+
+    return result;
+  }
+
   private async processCallbackUrls(
     postable: string | AdapterPostableMessage
   ): Promise<string | AdapterPostableMessage> {
@@ -955,7 +1011,8 @@ export class ThreadImpl<TState = Record<string, unknown>>
   private createSentMessage(
     messageId: string,
     postable: AdapterPostableMessage,
-    threadIdOverride?: string
+    threadIdOverride?: string,
+    replyTo?: Message
   ): SentMessage {
     const adapter = this.adapter;
     // Use the threadId returned by postMessage if available (may differ after thread creation)
@@ -985,6 +1042,7 @@ export class ThreadImpl<TState = Record<string, unknown>>
         edited: false,
       },
       attachments,
+      replyTo,
 
       toJSON() {
         return new Message(this).toJSON();
@@ -1005,7 +1063,7 @@ export class ThreadImpl<TState = Record<string, unknown>>
         }
         postable = await self.processCallbackUrls(postable);
         await adapter.editMessage(threadId, messageId, postable);
-        return self.createSentMessage(messageId, postable);
+        return self.createSentMessage(messageId, postable, threadId, replyTo);
       },
 
       async delete(): Promise<void> {
@@ -1062,7 +1120,12 @@ export class ThreadImpl<TState = Record<string, unknown>>
         }
         postable = await self.processCallbackUrls(postable);
         await adapter.editMessage(threadId, messageId, postable);
-        return self.createSentMessage(messageId, postable, threadId);
+        return self.createSentMessage(
+          messageId,
+          postable,
+          threadId,
+          message.replyTo
+        );
       },
 
       async delete(): Promise<void> {

--- a/packages/chat/src/types.ts
+++ b/packages/chat/src/types.ts
@@ -1294,6 +1294,28 @@ export interface Thread<TState = Record<string, unknown>, TRawMessage = unknown>
    */
   refresh(): Promise<void>;
 
+  /**
+   * Reply to a specific message in this thread, using the platform's native
+   * reply (quote, threaded reply) rather than posting a loose message.
+   *
+   * Throws `NotImplementedError` on adapters without native reply support.
+   *
+   * @param target - The message to reply to, or its id. Prefer passing the
+   *   `Message`: it is checked against this thread, and it is carried through
+   *   to `SentMessage.replyTo` and cached thread history. A raw id is resolved
+   *   only if it matches a message this thread already holds (`recentMessages`
+   *   or the message being handled); otherwise the reply is still sent, but
+   *   `replyTo` is left undefined and no cross-thread check happens.
+   * @param message - Reply content. Streams are buffered and posted as one
+   *   message rather than streamed edit-by-edit.
+   *
+   * @example
+   * ```typescript
+   * chat.onNewMessage(async (thread, message) => {
+   *   await thread.reply(message, 'Got it');
+   * });
+   * ```
+   */
   reply(
     target: string | Message<TRawMessage>,
     message:

--- a/packages/chat/src/types.ts
+++ b/packages/chat/src/types.ts
@@ -504,6 +504,12 @@ export interface Adapter<TThreadId = unknown, TRawMessage = unknown> {
   /** Render formatted content to platform-specific string */
   renderFormatted(content: FormattedContent): string;
 
+  reply?(
+    threadId: string,
+    messageId: string,
+    message: AdapterPostableMessage
+  ): Promise<RawMessage<TRawMessage>>;
+
   /**
    * Schedule a message for future delivery.
    *
@@ -1287,6 +1293,14 @@ export interface Thread<TState = Record<string, unknown>, TRawMessage = unknown>
    * Fetches the latest 50 messages and updates `recentMessages`.
    */
   refresh(): Promise<void>;
+
+  reply(
+    target: string | Message<TRawMessage>,
+    message:
+      | AdapterPostableMessage
+      | AsyncIterable<string | StreamChunk | StreamEvent>
+      | ChatElement
+  ): Promise<SentMessage<TRawMessage>>;
 
   /**
    * Show typing indicator in the thread.


### PR DESCRIPTION
## summary

- add `thread.reply()` for sending messages with native references to existing messages
- accept either a message object from the same thread or a message id as the reply target
- support text, markdown, AST, cards, files, and buffered streams
- add WhatsApp contextual replies using the Cloud API `context.message_id` field
- apply reply context only to the first outgoing message when content is split across multiple sends
- preserve the target message through sent message edits and thread history
- throw `NotImplementedError` for adapters without native reply support
- document the API and add message replies to the adapter feature matrix

fixes #786

## test plan

- verify message ids and message objects are forwarded to the adapter correctly
- verify messages from another thread are rejected
- verify unsupported adapters throw `NotImplementedError`
- verify streams are buffered before sending
- verify WhatsApp text, card, and media replies include the expected context
- verify split WhatsApp messages include context only on the first request
- run workspace typechecking, tests, builds, adapter integration tests, targeted lint, and scoped Knip
