### PR TITLE
fix(chat): isolate channel-scoped queue dispatch by thread

### DIFF
--- a/.changeset/calm-melons-retire.md
+++ b/.changeset/calm-melons-retire.md
@@ -1,0 +1,5 @@
+---
+"chat": patch
+---
+
+isolate queued and debounced messages by thread when using channel-scoped locks

--- a/packages/chat/src/chat.test.ts
+++ b/packages/chat/src/chat.test.ts
@@ -5268,6 +5268,144 @@ describe("Chat", () => {
         expect(call[0]).toBe("telegram:C123");
       }
     });
+
+    it("should isolate queued messages across channel-scoped threads", async () => {
+      const state = createMockState();
+      const adapter = createMockAdapter("telegram");
+      (adapter as { lockScope: string }).lockScope = "channel";
+
+      const queueChat = new Chat({
+        userName: "testbot",
+        adapters: { telegram: adapter },
+        state,
+        logger: mockLogger,
+        concurrency: "queue",
+      });
+
+      await queueChat.webhooks.telegram(
+        new Request("http://test.com", { method: "POST" })
+      );
+
+      const first = "telegram:C123:topic1";
+      const second = "telegram:C123:topic2";
+      const mentions = vi.fn().mockResolvedValue(undefined);
+      const subscribed = vi.fn().mockImplementation(async (thread, message) => {
+        await thread.setState({ request: message.text });
+      });
+      queueChat.onNewMention(mentions);
+      queueChat.onSubscribedMessage(subscribed);
+      await state.subscribe(second);
+      await state.acquireLock("telegram:C123", 30000);
+
+      await queueChat.handleIncomingMessage(
+        adapter,
+        first,
+        createTestMessage("msg-isolation-1", "Hey @telegram-bot", {
+          threadId: first,
+        })
+      );
+      await queueChat.handleIncomingMessage(
+        adapter,
+        second,
+        createTestMessage("msg-isolation-2", "private request", {
+          threadId: second,
+        })
+      );
+
+      await state.forceReleaseLock("telegram:C123");
+      await queueChat.handleIncomingMessage(
+        adapter,
+        first,
+        createTestMessage("msg-isolation-3", "Hey @telegram-bot", {
+          threadId: first,
+        })
+      );
+
+      expect(mentions).toHaveBeenCalledTimes(1);
+      expect(subscribed).toHaveBeenCalledTimes(1);
+      expect(subscribed.mock.calls[0][0].id).toBe(second);
+      expect(subscribed.mock.calls[0][1].threadId).toBe(second);
+      expect(subscribed.mock.calls[0][2]).toEqual({
+        skipped: [],
+        totalSinceLastHandler: 1,
+      });
+      expect(state.cache.get(`thread-state:${second}`)).toEqual({
+        request: "private request",
+      });
+      expect(state.cache.has(`thread-state:${first}`)).toBe(false);
+      expect(mockLogger.info).toHaveBeenCalledWith(
+        "message-dequeued",
+        expect.objectContaining({
+          threadId: second,
+          messageId: "msg-isolation-2",
+        })
+      );
+    });
+
+    it("should isolate debounced messages across channel-scoped threads", async () => {
+      vi.useFakeTimers();
+      try {
+        const state = createMockState();
+        const adapter = createMockAdapter("telegram");
+        (adapter as { lockScope: string }).lockScope = "channel";
+
+        const debounceChat = new Chat({
+          userName: "testbot",
+          adapters: { telegram: adapter },
+          state,
+          logger: mockLogger,
+          concurrency: { strategy: "debounce", debounceMs: 100 },
+        });
+
+        await debounceChat.webhooks.telegram(
+          new Request("http://test.com", { method: "POST" })
+        );
+
+        const first = "telegram:C123:topic1";
+        const second = "telegram:C123:topic2";
+        const mentions = vi.fn().mockResolvedValue(undefined);
+        const subscribed = vi.fn().mockResolvedValue(undefined);
+        debounceChat.onNewMention(mentions);
+        debounceChat.onSubscribedMessage(subscribed);
+        await state.subscribe(second);
+
+        const pending = debounceChat.handleIncomingMessage(
+          adapter,
+          first,
+          createTestMessage("msg-debounce-isolation-1", "Hey @telegram-bot", {
+            threadId: first,
+          })
+        );
+        await debounceChat.handleIncomingMessage(
+          adapter,
+          second,
+          createTestMessage("msg-debounce-isolation-2", "private request", {
+            threadId: second,
+          })
+        );
+
+        await vi.advanceTimersByTimeAsync(150);
+        await pending;
+
+        expect(mentions).not.toHaveBeenCalled();
+        expect(subscribed).toHaveBeenCalledTimes(1);
+        expect(subscribed.mock.calls[0][0].id).toBe(second);
+        expect(subscribed.mock.calls[0][1].threadId).toBe(second);
+        expect(subscribed.mock.calls[0][2]).toEqual({
+          skipped: [],
+          totalSinceLastHandler: 1,
+        });
+        expect(mockLogger.info).toHaveBeenCalledWith(
+          "message-dequeued",
+          expect.objectContaining({
+            threadId: second,
+            messageId: "msg-debounce-isolation-2",
+          })
+        );
+      } finally {
+        vi.useRealTimers();
+      }
+    });
   });
 
   describe("persistThreadHistory", () => {

--- a/packages/chat/src/chat.ts
+++ b/packages/chat/src/chat.ts
@@ -2453,7 +2453,7 @@ export class Chat<
           messageId: message.id,
           debounceMs,
         });
-        await this.debounceLoop(lock, adapter, threadId, lockKey);
+        await this.debounceLoop(lock, adapter, lockKey);
       } else if (strategy === "burst") {
         await this._stateAdapter.enqueue(
           lockKey,
@@ -2472,11 +2472,11 @@ export class Chat<
         });
         await sleep(debounceMs);
         await this._stateAdapter.extendLock(lock, DEFAULT_LOCK_TTL_MS);
-        await this.drainQueue(lock, adapter, threadId, lockKey);
+        await this.drainQueue(lock, adapter, lockKey);
       } else {
         // Queue: process our message immediately, then drain any queued messages
         await this.dispatchToHandlers(adapter, threadId, message);
-        await this.drainQueue(lock, adapter, threadId, lockKey);
+        await this.drainQueue(lock, adapter, lockKey);
       }
     } finally {
       await this._stateAdapter.releaseLock(lock);
@@ -2491,7 +2491,6 @@ export class Chat<
   private async debounceLoop(
     lock: Lock,
     adapter: Adapter,
-    threadId: string,
     lockKey: string
   ): Promise<void> {
     const { debounceMs } = this._concurrencyConfig;
@@ -2513,7 +2512,7 @@ export class Chat<
           pending.push({ message: msg, expiresAt: entry.expiresAt });
         } else {
           this.logger.info("message-expired", {
-            threadId,
+            threadId: msg.threadId,
             lockKey,
             messageId: msg.id,
           });
@@ -2536,7 +2535,7 @@ export class Chat<
         // Newer message superseded this one — loop again
         skipped.push(latest.message);
         this.logger.info("message-superseded", {
-          threadId,
+          threadId: latest.message.threadId,
           lockKey,
           droppedId: latest.message.id,
         });
@@ -2544,14 +2543,18 @@ export class Chat<
       }
 
       // Nothing new — this is the final message in the burst
+      const messageThreadId = latest.message.threadId;
+      const messageSkipped = skipped.filter(
+        (message) => message.threadId === messageThreadId
+      );
       this.logger.info("message-dequeued", {
-        threadId,
+        threadId: messageThreadId,
         lockKey,
         messageId: latest.message.id,
       });
-      await this.dispatchToHandlers(adapter, threadId, latest.message, {
-        skipped,
-        totalSinceLastHandler: skipped.length + 1,
+      await this.dispatchToHandlers(adapter, messageThreadId, latest.message, {
+        skipped: messageSkipped,
+        totalSinceLastHandler: messageSkipped.length + 1,
       });
       break;
     }
@@ -2564,7 +2567,6 @@ export class Chat<
   private async drainQueue(
     lock: Lock,
     adapter: Adapter,
-    threadId: string,
     lockKey: string
   ): Promise<void> {
     while (true) {
@@ -2580,7 +2582,7 @@ export class Chat<
           pending.push({ message: msg, expiresAt: entry.expiresAt });
         } else {
           this.logger.info("message-expired", {
-            threadId,
+            threadId: msg.threadId,
             lockKey,
             messageId: msg.id,
           });
@@ -2598,23 +2600,31 @@ export class Chat<
       if (!latest) {
         return;
       }
-      // Everything before it is "skipped" context
-      const skipped = pending.slice(0, -1).map((e) => e.message);
+      const messageThreadId = latest.message.threadId;
+      const skipped = pending
+        .slice(0, -1)
+        .map((entry) => entry.message)
+        .filter((message) => message.threadId === messageThreadId);
 
       this.logger.info("message-dequeued", {
-        threadId,
+        threadId: messageThreadId,
         lockKey,
         messageId: latest.message.id,
         skippedCount: skipped.length,
-        totalSinceLastHandler: pending.length,
+        totalSinceLastHandler: skipped.length + 1,
       });
 
       const context: MessageContext = {
         skipped,
-        totalSinceLastHandler: pending.length,
+        totalSinceLastHandler: skipped.length + 1,
       };
 
-      await this.dispatchToHandlers(adapter, threadId, latest.message, context);
+      await this.dispatchToHandlers(
+        adapter,
+        messageThreadId,
+        latest.message,
+        context
+      );
 
       // After processing, check if MORE messages arrived during this handler
       // (loop continues)


### PR DESCRIPTION
## summary

- dispatch queued, debounced, and burst messages using the dequeued message's thread id instead of the lock holder's thread id
- restrict skipped message context and queue logs to the dispatched message's thread
- prevent subscriptions, mentions, state, and replies from crossing thread boundaries
- add regressions for queue and debounce with channel-scoped locks