### PR TITLE
fix(twilio): restrict authenticated media downloads

### DIFF
--- a/.changeset/stale-frogs-fetch.md
+++ b/.changeset/stale-frogs-fetch.md
@@ -1,0 +1,5 @@
+---
+"@chat-adapter/twilio": patch
+---
+
+prevent credentials from being sent to untrusted media origins

--- a/apps/docs/content/adapters/official/twilio.mdx
+++ b/apps/docs/content/adapters/official/twilio.mdx
@@ -131,7 +131,8 @@ https://your-domain.com/api/webhooks/twilio
     },
     apiUrl: {
       type: "string",
-      description: "Override the Twilio API base URL.",
+      description:
+        "Override the Twilio API base URL and trusted origin for media downloads.",
     },
   }}
 />

--- a/packages/adapter-twilio/src/api/index.test.ts
+++ b/packages/adapter-twilio/src/api/index.test.ts
@@ -174,6 +174,41 @@ describe("Twilio api helpers", () => {
     });
   });
 
+  it("fetches media from the configured regional api origin", async () => {
+    const request = vi.fn(async () => new Response("photo"));
+
+    const media = await fetchTwilioMedia({
+      apiUrl: "https://api.dublin.ie1.twilio.com",
+      credentials: credentials(),
+      fetch: request,
+      url: "https://api.dublin.ie1.twilio.com/2010-04-01/media/photo",
+    });
+
+    expect(new TextDecoder().decode(media)).toBe("photo");
+  });
+
+  it.each([
+    "https://api.twilio.com.attacker.example/media/photo",
+    "http://api.twilio.com/media/photo",
+    "https://api.twilio.com:444/media/photo",
+  ])("rejects media outside the configured api origin", async (url) => {
+    const accountSid = vi.fn(() => "AC123");
+    const authToken = vi.fn(() => "token");
+    const request = vi.fn(async () => new Response("photo"));
+
+    await expect(
+      fetchTwilioMedia({
+        credentials: { accountSid, authToken },
+        fetch: request,
+        url,
+      })
+    ).rejects.toThrow("configured Twilio API origin");
+
+    expect(accountSid).not.toHaveBeenCalled();
+    expect(authToken).not.toHaveBeenCalled();
+    expect(request).not.toHaveBeenCalled();
+  });
+
   it("throws TwilioApiError for non-ok responses", async () => {
     const request = mockFetch({ message: "bad" }, 400);
 

--- a/packages/adapter-twilio/src/api/index.ts
+++ b/packages/adapter-twilio/src/api/index.ts
@@ -276,6 +276,16 @@ export async function updateTwilioCall(
 export async function fetchTwilioMedia(
   options: FetchTwilioMediaOptions
 ): Promise<ArrayBuffer> {
+  const apiUrl = new URL(
+    options.apiUrl ?? options.apiBaseUrl ?? DEFAULT_API_URL
+  );
+  const mediaUrl = new URL(options.url);
+  if (mediaUrl.origin !== apiUrl.origin) {
+    throw new TwilioApiError(
+      "Twilio media URL must match the configured Twilio API origin",
+      { body: null, status: 0 }
+    );
+  }
   const accountSid = await resolveTwilioCredential(
     options.credentials?.accountSid,
     "TWILIO_ACCOUNT_SID"

--- a/packages/adapter-twilio/src/index.test.ts
+++ b/packages/adapter-twilio/src/index.test.ts
@@ -79,6 +79,26 @@ describe("TwilioAdapter", () => {
     });
   });
 
+  it("rejects rehydrated media from an untrusted origin", async () => {
+    const fetch = mockFetch("photo");
+    const adapter = createTwilioAdapter({
+      accountSid: "AC123",
+      authToken: "token",
+      fetch,
+    });
+    const attachment = adapter.rehydrateAttachment({
+      fetchMetadata: {
+        twilioMediaUrl: "https://attacker.example/media/photo",
+      },
+      type: "image",
+    });
+
+    await expect(attachment.fetchData?.()).rejects.toThrow(
+      "configured Twilio API origin"
+    );
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
   it("posts SMS messages through the Messages API", async () => {
     const fetch = mockFetch({
       body: "hello",


### PR DESCRIPTION
## summary

- validate media URLs against the configured Twilio API origin before resolving credentials
- reject protocol, hostname, and port mismatches without making a network request
- preserve support for configured regional Twilio API origins
- document that `apiUrl` defines the trusted origin for media downloads

## test plan

- added API-level coverage for trusted regional origins and untrusted URL variants
- added adapter-level coverage for rehydrated attachments from untrusted origins
- ran the Twilio build, tests, typecheck, integration tests, and formatting checks