### PR TITLE
fix(discord): preserve forwarded message snapshots

### DIFF
--- a/.changeset/discord-forwarded-snapshots.md
+++ b/.changeset/discord-forwarded-snapshots.md
@@ -1,0 +1,5 @@
+---
+"@chat-adapter/discord": patch
+---
+
+Preserve content and attachments from forwarded Discord message snapshots.

--- a/packages/adapter-discord/src/index.test.ts
+++ b/packages/adapter-discord/src/index.test.ts
@@ -1209,6 +1209,32 @@ describe("parseMessage", () => {
     expect(message.attachments?.[0].fetchData).toEqual(expect.any(Function));
   });
 
+  it("handles a message without attachments", () => {
+    const raw = {
+      id: "message123",
+      channel_id: "channel456",
+      author: {
+        id: "user123",
+        username: "testuser",
+      },
+      content: "Message without attachments",
+      timestamp: "2021-01-01T00:00:00.000Z",
+      edited_timestamp: null,
+      tts: false,
+      mention_everyone: false,
+      mentions: [],
+      mention_roles: [],
+      embeds: [],
+      pinned: false,
+      type: 0,
+    };
+
+    const message = adapter.parseMessage(raw);
+
+    expect(message.text).toBe("Message without attachments");
+    expect(message.attachments).toEqual([]);
+  });
+
   it("parses outer and snapshot content and attachments", () => {
     const rawMessage = {
       id: "message123",

--- a/packages/adapter-discord/src/index.test.ts
+++ b/packages/adapter-discord/src/index.test.ts
@@ -3930,6 +3930,67 @@ describe("legacy gateway interactions", () => {
     );
   });
 
+  it("reads content and attachments from forwarded message snapshots", async () => {
+    const adapter = new TestGatewayDiscordAdapter({
+      botToken: "test-token",
+      publicKey: testPublicKey,
+      applicationId: "test-app-id",
+      logger: mockLogger,
+      respondToChannelIds: ["channel456"],
+    });
+    const chat = createMockChatInstance();
+    await adapter.initialize(chat);
+
+    const client = createGatewayClient();
+    adapter.listen(client);
+    client.emit(Events.MessageCreate, {
+      id: "forwarded-message",
+      channelId: "thread789",
+      guildId: "guild1",
+      content: "",
+      author: {
+        id: "user789",
+        username: "testuser",
+        displayName: "Test User",
+        bot: false,
+      },
+      mentions: { everyone: false, roles: [], has: () => false },
+      channel: { isThread: () => true, parentId: "channel456" },
+      createdAt: new Date("2026-08-14T15:39:39.136Z"),
+      editedAt: null,
+      attachments: [],
+      messageSnapshots: [
+        {
+          content: "Forwarded voice note",
+          attachments: [
+            {
+              contentType: "audio/ogg",
+              url: "https://cdn.discordapp.com/attachments/1/2/voice.ogg",
+              name: "voice.ogg",
+              size: 1234,
+            },
+          ],
+        },
+      ],
+    });
+    await waitForGatewayHandlers();
+
+    expect(chat.handleIncomingMessage).toHaveBeenCalledWith(
+      adapter,
+      "discord:guild1:channel456:thread789",
+      expect.objectContaining({
+        text: "Forwarded voice note",
+        attachments: [
+          expect.objectContaining({
+            mimeType: "audio/ogg",
+            name: "voice.ogg",
+            url: "https://cdn.discordapp.com/attachments/1/2/voice.ogg",
+          }),
+        ],
+      })
+    );
+  });
+
   it("does not treat a parentless thread message as allowlisted", async () => {
     const adapter = new TestGatewayDiscordAdapter({
       botToken: "test-token",
@@ -4137,7 +4198,7 @@ describe("handleWebhook - forwarded gateway events", () => {
         id: "msg123",
         channel_id: "channel456",
         guild_id: "guild1",
-        content: "Hello from gateway",
+        content: "",
         timestamp: "2021-01-01T00:00:00.000Z",
         author: {
           id: "user789",
@@ -4145,13 +4206,21 @@ describe("handleWebhook - forwarded gateway events", () => {
           bot: false,
         },
         mentions: [],
-        attachments: [
+        attachments: [],
+        message_snapshots: [
           {
-            id: "attachment123",
-            filename: "voice.ogg",
-            size: 1234,
-            url: "https://cdn.discordapp.com/attachments/1/2/voice.ogg",
-            content_type: "audio/ogg",
+            message: {
+              content: "Forwarded voice note",
+              attachments: [
+                {
+                  id: "attachment123",
+                  filename: "voice.ogg",
+                  size: 1234,
+                  url: "https://cdn.discordapp.com/attachments/1/2/voice.ogg",
+                  content_type: "audio/ogg",
+                },
+              ],
+            },
           },
         ],
       },
@@ -4172,6 +4241,7 @@ describe("handleWebhook - forwarded gateway events", () => {
       adapter,
       expect.any(String),
       expect.objectContaining({
+        text: "Forwarded voice note",
         attachments: [
           expect.objectContaining({ fetchData: expect.any(Function) }),
         ],

--- a/packages/adapter-discord/src/index.test.ts
+++ b/packages/adapter-discord/src/index.test.ts
@@ -1209,6 +1209,79 @@ describe("parseMessage", () => {
     expect(message.attachments?.[0].fetchData).toEqual(expect.any(Function));
   });
 
+  it("parses outer and snapshot content and attachments", () => {
+    const rawMessage = {
+      id: "message123",
+      channel_id: "channel456",
+      guild_id: "guild789",
+      author: {
+        id: "user123",
+        username: "testuser",
+        discriminator: "0001",
+      },
+      content: "Outer context",
+      timestamp: "2021-01-01T00:00:00.000Z",
+      edited_timestamp: null,
+      tts: false,
+      mention_everyone: false,
+      mentions: [],
+      mention_roles: [],
+      attachments: [
+        {
+          id: "outer123",
+          filename: "outer.txt",
+          size: 100,
+          url: "https://cdn.discord.com/outer.txt",
+          proxy_url: "https://media.discord.com/outer.txt",
+          content_type: "text/plain",
+        },
+      ],
+      embeds: [],
+      pinned: false,
+      type: 0,
+      message_reference: {
+        type: 1,
+        message_id: "source123",
+        channel_id: "source456",
+        guild_id: "guild789",
+      },
+      message_snapshots: [
+        {
+          message: {
+            type: 0,
+            content: "Forwarded voice note",
+            timestamp: "2021-01-01T00:00:00.000Z",
+            edited_timestamp: null,
+            flags: 0,
+            mentions: [],
+            mention_roles: [],
+            attachments: [
+              {
+                id: "snapshot123",
+                filename: "voice.ogg",
+                size: 1234,
+                url: "https://cdn.discord.com/voice.ogg",
+                proxy_url: "https://media.discord.com/voice.ogg",
+                content_type: "audio/ogg",
+              },
+            ],
+            embeds: [],
+            components: [],
+            sticker_items: [],
+          },
+        },
+      ],
+    };
+
+    const message = adapter.parseMessage(rawMessage);
+
+    expect(message.text).toBe("Outer context\n\nForwarded voice note");
+    expect(message.attachments?.map(({ name }) => name)).toEqual([
+      "outer.txt",
+      "voice.ogg",
+    ]);
+  });
+
   it("handles different attachment types", () => {
     const createMessage = (contentType: string) => ({
       id: "message123",

--- a/packages/adapter-discord/src/index.ts
+++ b/packages/adapter-discord/src/index.ts
@@ -981,13 +981,18 @@ export class DiscordAdapter implements Adapter<DiscordThreadId, unknown> {
       channelId: parentChannelId,
       threadId: discordThreadId,
     });
+    const snapshots =
+      data.message_snapshots?.map(({ message }) => message) ?? [];
+    const text = [data.content, ...snapshots.map(({ content }) => content)]
+      .filter(Boolean)
+      .join("\n\n");
 
     // Convert to SDK Message format
     const chatMessage = new Message({
       id: data.id,
       threadId,
-      text: data.content,
-      formatted: this.formatConverter.toAst(data.content),
+      text,
+      formatted: this.formatConverter.toAst(text),
       author: {
         userId: data.author.id,
         userName: data.author.username,
@@ -999,7 +1004,10 @@ export class DiscordAdapter implements Adapter<DiscordThreadId, unknown> {
         dateSent: new Date(data.timestamp),
         edited: false,
       },
-      attachments: data.attachments.map((a) =>
+      attachments: [
+        ...data.attachments,
+        ...snapshots.flatMap(({ attachments }) => attachments),
+      ].map((a) =>
         this.rehydrateAttachment({
           type: this.getAttachmentType(a.content_type),
           url: a.url,
@@ -2498,13 +2506,18 @@ export class DiscordAdapter implements Adapter<DiscordThreadId, unknown> {
       channelId: parentChannelId,
       threadId: discordThreadId,
     });
+    const snapshots =
+      message.messageSnapshots?.map((snapshot) => snapshot) ?? [];
+    const text = [message.content, ...snapshots.map(({ content }) => content)]
+      .filter(Boolean)
+      .join("\n\n");
 
     // Convert discord.js message to our Message format
     const chatMessage = new Message({
       id: message.id,
       threadId,
-      text: message.content,
-      formatted: this.formatConverter.toAst(message.content),
+      text,
+      formatted: this.formatConverter.toAst(text),
       author: {
         userId: message.author.id,
         userName: message.author.username,
@@ -2517,7 +2530,10 @@ export class DiscordAdapter implements Adapter<DiscordThreadId, unknown> {
         edited: message.editedAt !== null,
         editedAt: message.editedAt ?? undefined,
       },
-      attachments: message.attachments.map((a) =>
+      attachments: [
+        ...message.attachments.values(),
+        ...snapshots.flatMap(({ attachments }) => [...attachments.values()]),
+      ].map((a) =>
         this.rehydrateAttachment({
           type: this.getAttachmentType(a.contentType),
           url: a.url,

--- a/packages/adapter-discord/src/index.ts
+++ b/packages/adapter-discord/src/index.ts
@@ -1943,7 +1943,7 @@ export class DiscordAdapter implements Adapter<DiscordThreadId, unknown> {
     const isMe = author.id === this.botUserId;
     const content = flatten(
       msg.content,
-      msg.attachments,
+      msg.attachments ?? [],
       msg.message_snapshots?.map(({ message }) => message) ?? []
     );
 

--- a/packages/adapter-discord/src/index.ts
+++ b/packages/adapter-discord/src/index.ts
@@ -113,6 +113,26 @@ interface DiscordFileUpload {
   mimeType?: string;
 }
 
+function flatten<T>(
+  text: string,
+  files: Iterable<T>,
+  snapshots: Iterable<{
+    attachments: { values: () => IterableIterator<T> };
+    content: string;
+  }>
+): { attachments: T[]; text: string } {
+  const items = [...snapshots];
+  return {
+    attachments: [
+      ...files,
+      ...items.flatMap((item) => [...item.attachments.values()]),
+    ],
+    text: [text, ...items.map((item) => item.content)]
+      .filter(Boolean)
+      .join("\n\n"),
+  };
+}
+
 function normalizeCredentialProvider(
   value: string | (() => string | Promise<string>)
 ): () => Promise<string> {
@@ -981,18 +1001,18 @@ export class DiscordAdapter implements Adapter<DiscordThreadId, unknown> {
       channelId: parentChannelId,
       threadId: discordThreadId,
     });
-    const snapshots =
-      data.message_snapshots?.map(({ message }) => message) ?? [];
-    const text = [data.content, ...snapshots.map(({ content }) => content)]
-      .filter(Boolean)
-      .join("\n\n");
+    const content = flatten(
+      data.content,
+      data.attachments,
+      data.message_snapshots?.map(({ message }) => message) ?? []
+    );
 
     // Convert to SDK Message format
     const chatMessage = new Message({
       id: data.id,
       threadId,
-      text,
-      formatted: this.formatConverter.toAst(text),
+      text: content.text,
+      formatted: this.formatConverter.toAst(content.text),
       author: {
         userId: data.author.id,
         userName: data.author.username,
@@ -1004,10 +1024,7 @@ export class DiscordAdapter implements Adapter<DiscordThreadId, unknown> {
         dateSent: new Date(data.timestamp),
         edited: false,
       },
-      attachments: [
-        ...data.attachments,
-        ...snapshots.flatMap(({ attachments }) => attachments),
-      ].map((a) =>
+      attachments: content.attachments.map((a) =>
         this.rehydrateAttachment({
           type: this.getAttachmentType(a.content_type),
           url: a.url,
@@ -1924,12 +1941,17 @@ export class DiscordAdapter implements Adapter<DiscordThreadId, unknown> {
     const author = msg.author;
     const isBot = author.bot ?? false;
     const isMe = author.id === this.botUserId;
+    const content = flatten(
+      msg.content,
+      msg.attachments,
+      msg.message_snapshots?.map(({ message }) => message) ?? []
+    );
 
     return new Message({
       id: msg.id,
       threadId,
-      text: this.formatConverter.extractPlainText(msg.content),
-      formatted: this.formatConverter.toAst(msg.content),
+      text: this.formatConverter.extractPlainText(content.text),
+      formatted: this.formatConverter.toAst(content.text),
       raw,
       author: {
         userId: author.id,
@@ -1945,7 +1967,7 @@ export class DiscordAdapter implements Adapter<DiscordThreadId, unknown> {
           ? new Date(msg.edited_timestamp)
           : undefined,
       },
-      attachments: (msg.attachments || []).map((att) =>
+      attachments: content.attachments.map((att) =>
         this.rehydrateAttachment({
           type: this.getAttachmentType(att.content_type),
           url: att.url,
@@ -2506,18 +2528,18 @@ export class DiscordAdapter implements Adapter<DiscordThreadId, unknown> {
       channelId: parentChannelId,
       threadId: discordThreadId,
     });
-    const snapshots =
-      message.messageSnapshots?.map((snapshot) => snapshot) ?? [];
-    const text = [message.content, ...snapshots.map(({ content }) => content)]
-      .filter(Boolean)
-      .join("\n\n");
+    const content = flatten(
+      message.content,
+      message.attachments.values(),
+      message.messageSnapshots?.values() ?? []
+    );
 
     // Convert discord.js message to our Message format
     const chatMessage = new Message({
       id: message.id,
       threadId,
-      text,
-      formatted: this.formatConverter.toAst(text),
+      text: content.text,
+      formatted: this.formatConverter.toAst(content.text),
       author: {
         userId: message.author.id,
         userName: message.author.username,
@@ -2530,10 +2552,7 @@ export class DiscordAdapter implements Adapter<DiscordThreadId, unknown> {
         edited: message.editedAt !== null,
         editedAt: message.editedAt ?? undefined,
       },
-      attachments: [
-        ...message.attachments.values(),
-        ...snapshots.flatMap(({ attachments }) => [...attachments.values()]),
-      ].map((a) =>
+      attachments: content.attachments.map((a) =>
         this.rehydrateAttachment({
           type: this.getAttachmentType(a.contentType),
           url: a.url,

--- a/packages/adapter-discord/src/types.ts
+++ b/packages/adapter-discord/src/types.ts
@@ -446,6 +446,13 @@ export interface DiscordGatewayMessageData {
   mention_roles?: string[];
   /** Users mentioned in the message */
   mentions: Array<{ id: string; username: string }>;
+  /** Immutable content captured from a forwarded message */
+  message_snapshots?: Array<{
+    message: {
+      attachments: DiscordGatewayMessageData["attachments"];
+      content: string;
+    };
+  }>;
   /** Thread info if message is in a thread */
   thread?: {
     id: string;


### PR DESCRIPTION
Discord forwards place the original content and attachments under `message_snapshots`, while the outer message fields are empty. The Discord adapter currently reads only the outer fields in both direct Gateway and forwarded-webhook modes, so forwarded voice notes and files arrive as blank messages.

This flattens the snapshot content and attachments into the normalized Chat SDK message while preserving any outer content and attachments.

Verified with focused regressions for both Gateway modes, the full Discord adapter test suite (285 tests), typecheck, build, and repository formatting checks.
