### PR TITLE
fix(adapters): harden Telegram streaming and XChat read receipts

### DIFF
--- a/.changeset/neat-deserts-beam.md
+++ b/.changeset/neat-deserts-beam.md
@@ -1,0 +1,6 @@
+---
+"@chat-adapter/telegram": patch
+"@chat-adapter/x": patch
+---
+
+respect Telegram streaming rate limits and target XChat read receipts exactly

--- a/apps/docs/content/adapters/official/telegram.mdx
+++ b/apps/docs/content/adapters/official/telegram.mdx
@@ -169,7 +169,7 @@ const telegram = createTelegramAdapter({
     },
     streamingEditIntervalMs: {
       type: "number",
-      default: "1100",
+      default: "1100 private, 3100 other",
       description:
         "Minimum interval between edits on the post-and-edit streaming path. Acts as a floor, so a lower Chat-level `streamingUpdateIntervalMs` is raised to this value. Config only, no env var.",
     },
@@ -237,13 +237,13 @@ const telegram = createTelegramAdapter({ nativeStreaming: true });
 
 [Telegram clients should dismiss a draft preview](https://core.telegram.org/api/bots/ai#live-response-streaming) when the final message arrives, but draft rendering varies between clients. Keep the default when your bot must work consistently across Telegram clients.
 
-Telegram allows roughly one message per second per chat and edits count against that budget, so the post-and-edit path throttles edits to 1100ms. This is a floor: setting a lower `streamingUpdateIntervalMs` on your `Chat` instance does not push the adapter past the limit. Adjust it with `streamingEditIntervalMs`:
+Telegram recommends at most one message per second in a single chat and limits groups to 20 messages per minute. Sends and edits share flood control, so the post-and-edit path defaults to 1100ms between operations in private chats and 3100ms in other chats. This is a floor: setting a lower `streamingUpdateIntervalMs` on your `Chat` instance does not push the adapter past it. Override it with `streamingEditIntervalMs`:
 
 ```typescript
-const telegram = createTelegramAdapter({ streamingEditIntervalMs: 2000 });
+const telegram = createTelegramAdapter({ streamingEditIntervalMs: 4000 });
 ```
 
-If Telegram still rate limits the final edit, the adapter retries once when the requested wait is 5 seconds or less, then leaves the last successful edit in place rather than failing the post.
+If Telegram rate limits the final edit, the adapter waits and retries when the requested delay is 5 seconds or less. Longer delays and failed retries reject the post so it never reports text that Telegram did not receive.
 
 ### Markdown formatting
 

--- a/apps/docs/content/adapters/official/xchat.mdx
+++ b/apps/docs/content/adapters/official/xchat.mdx
@@ -289,7 +289,7 @@ bot.onDirectMessage(async (thread) => {
 
 Automatic receipts never interrupt a handler, since a failure is logged and swallowed. A `thread.markAsRead()` call you make yourself rejects on failure, so await it or attach a `.catch()`.
 
-When the message's sequence id is not known, such as an event the adapter could not decrypt, the watermark advances to the latest event in the conversation instead.
+When a delivered message has no sequence id, such as an event the adapter could not decrypt, the watermark advances to the latest event in the conversation. When only an explicit message id is available, the adapter replays recent history and rejects if it cannot resolve that exact message rather than advancing through newer messages.
 
 ### Thread ID format
 

--- a/packages/adapter-telegram/README.md
+++ b/packages/adapter-telegram/README.md
@@ -158,7 +158,7 @@ Most options are auto-detected from environment variables when not provided. `na
 | `longPolling` | No | Optional long polling config for `getUpdates` (`timeout`, `limit`, `allowedUpdates`, `deleteWebhook`, `dropPendingUpdates`, `retryDelayMs`) |
 | `userName` | No | Bot username used for mention detection. Auto-detected from `TELEGRAM_BOT_USERNAME` or `getMe` |
 | `nativeStreaming` | No | Stream with Telegram's native draft previews in private chats. Defaults to `false`, which uses post-and-edit in every chat type |
-| `streamingEditIntervalMs` | No | Minimum interval between edits on the post-and-edit streaming path. Defaults to `1100` and acts as a floor for the Chat-level `streamingUpdateIntervalMs` |
+| `streamingEditIntervalMs` | No | Minimum interval between edits on the post-and-edit streaming path. Defaults to `1100` in private chats and `3100` in other chats, and acts as a floor for the Chat-level `streamingUpdateIntervalMs` |
 | `apiUrl` | No | Telegram API base URL. Auto-detected from `TELEGRAM_API_BASE_URL`. Use `apiUrl` for cross-adapter consistency; the legacy `apiBaseUrl` alias is still accepted |
 | `logger` | No | Logger instance (defaults to `ConsoleLogger("info")`) |
 
@@ -235,11 +235,13 @@ const telegram = createTelegramAdapter({ nativeStreaming: true });
 
 [Telegram clients should dismiss a draft preview](https://core.telegram.org/api/bots/ai#live-response-streaming) when the final message arrives, but draft rendering varies between clients. Keep the default when your bot must work consistently across Telegram clients.
 
-Telegram allows roughly one message per second per chat and edits count against that budget, so the post-and-edit path throttles edits to 1100ms. This is a floor: a lower `streamingUpdateIntervalMs` on your `Chat` instance does not push the adapter past the limit. Adjust it with `streamingEditIntervalMs`:
+Telegram recommends at most one message per second in a single chat and limits groups to 20 messages per minute. Sends and edits share flood control, so the post-and-edit path defaults to 1100ms between operations in private chats and 3100ms in other chats. This is a floor: a lower `streamingUpdateIntervalMs` on your `Chat` instance does not push the adapter past it. Override it with `streamingEditIntervalMs`:
 
 ```typescript
-const telegram = createTelegramAdapter({ streamingEditIntervalMs: 2000 });
+const telegram = createTelegramAdapter({ streamingEditIntervalMs: 4000 });
 ```
+
+If Telegram rate limits the final edit, the adapter waits and retries when the requested delay is 5 seconds or less. Longer delays and failed retries reject the post so it never reports text that Telegram did not receive.
 
 ## Markdown formatting
 

--- a/packages/adapter-telegram/src/index.test.ts
+++ b/packages/adapter-telegram/src/index.test.ts
@@ -2271,14 +2271,14 @@ describe("TelegramAdapter", () => {
       mode: "webhook",
       logger: mockLogger,
       nativeStreaming: true,
+      streamingEditIntervalMs: 0,
       userName: "mybot",
     });
 
     await adapter.initialize(createMockChat());
 
     async function* textStream(): AsyncIterable<string> {
-      yield "hello";
-      yield " world";
+      yield "hello world";
     }
 
     const result = await adapter.stream("telegram:-100123", textStream(), {
@@ -2312,14 +2312,14 @@ describe("TelegramAdapter", () => {
       botToken: "token",
       mode: "webhook",
       logger: mockLogger,
+      streamingEditIntervalMs: 0,
       userName: "mybot",
     });
 
     await adapter.initialize(createMockChat());
 
     async function* stream(): AsyncIterable<string> {
-      yield "hello";
-      yield " world";
+      yield "hello world";
     }
 
     const result = await adapter.stream("telegram:123", stream(), {
@@ -2337,7 +2337,9 @@ describe("TelegramAdapter", () => {
     );
   });
 
-  it("raises a lower core update interval to the Telegram edit floor", async () => {
+  it("uses the private chat streaming edit floor", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(0);
     mockFetch
       .mockResolvedValueOnce(
         telegramOk({
@@ -2363,13 +2365,73 @@ describe("TelegramAdapter", () => {
 
     async function* stream(): AsyncIterable<string> {
       yield "one ";
+      vi.setSystemTime(1200);
       yield "two ";
+      vi.setSystemTime(1300);
       yield "three";
     }
 
-    // The core default of 500ms is below Telegram's ~1 msg/sec per-chat limit,
-    // so every chunk collapses into the single final edit.
-    await adapter.stream("telegram:123", stream(), { updateIntervalMs: 500 });
+    const result = adapter.stream("telegram:123", stream(), {
+      updateIntervalMs: 0,
+    });
+
+    await vi.advanceTimersByTimeAsync(999);
+    expect(
+      telegramMethods().filter((method) => method === "editMessageText")
+    ).toHaveLength(1);
+
+    await vi.advanceTimersByTimeAsync(1);
+    await result;
+
+    expect(
+      telegramMethods().filter((method) => method === "editMessageText")
+    ).toHaveLength(2);
+  });
+
+  it("uses the group streaming edit floor", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(0);
+    mockFetch
+      .mockResolvedValueOnce(
+        telegramOk({
+          id: 999,
+          is_bot: true,
+          first_name: "Bot",
+          username: "mybot",
+        })
+      )
+      .mockImplementation(() =>
+        Promise.resolve(telegramOk(groupStreamMessage("chunk")))
+      );
+
+    const adapter = createTelegramAdapter({
+      botToken: "token",
+      mode: "webhook",
+      logger: mockLogger,
+      userName: "mybot",
+    });
+
+    await adapter.initialize(createMockChat());
+
+    async function* stream(): AsyncIterable<string> {
+      yield "one ";
+      vi.setSystemTime(1200);
+      yield "two ";
+      vi.setSystemTime(1300);
+      yield "three";
+    }
+
+    const result = adapter.stream("telegram:-100123", stream(), {
+      updateIntervalMs: 0,
+    });
+
+    await vi.advanceTimersByTimeAsync(1799);
+    expect(
+      telegramMethods().filter((method) => method === "editMessageText")
+    ).toHaveLength(0);
+
+    await vi.advanceTimersByTimeAsync(1);
+    await result;
 
     expect(
       telegramMethods().filter((method) => method === "editMessageText")
@@ -2434,6 +2496,7 @@ describe("TelegramAdapter", () => {
       botToken: "token",
       mode: "webhook",
       logger: mockLogger,
+      streamingEditIntervalMs: 0,
       userName: "mybot",
     });
 
@@ -2453,7 +2516,42 @@ describe("TelegramAdapter", () => {
     ).toHaveLength(2);
   });
 
-  it("keeps the last successful edit when the final retry_after exceeds the cap", async () => {
+  it("rejects when the final streamed edit retry fails", async () => {
+    mockFetch
+      .mockResolvedValueOnce(
+        telegramOk({
+          id: 999,
+          is_bot: true,
+          first_name: "Bot",
+          username: "mybot",
+        })
+      )
+      .mockResolvedValueOnce(telegramOk(sampleMessage({ text: "..." })))
+      .mockResolvedValueOnce(
+        telegramError(429, 429, "Too Many Requests", { retry_after: 0 })
+      )
+      .mockResolvedValueOnce(telegramError(500, 500, "Internal Server Error"));
+
+    const adapter = createTelegramAdapter({
+      botToken: "token",
+      mode: "webhook",
+      logger: mockLogger,
+      streamingEditIntervalMs: 0,
+      userName: "mybot",
+    });
+
+    await adapter.initialize(createMockChat());
+
+    async function* stream(): AsyncIterable<string> {
+      yield "hello";
+    }
+
+    await expect(
+      adapter.stream("telegram:123", stream(), { updateIntervalMs: 0 })
+    ).rejects.toBeInstanceOf(NetworkError);
+  });
+
+  it("rejects when the final retry_after exceeds the cap", async () => {
     mockFetch
       .mockResolvedValueOnce(
         telegramOk({
@@ -2472,6 +2570,7 @@ describe("TelegramAdapter", () => {
       botToken: "token",
       mode: "webhook",
       logger: mockLogger,
+      streamingEditIntervalMs: 0,
       userName: "mybot",
     });
 
@@ -2481,13 +2580,51 @@ describe("TelegramAdapter", () => {
       yield "hello";
     }
 
-    // The placeholder message is still returned rather than rejecting out of
-    // thread.post() and stranding the caller.
-    const result = await adapter.stream("telegram:123", stream(), {
-      updateIntervalMs: 0,
+    await expect(
+      adapter.stream("telegram:123", stream(), { updateIntervalMs: 0 })
+    ).rejects.toBeInstanceOf(AdapterRateLimitError);
+    expect(
+      telegramMethods().filter((method) => method === "editMessageText")
+    ).toHaveLength(1);
+  });
+
+  it("respects retry_after after an intermediate streamed edit", async () => {
+    mockFetch
+      .mockResolvedValueOnce(
+        telegramOk({
+          id: 999,
+          is_bot: true,
+          first_name: "Bot",
+          username: "mybot",
+        })
+      )
+      .mockResolvedValueOnce(telegramOk(sampleMessage({ text: "..." })))
+      .mockResolvedValueOnce(
+        telegramError(429, 429, "Too Many Requests", { retry_after: 30 })
+      )
+      .mockImplementation(() =>
+        Promise.resolve(telegramOk(sampleMessage({ text: "chunk" })))
+      );
+
+    const adapter = createTelegramAdapter({
+      botToken: "token",
+      mode: "webhook",
+      logger: mockLogger,
+      streamingEditIntervalMs: 0,
+      userName: "mybot",
     });
 
-    expect(result).not.toBeNull();
+    await adapter.initialize(createMockChat());
+
+    async function* stream(): AsyncIterable<string> {
+      yield "one ";
+      yield "two ";
+      yield "three";
+    }
+
+    await expect(
+      adapter.stream("telegram:123", stream(), { updateIntervalMs: 0 })
+    ).rejects.toBeInstanceOf(AdapterRateLimitError);
     expect(
       telegramMethods().filter((method) => method === "editMessageText")
     ).toHaveLength(1);

--- a/packages/adapter-telegram/src/index.ts
+++ b/packages/adapter-telegram/src/index.ts
@@ -117,10 +117,8 @@ const TELEGRAM_DEFAULT_POLLING_TIMEOUT_SECONDS = 30;
 const TELEGRAM_DEFAULT_POLLING_LIMIT = 100;
 const TELEGRAM_DEFAULT_POLLING_RETRY_DELAY_MS = 1000;
 const TELEGRAM_DEFAULT_STREAM_UPDATE_INTERVAL_MS = 250;
-// Telegram allows roughly one message per second per chat and edits count
-// against that budget, so the post-and-edit path throttles harder than the
-// draft path (drafts are not persisted messages).
-const TELEGRAM_DEFAULT_STREAMING_EDIT_INTERVAL_MS = 1100;
+const TELEGRAM_DEFAULT_PRIVATE_STREAMING_EDIT_INTERVAL_MS = 1100;
+const TELEGRAM_DEFAULT_NON_PRIVATE_STREAMING_EDIT_INTERVAL_MS = 3100;
 const TELEGRAM_STREAM_FINAL_EDIT_RETRY_CAP_MS = 5000;
 const TELEGRAM_STREAM_PLACEHOLDER_TEXT = "...";
 const TELEGRAM_INCOMING_MEDIA_GROUP_BUFFER_TTL_MS = 30_000;
@@ -301,7 +299,7 @@ export class TelegramAdapter
   protected readonly hasExplicitUserName: boolean;
   protected readonly mode: TelegramAdapterMode;
   protected readonly nativeStreaming: boolean;
-  protected readonly streamingEditIntervalMs: number;
+  protected readonly streamingEditIntervalMs?: number;
   protected readonly longPolling?: TelegramLongPollingConfig;
   private _runtimeMode: TelegramRuntimeMode = "webhook";
   private pollingAbortController: AbortController | null = null;
@@ -359,12 +357,16 @@ export class TelegramAdapter
     this.hasExplicitUserName = Boolean(userName);
     this.mode = config.mode ?? "auto";
     this.nativeStreaming = config.nativeStreaming ?? false;
-    this.streamingEditIntervalMs = this.clampInteger(
-      config.streamingEditIntervalMs,
-      TELEGRAM_DEFAULT_STREAMING_EDIT_INTERVAL_MS,
-      0,
-      Number.MAX_SAFE_INTEGER
-    );
+    this.streamingEditIntervalMs =
+      typeof config.streamingEditIntervalMs !== "number" ||
+      !Number.isFinite(config.streamingEditIntervalMs)
+        ? undefined
+        : this.clampInteger(
+            config.streamingEditIntervalMs,
+            0,
+            0,
+            Number.MAX_SAFE_INTEGER
+          );
     this.longPolling = config.longPolling;
 
     if (!["auto", "webhook", "polling"].includes(this.mode)) {
@@ -1494,8 +1496,9 @@ export class TelegramAdapter
     textStream: AsyncIterable<string | StreamChunk>,
     options?: StreamOptions
   ): Promise<RawMessage<TelegramRawMessage>> {
-    // Treat the adapter interval as a floor: a lower Chat-level
-    // streamingUpdateIntervalMs must not push us past Telegram's limit.
+    const defaultIntervalMs = this.isDM(threadId)
+      ? TELEGRAM_DEFAULT_PRIVATE_STREAMING_EDIT_INTERVAL_MS
+      : TELEGRAM_DEFAULT_NON_PRIVATE_STREAMING_EDIT_INTERVAL_MS;
     const intervalMs = Math.max(
       this.clampInteger(
         options?.updateIntervalMs,
@@ -1503,7 +1506,7 @@ export class TelegramAdapter
         0,
         Number.MAX_SAFE_INTEGER
       ),
-      this.streamingEditIntervalMs
+      this.streamingEditIntervalMs ?? defaultIntervalMs
     );
     const placeholderText =
       options?.fallbackStreamingPlaceholderText === undefined
@@ -1516,6 +1519,8 @@ export class TelegramAdapter
     let editThreadId = threadId;
     let lastEditContent = "";
     let lastEditAt = 0;
+    let blockedUntil = 0;
+    let rateLimitError: AdapterRateLimitError | null = null;
 
     if (placeholderText !== null) {
       posted = await this.postMessage(threadId, placeholderText);
@@ -1535,6 +1540,14 @@ export class TelegramAdapter
       editThreadId = posted.threadId || editThreadId;
       lastEditContent = content;
       lastEditAt = Date.now();
+      blockedUntil = 0;
+      rateLimitError = null;
+    };
+
+    const rememberRateLimit = (error: AdapterRateLimitError): void => {
+      const retryAfterMs = Math.max(0, error.retryAfter ?? 1) * 1000;
+      blockedUntil = Math.max(blockedUntil, Date.now() + retryAfterMs);
+      rateLimitError = error;
     };
 
     const shouldEdit = (content: string): boolean =>
@@ -1550,6 +1563,9 @@ export class TelegramAdapter
       try {
         await applyEdit(content);
       } catch (error) {
+        if (error instanceof AdapterRateLimitError) {
+          rememberRateLimit(error);
+        }
         this.logger.warn("Telegram stream edit failed", {
           error: String(error),
           threadId,
@@ -1562,6 +1578,16 @@ export class TelegramAdapter
         return;
       }
 
+      const blockedMs = Math.max(0, blockedUntil - Date.now());
+      const pacingMs = Math.max(0, intervalMs - (Date.now() - lastEditAt));
+      if (
+        blockedMs > TELEGRAM_STREAM_FINAL_EDIT_RETRY_CAP_MS &&
+        rateLimitError
+      ) {
+        throw rateLimitError;
+      }
+      await this.sleep(Math.max(blockedMs, pacingMs));
+
       try {
         await applyEdit(content);
         return;
@@ -1570,29 +1596,16 @@ export class TelegramAdapter
           throw error;
         }
 
-        // The final edit carries the complete response, so it earns one retry
-        // when Telegram tells us how long to wait. Anything longer than the cap
-        // is left as the last successful edit rather than stalling the caller.
+        rememberRateLimit(error);
         const retryAfterMs = (error.retryAfter ?? 1) * 1000;
         if (retryAfterMs > TELEGRAM_STREAM_FINAL_EDIT_RETRY_CAP_MS) {
-          this.logger.warn("Telegram stream final edit rate limited", {
-            error: String(error),
-            threadId,
-          });
-          return;
+          throw error;
         }
 
         await this.sleep(retryAfterMs);
       }
 
-      try {
-        await applyEdit(content);
-      } catch (retryError) {
-        this.logger.warn("Telegram stream final edit failed", {
-          error: String(retryError),
-          threadId,
-        });
-      }
+      await applyEdit(content);
     };
 
     for await (const chunk of textStream) {
@@ -1611,7 +1624,10 @@ export class TelegramAdapter
       renderer.push(text);
 
       if (posted) {
-        if (Date.now() - lastEditAt >= intervalMs) {
+        if (
+          Date.now() >= blockedUntil &&
+          Date.now() - lastEditAt >= intervalMs
+        ) {
           await flushEdit(renderer.render());
         }
         continue;

--- a/packages/adapter-telegram/src/types.ts
+++ b/packages/adapter-telegram/src/types.ts
@@ -39,9 +39,9 @@ export interface TelegramAdapterConfig {
   secretToken?: string;
   /**
    * Minimum interval between edits on the post-and-edit streaming path.
-   * Telegram allows roughly one message per second per chat and edits count
-   * against that budget, so this acts as a floor: a lower Chat-level
-   * `streamingUpdateIntervalMs` is raised to this value. Defaults to 1100.
+   * Defaults to 1100ms for private chats and 3100ms for other chats. Acts as a
+   * floor: a lower Chat-level `streamingUpdateIntervalMs` is raised to this
+   * value.
    */
   streamingEditIntervalMs?: number;
   /** Override bot username (optional). Defaults to TELEGRAM_BOT_USERNAME env var. */

--- a/packages/adapter-x/src/chat/index.test.ts
+++ b/packages/adapter-x/src/chat/index.test.ts
@@ -1908,6 +1908,39 @@ describe("markAsRead", () => {
     }
   });
 
+  it("rejects an unresolved explicit message id", async () => {
+    const { adapter, getXdkClient, restore } =
+      await createInitializedTestAdapter();
+    try {
+      const xdk = getXdkClient();
+      xdk.chat.getConversationEvents = vi.fn().mockResolvedValue({
+        data: [
+          {
+            id: "evt-latest",
+            sequenceId: "seq-99",
+            senderId: TEST_OTHER_USER_ID,
+            conversationId: TEST_CONVERSATION_ID,
+            encodedEvent: "not-a-real-encrypted-event",
+          },
+        ],
+        meta: {},
+      });
+      xdk.users.getPublicKey = vi.fn().mockResolvedValue({ data: [] });
+      xdk.chat.markConversationRead = vi
+        .fn()
+        .mockResolvedValue({ data: { success: true } });
+
+      await expect(
+        adapter.markAsRead(TEST_THREAD_ID, "missing-message")
+      ).rejects.toThrow(NO_SEQUENCE_ID_RE);
+
+      expect(xdk.chat.getConversationEvents).toHaveBeenCalledOnce();
+      expect(xdk.chat.markConversationRead).not.toHaveBeenCalled();
+    } finally {
+      restore();
+    }
+  });
+
   it("propagates explicit read receipt failures", async () => {
     const { adapter, getXdkClient, restore } =
       await createInitializedTestAdapter();

--- a/packages/adapter-x/src/chat/index.ts
+++ b/packages/adapter-x/src/chat/index.ts
@@ -2215,11 +2215,9 @@ export class XchatAdapter implements Adapter<XchatThreadId, XchatRawMessage> {
     const apiConvId = conversationPathId(conversationId, this.userId);
 
     if (!sequenceId && typeof messageIdOrMessage === "string") {
-      // A miss here is not fatal for a read watermark: unlike edits, deletes,
-      // and reactions, we can still fall back to the latest event below.
-      sequenceId = await this.resolveSequenceId(threadId, messageId).catch(
-        () => ""
-      );
+      sequenceId = target
+        ? await this.resolveSequenceId(threadId, messageId).catch(() => "")
+        : await this.resolveSequenceId(threadId, messageId);
     }
 
     // Fallback: mark read up to the latest event in the conversation.

--- a/packages/integration-tests/src/replay-telegram.test.ts
+++ b/packages/integration-tests/src/replay-telegram.test.ts
@@ -55,6 +55,7 @@ describe("Replay Tests - Telegram", () => {
     adapter = createTelegramAdapter({
       botToken: TELEGRAM_BOT_TOKEN,
       logger: mockLogger,
+      mode: "webhook",
       userName: fixtures.botName,
     });
 


### PR DESCRIPTION
## summary

- pace Telegram post-and-edit streams for private and non-private chat limits, including the final edit
- respect Telegram `retry_after` cooldowns and reject when the complete response cannot be delivered
- prevent explicit XChat read receipts from advancing past an unresolved message
- preserve latest-event fallback for delivered XChat messages without a sequence id
- update adapter documentation and regression coverage