### PR TITLE
fix(telegram): return portable file data

### DIFF
--- a/.changeset/portable-telegram-files.md
+++ b/.changeset/portable-telegram-files.md
@@ -1,0 +1,6 @@
+---
+"@chat-adapter/telegram": patch
+"chat": patch
+---
+
+Return Telegram file downloads as portable ArrayBuffer data while preserving Buffer support in the shared attachment contract.

--- a/apps/docs/content/docs/api/message.mdx
+++ b/apps/docs/content/docs/api/message.mdx
@@ -171,7 +171,7 @@ All adapters return `false` if the bot ID isn't known yet. This is a safe defaul
     },
     'fetchData()': {
       description: 'Fetch the attachment data. Handles platform auth automatically.',
-      type: '() => Promise<Buffer> | undefined',
+      type: '() => Promise<Buffer | ArrayBuffer> | undefined',
     },
     fetchMetadata: {
       description: 'Platform-specific IDs for reconstructing fetchData after serialization (e.g. WhatsApp mediaId, Telegram fileId).',

--- a/apps/docs/content/docs/files.mdx
+++ b/apps/docs/content/docs/files.mdx
@@ -77,7 +77,7 @@ bot.onSubscribedMessage(async (thread, message) => {
 
     if (attachment.fetchData) {
       const data = await attachment.fetchData();
-      console.log(`Downloaded ${data.length} bytes`);
+      console.log(`Downloaded ${data.byteLength} bytes`);
     }
   }
 });
@@ -94,5 +94,5 @@ bot.onSubscribedMessage(async (thread, message) => {
 | `size` | `number` (optional) | File size in bytes |
 | `width` | `number` (optional) | Image width |
 | `height` | `number` (optional) | Image height |
-| `fetchData` | `() => Promise<Buffer>` (optional) | Download the file data |
+| `fetchData` | `() => Promise<Buffer \| ArrayBuffer>` (optional) | Download the file data |
 | `fetchMetadata` | `Record<string, string>` (optional) | Platform-specific IDs for reconstructing `fetchData` after serialization |

--- a/packages/adapter-telegram/src/index.test.ts
+++ b/packages/adapter-telegram/src/index.test.ts
@@ -398,7 +398,7 @@ describe("bot token resolver", () => {
 
     await (
       adapter as unknown as {
-        downloadFile(fileId: string): Promise<Buffer>;
+        downloadFile(fileId: string): Promise<Buffer | ArrayBuffer>;
       }
     ).downloadFile("file-1");
 
@@ -407,6 +407,40 @@ describe("bot token resolver", () => {
       "https://api.telegram.org/bottelegram-api-token/getFile",
       "https://api.telegram.org/file/bottelegram-file-token/documents/file.txt",
     ]);
+  });
+
+  it("downloads file bytes without the Node Buffer global", async () => {
+    const expected = new Uint8Array([0, 127, 255]);
+    mockFetch
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          ok: true,
+          result: {
+            file_id: "file-1",
+            file_path: "documents/file.bin",
+          },
+        }),
+      } as Response)
+      .mockResolvedValueOnce({
+        ok: true,
+        arrayBuffer: async () => expected.buffer,
+      } as Response);
+    const adapter = createTelegramAdapter({
+      botToken: "telegram-token",
+      mode: "webhook",
+      logger: mockLogger,
+    });
+    vi.stubGlobal("Buffer", undefined);
+
+    const data = await (
+      adapter as unknown as {
+        downloadFile(fileId: string): Promise<Buffer | ArrayBuffer>;
+      }
+    ).downloadFile("file-1");
+
+    expect(data).toBeInstanceOf(ArrayBuffer);
+    expect(new Uint8Array(data)).toEqual(expected);
   });
 
   it("scopes webhook deduplication with the stable bot identity", async () => {

--- a/packages/adapter-telegram/src/index.ts
+++ b/packages/adapter-telegram/src/index.ts
@@ -2266,7 +2266,7 @@ export class TelegramAdapter
     };
   }
 
-  protected async downloadFile(fileId: string): Promise<Buffer> {
+  protected async downloadFile(fileId: string): Promise<Buffer | ArrayBuffer> {
     const file = await this.telegramFetch<TelegramFile>("getFile", {
       file_id: fileId,
     });
@@ -2296,7 +2296,7 @@ export class TelegramAdapter
       );
     }
 
-    return Buffer.from(await response.arrayBuffer());
+    return response.arrayBuffer();
   }
 
   protected async sendDocument(

--- a/packages/adapter-x/src/index.ts
+++ b/packages/adapter-x/src/index.ts
@@ -537,9 +537,13 @@ export class XAdapter implements Adapter<XThreadId, XRawMessage> {
       });
     }
     for (const attachment of extractPostableAttachments(message)) {
-      const load = attachment.data
-        ? () => toBytes(attachment.data as Buffer | Blob)
-        : attachment.fetchData;
+      const fetchData = attachment.fetchData;
+      let load: (() => Promise<Buffer>) | undefined;
+      if (attachment.data) {
+        load = () => toBytes(attachment.data as Buffer | Blob);
+      } else if (fetchData) {
+        load = async () => toBytes(await fetchData());
+      }
       if (!load) {
         throw new ValidationError(
           "x",

--- a/packages/chat/src/ai/messages.test.ts
+++ b/packages/chat/src/ai/messages.test.ts
@@ -449,6 +449,31 @@ describe("toAiMessages", () => {
     expect(imgPart.mediaType).toBe("image/png");
   });
 
+  it("uses ArrayBuffer attachment data without Buffer conversion", async () => {
+    const data = new Uint8Array([1, 2, 3]).buffer;
+    const messages = [
+      createTestMessage("1", "Portable image", {
+        attachments: [
+          {
+            type: "image",
+            mimeType: "image/png",
+            fetchData: async () => data,
+          },
+        ],
+      }),
+    ];
+
+    const result = await toAiMessages(messages);
+    const content = result[0]?.content as AiMessagePart[];
+
+    expect(content[1]).toEqual({
+      type: "file",
+      data,
+      mediaType: "image/png",
+      filename: undefined,
+    });
+  });
+
   it("uses fetchData to inline text file as base64", async () => {
     const messages = [
       createTestMessage("1", "Here is a log", {

--- a/packages/chat/src/ai/messages.ts
+++ b/packages/chat/src/ai/messages.ts
@@ -156,7 +156,7 @@ async function attachmentToPart(
  * - Uses `message.text` for content
  * - Appends link metadata when available
  * - Includes image attachments and text files as `FilePart`
- * - Uses `fetchData()` when available to include attachment data inline (base64)
+ * - Uses `fetchData()` when available to include attachment data inline
  * - Warns on unsupported attachment types (video, audio)
  *
  * Works with `FetchResult.messages`, `thread.recentMessages`, or collected iterables.

--- a/packages/chat/src/ai/messages.ts
+++ b/packages/chat/src/ai/messages.ts
@@ -94,7 +94,7 @@ function isTextMimeType(mimeType: string): boolean {
 
 /**
  * Build an AI SDK content part from an attachment.
- * Uses fetchData to get base64 data when available.
+ * Uses fetchData to get attachment bytes when available.
  * Returns null for unsupported attachments or when fetchData is unavailable.
  */
 async function attachmentToPart(
@@ -103,11 +103,14 @@ async function attachmentToPart(
   if (att.type === "image") {
     if (att.fetchData) {
       try {
-        const buffer = await att.fetchData();
+        const data = await att.fetchData();
         const mimeType = att.mimeType ?? "image/png";
         return {
           type: "file",
-          data: `data:${mimeType};base64,${buffer.toString("base64")}`,
+          data:
+            data instanceof ArrayBuffer
+              ? data
+              : `data:${mimeType};base64,${data.toString("base64")}`,
           mediaType: mimeType,
           filename: att.name,
         };
@@ -122,10 +125,13 @@ async function attachmentToPart(
   if (att.type === "file" && att.mimeType && isTextMimeType(att.mimeType)) {
     if (att.fetchData) {
       try {
-        const buffer = await att.fetchData();
+        const data = await att.fetchData();
         return {
           type: "file",
-          data: `data:${att.mimeType};base64,${buffer.toString("base64")}`,
+          data:
+            data instanceof ArrayBuffer
+              ? data
+              : `data:${att.mimeType};base64,${data.toString("base64")}`,
           filename: att.name,
           mediaType: att.mimeType,
         };

--- a/packages/chat/src/types.ts
+++ b/packages/chat/src/types.ts
@@ -1742,7 +1742,7 @@ export interface Attachment {
    * For platforms that require authentication (like Slack private URLs),
    * this method handles the auth automatically.
    */
-  fetchData?: () => Promise<Buffer>;
+  fetchData?: () => Promise<Buffer | ArrayBuffer>;
   /**
    * Platform-specific metadata needed to reconstruct fetchData after serialization.
    * Adapters store IDs here (e.g. WhatsApp mediaId, Telegram fileId) so that


### PR DESCRIPTION
## Summary

Telegram file downloads already receive their bytes from the Web Fetch API as an `ArrayBuffer`, but the adapter immediately converts them with `Buffer.from(...)` before returning. That conversion is unnecessary for consumers that accept web-standard binary data, and it throws when the Node `Buffer` global is unavailable. The [Fetch standard](https://fetch.spec.whatwg.org/#dom-body-arraybuffer) defines `Response.arrayBuffer()` as returning an `ArrayBuffer`; Cloudflare Workers exposes the [Fetch API natively](https://developers.cloudflare.com/workers/runtime-apis/fetch/), while `Buffer` belongs to its [Node.js compatibility surface](https://developers.cloudflare.com/workers/runtime-apis/nodejs/buffer/).

This change returns the fetched `ArrayBuffer` directly from Telegram. The shared `Attachment.fetchData` and protected Telegram method use `Buffer | ArrayBuffer` so existing adapters and subclasses that return `Buffer` remain source-compatible. The two consumers of that contract now accept the portable value: `chat/ai` passes `ArrayBuffer` directly to the AI SDK, and the X adapter normalizes either type at its Buffer-based upload boundary. The public file documentation and patch changesets are updated with the same contract.

The downstream evidence is a pnpm patch in the private Calories Cloudflare Workers consumer at `patches/@chat-adapter__telegram@4.36.0.patch`. Its portability hunk changes `downloadFile` from `Promise<Buffer>` to `Promise<ArrayBuffer>` and changes `Buffer.from(await response.arrayBuffer())` to `response.arrayBuffer()`; the other Telegram hunks in that patch are already upstream and are intentionally excluded here.

## Test plan

- `pnpm validate`
- `pnpm --filter @chat-adapter/telegram test` (269 tests)
- `pnpm --filter @chat-adapter/telegram typecheck`
- `pnpm --filter chat test` (1,131 tests)
- `pnpm --filter chat typecheck`
- `pnpm --filter @chat-adapter/x test` (222 tests)
- `pnpm --filter @chat-adapter/x typecheck`
- Added a regression test that removes the global `Buffer`, exercises Telegram's mocked `getFile` and file-fetch path, and asserts the returned bytes are an `ArrayBuffer`.

The runtime proof is limited to the isolated download seam under Node with `Buffer` removed. This PR does not claim a deployed no-compatibility Cloudflare Worker or a live Telegram end-to-end request.

## Checklist

- [x] All commits are signed and verified
- [x] All commits are signed off for the DCO (`git commit -s`)
- [x] `pnpm validate` passes
- [x] Changeset added (or N/A — see [CONTRIBUTING.md](./CONTRIBUTING.md))
- [x] Documentation updated (or N/A)
