### PR TITLE
feat(telegram): implement native message replies

### DIFF
--- a/.changeset/telegram-native-replies.md
+++ b/.changeset/telegram-native-replies.md
@@ -2,4 +2,4 @@
 "@chat-adapter/telegram": minor
 ---
 
-Implement `reply` in the Telegram adapter so `Thread.reply()` threads the answer to its target instead of throwing `NotImplementedError`. The reference travels as Bot API `reply_parameters` and covers text, rich messages, documents, attachments and media groups; `allow_sending_without_reply` keeps delivery working when the target has been deleted.
+Implement `reply` in the Telegram adapter so `Thread.reply()` threads the answer to its target instead of throwing `NotImplementedError`. The reference travels as Bot API `reply_parameters` and covers text, rich messages, documents, attachments and media groups; `allow_sending_without_reply` keeps delivery working when the target has been deleted. Malformed reply target ids are rejected before anything is sent, and a rich-message gateway that rejects `reply_parameters` falls back to a regular threaded send.

--- a/.changeset/telegram-native-replies.md
+++ b/.changeset/telegram-native-replies.md
@@ -1,0 +1,5 @@
+---
+"@chat-adapter/telegram": minor
+---
+
+Implement `reply` in the Telegram adapter so `Thread.reply()` threads the answer to its target instead of throwing `NotImplementedError`. The reference travels as Bot API `reply_parameters` and covers text, rich messages, documents, attachments and media groups; `allow_sending_without_reply` keeps delivery working when the target has been deleted.

--- a/apps/docs/content/adapters/official/telegram.mdx
+++ b/apps/docs/content/adapters/official/telegram.mdx
@@ -9,6 +9,7 @@ tagline: Connect to Telegram with support for groups, channels, inline keyboards
 beta: true
 features:
   postMessage: yes
+  messageReplies: yes
   editMessage: yes
   deleteMessage: yes
   fileUploads: yes
@@ -263,6 +264,7 @@ Pass `{ raw: "..." }` only if you need to ship a fully pre-escaped MarkdownV2 st
 - Multiple `files` or compatible `attachments` are sent as Telegram media groups. `files` upload as documents; `attachments` preserve image, audio, video, or file media type.
 - Incoming media groups are delivered as one message after the album settles, with attachments ordered by Telegram message ID and the shared caption preserved.
 - Other rich card elements (images, select menus, radios) render as fallback text.
+- `Thread.reply()` threads with Bot API `reply_parameters` and sets `allow_sending_without_reply`, so a reply whose target was deleted, never existed, or lives in another forum topic is delivered unthreaded instead of failing. Only the chat half of a composite target id is validated up front.
 
 ## Feature support
 

--- a/packages/adapter-telegram/AGENTS.md
+++ b/packages/adapter-telegram/AGENTS.md
@@ -74,7 +74,7 @@ Main exports from `src/index.ts`:
   never the potentially rotating token. Failed startup identity lookups retry
   lazily on later verified webhooks.
 - `TelegramAdapter` class — implements `Adapter<TelegramThreadId,
-  unknown>`. Public methods: `handleWebhook`, `postMessage`,
+  unknown>`. Public methods: `handleWebhook`, `postMessage`, `reply`,
   `editMessage`, `deleteMessage`, `addReaction`, `removeReaction`,
   `startTyping`, `fetchThread`, `fetchMessages`, `fetchSingleMessage`,
   `fetchChannelInfo`, `postChannelMessage`, `openDM`, `setWebhook`,

--- a/packages/adapter-telegram/src/index.test.ts
+++ b/packages/adapter-telegram/src/index.test.ts
@@ -5867,7 +5867,12 @@ describe("reply", () => {
     });
   }
 
-  it("threads a text message to its target", async () => {
+  const expectedReplyParameters = {
+    message_id: 7,
+    allow_sending_without_reply: true,
+  };
+
+  it("threads a rich text message to its target", async () => {
     mockFetch
       .mockResolvedValueOnce(
         telegramOk({ id: 1, is_bot: true, username: "mybot" })
@@ -5879,13 +5884,160 @@ describe("reply", () => {
 
     await adapter.reply("telegram:123", "123:7", { markdown: "hello" });
 
+    expect(String(mockFetch.mock.calls[1]?.[0])).toContain("/sendRichMessage");
     const body = JSON.parse(
       String((mockFetch.mock.calls[1]?.[1] as RequestInit).body)
     );
-    expect(body.reply_parameters).toEqual({
-      message_id: 7,
-      allow_sending_without_reply: true,
+    expect(body.reply_parameters).toEqual(expectedReplyParameters);
+  });
+
+  it("threads a plain string message through sendMessage", async () => {
+    mockFetch
+      .mockResolvedValueOnce(
+        telegramOk({ id: 1, is_bot: true, username: "mybot" })
+      )
+      .mockResolvedValueOnce(telegramOk(sampleMessage({ message_id: 11 })));
+
+    const adapter = createReplyAdapter();
+    await adapter.initialize(createMockChat());
+
+    await adapter.reply("telegram:123", "123:7", "hello");
+
+    expect(String(mockFetch.mock.calls[1]?.[0])).toContain("/sendMessage");
+    const body = JSON.parse(
+      String((mockFetch.mock.calls[1]?.[1] as RequestInit).body)
+    );
+    expect(body.reply_parameters).toEqual(expectedReplyParameters);
+  });
+
+  it("threads a document upload to its target", async () => {
+    mockFetch
+      .mockResolvedValueOnce(
+        telegramOk({ id: 1, is_bot: true, username: "mybot" })
+      )
+      .mockResolvedValueOnce(telegramOk(sampleMessage({ message_id: 11 })));
+
+    const adapter = createReplyAdapter();
+    await adapter.initialize(createMockChat());
+
+    await adapter.reply("telegram:123", "123:7", {
+      raw: "",
+      files: [{ data: Buffer.from("doc"), filename: "doc.txt" }],
     });
+
+    expect(String(mockFetch.mock.calls[1]?.[0])).toContain("/sendDocument");
+    expect(readFormData(1).get("reply_parameters")).toBe(
+      JSON.stringify(expectedReplyParameters)
+    );
+  });
+
+  it("threads a URL attachment without an inline keyboard", async () => {
+    mockFetch
+      .mockResolvedValueOnce(
+        telegramOk({ id: 1, is_bot: true, username: "mybot" })
+      )
+      .mockResolvedValueOnce(telegramOk(sampleMessage({ message_id: 11 })));
+
+    const adapter = createReplyAdapter();
+    await adapter.initialize(createMockChat());
+
+    await adapter.reply("telegram:123", "123:7", {
+      markdown: "picture",
+      attachments: [
+        {
+          mimeType: "image/png",
+          name: "pic.png",
+          type: "image",
+          url: "https://cdn.example.com/pic.png",
+        },
+      ],
+    });
+
+    expect(String(mockFetch.mock.calls[1]?.[0])).toContain("/sendPhoto");
+    const body = JSON.parse(
+      String((mockFetch.mock.calls[1]?.[1] as RequestInit).body)
+    );
+    expect(body.reply_parameters).toEqual(expectedReplyParameters);
+  });
+
+  it("threads a buffer attachment to its target", async () => {
+    mockFetch
+      .mockResolvedValueOnce(
+        telegramOk({ id: 1, is_bot: true, username: "mybot" })
+      )
+      .mockResolvedValueOnce(telegramOk(sampleMessage({ message_id: 11 })));
+
+    const adapter = createReplyAdapter();
+    await adapter.initialize(createMockChat());
+
+    await adapter.reply("telegram:123", "123:7", {
+      markdown: "picture",
+      attachments: [
+        {
+          data: Buffer.from("payload"),
+          mimeType: "image/png",
+          name: "pic.png",
+          type: "image",
+        },
+      ],
+    });
+
+    expect(String(mockFetch.mock.calls[1]?.[0])).toContain("/sendPhoto");
+    expect(readFormData(1).get("reply_parameters")).toBe(
+      JSON.stringify(expectedReplyParameters)
+    );
+  });
+
+  it("threads a media group to its target", async () => {
+    mockFetch
+      .mockResolvedValueOnce(
+        telegramOk({ id: 1, is_bot: true, username: "mybot" })
+      )
+      .mockResolvedValueOnce(
+        telegramOk([
+          sampleMessage({ message_id: 11 }),
+          sampleMessage({ message_id: 12 }),
+        ])
+      );
+
+    const adapter = createReplyAdapter();
+    await adapter.initialize(createMockChat());
+
+    await adapter.reply("telegram:123", "123:7", {
+      markdown: "album",
+      attachments: [
+        { data: Buffer.from("one"), name: "one.png", type: "image" },
+        { data: Buffer.from("two"), name: "two.png", type: "image" },
+      ],
+    });
+
+    expect(String(mockFetch.mock.calls[1]?.[0])).toContain("/sendMediaGroup");
+    expect(readFormData(1).get("reply_parameters")).toBe(
+      JSON.stringify(expectedReplyParameters)
+    );
+  });
+
+  it("falls back to a regular send when the rich endpoint rejects reply_parameters", async () => {
+    mockFetch
+      .mockResolvedValueOnce(
+        telegramOk({ id: 1, is_bot: true, username: "mybot" })
+      )
+      .mockResolvedValueOnce(
+        telegramError(400, 400, "Bad Request: unknown field reply_parameters")
+      )
+      .mockResolvedValueOnce(telegramOk(sampleMessage({ message_id: 11 })));
+
+    const adapter = createReplyAdapter();
+    await adapter.initialize(createMockChat());
+
+    await adapter.reply("telegram:123", "123:7", { markdown: "hello" });
+
+    expect(String(mockFetch.mock.calls[1]?.[0])).toContain("/sendRichMessage");
+    expect(String(mockFetch.mock.calls[2]?.[0])).toContain("/sendMessage");
+    const body = JSON.parse(
+      String((mockFetch.mock.calls[2]?.[1] as RequestInit).body)
+    );
+    expect(body.reply_parameters).toEqual(expectedReplyParameters);
   });
 
   it("leaves a plain postMessage unthreaded", async () => {
@@ -5917,5 +6069,22 @@ describe("reply", () => {
     await expect(
       adapter.reply("telegram:123", "999:7", { markdown: "hello" })
     ).rejects.toThrow("chat mismatch");
+  });
+
+  it.each([
+    "7abc",
+    "7.9",
+    " 7",
+  ])("rejects the malformed bare message id %j", async (target) => {
+    mockFetch.mockResolvedValueOnce(
+      telegramOk({ id: 1, is_bot: true, username: "mybot" })
+    );
+
+    const adapter = createReplyAdapter();
+    await adapter.initialize(createMockChat());
+
+    await expect(
+      adapter.reply("telegram:123", target, { markdown: "hello" })
+    ).rejects.toThrow("Invalid Telegram message ID");
   });
 });

--- a/packages/adapter-telegram/src/index.test.ts
+++ b/packages/adapter-telegram/src/index.test.ts
@@ -5856,3 +5856,66 @@ describe("mention regex caching", () => {
     expect(adapter.checkMention("hi @first_bot")).toBe(false);
   });
 });
+
+describe("reply", () => {
+  function createReplyAdapter() {
+    return createTelegramAdapter({
+      botToken: "token",
+      mode: "webhook",
+      logger: mockLogger,
+      userName: "mybot",
+    });
+  }
+
+  it("threads a text message to its target", async () => {
+    mockFetch
+      .mockResolvedValueOnce(
+        telegramOk({ id: 1, is_bot: true, username: "mybot" })
+      )
+      .mockResolvedValueOnce(telegramOk(sampleMessage({ message_id: 11 })));
+
+    const adapter = createReplyAdapter();
+    await adapter.initialize(createMockChat());
+
+    await adapter.reply("telegram:123", "123:7", { markdown: "hello" });
+
+    const body = JSON.parse(
+      String((mockFetch.mock.calls[1]?.[1] as RequestInit).body)
+    );
+    expect(body.reply_parameters).toEqual({
+      message_id: 7,
+      allow_sending_without_reply: true,
+    });
+  });
+
+  it("leaves a plain postMessage unthreaded", async () => {
+    mockFetch
+      .mockResolvedValueOnce(
+        telegramOk({ id: 1, is_bot: true, username: "mybot" })
+      )
+      .mockResolvedValueOnce(telegramOk(sampleMessage({ message_id: 12 })));
+
+    const adapter = createReplyAdapter();
+    await adapter.initialize(createMockChat());
+
+    await adapter.postMessage("telegram:123", { markdown: "hello" });
+
+    const body = JSON.parse(
+      String((mockFetch.mock.calls[1]?.[1] as RequestInit).body)
+    );
+    expect(body.reply_parameters).toBeUndefined();
+  });
+
+  it("refuses a target that belongs to another chat", async () => {
+    mockFetch.mockResolvedValueOnce(
+      telegramOk({ id: 1, is_bot: true, username: "mybot" })
+    );
+
+    const adapter = createReplyAdapter();
+    await adapter.initialize(createMockChat());
+
+    await expect(
+      adapter.reply("telegram:123", "999:7", { markdown: "hello" })
+    ).rejects.toThrow("chat mismatch");
+  });
+});

--- a/packages/adapter-telegram/src/index.ts
+++ b/packages/adapter-telegram/src/index.ts
@@ -84,6 +84,12 @@ import type {
 const TELEGRAM_API_BASE = "https://api.telegram.org";
 const TELEGRAM_SECRET_TOKEN_HEADER = "x-telegram-bot-api-secret-token";
 const MESSAGE_ID_PATTERN = /^([^:]+):(\d+)$/;
+const BARE_MESSAGE_ID_PATTERN = /^\d+$/;
+
+interface TelegramReplyParameters {
+  allow_sending_without_reply: boolean;
+  message_id: number;
+}
 const trimTrailingSlashes = (url: string): string => {
   let end = url.length;
   while (end > 0 && url[end - 1] === "/") {
@@ -1104,6 +1110,12 @@ export class TelegramAdapter
     replyToMessageId?: string
   ): Promise<RawMessage<TelegramRawMessage>> {
     const parsedThread = this.resolveThreadId(threadId);
+    // Resolve the reply target once so a malformed id fails before any
+    // rendering or attachment downloads, and every send path threads it.
+    const replyParameters = this.buildReplyParameters(
+      replyToMessageId,
+      parsedThread.chatId
+    );
 
     const card = extractCard(message);
     const replyMarkup = card ? cardToTelegramInlineKeyboard(card) : undefined;
@@ -1163,7 +1175,7 @@ export class TelegramAdapter
                 plainText,
                 replyMarkup,
                 parseMode,
-                replyToMessageId
+                replyParameters
               ),
             ]
           : await this.sendDocumentMediaGroup(
@@ -1173,7 +1185,7 @@ export class TelegramAdapter
               plainText,
               replyMarkup,
               parseMode,
-              replyToMessageId
+              replyParameters
             );
     } else if (attachments.length > 0) {
       const [attachment] = attachments;
@@ -1194,7 +1206,7 @@ export class TelegramAdapter
                 plainText,
                 replyMarkup,
                 parseMode,
-                replyToMessageId
+                replyParameters
               ),
             ]
           : await this.sendAttachmentMediaGroup(
@@ -1204,7 +1216,7 @@ export class TelegramAdapter
               plainText,
               replyMarkup,
               parseMode,
-              replyToMessageId
+              replyParameters
             );
     } else {
       if (!text.trim()) {
@@ -1219,7 +1231,7 @@ export class TelegramAdapter
           parseMode,
           replyMarkup,
           threadId,
-          replyToMessageId
+          replyParameters
         );
 
       rawMessages = [
@@ -1233,10 +1245,7 @@ export class TelegramAdapter
                     markdown: rich.markdown,
                   },
                   reply_markup: replyMarkup,
-                  reply_parameters: this.buildReplyParameters(
-                    replyToMessageId,
-                    parsedThread.chatId
-                  ),
+                  reply_parameters: replyParameters,
                 }),
               sendRegular,
               {
@@ -1295,9 +1304,9 @@ export class TelegramAdapter
    * Post a message as a native Telegram reply to `messageId`.
    *
    * Telegram threads the answer to its question with `reply_parameters`, which
-   * is what `Thread.reply()` expects an adapter to provide. Only the first
-   * message carries the reference when content spans several sends, matching
-   * the behaviour of the other adapters.
+   * is what `Thread.reply()` expects an adapter to provide. Every Telegram
+   * send is a single API call (text is truncated, media groups are one
+   * request), so the reference always rides on that one call.
    */
   async reply(
     threadId: string,
@@ -2336,7 +2345,7 @@ export class TelegramAdapter
     plainText: string,
     replyMarkup?: TelegramInlineKeyboardMarkup,
     parseMode: TelegramParseMode = "plain",
-    replyToMessageId?: string
+    replyParameters?: TelegramReplyParameters
   ): Promise<TelegramMessage> {
     const buffer = await this.toTelegramBuffer(file.data);
 
@@ -2352,7 +2361,7 @@ export class TelegramAdapter
             resolvedText,
             replyMarkup,
             resolvedParseMode,
-            replyToMessageId
+            replyParameters
           )
         ),
       {
@@ -2374,17 +2383,11 @@ export class TelegramAdapter
     text: string,
     replyMarkup?: TelegramInlineKeyboardMarkup,
     parseMode: TelegramParseMode = "plain",
-    replyToMessageId?: string
+    replyParameters?: TelegramReplyParameters
   ): FormData {
     const formData = new FormData();
     formData.append("chat_id", thread.chatId);
-    const replyParameters = this.buildReplyParameters(
-      replyToMessageId,
-      thread.chatId
-    );
-    if (replyParameters) {
-      formData.append("reply_parameters", JSON.stringify(replyParameters));
-    }
+    this.appendReplyParameters(formData, replyParameters);
     if (typeof thread.messageThreadId === "number") {
       formData.append("message_thread_id", String(thread.messageThreadId));
     }
@@ -2418,7 +2421,7 @@ export class TelegramAdapter
     plainText: string,
     replyMarkup?: TelegramInlineKeyboardMarkup,
     parseMode: TelegramParseMode = "plain",
-    replyToMessageId?: string
+    replyParameters?: TelegramReplyParameters
   ): Promise<TelegramMessage> {
     const upload = ATTACHMENT_UPLOADS[attachment.type];
     const data =
@@ -2441,6 +2444,7 @@ export class TelegramAdapter
           const payload: Record<string, unknown> = {
             chat_id: thread.chatId,
             [upload.field]: attachment.url,
+            reply_parameters: replyParameters,
           };
 
           if (typeof thread.messageThreadId === "number") {
@@ -2470,13 +2474,6 @@ export class TelegramAdapter
 
           if (replyMarkup) {
             payload.reply_markup = replyMarkup;
-            const urlReplyParameters = this.buildReplyParameters(
-              replyToMessageId,
-              thread.chatId
-            );
-            if (urlReplyParameters) {
-              payload.reply_parameters = urlReplyParameters;
-            }
           }
 
           return this.telegramFetch<TelegramMessage>(upload.method, payload);
@@ -2520,16 +2517,7 @@ export class TelegramAdapter
         if (replyMarkup) {
           formData.append("reply_markup", JSON.stringify(replyMarkup));
         }
-        const bufferReplyParameters = this.buildReplyParameters(
-          replyToMessageId,
-          thread.chatId
-        );
-        if (bufferReplyParameters) {
-          formData.append(
-            "reply_parameters",
-            JSON.stringify(bufferReplyParameters)
-          );
-        }
+        this.appendReplyParameters(formData, replyParameters);
 
         return this.telegramFetch<TelegramMessage>(upload.method, formData);
       },
@@ -2549,7 +2537,7 @@ export class TelegramAdapter
     plainText: string,
     replyMarkup?: TelegramInlineKeyboardMarkup,
     parseMode: TelegramParseMode = "plain",
-    replyToMessageId?: string
+    replyParameters?: TelegramReplyParameters
   ): Promise<TelegramMessage[]> {
     this.validateMediaGroupLength(files.length);
 
@@ -2581,7 +2569,7 @@ export class TelegramAdapter
             parts,
             resolvedText,
             resolvedParseMode,
-            replyToMessageId
+            replyParameters
           )
         ),
       {
@@ -2600,7 +2588,7 @@ export class TelegramAdapter
     plainText: string,
     replyMarkup?: TelegramInlineKeyboardMarkup,
     parseMode: TelegramParseMode = "plain",
-    replyToMessageId?: string
+    replyParameters?: TelegramReplyParameters
   ): Promise<TelegramMessage[]> {
     this.validateMediaGroupLength(attachments.length);
     this.validateAttachmentMediaGroupTypes(attachments);
@@ -2655,7 +2643,7 @@ export class TelegramAdapter
             parts,
             resolvedText,
             resolvedParseMode,
-            replyToMessageId
+            replyParameters
           )
         ),
       {
@@ -2672,17 +2660,11 @@ export class TelegramAdapter
     parts: TelegramMediaGroupPart[],
     text: string,
     parseMode: TelegramParseMode,
-    replyToMessageId?: string
+    replyParameters?: TelegramReplyParameters
   ): FormData {
     const formData = new FormData();
     formData.append("chat_id", thread.chatId);
-    const replyParameters = this.buildReplyParameters(
-      replyToMessageId,
-      thread.chatId
-    );
-    if (replyParameters) {
-      formData.append("reply_parameters", JSON.stringify(replyParameters));
-    }
+    this.appendReplyParameters(formData, replyParameters);
     if (typeof thread.messageThreadId === "number") {
       formData.append("message_thread_id", String(thread.messageThreadId));
     }
@@ -2901,12 +2883,15 @@ export class TelegramAdapter
    *
    * `allow_sending_without_reply` keeps delivery working when the target was
    * deleted in the meantime: the message arrives unthreaded instead of the
-   * send failing outright.
+   * send failing outright. The same applies to a message id that never
+   * existed in the chat or lives in another forum topic — only the chat half
+   * of a composite target is validated here, so those deliver unthreaded
+   * without an error.
    */
   protected buildReplyParameters(
     replyToMessageId: string | undefined,
     expectedChatId: string
-  ): { message_id: number; allow_sending_without_reply: boolean } | undefined {
+  ): TelegramReplyParameters | undefined {
     if (!replyToMessageId) {
       return undefined;
     }
@@ -2917,6 +2902,15 @@ export class TelegramAdapter
     );
 
     return { message_id: messageId, allow_sending_without_reply: true };
+  }
+
+  private appendReplyParameters(
+    formData: FormData,
+    replyParameters: TelegramReplyParameters | undefined
+  ): void {
+    if (replyParameters) {
+      formData.append("reply_parameters", JSON.stringify(replyParameters));
+    }
   }
 
   protected decodeCompositeMessageId(
@@ -2950,13 +2944,13 @@ export class TelegramAdapter
       );
     }
 
-    const parsedMessageId = Number.parseInt(messageId, 10);
-    if (!Number.isFinite(parsedMessageId)) {
+    if (!BARE_MESSAGE_ID_PATTERN.test(messageId)) {
       throw new ValidationError(
         "telegram",
         `Invalid Telegram message ID: ${messageId}`
       );
     }
+    const parsedMessageId = Number.parseInt(messageId, 10);
 
     return {
       chatId: expectedChatId,
@@ -3177,7 +3171,7 @@ export class TelegramAdapter
     parseMode: TelegramParseMode,
     replyMarkup: TelegramInlineKeyboardMarkup | undefined,
     threadId: string,
-    replyToMessageId?: string
+    replyParameters?: TelegramReplyParameters
   ): Promise<TelegramMessage> {
     return this.withTelegramMarkdownFallback(
       parseMode,
@@ -3188,10 +3182,7 @@ export class TelegramAdapter
           text: resolvedText,
           reply_markup: replyMarkup,
           parse_mode: toBotApiParseMode(resolvedParseMode),
-          reply_parameters: this.buildReplyParameters(
-            replyToMessageId,
-            thread.chatId
-          ),
+          reply_parameters: replyParameters,
         }),
       {
         initialText: text,
@@ -3212,12 +3203,18 @@ export class TelegramAdapter
       message.includes("method") && message.includes("not found");
     const unsupportedRich =
       message.includes("rich message") && message.includes("unsupported");
+    // A gateway that predates reply support may reject the extra
+    // `reply_parameters` field; degrade to a regular send, which threads it.
+    const rejectedReplyParameters = message.includes("reply_parameters");
 
     return (
       (method.startsWith("sendRichMessage") &&
         error instanceof ResourceNotFoundError) ||
       (error instanceof ValidationError &&
-        (message.includes("can't parse") || missingMethod || unsupportedRich))
+        (message.includes("can't parse") ||
+          missingMethod ||
+          unsupportedRich ||
+          rejectedReplyParameters))
     );
   }
 

--- a/packages/adapter-telegram/src/index.ts
+++ b/packages/adapter-telegram/src/index.ts
@@ -1100,7 +1100,8 @@ export class TelegramAdapter
 
   async postMessage(
     threadId: string,
-    message: AdapterPostableMessage
+    message: AdapterPostableMessage,
+    replyToMessageId?: string
   ): Promise<RawMessage<TelegramRawMessage>> {
     const parsedThread = this.resolveThreadId(threadId);
 
@@ -1161,7 +1162,8 @@ export class TelegramAdapter
                 text,
                 plainText,
                 replyMarkup,
-                parseMode
+                parseMode,
+                replyToMessageId
               ),
             ]
           : await this.sendDocumentMediaGroup(
@@ -1170,7 +1172,8 @@ export class TelegramAdapter
               text,
               plainText,
               replyMarkup,
-              parseMode
+              parseMode,
+              replyToMessageId
             );
     } else if (attachments.length > 0) {
       const [attachment] = attachments;
@@ -1190,7 +1193,8 @@ export class TelegramAdapter
                 text,
                 plainText,
                 replyMarkup,
-                parseMode
+                parseMode,
+                replyToMessageId
               ),
             ]
           : await this.sendAttachmentMediaGroup(
@@ -1199,7 +1203,8 @@ export class TelegramAdapter
               text,
               plainText,
               replyMarkup,
-              parseMode
+              parseMode,
+              replyToMessageId
             );
     } else {
       if (!text.trim()) {
@@ -1213,7 +1218,8 @@ export class TelegramAdapter
           plainText,
           parseMode,
           replyMarkup,
-          threadId
+          threadId,
+          replyToMessageId
         );
 
       rawMessages = [
@@ -1227,6 +1233,10 @@ export class TelegramAdapter
                     markdown: rich.markdown,
                   },
                   reply_markup: replyMarkup,
+                  reply_parameters: this.buildReplyParameters(
+                    replyToMessageId,
+                    parsedThread.chatId
+                  ),
                 }),
               sendRegular,
               {
@@ -1279,6 +1289,22 @@ export class TelegramAdapter
     message: AdapterPostableMessage
   ): Promise<RawMessage<TelegramRawMessage>> {
     return this.postMessage(channelId, message);
+  }
+
+  /**
+   * Post a message as a native Telegram reply to `messageId`.
+   *
+   * Telegram threads the answer to its question with `reply_parameters`, which
+   * is what `Thread.reply()` expects an adapter to provide. Only the first
+   * message carries the reference when content spans several sends, matching
+   * the behaviour of the other adapters.
+   */
+  async reply(
+    threadId: string,
+    messageId: string,
+    message: AdapterPostableMessage
+  ): Promise<RawMessage<TelegramRawMessage>> {
+    return this.postMessage(threadId, message, messageId);
   }
 
   async editMessage(
@@ -2309,7 +2335,8 @@ export class TelegramAdapter
     text: string,
     plainText: string,
     replyMarkup?: TelegramInlineKeyboardMarkup,
-    parseMode: TelegramParseMode = "plain"
+    parseMode: TelegramParseMode = "plain",
+    replyToMessageId?: string
   ): Promise<TelegramMessage> {
     const buffer = await this.toTelegramBuffer(file.data);
 
@@ -2324,7 +2351,8 @@ export class TelegramAdapter
             buffer,
             resolvedText,
             replyMarkup,
-            resolvedParseMode
+            resolvedParseMode,
+            replyToMessageId
           )
         ),
       {
@@ -2345,10 +2373,18 @@ export class TelegramAdapter
     buffer: Buffer,
     text: string,
     replyMarkup?: TelegramInlineKeyboardMarkup,
-    parseMode: TelegramParseMode = "plain"
+    parseMode: TelegramParseMode = "plain",
+    replyToMessageId?: string
   ): FormData {
     const formData = new FormData();
     formData.append("chat_id", thread.chatId);
+    const replyParameters = this.buildReplyParameters(
+      replyToMessageId,
+      thread.chatId
+    );
+    if (replyParameters) {
+      formData.append("reply_parameters", JSON.stringify(replyParameters));
+    }
     if (typeof thread.messageThreadId === "number") {
       formData.append("message_thread_id", String(thread.messageThreadId));
     }
@@ -2381,7 +2417,8 @@ export class TelegramAdapter
     text: string,
     plainText: string,
     replyMarkup?: TelegramInlineKeyboardMarkup,
-    parseMode: TelegramParseMode = "plain"
+    parseMode: TelegramParseMode = "plain",
+    replyToMessageId?: string
   ): Promise<TelegramMessage> {
     const upload = ATTACHMENT_UPLOADS[attachment.type];
     const data =
@@ -2433,6 +2470,13 @@ export class TelegramAdapter
 
           if (replyMarkup) {
             payload.reply_markup = replyMarkup;
+            const urlReplyParameters = this.buildReplyParameters(
+              replyToMessageId,
+              thread.chatId
+            );
+            if (urlReplyParameters) {
+              payload.reply_parameters = urlReplyParameters;
+            }
           }
 
           return this.telegramFetch<TelegramMessage>(upload.method, payload);
@@ -2476,6 +2520,16 @@ export class TelegramAdapter
         if (replyMarkup) {
           formData.append("reply_markup", JSON.stringify(replyMarkup));
         }
+        const bufferReplyParameters = this.buildReplyParameters(
+          replyToMessageId,
+          thread.chatId
+        );
+        if (bufferReplyParameters) {
+          formData.append(
+            "reply_parameters",
+            JSON.stringify(bufferReplyParameters)
+          );
+        }
 
         return this.telegramFetch<TelegramMessage>(upload.method, formData);
       },
@@ -2494,7 +2548,8 @@ export class TelegramAdapter
     text: string,
     plainText: string,
     replyMarkup?: TelegramInlineKeyboardMarkup,
-    parseMode: TelegramParseMode = "plain"
+    parseMode: TelegramParseMode = "plain",
+    replyToMessageId?: string
   ): Promise<TelegramMessage[]> {
     this.validateMediaGroupLength(files.length);
 
@@ -2525,7 +2580,8 @@ export class TelegramAdapter
             thread,
             parts,
             resolvedText,
-            resolvedParseMode
+            resolvedParseMode,
+            replyToMessageId
           )
         ),
       {
@@ -2543,7 +2599,8 @@ export class TelegramAdapter
     text: string,
     plainText: string,
     replyMarkup?: TelegramInlineKeyboardMarkup,
-    parseMode: TelegramParseMode = "plain"
+    parseMode: TelegramParseMode = "plain",
+    replyToMessageId?: string
   ): Promise<TelegramMessage[]> {
     this.validateMediaGroupLength(attachments.length);
     this.validateAttachmentMediaGroupTypes(attachments);
@@ -2597,7 +2654,8 @@ export class TelegramAdapter
             thread,
             parts,
             resolvedText,
-            resolvedParseMode
+            resolvedParseMode,
+            replyToMessageId
           )
         ),
       {
@@ -2613,10 +2671,18 @@ export class TelegramAdapter
     thread: TelegramThreadId,
     parts: TelegramMediaGroupPart[],
     text: string,
-    parseMode: TelegramParseMode
+    parseMode: TelegramParseMode,
+    replyToMessageId?: string
   ): FormData {
     const formData = new FormData();
     formData.append("chat_id", thread.chatId);
+    const replyParameters = this.buildReplyParameters(
+      replyToMessageId,
+      thread.chatId
+    );
+    if (replyParameters) {
+      formData.append("reply_parameters", JSON.stringify(replyParameters));
+    }
     if (typeof thread.messageThreadId === "number") {
       formData.append("message_thread_id", String(thread.messageThreadId));
     }
@@ -2828,6 +2894,29 @@ export class TelegramAdapter
 
   protected encodeMessageId(chatId: string, messageId: number): string {
     return `${chatId}:${messageId}`;
+  }
+
+  /**
+   * Build Bot API `reply_parameters` for an optional reply target.
+   *
+   * `allow_sending_without_reply` keeps delivery working when the target was
+   * deleted in the meantime: the message arrives unthreaded instead of the
+   * send failing outright.
+   */
+  protected buildReplyParameters(
+    replyToMessageId: string | undefined,
+    expectedChatId: string
+  ): { message_id: number; allow_sending_without_reply: boolean } | undefined {
+    if (!replyToMessageId) {
+      return undefined;
+    }
+
+    const { messageId } = this.decodeCompositeMessageId(
+      replyToMessageId,
+      expectedChatId
+    );
+
+    return { message_id: messageId, allow_sending_without_reply: true };
   }
 
   protected decodeCompositeMessageId(
@@ -3087,7 +3176,8 @@ export class TelegramAdapter
     plainText: string,
     parseMode: TelegramParseMode,
     replyMarkup: TelegramInlineKeyboardMarkup | undefined,
-    threadId: string
+    threadId: string,
+    replyToMessageId?: string
   ): Promise<TelegramMessage> {
     return this.withTelegramMarkdownFallback(
       parseMode,
@@ -3098,6 +3188,10 @@ export class TelegramAdapter
           text: resolvedText,
           reply_markup: replyMarkup,
           parse_mode: toBotApiParseMode(resolvedParseMode),
+          reply_parameters: this.buildReplyParameters(
+            replyToMessageId,
+            thread.chatId
+          ),
         }),
       {
         initialText: text,


### PR DESCRIPTION
`Thread.reply()` throws `NotImplementedError` on Telegram: the adapter has no `reply` method, even though the Bot API threads an answer to its question with `reply_parameters`.

`postMessage` takes an optional reply target and passes it to every send path — text, rich messages, documents, attachments and both media group variants — and `reply()` delegates to it, the same shape the WhatsApp adapter uses for this contract. The target is decoded through the existing `decodeCompositeMessageId`, so a target from another chat is rejected exactly as an edit would be.

`allow_sending_without_reply` is set: a deleted target degrades to an unthreaded message instead of failing the send.

Three tests cover it: the reference lands on a reply, a plain `postMessage` stays unthreaded, and a target from another chat is refused.
