### PR TITLE
feat(chat): add mark as read support

### DIFF
--- a/.changeset/strict-plums-wait.md
+++ b/.changeset/strict-plums-wait.md
@@ -5,4 +5,6 @@
 "chat": minor
 ---
 
-add a shared thread API for marking messages as read across WhatsApp, Messenger, and XChat
+Add a shared thread API for marking messages as read across WhatsApp, Messenger, and XChat.
+
+Note for anyone calling `XchatAdapter.markAsRead()` directly: it now rejects when a receipt fails instead of logging a warning and resolving. Automatic read receipts are unaffected, since the adapter still catches and logs those internally. If you call the method yourself without awaiting it, add a `.catch()` so a failed receipt does not surface as an unhandled rejection.

--- a/.changeset/strict-plums-wait.md
+++ b/.changeset/strict-plums-wait.md
@@ -1,0 +1,8 @@
+---
+"@chat-adapter/messenger": minor
+"@chat-adapter/whatsapp": minor
+"@chat-adapter/x": minor
+"chat": minor
+---
+
+add a shared thread API for marking messages as read across WhatsApp, Messenger, and XChat

--- a/apps/docs/content/adapters/official/messenger.mdx
+++ b/apps/docs/content/adapters/official/messenger.mdx
@@ -39,6 +39,7 @@ features:
   addReactions: no
   removeReactions: no
   typingIndicator: yes
+  markAsRead: yes
   messageUpdatedEvents: no
   messageDeletedEvents: no
   directMessages: yes
@@ -183,6 +184,19 @@ Constraints:
 - Button titles limited to 20 characters (truncated with ellipsis).
 - Subtitles limited to 80 characters.
 - Button Template text limited to 640 characters.
+
+### Read receipts
+
+Use `thread.markAsRead()` in a message handler to send Messenger's `mark_seen` sender action:
+
+```typescript
+bot.onDirectMessage(async (thread) => {
+  await thread.markAsRead();
+  await thread.post("Thanks, I have seen your message.");
+});
+```
+
+Messenger applies this action to the conversation's seen state rather than a single message, even when you pass a message or message ID.
 
 ### Thread ID format
 

--- a/apps/docs/content/adapters/official/whatsapp.mdx
+++ b/apps/docs/content/adapters/official/whatsapp.mdx
@@ -39,6 +39,7 @@ features:
   addReactions: yes
   removeReactions: yes
   typingIndicator: yes
+  markAsRead: yes
   messageUpdatedEvents: no
   messageDeletedEvents: no
   directMessages: yes
@@ -228,6 +229,19 @@ WhatsApp-specific behavior:
 - The adapter uses the most recent inbound message ID from thread history.
 - If there is no inbound message context, `startTyping()` no-ops.
 - The typing indicator is dismissed when the bot sends its reply, or after the WhatsApp platform timeout.
+
+### Read receipts
+
+Mark the current inbound message as read before starting work:
+
+```typescript
+bot.onDirectMessage(async (thread) => {
+  await thread.markAsRead();
+  await thread.post("Thanks, I am checking that now.");
+});
+```
+
+You can also pass an inbound `Message` or its ID to `thread.markAsRead()`. WhatsApp marks that message and earlier messages in the conversation as read. It does not allow outgoing message IDs to be marked as read and recommends acknowledging inbound messages within 30 days.
 
 ### Thread ID format
 

--- a/apps/docs/content/adapters/official/xchat.mdx
+++ b/apps/docs/content/adapters/official/xchat.mdx
@@ -41,6 +41,7 @@ features:
   addReactions: yes
   removeReactions: yes
   typingIndicator: yes
+  markAsRead: yes
   messageUpdatedEvents: no
   messageDeletedEvents: no
   directMessages: yes
@@ -271,7 +272,20 @@ The adapter can edit and delete only the bot's own messages. The first edit of a
 
 ### Read receipts and typing
 
-A read receipt is sent for each delivered inbound message before handlers run unless `sendReadReceipts: false`. The typing indicator is re-sent every 3 seconds while a handler runs.
+A read receipt is sent for each delivered inbound message before handlers run unless `sendReadReceipts: false`. To control the timing yourself, disable automatic receipts and call `thread.markAsRead()` in the handler. XChat advances the conversation's read watermark through the target message sequence. The typing indicator is re-sent every 3 seconds while a handler runs.
+
+```typescript
+const xchat = createXchatAdapter({ sendReadReceipts: false });
+
+const bot = new Chat({
+  userName: "mybot",
+  adapters: { xchat },
+});
+
+bot.onDirectMessage(async (thread) => {
+  await thread.markAsRead();
+});
+```
 
 ### Thread ID format
 

--- a/apps/docs/content/adapters/official/xchat.mdx
+++ b/apps/docs/content/adapters/official/xchat.mdx
@@ -287,6 +287,10 @@ bot.onDirectMessage(async (thread) => {
 });
 ```
 
+Automatic receipts never interrupt a handler, since a failure is logged and swallowed. A `thread.markAsRead()` call you make yourself rejects on failure, so await it or attach a `.catch()`.
+
+When the message's sequence id is not known, such as an event the adapter could not decrypt, the watermark advances to the latest event in the conversation instead.
+
 ### Thread ID format
 
 ```

--- a/apps/docs/content/docs/api/thread.mdx
+++ b/apps/docs/content/docs/api/thread.mdx
@@ -204,7 +204,7 @@ await thread.markAsRead(message);
 await thread.markAsRead(message.id);
 ```
 
-The message must belong to the thread. Calling `markAsRead()` without an argument outside a message handler throws because there is no current message.
+A `Message` must belong to the thread, and passing one from another thread throws. A bare message ID is sent to the adapter as given, since there is nothing to check it against. Calling `markAsRead()` without an argument outside a message handler throws because there is no current message.
 
 Platforms may advance the conversation's read state through the target message, which also marks earlier messages as read.
 

--- a/apps/docs/content/docs/api/thread.mdx
+++ b/apps/docs/content/docs/api/thread.mdx
@@ -185,6 +185,29 @@ await thread.startTyping();
 await thread.startTyping("Searching documents...");
 ```
 
+## markAsRead
+
+Mark an inbound message as read. WhatsApp, Messenger, and XChat support this capability. Other adapters throw `NotImplementedError`.
+
+Inside a message handler, omit the argument to mark the current message:
+
+```typescript
+bot.onDirectMessage(async (thread) => {
+  await thread.markAsRead();
+});
+```
+
+Pass a `Message` or message ID when targeting a message explicitly:
+
+```typescript
+await thread.markAsRead(message);
+await thread.markAsRead(message.id);
+```
+
+The message must belong to the thread. Calling `markAsRead()` without an argument outside a message handler throws because there is no current message.
+
+Platforms may advance the conversation's read state through the target message, which also marks earlier messages as read.
+
 ## messages / allMessages
 
 Iterate through message history.

--- a/apps/docs/content/docs/threads-messages-channels.mdx
+++ b/apps/docs/content/docs/threads-messages-channels.mdx
@@ -89,6 +89,29 @@ await thread.startTyping();
 Not all platforms support typing indicators. The call is a no-op on unsupported platforms. See the [adapter feature matrix](/docs/platform-adapters) for details.
 </Callout>
 
+### Mark as read
+
+Inside a message handler, mark the current inbound message as read without passing platform-specific IDs:
+
+```typescript title="lib/bot.ts"
+bot.onDirectMessage(async (thread) => {
+  await thread.markAsRead();
+});
+```
+
+You can pass a `Message` or message ID when you need an explicit target:
+
+```typescript
+await thread.markAsRead(message);
+await thread.markAsRead(message.id);
+```
+
+Platforms may advance the conversation's read state through the target message, which also marks earlier messages as read.
+
+<Callout type="info">
+WhatsApp, Messenger, and XChat support marking messages as read. Other adapters throw `NotImplementedError`. See the [adapter feature matrix](/docs/platform-adapters) for details.
+</Callout>
+
 ### Message history
 
 Access recent messages or iterate through full history:

--- a/apps/docs/lib/adapter-features.ts
+++ b/apps/docs/lib/adapter-features.ts
@@ -55,6 +55,7 @@ export const PLATFORM_FEATURE_CATEGORIES: AdapterFeatureCategory[] = [
       { key: "addReactions", label: "Add reactions" },
       { key: "removeReactions", label: "Remove reactions" },
       { key: "typingIndicator", label: "Typing indicator" },
+      { key: "markAsRead", label: "Mark as read" },
       { key: "messageUpdatedEvents", label: "Message edit events" },
       { key: "messageDeletedEvents", label: "Message delete events" },
       { key: "directMessages", label: "DMs" },

--- a/packages/adapter-messenger/README.md
+++ b/packages/adapter-messenger/README.md
@@ -135,6 +135,7 @@ export async function POST(request: Request) {
 | Delete message | No (Messenger limitation) |
 | Streaming | Buffered (accumulates then sends) |
 | Typing indicator | Yes |
+| Mark as read | Yes |
 
 ### Rich content
 
@@ -157,6 +158,16 @@ export async function POST(request: Request) {
 | Typing indicator | Yes |
 | DMs | Yes (DM-only platform) |
 | Postbacks | Yes |
+
+### Read receipts
+
+Use `thread.markAsRead()` in a message handler to send Messenger's `mark_seen` sender action:
+
+```typescript
+await thread.markAsRead();
+```
+
+Messenger applies this action to the conversation's seen state rather than a single message, even when you pass a message or message ID.
 
 ### Message history
 

--- a/packages/adapter-messenger/src/index.test.ts
+++ b/packages/adapter-messenger/src/index.test.ts
@@ -1220,6 +1220,31 @@ describe("MessengerAdapter", () => {
       });
     });
 
+    describe("markAsRead", () => {
+      it("sends the mark_seen sender action", async () => {
+        const adapter = createAdapter();
+        const chat = createMockChat();
+
+        mockFetch.mockResolvedValueOnce(
+          graphApiOk({ id: "PAGE_456", name: "Test Page" })
+        );
+        await adapter.initialize(chat);
+
+        mockFetch.mockResolvedValueOnce(
+          graphApiOk({ recipient_id: "USER_123" })
+        );
+
+        await adapter.markAsRead("messenger:USER_123", "mid.1");
+
+        const [url, options] = mockFetch.mock.calls[1];
+        expect(url.toString()).toContain("me/messages");
+        expect(JSON.parse(options?.body as string)).toEqual({
+          recipient: { id: "USER_123" },
+          sender_action: "mark_seen",
+        });
+      });
+    });
+
     describe("unsupported operations", () => {
       it("throws on editMessage", async () => {
         const adapter = createAdapter();

--- a/packages/adapter-messenger/src/index.ts
+++ b/packages/adapter-messenger/src/index.ts
@@ -527,6 +527,14 @@ export class MessengerAdapter
     });
   }
 
+  async markAsRead(threadId: string, _messageId: string): Promise<void> {
+    const { recipientId } = this.resolveThreadId(threadId);
+    await this.graphApiFetch("me/messages", "POST", {
+      recipient: { id: recipientId },
+      sender_action: "mark_seen",
+    });
+  }
+
   async fetchMessages(
     threadId: string,
     options: FetchOptions = {}

--- a/packages/adapter-whatsapp/README.md
+++ b/packages/adapter-whatsapp/README.md
@@ -173,6 +173,16 @@ WhatsApp-specific behavior:
 - If there is no inbound message context, `startTyping()` no-ops.
 - The typing indicator is dismissed when the bot sends its reply, or after the WhatsApp platform timeout.
 
+### Read receipts
+
+Use `thread.markAsRead()` in a message handler to acknowledge the current inbound message:
+
+```typescript
+await thread.markAsRead();
+```
+
+You can also pass an inbound `Message` or its ID. WhatsApp marks that message and earlier messages in the conversation as read. It does not allow outgoing message IDs to be marked as read and recommends acknowledging inbound messages within 30 days.
+
 ### Incoming message types
 
 | Type | Supported |

--- a/packages/adapter-whatsapp/src/index.test.ts
+++ b/packages/adapter-whatsapp/src/index.test.ts
@@ -1771,6 +1771,66 @@ describe("addReaction / removeReaction", () => {
   });
 });
 
+describe("markAsRead", () => {
+  let fetchSpy: MockInstance;
+
+  beforeEach(() => {
+    fetchSpy = vi.spyOn(global, "fetch").mockImplementation(() =>
+      Promise.resolve(
+        new Response(JSON.stringify({ success: true }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        })
+      )
+    );
+  });
+
+  afterEach(() => {
+    fetchSpy.mockRestore();
+  });
+
+  it("marks an inbound message as read", async () => {
+    const adapter = createTestAdapter();
+
+    await adapter.markAsRead("whatsapp:123456789:15551234567", "wamid.inbound");
+
+    const [url, init] = fetchSpy.mock.calls[0];
+    expect(String(url)).toContain("/123456789/messages");
+    expect(init?.method).toBe("POST");
+    expect(JSON.parse(init?.body as string)).toEqual({
+      messaging_product: "whatsapp",
+      status: "read",
+      message_id: "wamid.inbound",
+    });
+  });
+
+  it("preserves the adapter-level message id signature", async () => {
+    const adapter = createTestAdapter();
+
+    await adapter.markAsRead("wamid.inbound");
+
+    expect(JSON.parse(fetchSpy.mock.calls[0][1]?.body as string)).toEqual({
+      messaging_product: "whatsapp",
+      status: "read",
+      message_id: "wamid.inbound",
+    });
+  });
+
+  it("rejects an unsuccessful API response", async () => {
+    fetchSpy.mockResolvedValueOnce(
+      new Response(JSON.stringify({ success: false }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      })
+    );
+    const adapter = createTestAdapter();
+
+    await expect(adapter.markAsRead("wamid.inbound")).rejects.toThrow(
+      "WhatsApp mark as read failed"
+    );
+  });
+});
+
 // ---------------------------------------------------------------------------
 // startTyping
 // ---------------------------------------------------------------------------

--- a/packages/adapter-whatsapp/src/index.ts
+++ b/packages/adapter-whatsapp/src/index.ts
@@ -1531,12 +1531,24 @@ export class WhatsAppAdapter
    *
    * @see https://developers.facebook.com/docs/whatsapp/cloud-api/messages/mark-messages-as-read
    */
-  async markAsRead(messageId: string): Promise<void> {
-    await this.graphApiRequest(`/${this.phoneNumberId}/messages`, {
-      messaging_product: "whatsapp",
-      status: "read",
-      message_id: messageId,
-    });
+  async markAsRead(
+    threadIdOrMessageId: string,
+    messageId?: string,
+    _message?: Message<WhatsAppRawMessage>
+  ): Promise<void> {
+    const response =
+      await this.graphApiRequest<WhatsAppTypingIndicatorResponse>(
+        `/${this.phoneNumberId}/messages`,
+        {
+          messaging_product: "whatsapp",
+          status: "read",
+          message_id: messageId ?? threadIdOrMessageId,
+        }
+      );
+
+    if (!response.success) {
+      throw new AdapterError("WhatsApp mark as read failed", "whatsapp");
+    }
   }
 
   // =============================================================================

--- a/packages/adapter-x/README.md
+++ b/packages/adapter-x/README.md
@@ -357,7 +357,7 @@ X_VERIFY_SIGNATURES=true           # Optional; set false to accept unverifiable 
 | Edit message | Yes (encrypted edit event targeting the original's sequence id; only the bot's own text messages). The first edit of a fresh message is held until the message is `editSafetyDelayMs` old, so receiving clients have stored the original before the edit arrives |
 | Delete message | Yes (delete-for-all: a locally signed delete action removes the message for every participant; only the bot's own messages) |
 | Streaming | Limited (message edits work, but the first edit is age-gated by `editSafetyDelayMs`, so rapid token-by-token updates are coarse) |
-| Read receipts | Yes (sent for each delivered inbound message unless `sendReadReceipts: false`; falls back to the latest conversation event) |
+| Read receipts | Yes (advances the conversation read watermark through each delivered inbound message unless `sendReadReceipts: false`; call `thread.markAsRead()` for manual control) |
 | TTL propagation | Yes (replies inherit the inbound message's disappearing-message TTL) |
 
 ### Rich content

--- a/packages/adapter-x/src/chat/index.test.ts
+++ b/packages/adapter-x/src/chat/index.test.ts
@@ -1114,6 +1114,27 @@ describe("read receipts on delivery (real crypto)", () => {
       restore();
     }
   });
+
+  it("delivers messages when an automatic read receipt fails", async () => {
+    const { adapter, mockChat, getXdkClient, restore } =
+      await createInitializedTestAdapter();
+    try {
+      const xdk = getXdkClient();
+      const request = primeFixtureDelivery(adapter, xdk);
+      xdk.chat.markConversationRead = vi
+        .fn()
+        .mockRejectedValue(new Error("receipt failed"));
+
+      const response = await adapter.handleWebhook(request);
+      expect(response.status).toBe(200);
+
+      await vi.waitFor(() => {
+        expect(mockChat.handleIncomingMessage).toHaveBeenCalledOnce();
+      });
+    } finally {
+      restore();
+    }
+  });
 });
 
 describe("withChatSdkUserAgent", () => {
@@ -1776,7 +1797,37 @@ describe("media upload/download via the XDK client (real crypto)", () => {
   });
 });
 
-describe("markAsRead fallback", () => {
+describe("markAsRead", () => {
+  it("uses message context from the shared adapter capability", async () => {
+    const { adapter, getXdkClient, restore } =
+      await createInitializedTestAdapter();
+    try {
+      const xdk = getXdkClient();
+      xdk.chat.markConversationRead = vi
+        .fn()
+        .mockResolvedValue({ data: { success: true } });
+      const message = adapter.parseMessage({
+        event: {
+          id: "evt-read",
+          conversationId: TEST_CONVERSATION_ID,
+          senderId: TEST_OTHER_USER_ID,
+          encodedEvent: "x",
+          sequenceId: "seq-77",
+        },
+        decrypted: null,
+      });
+
+      await adapter.markAsRead(TEST_THREAD_ID, message.id, message);
+
+      expect(xdk.chat.markConversationRead).toHaveBeenCalledWith(
+        TEST_OTHER_USER_ID,
+        { seenUntilSequenceId: "seq-77" }
+      );
+    } finally {
+      restore();
+    }
+  });
+
   it("falls back to the latest event sequence id when the message has none", async () => {
     const { adapter, getXdkClient, restore } =
       await createInitializedTestAdapter();
@@ -1785,7 +1836,9 @@ describe("markAsRead fallback", () => {
       xdk.chat.getConversationEvents = vi.fn().mockResolvedValue({
         data: [{ id: "evt-l", sequenceId: "seq-99" }],
       });
-      xdk.chat.markConversationRead = vi.fn().mockResolvedValue({ data: {} });
+      xdk.chat.markConversationRead = vi
+        .fn()
+        .mockResolvedValue({ data: { success: true } });
 
       const message = adapter.parseMessage({
         event: {
@@ -1802,6 +1855,60 @@ describe("markAsRead fallback", () => {
         TEST_OTHER_USER_ID,
         { seenUntilSequenceId: "seq-99" }
       );
+    } finally {
+      restore();
+    }
+  });
+
+  it("propagates explicit read receipt failures", async () => {
+    const { adapter, getXdkClient, restore } =
+      await createInitializedTestAdapter();
+    try {
+      const xdk = getXdkClient();
+      xdk.chat.markConversationRead = vi
+        .fn()
+        .mockRejectedValue(new Error("receipt failed"));
+      const message = adapter.parseMessage({
+        event: {
+          id: "evt-read-fail",
+          conversationId: TEST_CONVERSATION_ID,
+          senderId: TEST_OTHER_USER_ID,
+          encodedEvent: "x",
+          sequenceId: "seq-fail",
+        },
+        decrypted: null,
+      });
+
+      await expect(
+        adapter.markAsRead(TEST_THREAD_ID, message.id, message)
+      ).rejects.toThrow("receipt failed");
+    } finally {
+      restore();
+    }
+  });
+
+  it("rejects an unsuccessful read receipt response", async () => {
+    const { adapter, getXdkClient, restore } =
+      await createInitializedTestAdapter();
+    try {
+      const xdk = getXdkClient();
+      xdk.chat.markConversationRead = vi
+        .fn()
+        .mockResolvedValue({ data: { success: false } });
+      const message = adapter.parseMessage({
+        event: {
+          id: "evt-read-unsuccessful",
+          conversationId: TEST_CONVERSATION_ID,
+          senderId: TEST_OTHER_USER_ID,
+          encodedEvent: "x",
+          sequenceId: "seq-unsuccessful",
+        },
+        decrypted: null,
+      });
+
+      await expect(
+        adapter.markAsRead(TEST_THREAD_ID, message.id, message)
+      ).rejects.toThrow("XChat mark as read failed");
     } finally {
       restore();
     }

--- a/packages/adapter-x/src/chat/index.test.ts
+++ b/packages/adapter-x/src/chat/index.test.ts
@@ -1860,6 +1860,54 @@ describe("markAsRead", () => {
     }
   });
 
+  it("reaches the latest-event fallback when called with a message id", async () => {
+    const { adapter, getXdkClient, restore } =
+      await createInitializedTestAdapter();
+    try {
+      const xdk = getXdkClient();
+      // Serves both the history replay inside resolveSequenceId and the
+      // latest-event fallback. The event is undecryptable, so the replay
+      // caches no sequence id for our message.
+      xdk.chat.getConversationEvents = vi.fn().mockResolvedValue({
+        data: [
+          {
+            id: "evt-latest",
+            sequenceId: "seq-99",
+            senderId: TEST_OTHER_USER_ID,
+            conversationId: TEST_CONVERSATION_ID,
+            encodedEvent: "not-a-real-encrypted-event",
+          },
+        ],
+        meta: {},
+      });
+      xdk.users.getPublicKey = vi.fn().mockResolvedValue({ data: [] });
+      xdk.chat.markConversationRead = vi
+        .fn()
+        .mockResolvedValue({ data: { success: true } });
+
+      const message = adapter.parseMessage({
+        event: {
+          id: "evt-no-seq",
+          conversationId: TEST_CONVERSATION_ID,
+          senderId: TEST_OTHER_USER_ID,
+          encodedEvent: "x",
+        },
+        decrypted: null,
+      });
+
+      // The argument shape Thread.markAsRead() uses: id in slot two, message
+      // in slot three. A resolveSequenceId miss must not abort the receipt.
+      await adapter.markAsRead(TEST_THREAD_ID, message.id, message);
+
+      expect(xdk.chat.markConversationRead).toHaveBeenCalledWith(
+        TEST_OTHER_USER_ID,
+        { seenUntilSequenceId: "seq-99" }
+      );
+    } finally {
+      restore();
+    }
+  });
+
   it("propagates explicit read receipt failures", async () => {
     const { adapter, getXdkClient, restore } =
       await createInitializedTestAdapter();

--- a/packages/adapter-x/src/chat/index.ts
+++ b/packages/adapter-x/src/chat/index.ts
@@ -23,7 +23,7 @@
 
 import { createHmac, timingSafeEqual } from "node:crypto";
 import { createRequire } from "node:module";
-import { ValidationError } from "@chat-adapter/shared";
+import { AdapterError, ValidationError } from "@chat-adapter/shared";
 import {
   type AttachmentDescriptor,
   type ChatWithJuicebox,
@@ -1123,10 +1123,10 @@ export class XchatAdapter implements Adapter<XchatThreadId, XchatRawMessage> {
         return;
       }
 
-      // Read receipt before handlers run; markAsRead logs and swallows its
+      // Read receipt before handlers run; acknowledge logs and swallows its
       // own failures, so delivery is never blocked by a receipt error.
       if (this.sendReadReceipts) {
-        await this.markAsRead(threadId, parsed);
+        await this.acknowledge(threadId, parsed);
       }
 
       await this.chat?.handleIncomingMessage(this, threadId, parsed);
@@ -1309,10 +1309,10 @@ export class XchatAdapter implements Adapter<XchatThreadId, XchatRawMessage> {
       conversationId: event.conversationId,
     });
 
-    // Read receipt before handlers run; markAsRead logs and swallows its
+    // Read receipt before handlers run; acknowledge logs and swallows its
     // own failures, so delivery is never blocked by a receipt error.
     if (this.sendReadReceipts) {
-      await this.markAsRead(threadId, message);
+      await this.acknowledge(threadId, message);
     }
 
     await this.chat.handleIncomingMessage(this, threadId, message);
@@ -2191,46 +2191,71 @@ export class XchatAdapter implements Adapter<XchatThreadId, XchatRawMessage> {
    * Send a read receipt (seen-until watermark) for an inbound message.
    *
    * Called automatically for each delivered inbound message when
-   * `sendReadReceipts` is enabled (the default). Failures are logged and
-   * swallowed so message delivery is never blocked by a receipt error.
+   * `sendReadReceipts` is enabled (the default).
    */
-  async markAsRead(threadId: string, message: Message): Promise<void> {
+  async markAsRead(
+    threadId: string,
+    messageIdOrMessage: string | Message<XchatRawMessage>,
+    message?: Message<XchatRawMessage>
+  ): Promise<void> {
     const { conversationId } = this.decodeThreadId(threadId);
-    const raw = message.raw as XchatRawMessage | undefined;
-    let sequenceId = raw?.decrypted?.sequenceId ?? raw?.event?.sequenceId ?? "";
+    const target =
+      typeof messageIdOrMessage === "string" ? message : messageIdOrMessage;
+    const messageId =
+      typeof messageIdOrMessage === "string"
+        ? messageIdOrMessage
+        : messageIdOrMessage.id;
+    const raw = target?.raw;
+    let sequenceId =
+      raw?.decrypted?.sequenceId ??
+      raw?.event?.sequenceId ??
+      this.sequenceIdByMessageId.get(messageId) ??
+      "";
+    const client = this.getXdkClient();
+    const apiConvId = conversationPathId(conversationId, this.userId);
 
-    try {
-      const client = this.getXdkClient();
-      const apiConvId = conversationPathId(conversationId, this.userId);
+    if (!sequenceId && typeof messageIdOrMessage === "string") {
+      sequenceId = await this.resolveSequenceId(threadId, messageId);
+    }
 
-      // Fallback: mark read up to the latest event in the conversation.
+    // Fallback: mark read up to the latest event in the conversation.
+    if (!sequenceId) {
+      const response = (await client.chat.getConversationEvents(apiConvId, {
+        maxResults: 1,
+        chatMessageEventFields: [
+          ...MESSAGE_EVENT_FIELDS,
+        ] as unknown as MessageEventFields,
+      })) as unknown as ConversationEventsResponse;
+      const latest = response?.data?.[0];
+      // Event ids use a different namespace. Only a real sequence id is a
+      // valid read watermark, so fail when the latest event lacks one.
+      sequenceId = latest?.sequenceId ?? "";
       if (!sequenceId) {
-        const response = (await client.chat.getConversationEvents(apiConvId, {
-          maxResults: 1,
-          chatMessageEventFields: [
-            ...MESSAGE_EVENT_FIELDS,
-          ] as unknown as MessageEventFields,
-        })) as unknown as ConversationEventsResponse;
-        const latest = response?.data?.[0];
-        // Event ids are a different namespace — only a real sequence id is a
-        // valid read watermark, so skip when the latest event lacks one.
-        sequenceId = latest?.sequenceId ?? "";
-        if (!sequenceId) {
-          this.logger.debug("markAsRead skipped: no sequenceId available", {
-            messageId: message.id,
-            threadId,
-          });
-          return;
-        }
+        throw new ValidationError(
+          "xchat",
+          `No sequence id known for message ${messageId}`
+        );
       }
+    }
 
-      await client.chat.markConversationRead(apiConvId, {
-        seenUntilSequenceId: sequenceId,
-      });
-      this.logger.debug("Read receipt sent", {
-        conversationId: apiConvId,
-        sequenceId,
-      });
+    const response = await client.chat.markConversationRead(apiConvId, {
+      seenUntilSequenceId: sequenceId,
+    });
+    if (!response.data?.success) {
+      throw new AdapterError("XChat mark as read failed", "xchat");
+    }
+    this.logger.debug("Read receipt sent", {
+      conversationId: apiConvId,
+      sequenceId,
+    });
+  }
+
+  private async acknowledge(
+    threadId: string,
+    message: Message<XchatRawMessage>
+  ): Promise<void> {
+    try {
+      await this.markAsRead(threadId, message);
     } catch (err) {
       this.logger.warn("Failed to send read receipt", {
         threadId,

--- a/packages/adapter-x/src/chat/index.ts
+++ b/packages/adapter-x/src/chat/index.ts
@@ -2215,7 +2215,11 @@ export class XchatAdapter implements Adapter<XchatThreadId, XchatRawMessage> {
     const apiConvId = conversationPathId(conversationId, this.userId);
 
     if (!sequenceId && typeof messageIdOrMessage === "string") {
-      sequenceId = await this.resolveSequenceId(threadId, messageId);
+      // A miss here is not fatal for a read watermark: unlike edits, deletes,
+      // and reactions, we can still fall back to the latest event below.
+      sequenceId = await this.resolveSequenceId(threadId, messageId).catch(
+        () => ""
+      );
     }
 
     // Fallback: mark read up to the latest event in the conversation.

--- a/packages/adapter-x/src/chat/test-utils.ts
+++ b/packages/adapter-x/src/chat/test-utils.ts
@@ -237,7 +237,9 @@ export async function createInitializedTestAdapter(
       addConversationKeys: vi.fn(),
       deleteMessages: vi.fn(),
       getConversationEvents: vi.fn(),
-      markConversationRead: vi.fn().mockResolvedValue({ data: {} }),
+      markConversationRead: vi
+        .fn()
+        .mockResolvedValue({ data: { success: true } }),
       sendMessage: vi.fn(),
       sendTypingIndicator: vi.fn(),
       mediaDownload: vi.fn(),

--- a/packages/chat/src/mock-adapter.ts
+++ b/packages/chat/src/mock-adapter.ts
@@ -45,6 +45,7 @@ export function createMockAdapter(name = "slack"): Adapter {
     addReaction: vi.fn().mockResolvedValue(undefined),
     removeReaction: vi.fn().mockResolvedValue(undefined),
     startTyping: vi.fn().mockResolvedValue(undefined),
+    markAsRead: vi.fn().mockResolvedValue(undefined),
     fetchMessages: vi
       .fn()
       .mockResolvedValue({ messages: [], nextCursor: undefined }),

--- a/packages/chat/src/thread.test.ts
+++ b/packages/chat/src/thread.test.ts
@@ -2458,9 +2458,11 @@ describe("ThreadImpl", () => {
     });
 
     it("throws when the adapter does not support read receipts", async () => {
+      const adapter = createMockAdapter();
+      adapter.markAsRead = undefined;
       const thread = new ThreadImpl({
         id: "slack:C123:1234.5678",
-        adapter: createMockAdapter(),
+        adapter,
         channelId: "C123",
         stateAdapter: createMockState(),
         currentMessage: createTestMessage("msg-5", "Hello"),

--- a/packages/chat/src/thread.test.ts
+++ b/packages/chat/src/thread.test.ts
@@ -2361,6 +2361,142 @@ describe("ThreadImpl", () => {
     });
   });
 
+  describe("markAsRead", () => {
+    it("marks the current message when no target is provided", async () => {
+      const adapter = createMockAdapter();
+      adapter.markAsRead = vi.fn().mockResolvedValue(undefined);
+      const message = createTestMessage("msg-1", "Hello");
+      const thread = new ThreadImpl({
+        id: "slack:C123:1234.5678",
+        adapter,
+        channelId: "C123",
+        stateAdapter: createMockState(),
+        currentMessage: message,
+      });
+
+      await thread.markAsRead();
+
+      expect(adapter.markAsRead).toHaveBeenCalledWith(
+        "slack:C123:1234.5678",
+        "msg-1",
+        message
+      );
+    });
+
+    it("marks an explicit message id", async () => {
+      const adapter = createMockAdapter();
+      adapter.markAsRead = vi.fn().mockResolvedValue(undefined);
+      const thread = new ThreadImpl({
+        id: "slack:C123:1234.5678",
+        adapter,
+        channelId: "C123",
+        stateAdapter: createMockState(),
+      });
+
+      await thread.markAsRead("msg-2");
+
+      expect(adapter.markAsRead).toHaveBeenCalledWith(
+        "slack:C123:1234.5678",
+        "msg-2",
+        undefined
+      );
+    });
+
+    it("marks an explicit message", async () => {
+      const adapter = createMockAdapter();
+      adapter.markAsRead = vi.fn().mockResolvedValue(undefined);
+      const message = createTestMessage("msg-3", "Hello");
+      const thread = new ThreadImpl({
+        id: "slack:C123:1234.5678",
+        adapter,
+        channelId: "C123",
+        stateAdapter: createMockState(),
+      });
+
+      await thread.markAsRead(message);
+
+      expect(adapter.markAsRead).toHaveBeenCalledWith(
+        "slack:C123:1234.5678",
+        "msg-3",
+        message
+      );
+    });
+
+    it("rejects a message from another thread", async () => {
+      const adapter = createMockAdapter();
+      adapter.markAsRead = vi.fn().mockResolvedValue(undefined);
+      const message = createTestMessage("msg-4", "Hello", {
+        threadId: "slack:C999:9999.0000",
+      });
+      const thread = new ThreadImpl({
+        id: "slack:C123:1234.5678",
+        adapter,
+        channelId: "C123",
+        stateAdapter: createMockState(),
+      });
+
+      await expect(thread.markAsRead(message)).rejects.toThrow(
+        "Cannot mark a message from another thread as read"
+      );
+      expect(adapter.markAsRead).not.toHaveBeenCalled();
+    });
+
+    it("requires a target outside a message handler", async () => {
+      const adapter = createMockAdapter();
+      adapter.markAsRead = vi.fn().mockResolvedValue(undefined);
+      const thread = new ThreadImpl({
+        id: "slack:C123:1234.5678",
+        adapter,
+        channelId: "C123",
+        stateAdapter: createMockState(),
+      });
+
+      await expect(thread.markAsRead()).rejects.toThrow(
+        "A message is required outside a message handler"
+      );
+      expect(adapter.markAsRead).not.toHaveBeenCalled();
+    });
+
+    it("throws when the adapter does not support read receipts", async () => {
+      const thread = new ThreadImpl({
+        id: "slack:C123:1234.5678",
+        adapter: createMockAdapter(),
+        channelId: "C123",
+        stateAdapter: createMockState(),
+        currentMessage: createTestMessage("msg-5", "Hello"),
+      });
+
+      await expect(thread.markAsRead()).rejects.toThrow(NotImplementedError);
+
+      try {
+        await thread.markAsRead();
+      } catch (error) {
+        expect((error as NotImplementedError).feature).toBe("read-receipts");
+      }
+    });
+
+    it("preserves the current message through serialization", async () => {
+      const adapter = createMockAdapter();
+      adapter.markAsRead = vi.fn().mockResolvedValue(undefined);
+      const original = new ThreadImpl({
+        id: "slack:C123:1234.5678",
+        adapter,
+        channelId: "C123",
+        stateAdapter: createMockState(),
+        currentMessage: createTestMessage("msg-6", "Hello"),
+      });
+      const restored = ThreadImpl.fromJSON(original.toJSON(), adapter);
+
+      await restored.markAsRead();
+
+      expect(adapter.markAsRead).toHaveBeenCalledWith(
+        "slack:C123:1234.5678",
+        "msg-6",
+        expect.objectContaining({ id: "msg-6" })
+      );
+    });
+  });
+
   describe("mentionUser", () => {
     it("should return formatted mention string", () => {
       const mockAdapter = createMockAdapter();

--- a/packages/chat/src/thread.ts
+++ b/packages/chat/src/thread.ts
@@ -37,7 +37,7 @@ import type {
   StreamOptions,
   Thread,
 } from "./types";
-import { NotImplementedError, THREAD_STATE_TTL_MS } from "./types";
+import { ChatError, NotImplementedError, THREAD_STATE_TTL_MS } from "./types";
 
 /**
  * Serialized thread data for passing to external systems (e.g., workflow engines).
@@ -735,6 +735,36 @@ export class ThreadImpl<TState = Record<string, unknown>>
 
   async startTyping(status?: string): Promise<void> {
     await this.adapter.startTyping(this.id, status);
+  }
+
+  async markAsRead(message?: string | Message): Promise<void> {
+    if (!this.adapter.markAsRead) {
+      throw new NotImplementedError(
+        "Read receipts are not supported by this adapter",
+        "read-receipts"
+      );
+    }
+
+    const target = message ?? this._currentMessage;
+    if (!target) {
+      throw new ChatError(
+        "A message is required outside a message handler",
+        "MESSAGE_REQUIRED"
+      );
+    }
+
+    if (typeof target !== "string" && target.threadId !== this.id) {
+      throw new ChatError(
+        "Cannot mark a message from another thread as read",
+        "THREAD_MISMATCH"
+      );
+    }
+
+    await this.adapter.markAsRead(
+      this.id,
+      typeof target === "string" ? target : target.id,
+      typeof target === "string" ? undefined : target
+    );
   }
 
   /**

--- a/packages/chat/src/types.ts
+++ b/packages/chat/src/types.ts
@@ -389,11 +389,24 @@ export interface Adapter<TThreadId = unknown, TRawMessage = unknown> {
    */
   readonly lockScope?: LockScope;
 
+  /**
+   * Send a read receipt for an inbound message.
+   *
+   * Optional: `Thread.markAsRead()` throws `NotImplementedError` when an
+   * adapter leaves this out. The full message is passed alongside its ID when
+   * the caller has one, so adapters can read platform data off `message.raw`
+   * instead of resolving the ID themselves.
+   *
+   * @param threadId - Thread containing the message
+   * @param messageId - ID of the message to acknowledge
+   * @param message - The message itself, when the caller has it
+   */
   markAsRead?(
     threadId: string,
     messageId: string,
     message?: Message<TRawMessage>
   ): Promise<void>;
+
   /** Unique name for this adapter (e.g., "slack", "teams") */
   readonly name: string;
 
@@ -1191,6 +1204,19 @@ export interface Thread<TState = Record<string, unknown>, TRawMessage = unknown>
    */
   isSubscribed(): Promise<boolean>;
 
+  /**
+   * Send a read receipt for an inbound message.
+   *
+   * Defaults to the message being handled, so it takes no argument inside a
+   * message handler. Pass a `Message` or a message ID to target one explicitly;
+   * a `Message` must belong to this thread.
+   *
+   * Platforms may treat the receipt as a watermark and mark earlier messages
+   * read along with the target.
+   *
+   * @param message - Message or message ID to acknowledge; defaults to the current message
+   * @throws NotImplementedError when the adapter does not support read receipts
+   */
   markAsRead(message?: string | Message<TRawMessage>): Promise<void>;
 
   /**

--- a/packages/chat/src/types.ts
+++ b/packages/chat/src/types.ts
@@ -388,6 +388,12 @@ export interface Adapter<TThreadId = unknown, TRawMessage = unknown> {
    * Can be overridden by `ChatConfig.lockScope`.
    */
   readonly lockScope?: LockScope;
+
+  markAsRead?(
+    threadId: string,
+    messageId: string,
+    message?: Message<TRawMessage>
+  ): Promise<void>;
   /** Unique name for this adapter (e.g., "slack", "teams") */
   readonly name: string;
 
@@ -1184,6 +1190,8 @@ export interface Thread<TState = Record<string, unknown>, TRawMessage = unknown>
    * @returns Promise resolving to true if subscribed, false otherwise
    */
   isSubscribed(): Promise<boolean>;
+
+  markAsRead(message?: string | Message<TRawMessage>): Promise<void>;
 
   /**
    * Get a platform-specific mention string for a user.


### PR DESCRIPTION
## summary

- add `thread.markAsRead()` for the current message, an explicit `Message`, or a message ID
- expose read receipts as an optional adapter capability with explicit unsupported and thread mismatch errors
- support WhatsApp read acknowledgements, Messenger `mark_seen`, and XChat read watermarks
- preserve automatic XChat receipts while allowing manual timing and surfacing explicit failures
- document provider-specific behavior and capability support
- closes #785

## test plan

- verify current-message and explicit-message read acknowledgements
- verify unsupported adapters, missing message context, and cross-thread validation
- verify WhatsApp request payloads and unsuccessful responses
- verify Messenger `mark_seen` requests
- verify XChat sequence watermarks, response validation, and automatic receipt failure handling
- run adapter and integration tests
- run full typechecking and consistency checks
- build the documentation site
