### PR TITLE
fix(telegram): make native draft streaming opt-in

### DIFF
--- a/.changeset/tender-times-argue.md
+++ b/.changeset/tender-times-argue.md
@@ -1,5 +1,7 @@
 ---
-"@chat-adapter/telegram": patch
+"@chat-adapter/telegram": minor
 ---
 
-use post-and-edit streaming by default and make native Telegram drafts opt-in
+Use post-and-edit streaming by default and make native Telegram drafts opt-in. Streams now render the same way in every chat type; set the new `nativeStreaming: true` config option to restore draft previews in private chats.
+
+The adapter now owns the post-and-edit loop so edits stay under Telegram's per-chat rate limit. Edits are throttled to a 1100ms floor, configurable with the new `streamingEditIntervalMs` option, and a rate-limited final edit is retried once instead of failing the post.

--- a/.changeset/tender-times-argue.md
+++ b/.changeset/tender-times-argue.md
@@ -1,0 +1,5 @@
+---
+"@chat-adapter/telegram": patch
+---
+
+use post-and-edit streaming by default and make native Telegram drafts opt-in

--- a/apps/docs/content/adapters/official/telegram.mdx
+++ b/apps/docs/content/adapters/official/telegram.mdx
@@ -161,6 +161,18 @@ const telegram = createTelegramAdapter({
       description:
         "Bot username for mention detection. Auto-detected from `TELEGRAM_BOT_USERNAME` or `getMe`.",
     },
+    nativeStreaming: {
+      type: "boolean",
+      default: "false",
+      description:
+        "Use Telegram's native draft previews for streamed posts in private chats. Defaults to post-and-edit in every chat type. Config only, no env var.",
+    },
+    streamingEditIntervalMs: {
+      type: "number",
+      default: "1100",
+      description:
+        "Minimum interval between edits on the post-and-edit streaming path. Acts as a floor, so a lower Chat-level `streamingUpdateIntervalMs` is raised to this value. Config only, no env var.",
+    },
     apiUrl: {
       type: "string",
       description:
@@ -224,6 +236,14 @@ const telegram = createTelegramAdapter({ nativeStreaming: true });
 ```
 
 [Telegram clients should dismiss a draft preview](https://core.telegram.org/api/bots/ai#live-response-streaming) when the final message arrives, but draft rendering varies between clients. Keep the default when your bot must work consistently across Telegram clients.
+
+Telegram allows roughly one message per second per chat and edits count against that budget, so the post-and-edit path throttles edits to 1100ms. This is a floor: setting a lower `streamingUpdateIntervalMs` on your `Chat` instance does not push the adapter past the limit. Adjust it with `streamingEditIntervalMs`:
+
+```typescript
+const telegram = createTelegramAdapter({ streamingEditIntervalMs: 2000 });
+```
+
+If Telegram still rate limits the final edit, the adapter retries once when the requested wait is 5 seconds or less, then leaves the last successful edit in place rather than failing the post.
 
 ### Markdown formatting
 

--- a/apps/docs/content/adapters/official/telegram.mdx
+++ b/apps/docs/content/adapters/official/telegram.mdx
@@ -14,7 +14,7 @@ features:
   fileUploads: yes
   streaming:
     status: partial
-    label: Rich drafts / Post+Edit
+    label: Post+Edit / Opt-in rich drafts
   scheduledMessages: no
   cardFormat:
     status: partial
@@ -215,9 +215,19 @@ console.log(telegram.runtimeMode); // "webhook" | "polling"
 
 Use `bot.onSlashCommand` to handle Telegram bot commands such as `/status` and `/status@mybot`. Commands addressed to another bot are ignored as slash commands and continue through the normal message path.
 
+### Streaming
+
+Streams use post-and-edit by default for consistent behavior across Telegram clients. To opt into native draft previews in private chats:
+
+```typescript
+const telegram = createTelegramAdapter({ nativeStreaming: true });
+```
+
+[Telegram clients should dismiss a draft preview](https://core.telegram.org/api/bots/ai#live-response-streaming) when the final message arrives, but draft rendering varies between clients. Keep the default when your bot must work consistently across Telegram clients.
+
 ### Markdown formatting
 
-On Telegram Bot API 10.1 and newer, explicit `{ markdown }` and `{ ast }` messages use rich messages. Standard markdown gains native headings, lists, tables, task lists, formulas, details, and separate media blocks where supported by Telegram. Private chat streams use rich draft previews and persist the completed response as a rich message.
+On Telegram Bot API 10.1 and newer, explicit `{ markdown }` and `{ ast }` messages use rich messages. Standard markdown gains native headings, lists, tables, task lists, formulas, details, and separate media blocks where supported by Telegram.
 
 Plain strings, raw messages, cards, and media captions retain their existing lightweight message paths. Cards and captions use Telegram's `MarkdownV2` parse mode with context-aware escaping. Older or custom Bot API servers automatically fall back to this existing path when rich message methods are unavailable.
 

--- a/apps/docs/content/docs/streaming.mdx
+++ b/apps/docs/content/docs/streaming.mdx
@@ -63,7 +63,7 @@ await thread.post(stream);
 | Platform | Method | Description |
 |----------|--------|-------------|
 | Slack | Native streaming API | Uses Slack's `chatStream` for smooth, real-time updates |
-| Telegram | Private chat rich draft previews | Uses Telegram's `sendRichMessageDraft` in private chats, persists the final response with `sendRichMessage`, and falls back to post + edit elsewhere |
+| Telegram | Post + Edit | Posts a message then edits it as chunks arrive (throttled to ~1 edit/s). Set `nativeStreaming: true` to use `sendRichMessageDraft` previews in private chats instead, persisted with `sendRichMessage` |
 | Teams | Native (DMs) / Buffered (group chats) | Uses the Teams SDK's native `stream.emit()` for direct messages; accumulates chunks and posts one final message when no native streamer is active |
 | Google Chat | Post + Edit | Posts a message then edits it as chunks arrive |
 | Discord | Post + Edit | Posts a message then edits it as chunks arrive |

--- a/packages/adapter-telegram/README.md
+++ b/packages/adapter-telegram/README.md
@@ -147,7 +147,7 @@ console.log(telegram.runtimeMode); // "webhook" | "polling"
 
 ## Configuration
 
-All options are auto-detected from environment variables when not provided.
+Most options are auto-detected from environment variables when not provided. `nativeStreaming` and `streamingEditIntervalMs` are config only and have no environment variables.
 
 | Option | Required | Description |
 |--------|----------|-------------|
@@ -157,6 +157,8 @@ All options are auto-detected from environment variables when not provided.
 | `mode` | No | Adapter mode: `auto` (default), `webhook`, or `polling` |
 | `longPolling` | No | Optional long polling config for `getUpdates` (`timeout`, `limit`, `allowedUpdates`, `deleteWebhook`, `dropPendingUpdates`, `retryDelayMs`) |
 | `userName` | No | Bot username used for mention detection. Auto-detected from `TELEGRAM_BOT_USERNAME` or `getMe` |
+| `nativeStreaming` | No | Stream with Telegram's native draft previews in private chats. Defaults to `false`, which uses post-and-edit in every chat type |
+| `streamingEditIntervalMs` | No | Minimum interval between edits on the post-and-edit streaming path. Defaults to `1100` and acts as a floor for the Chat-level `streamingUpdateIntervalMs` |
 | `apiUrl` | No | Telegram API base URL. Auto-detected from `TELEGRAM_API_BASE_URL`. Use `apiUrl` for cross-adapter consistency; the legacy `apiBaseUrl` alias is still accepted |
 | `logger` | No | Logger instance (defaults to `ConsoleLogger("info")`) |
 
@@ -232,6 +234,12 @@ const telegram = createTelegramAdapter({ nativeStreaming: true });
 ```
 
 [Telegram clients should dismiss a draft preview](https://core.telegram.org/api/bots/ai#live-response-streaming) when the final message arrives, but draft rendering varies between clients. Keep the default when your bot must work consistently across Telegram clients.
+
+Telegram allows roughly one message per second per chat and edits count against that budget, so the post-and-edit path throttles edits to 1100ms. This is a floor: a lower `streamingUpdateIntervalMs` on your `Chat` instance does not push the adapter past the limit. Adjust it with `streamingEditIntervalMs`:
+
+```typescript
+const telegram = createTelegramAdapter({ streamingEditIntervalMs: 2000 });
+```
 
 ## Markdown formatting
 

--- a/packages/adapter-telegram/README.md
+++ b/packages/adapter-telegram/README.md
@@ -184,7 +184,7 @@ TELEGRAM_API_BASE_URL=https://api.telegram.org
 | Delete message | Yes |
 | File uploads | Yes (`sendDocument`, `sendMediaGroup`) |
 | Attachment uploads | Yes (`sendPhoto`, `sendAudio`, `sendVideo`, `sendDocument`, `sendMediaGroup`) |
-| Streaming | Private chat rich draft previews + post/edit fallback |
+| Streaming | Post/edit + opt-in private chat rich drafts |
 
 ### Rich content
 
@@ -223,9 +223,19 @@ TELEGRAM_API_BASE_URL=https://api.telegram.org
 | Fetch channel info | Yes |
 | Post channel message | Yes |
 
+## Streaming
+
+Streams use post-and-edit by default for consistent behavior across Telegram clients. To opt into native draft previews in private chats:
+
+```typescript
+const telegram = createTelegramAdapter({ nativeStreaming: true });
+```
+
+[Telegram clients should dismiss a draft preview](https://core.telegram.org/api/bots/ai#live-response-streaming) when the final message arrives, but draft rendering varies between clients. Keep the default when your bot must work consistently across Telegram clients.
+
 ## Markdown formatting
 
-On Telegram Bot API 10.1 and newer, explicit `{ markdown }` and `{ ast }` messages use rich messages, including native headings, lists, tables, task lists, formulas, details, and separate media blocks supported by the Bot API. Private chat streams use rich draft previews and persist the completed response as a rich message.
+On Telegram Bot API 10.1 and newer, explicit `{ markdown }` and `{ ast }` messages use rich messages, including native headings, lists, tables, task lists, formulas, details, and separate media blocks supported by the Bot API.
 
 Plain strings, raw messages, cards, and media captions retain their existing lightweight message paths. Cards and captions use Telegram's `MarkdownV2` parse mode with context-aware escaping. If an older or custom Bot API server does not support rich message methods, the adapter automatically falls back to the existing MarkdownV2 path.
 

--- a/packages/adapter-telegram/src/index.test.ts
+++ b/packages/adapter-telegram/src/index.test.ts
@@ -1988,7 +1988,7 @@ describe("TelegramAdapter", () => {
     expect(sendMessageBody.rich_message.markdown).toBe("hello");
   });
 
-  it("streams draft updates for private chats and sends a final message", async () => {
+  it("streams draft updates when native streaming is enabled", async () => {
     mockFetch
       .mockResolvedValueOnce(
         telegramOk({
@@ -2015,6 +2015,7 @@ describe("TelegramAdapter", () => {
       botToken: "token",
       mode: "webhook",
       logger: mockLogger,
+      nativeStreaming: true,
       userName: "mybot",
     });
 
@@ -2094,6 +2095,7 @@ describe("TelegramAdapter", () => {
       botToken: "token",
       mode: "webhook",
       logger: mockLogger,
+      nativeStreaming: true,
       userName: "mybot",
     });
 
@@ -2177,6 +2179,7 @@ describe("TelegramAdapter", () => {
       botToken: "token",
       mode: "webhook",
       logger: mockLogger,
+      nativeStreaming: true,
       userName: "mybot",
     });
 
@@ -2248,6 +2251,7 @@ describe("TelegramAdapter", () => {
       botToken: "token",
       mode: "webhook",
       logger: mockLogger,
+      nativeStreaming: true,
       userName: "mybot",
     });
 
@@ -2262,6 +2266,39 @@ describe("TelegramAdapter", () => {
     });
 
     expect(result).toBeNull();
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns null before consuming private streams by default", async () => {
+    mockFetch.mockResolvedValueOnce(
+      telegramOk({
+        id: 999,
+        is_bot: true,
+        first_name: "Bot",
+        username: "mybot",
+      })
+    );
+
+    const adapter = createTelegramAdapter({
+      botToken: "token",
+      mode: "webhook",
+      userName: "mybot",
+    });
+
+    await adapter.initialize(createMockChat());
+
+    let consumed = false;
+    async function* stream(): AsyncIterable<string> {
+      consumed = true;
+      yield "hello";
+    }
+
+    const result = await adapter.stream("telegram:123", stream(), {
+      updateIntervalMs: 0,
+    });
+
+    expect(result).toBeNull();
+    expect(consumed).toBe(false);
     expect(mockFetch).toHaveBeenCalledTimes(1);
   });
 
@@ -2291,6 +2328,7 @@ describe("TelegramAdapter", () => {
       botToken: "token",
       mode: "webhook",
       logger: mockLogger,
+      nativeStreaming: true,
       userName: "mybot",
     });
 
@@ -2361,6 +2399,7 @@ describe("TelegramAdapter", () => {
       botToken: "token",
       mode: "webhook",
       logger: mockLogger,
+      nativeStreaming: true,
       userName: "mybot",
     });
 
@@ -3458,6 +3497,7 @@ describe("TelegramAdapter", () => {
       botToken: "token",
       mode: "webhook",
       logger: mockLogger,
+      nativeStreaming: true,
       userName: "mybot",
     });
 
@@ -3527,6 +3567,7 @@ describe("TelegramAdapter", () => {
       botToken: "token",
       mode: "webhook",
       logger: mockLogger,
+      nativeStreaming: true,
       userName: "mybot",
     });
 

--- a/packages/adapter-telegram/src/index.test.ts
+++ b/packages/adapter-telegram/src/index.test.ts
@@ -119,6 +119,22 @@ function sampleMessage(overrides?: Partial<TelegramMessage>): TelegramMessage {
   };
 }
 
+function groupStreamMessage(text: string): TelegramMessage {
+  return sampleMessage({
+    chat: { id: -100_123, title: "Group", type: "supergroup" },
+    message_id: 21,
+    text,
+  });
+}
+
+/** Bot API method names in call order, e.g. ["getMe", "sendMessage"]. */
+function telegramMethods(): string[] {
+  return mockFetch.mock.calls.map(([url]) => {
+    const { pathname } = new URL(String(url));
+    return pathname.slice(pathname.lastIndexOf("/") + 1);
+  });
+}
+
 function readFormData(callIndex: number): FormData {
   const body = mockFetch.mock.calls[callIndex]?.[1]?.body;
   if (!(body instanceof FormData)) {
@@ -2237,15 +2253,18 @@ describe("TelegramAdapter", () => {
     expect(finalSendBody.rich_message.markdown).toBe(longMarkdown);
   });
 
-  it("returns null for non-DM streaming so Chat SDK can use fallback streaming", async () => {
-    mockFetch.mockResolvedValueOnce(
-      telegramOk({
-        id: 999,
-        is_bot: true,
-        first_name: "Bot",
-        username: "mybot",
-      })
-    );
+  it("streams non-DM chats with post-and-edit even when nativeStreaming is on", async () => {
+    mockFetch
+      .mockResolvedValueOnce(
+        telegramOk({
+          id: 999,
+          is_bot: true,
+          first_name: "Bot",
+          username: "mybot",
+        })
+      )
+      .mockResolvedValueOnce(telegramOk(groupStreamMessage("...")))
+      .mockResolvedValueOnce(telegramOk(groupStreamMessage("hello world")));
 
     const adapter = createTelegramAdapter({
       botToken: "token",
@@ -2259,37 +2278,168 @@ describe("TelegramAdapter", () => {
 
     async function* textStream(): AsyncIterable<string> {
       yield "hello";
+      yield " world";
     }
 
     const result = await adapter.stream("telegram:-100123", textStream(), {
       updateIntervalMs: 0,
     });
 
-    expect(result).toBeNull();
-    expect(mockFetch).toHaveBeenCalledTimes(1);
+    expect(result).not.toBeNull();
+    expect(telegramMethods()).toEqual([
+      "getMe",
+      "sendMessage",
+      "editMessageText",
+    ]);
   });
 
-  it("returns null before consuming private streams by default", async () => {
-    mockFetch.mockResolvedValueOnce(
-      telegramOk({
-        id: 999,
-        is_bot: true,
-        first_name: "Bot",
-        username: "mybot",
-      })
-    );
+  it("streams private chats with post-and-edit by default", async () => {
+    mockFetch
+      .mockResolvedValueOnce(
+        telegramOk({
+          id: 999,
+          is_bot: true,
+          first_name: "Bot",
+          username: "mybot",
+        })
+      )
+      .mockResolvedValueOnce(telegramOk(sampleMessage({ text: "..." })))
+      .mockResolvedValueOnce(
+        telegramOk(sampleMessage({ text: "hello world" }))
+      );
 
     const adapter = createTelegramAdapter({
       botToken: "token",
       mode: "webhook",
+      logger: mockLogger,
       userName: "mybot",
     });
 
     await adapter.initialize(createMockChat());
 
-    let consumed = false;
     async function* stream(): AsyncIterable<string> {
-      consumed = true;
+      yield "hello";
+      yield " world";
+    }
+
+    const result = await adapter.stream("telegram:123", stream(), {
+      updateIntervalMs: 0,
+    });
+
+    expect(result).not.toBeNull();
+    expect(telegramMethods()).toEqual([
+      "getMe",
+      "sendMessage",
+      "editMessageText",
+    ]);
+    expect(telegramMethods().some((method) => method.includes("Draft"))).toBe(
+      false
+    );
+  });
+
+  it("raises a lower core update interval to the Telegram edit floor", async () => {
+    mockFetch
+      .mockResolvedValueOnce(
+        telegramOk({
+          id: 999,
+          is_bot: true,
+          first_name: "Bot",
+          username: "mybot",
+        })
+      )
+      // A Response body can only be read once, so build a fresh one per call.
+      .mockImplementation(() =>
+        Promise.resolve(telegramOk(sampleMessage({ text: "chunk" })))
+      );
+
+    const adapter = createTelegramAdapter({
+      botToken: "token",
+      mode: "webhook",
+      logger: mockLogger,
+      userName: "mybot",
+    });
+
+    await adapter.initialize(createMockChat());
+
+    async function* stream(): AsyncIterable<string> {
+      yield "one ";
+      yield "two ";
+      yield "three";
+    }
+
+    // The core default of 500ms is below Telegram's ~1 msg/sec per-chat limit,
+    // so every chunk collapses into the single final edit.
+    await adapter.stream("telegram:123", stream(), { updateIntervalMs: 500 });
+
+    expect(
+      telegramMethods().filter((method) => method === "editMessageText")
+    ).toHaveLength(1);
+  });
+
+  it("edits per chunk when streamingEditIntervalMs opts out of throttling", async () => {
+    mockFetch
+      .mockResolvedValueOnce(
+        telegramOk({
+          id: 999,
+          is_bot: true,
+          first_name: "Bot",
+          username: "mybot",
+        })
+      )
+      // A Response body can only be read once, so build a fresh one per call.
+      .mockImplementation(() =>
+        Promise.resolve(telegramOk(sampleMessage({ text: "chunk" })))
+      );
+
+    const adapter = createTelegramAdapter({
+      botToken: "token",
+      mode: "webhook",
+      logger: mockLogger,
+      streamingEditIntervalMs: 0,
+      userName: "mybot",
+    });
+
+    await adapter.initialize(createMockChat());
+
+    async function* stream(): AsyncIterable<string> {
+      yield "one ";
+      yield "two ";
+      yield "three";
+    }
+
+    await adapter.stream("telegram:123", stream(), { updateIntervalMs: 0 });
+
+    expect(
+      telegramMethods().filter((method) => method === "editMessageText").length
+    ).toBeGreaterThan(1);
+  });
+
+  it("retries the final streamed edit once when Telegram rate limits it", async () => {
+    mockFetch
+      .mockResolvedValueOnce(
+        telegramOk({
+          id: 999,
+          is_bot: true,
+          first_name: "Bot",
+          username: "mybot",
+        })
+      )
+      .mockResolvedValueOnce(telegramOk(sampleMessage({ text: "..." })))
+      .mockResolvedValueOnce(
+        telegramError(429, 429, "Too Many Requests", { retry_after: 0 })
+      )
+      .mockResolvedValueOnce(telegramOk(sampleMessage({ text: "hello" })));
+
+    const adapter = createTelegramAdapter({
+      botToken: "token",
+      mode: "webhook",
+      logger: mockLogger,
+      userName: "mybot",
+    });
+
+    await adapter.initialize(createMockChat());
+
+    async function* stream(): AsyncIterable<string> {
       yield "hello";
     }
 
@@ -2297,9 +2447,50 @@ describe("TelegramAdapter", () => {
       updateIntervalMs: 0,
     });
 
-    expect(result).toBeNull();
-    expect(consumed).toBe(false);
-    expect(mockFetch).toHaveBeenCalledTimes(1);
+    expect(result).not.toBeNull();
+    expect(
+      telegramMethods().filter((method) => method === "editMessageText")
+    ).toHaveLength(2);
+  });
+
+  it("keeps the last successful edit when the final retry_after exceeds the cap", async () => {
+    mockFetch
+      .mockResolvedValueOnce(
+        telegramOk({
+          id: 999,
+          is_bot: true,
+          first_name: "Bot",
+          username: "mybot",
+        })
+      )
+      .mockResolvedValueOnce(telegramOk(sampleMessage({ text: "..." })))
+      .mockResolvedValueOnce(
+        telegramError(429, 429, "Too Many Requests", { retry_after: 30 })
+      );
+
+    const adapter = createTelegramAdapter({
+      botToken: "token",
+      mode: "webhook",
+      logger: mockLogger,
+      userName: "mybot",
+    });
+
+    await adapter.initialize(createMockChat());
+
+    async function* stream(): AsyncIterable<string> {
+      yield "hello";
+    }
+
+    // The placeholder message is still returned rather than rejecting out of
+    // thread.post() and stranding the caller.
+    const result = await adapter.stream("telegram:123", stream(), {
+      updateIntervalMs: 0,
+    });
+
+    expect(result).not.toBeNull();
+    expect(
+      telegramMethods().filter((method) => method === "editMessageText")
+    ).toHaveLength(1);
   });
 
   it("renders MarkdownV2 when rich draft streaming is unavailable", async () => {

--- a/packages/adapter-telegram/src/index.ts
+++ b/packages/adapter-telegram/src/index.ts
@@ -294,6 +294,7 @@ export class TelegramAdapter
   private _mentionRegex?: RegExp;
   protected readonly hasExplicitUserName: boolean;
   protected readonly mode: TelegramAdapterMode;
+  protected readonly nativeStreaming: boolean;
   protected readonly longPolling?: TelegramLongPollingConfig;
   private _runtimeMode: TelegramRuntimeMode = "webhook";
   private pollingAbortController: AbortController | null = null;
@@ -350,6 +351,7 @@ export class TelegramAdapter
     this._userName = this.normalizeUserName(userName ?? "bot");
     this.hasExplicitUserName = Boolean(userName);
     this.mode = config.mode ?? "auto";
+    this.nativeStreaming = config.nativeStreaming ?? false;
     this.longPolling = config.longPolling;
 
     if (!["auto", "webhook", "polling"].includes(this.mode)) {
@@ -1460,7 +1462,7 @@ export class TelegramAdapter
     textStream: AsyncIterable<string | StreamChunk>,
     options?: StreamOptions
   ): Promise<RawMessage<TelegramRawMessage> | null> {
-    if (!this.isDM(threadId)) {
+    if (!(this.nativeStreaming && this.isDM(threadId))) {
       return null;
     }
 

--- a/packages/adapter-telegram/src/index.ts
+++ b/packages/adapter-telegram/src/index.ts
@@ -117,6 +117,12 @@ const TELEGRAM_DEFAULT_POLLING_TIMEOUT_SECONDS = 30;
 const TELEGRAM_DEFAULT_POLLING_LIMIT = 100;
 const TELEGRAM_DEFAULT_POLLING_RETRY_DELAY_MS = 1000;
 const TELEGRAM_DEFAULT_STREAM_UPDATE_INTERVAL_MS = 250;
+// Telegram allows roughly one message per second per chat and edits count
+// against that budget, so the post-and-edit path throttles harder than the
+// draft path (drafts are not persisted messages).
+const TELEGRAM_DEFAULT_STREAMING_EDIT_INTERVAL_MS = 1100;
+const TELEGRAM_STREAM_FINAL_EDIT_RETRY_CAP_MS = 5000;
+const TELEGRAM_STREAM_PLACEHOLDER_TEXT = "...";
 const TELEGRAM_INCOMING_MEDIA_GROUP_BUFFER_TTL_MS = 30_000;
 const TELEGRAM_INCOMING_MEDIA_GROUP_LOCK_TTL_MS = 5_000;
 const TELEGRAM_INCOMING_MEDIA_GROUP_RETRY_MS = 50;
@@ -295,6 +301,7 @@ export class TelegramAdapter
   protected readonly hasExplicitUserName: boolean;
   protected readonly mode: TelegramAdapterMode;
   protected readonly nativeStreaming: boolean;
+  protected readonly streamingEditIntervalMs: number;
   protected readonly longPolling?: TelegramLongPollingConfig;
   private _runtimeMode: TelegramRuntimeMode = "webhook";
   private pollingAbortController: AbortController | null = null;
@@ -352,6 +359,12 @@ export class TelegramAdapter
     this.hasExplicitUserName = Boolean(userName);
     this.mode = config.mode ?? "auto";
     this.nativeStreaming = config.nativeStreaming ?? false;
+    this.streamingEditIntervalMs = this.clampInteger(
+      config.streamingEditIntervalMs,
+      TELEGRAM_DEFAULT_STREAMING_EDIT_INTERVAL_MS,
+      0,
+      Number.MAX_SAFE_INTEGER
+    );
     this.longPolling = config.longPolling;
 
     if (!["auto", "webhook", "polling"].includes(this.mode)) {
@@ -1462,10 +1475,181 @@ export class TelegramAdapter
     textStream: AsyncIterable<string | StreamChunk>,
     options?: StreamOptions
   ): Promise<RawMessage<TelegramRawMessage> | null> {
-    if (!(this.nativeStreaming && this.isDM(threadId))) {
-      return null;
+    if (this.nativeStreaming && this.isDM(threadId)) {
+      return await this.nativeDraftStream(threadId, textStream, options);
     }
 
+    return await this.postAndEditStream(threadId, textStream, options);
+  }
+
+  /**
+   * Post a placeholder message and edit it as chunks arrive.
+   *
+   * The adapter owns this loop rather than deferring to the chat core's
+   * fallback so edits can be throttled to Telegram's per-chat rate limit,
+   * which the core interval (500ms by default) sits under.
+   */
+  private async postAndEditStream(
+    threadId: string,
+    textStream: AsyncIterable<string | StreamChunk>,
+    options?: StreamOptions
+  ): Promise<RawMessage<TelegramRawMessage>> {
+    // Treat the adapter interval as a floor: a lower Chat-level
+    // streamingUpdateIntervalMs must not push us past Telegram's limit.
+    const intervalMs = Math.max(
+      this.clampInteger(
+        options?.updateIntervalMs,
+        0,
+        0,
+        Number.MAX_SAFE_INTEGER
+      ),
+      this.streamingEditIntervalMs
+    );
+    const placeholderText =
+      options?.fallbackStreamingPlaceholderText === undefined
+        ? TELEGRAM_STREAM_PLACEHOLDER_TEXT
+        : options.fallbackStreamingPlaceholderText;
+
+    const renderer = new StreamingMarkdownRenderer();
+    let accumulated = "";
+    let posted: RawMessage<TelegramRawMessage> | null = null;
+    let editThreadId = threadId;
+    let lastEditContent = "";
+    let lastEditAt = 0;
+
+    if (placeholderText !== null) {
+      posted = await this.postMessage(threadId, placeholderText);
+      editThreadId = posted.threadId || threadId;
+      lastEditContent = placeholderText;
+      lastEditAt = Date.now();
+    }
+
+    const applyEdit = async (content: string): Promise<void> => {
+      if (!posted) {
+        return;
+      }
+
+      posted = await this.editMessage(editThreadId, posted.id, {
+        markdown: content,
+      });
+      editThreadId = posted.threadId || editThreadId;
+      lastEditContent = content;
+      lastEditAt = Date.now();
+    };
+
+    const shouldEdit = (content: string): boolean =>
+      Boolean(posted) &&
+      content.trim().length > 0 &&
+      content !== lastEditContent;
+
+    const flushEdit = async (content: string): Promise<void> => {
+      if (!shouldEdit(content)) {
+        return;
+      }
+
+      try {
+        await applyEdit(content);
+      } catch (error) {
+        this.logger.warn("Telegram stream edit failed", {
+          error: String(error),
+          threadId,
+        });
+      }
+    };
+
+    const flushFinalEdit = async (content: string): Promise<void> => {
+      if (!shouldEdit(content)) {
+        return;
+      }
+
+      try {
+        await applyEdit(content);
+        return;
+      } catch (error) {
+        if (!(error instanceof AdapterRateLimitError)) {
+          throw error;
+        }
+
+        // The final edit carries the complete response, so it earns one retry
+        // when Telegram tells us how long to wait. Anything longer than the cap
+        // is left as the last successful edit rather than stalling the caller.
+        const retryAfterMs = (error.retryAfter ?? 1) * 1000;
+        if (retryAfterMs > TELEGRAM_STREAM_FINAL_EDIT_RETRY_CAP_MS) {
+          this.logger.warn("Telegram stream final edit rate limited", {
+            error: String(error),
+            threadId,
+          });
+          return;
+        }
+
+        await this.sleep(retryAfterMs);
+      }
+
+      try {
+        await applyEdit(content);
+      } catch (retryError) {
+        this.logger.warn("Telegram stream final edit failed", {
+          error: String(retryError),
+          threadId,
+        });
+      }
+    };
+
+    for await (const chunk of textStream) {
+      let text: string | null = null;
+      if (typeof chunk === "string") {
+        text = chunk;
+      } else if (chunk.type === "markdown_text") {
+        text = chunk.text;
+      }
+
+      if (text === null) {
+        continue;
+      }
+
+      accumulated += text;
+      renderer.push(text);
+
+      if (posted) {
+        if (Date.now() - lastEditAt >= intervalMs) {
+          await flushEdit(renderer.render());
+        }
+        continue;
+      }
+
+      const initial = renderer.render();
+      if (initial.trim()) {
+        posted = await this.postMessage(threadId, { markdown: initial });
+        editThreadId = posted.threadId || threadId;
+        lastEditContent = initial;
+        lastEditAt = Date.now();
+      }
+    }
+
+    const finalContent = renderer.finish();
+
+    if (posted) {
+      await flushFinalEdit(finalContent);
+      return posted;
+    }
+
+    // Nothing was posted: the caller suppressed the placeholder and the stream
+    // produced no renderable text.
+    if (!accumulated.trim()) {
+      throw new ValidationError(
+        "telegram",
+        "Telegram streaming requires text content"
+      );
+    }
+
+    return await this.postMessage(threadId, { markdown: accumulated });
+  }
+
+  private async nativeDraftStream(
+    threadId: string,
+    textStream: AsyncIterable<string | StreamChunk>,
+    options?: StreamOptions
+  ): Promise<RawMessage<TelegramRawMessage>> {
     const parsedThread = this.resolveThreadId(threadId);
     const updateIntervalMs = this.clampInteger(
       options?.updateIntervalMs,

--- a/packages/adapter-telegram/src/types.ts
+++ b/packages/adapter-telegram/src/types.ts
@@ -27,9 +27,23 @@ export interface TelegramAdapterConfig {
    * - polling: polling-only mode
    */
   mode?: TelegramAdapterMode;
+  /**
+   * Use Telegram's native draft previews (`sendRichMessageDraft`, persisted
+   * with `sendRichMessage`) for streamed posts in private chats. Defaults to
+   * false, so streams use post-and-edit everywhere for consistent rendering
+   * across Telegram clients. Group, supergroup, and channel streams always use
+   * post-and-edit regardless of this setting.
+   */
   nativeStreaming?: boolean;
   /** Optional webhook secret token checked against x-telegram-bot-api-secret-token. Defaults to TELEGRAM_WEBHOOK_SECRET_TOKEN env var. */
   secretToken?: string;
+  /**
+   * Minimum interval between edits on the post-and-edit streaming path.
+   * Telegram allows roughly one message per second per chat and edits count
+   * against that budget, so this acts as a floor: a lower Chat-level
+   * `streamingUpdateIntervalMs` is raised to this value. Defaults to 1100.
+   */
+  streamingEditIntervalMs?: number;
   /** Override bot username (optional). Defaults to TELEGRAM_BOT_USERNAME env var. */
   userName?: string;
 }

--- a/packages/adapter-telegram/src/types.ts
+++ b/packages/adapter-telegram/src/types.ts
@@ -27,6 +27,7 @@ export interface TelegramAdapterConfig {
    * - polling: polling-only mode
    */
   mode?: TelegramAdapterMode;
+  nativeStreaming?: boolean;
   /** Optional webhook secret token checked against x-telegram-bot-api-secret-token. Defaults to TELEGRAM_WEBHOOK_SECRET_TOKEN env var. */
   secretToken?: string;
   /** Override bot username (optional). Defaults to TELEGRAM_BOT_USERNAME env var. */

--- a/packages/chat/src/adapters/index.ts
+++ b/packages/chat/src/adapters/index.ts
@@ -995,6 +995,7 @@ export const ADAPTERS = {
     description:
       "Connect to Telegram with support for groups, channels, and inline keyboards.",
     env: {
+      config: ["nativeStreaming", "streamingEditIntervalMs"],
       optional: [
         env(
           "TELEGRAM_ALLOWED_USER_IDS",

--- a/packages/integration-tests/src/replay-telegram.test.ts
+++ b/packages/integration-tests/src/replay-telegram.test.ts
@@ -142,4 +142,26 @@ describe("Replay Tests - Telegram", () => {
       })
     );
   });
+
+  it("streams with post and edit by default", async () => {
+    await sendWebhook(fixtures.mention);
+    mockApi.clearMocks();
+
+    const thread = captured.mentionThread;
+    if (!thread) {
+      throw new Error("Expected mention thread");
+    }
+
+    async function* stream(): AsyncIterable<string> {
+      yield "hello";
+      yield " world";
+    }
+
+    await thread.post(stream());
+
+    expect(mockApi.calls.map(({ method }) => method)).toEqual([
+      "sendMessage",
+      "editMessageText",
+    ]);
+  });
 });


### PR DESCRIPTION
## summary

- use post-and-edit streaming by default to avoid leaked draft previews in Telegram clients
- add `nativeStreaming: true` for explicitly enabling native draft previews in private chats
- preserve existing native streaming behavior when enabled
- document the client compatibility tradeoff
- closes #782

before: private chat streams used native Telegram drafts by default, which could remain visible over the final message on Telegram macOS

after: streams use post-and-edit by default across Telegram clients, while native drafts remain available as an opt-in

## test plan

- verify the default returns control to post-and-edit without consuming the stream
- verify `thread.post(stream)` uses `sendMessage` and `editMessageText` without calling a draft API
- verify native draft streaming still works when explicitly enabled
- run Telegram adapter tests
- run integration tests
- run typecheck, build, and formatting checks
- verify the behavior against the current Telegram Bot API and live response streaming documentation