### PR TITLE
feat(telegram): treat a reply to the bot as a mention

### DIFF
--- a/.changeset/telegram-mention-on-reply.md
+++ b/.changeset/telegram-mention-on-reply.md
@@ -2,4 +2,4 @@
 "@chat-adapter/telegram": minor
 ---
 
-Add `mentionOnReply`: when enabled, a reply to one of the bot own messages reports `isMention`, so a bot in a group keeps the conversation going without the handle being repeated. Off by default — existing mention-only bots are unaffected — and readable from `TELEGRAM_MENTION_ON_REPLY`.
+Add `mentionOnReply`: when enabled, a reply to one of the bot's own messages reports `isMention`, so a bot in a group keeps the conversation going without the handle being repeated. Off by default, so existing mention-only bots are unaffected, and readable from `TELEGRAM_MENTION_ON_REPLY`. Implicit forum-topic replies and the bot's own echoed messages never count, and polling mode now retries the startup `getMe` lazily so a transient outage cannot leave mention detection disabled.

--- a/.changeset/telegram-mention-on-reply.md
+++ b/.changeset/telegram-mention-on-reply.md
@@ -1,0 +1,5 @@
+---
+"@chat-adapter/telegram": minor
+---
+
+Add `mentionOnReply`: when enabled, a reply to one of the bot own messages reports `isMention`, so a bot in a group keeps the conversation going without the handle being repeated. Off by default — existing mention-only bots are unaffected — and readable from `TELEGRAM_MENTION_ON_REPLY`.

--- a/apps/docs/content/adapters/official/telegram.mdx
+++ b/apps/docs/content/adapters/official/telegram.mdx
@@ -68,7 +68,7 @@ features:
 ## Quick start
 
 <Callout type="info">
-The adapter auto-detects `TELEGRAM_ALLOWED_USER_IDS`, `TELEGRAM_BOT_TOKEN`, `TELEGRAM_WEBHOOK_SECRET_TOKEN`, `TELEGRAM_ALLOW_UNVERIFIED_WEBHOOKS`, and `TELEGRAM_BOT_USERNAME` from the environment.
+The adapter auto-detects `TELEGRAM_ALLOWED_USER_IDS`, `TELEGRAM_BOT_TOKEN`, `TELEGRAM_WEBHOOK_SECRET_TOKEN`, `TELEGRAM_ALLOW_UNVERIFIED_WEBHOOKS`, `TELEGRAM_BOT_USERNAME`, and `TELEGRAM_MENTION_ON_REPLY` from the environment.
 </Callout>
 
 ```typescript title="lib/bot.ts" lineNumbers
@@ -162,6 +162,12 @@ const telegram = createTelegramAdapter({
       type: "LongPollingOptions",
       description:
         "Long polling tuning. Fields: `timeout`, `limit`, `allowedUpdates`, `deleteWebhook`, `dropPendingUpdates`, `retryDelayMs`.",
+    },
+    mentionOnReply: {
+      type: "boolean",
+      default: "false",
+      description:
+        "Treat a reply to one of the bot's own messages as a mention, so it routes to `onNewMention`. Telegram users usually continue a conversation by replying instead of repeating `@name`. Auto-detected from `TELEGRAM_MENTION_ON_REPLY=true`. Implicit forum-topic replies and the bot's own messages never count.",
     },
     userName: {
       type: "string",

--- a/packages/adapter-telegram/README.md
+++ b/packages/adapter-telegram/README.md
@@ -29,7 +29,7 @@ Visit the [adapters directory](https://chat-sdk.dev/adapters) to see other avail
 
 ## Usage
 
-The adapter auto-detects `TELEGRAM_BOT_TOKEN`, `TELEGRAM_WEBHOOK_SECRET_TOKEN`, `TELEGRAM_ALLOW_UNVERIFIED_WEBHOOKS`, `TELEGRAM_BOT_USERNAME`, and `TELEGRAM_API_BASE_URL` from environment variables:
+The adapter auto-detects `TELEGRAM_BOT_TOKEN`, `TELEGRAM_WEBHOOK_SECRET_TOKEN`, `TELEGRAM_ALLOW_UNVERIFIED_WEBHOOKS`, `TELEGRAM_BOT_USERNAME`, `TELEGRAM_MENTION_ON_REPLY`, and `TELEGRAM_API_BASE_URL` from environment variables:
 
 ```typescript
 import { Chat } from "chat";
@@ -162,6 +162,7 @@ Most options are auto-detected from environment variables when not provided. `na
 | `mode` | No | Adapter mode: `auto` (default), `webhook`, or `polling` |
 | `longPolling` | No | Optional long polling config for `getUpdates` (`timeout`, `limit`, `allowedUpdates`, `deleteWebhook`, `dropPendingUpdates`, `retryDelayMs`) |
 | `userName` | No | Bot username used for mention detection. Auto-detected from `TELEGRAM_BOT_USERNAME` or `getMe` |
+| `mentionOnReply` | No | Treat a reply to one of the bot's own messages as a mention, so it routes to `onNewMention`. Defaults to `false`. Auto-detected from `TELEGRAM_MENTION_ON_REPLY=true`. Implicit forum-topic replies and the bot's own messages never count |
 | `nativeStreaming` | No | Stream with Telegram's native draft previews in private chats. Defaults to `false`, which uses post-and-edit in every chat type |
 | `streamingEditIntervalMs` | No | Minimum interval between edits on the post-and-edit streaming path. Defaults to `1100` in private chats and `3100` in other chats, and acts as a floor for the Chat-level `streamingUpdateIntervalMs` |
 | `apiUrl` | No | Telegram API base URL. Auto-detected from `TELEGRAM_API_BASE_URL`. Use `apiUrl` for cross-adapter consistency; the legacy `apiBaseUrl` alias is still accepted |
@@ -176,6 +177,8 @@ TELEGRAM_ALLOWED_USER_IDS=123456789,987654321
 TELEGRAM_BOT_TOKEN=123456:ABCDEF...
 TELEGRAM_WEBHOOK_SECRET_TOKEN=your-webhook-secret
 TELEGRAM_BOT_USERNAME=mybot
+# Optional (treat replies to the bot as mentions)
+TELEGRAM_MENTION_ON_REPLY=true
 # Optional (self-hosted API gateway)
 TELEGRAM_API_BASE_URL=https://api.telegram.org
 ```

--- a/packages/adapter-telegram/sample-messages.md
+++ b/packages/adapter-telegram/sample-messages.md
@@ -56,3 +56,105 @@ Sanitized from a [captured Telegram webhook](https://gist.github.com/otnansirk/7
   }
 }
 ```
+
+## Reply to a bot message in a group
+
+Sanitized from a captured webhook: a user replies to one of the bot's own
+messages in a supergroup. `reply_to_message.from` is the bot account. With
+`mentionOnReply` enabled this counts as a mention.
+
+```json
+{
+  "update_id": 312744885,
+  "message": {
+    "message_id": 108,
+    "from": {
+      "id": 100000001,
+      "is_bot": false,
+      "first_name": "Test User",
+      "username": "testuser",
+      "language_code": "en"
+    },
+    "chat": {
+      "id": -1001000000001,
+      "title": "Test Group",
+      "type": "supergroup"
+    },
+    "date": 1756290000,
+    "reply_to_message": {
+      "message_id": 105,
+      "from": {
+        "id": 8000000001,
+        "is_bot": true,
+        "first_name": "Test Bot",
+        "username": "testbot"
+      },
+      "chat": {
+        "id": -1001000000001,
+        "title": "Test Group",
+        "type": "supergroup"
+      },
+      "date": 1756289940,
+      "text": "The first option is usually the safer choice."
+    },
+    "text": "and the second one?"
+  }
+}
+```
+
+## Forum topic message with an implicit reply
+
+Sanitized from a captured webhook in a forum supergroup. Every message posted
+inside a topic carries `reply_to_message` pointing at the topic-creation
+service message, whose `message_id` equals `message_thread_id` and whose
+`from` is whoever created the topic (the bot, when it called
+`createForumTopic`). This is not an explicit reply and must not count as a
+mention under `mentionOnReply`.
+
+```json
+{
+  "update_id": 312744886,
+  "message": {
+    "message_id": 214,
+    "from": {
+      "id": 100000001,
+      "is_bot": false,
+      "first_name": "Test User",
+      "username": "testuser",
+      "language_code": "en"
+    },
+    "chat": {
+      "id": -1001000000002,
+      "title": "Test Forum",
+      "type": "supergroup",
+      "is_forum": true
+    },
+    "date": 1756290060,
+    "message_thread_id": 200,
+    "is_topic_message": true,
+    "reply_to_message": {
+      "message_id": 200,
+      "from": {
+        "id": 8000000001,
+        "is_bot": true,
+        "first_name": "Test Bot",
+        "username": "testbot"
+      },
+      "chat": {
+        "id": -1001000000002,
+        "title": "Test Forum",
+        "type": "supergroup",
+        "is_forum": true
+      },
+      "date": 1756289000,
+      "message_thread_id": 200,
+      "is_topic_message": true,
+      "forum_topic_created": {
+        "name": "Support",
+        "icon_color": 7322096
+      }
+    },
+    "text": "does anyone know how to configure this?"
+  }
+}
+```

--- a/packages/adapter-telegram/src/index.test.ts
+++ b/packages/adapter-telegram/src/index.test.ts
@@ -6250,3 +6250,94 @@ describe("reply", () => {
     ).rejects.toThrow("Invalid Telegram message ID");
   });
 });
+
+describe("mentionOnReply", () => {
+  const BOT_USER_ID = 8981792219;
+
+  async function deliverReply(options: {
+    mentionOnReply?: boolean;
+    replyFromBot: boolean;
+  }) {
+    mockFetch.mockResolvedValue(
+      telegramOk({
+        id: BOT_USER_ID,
+        is_bot: true,
+        first_name: "Bot",
+        username: "mybot",
+      })
+    );
+    const chat = createMockChatInstance({
+      logger: mockLogger,
+      state: createMockState(),
+      userName: "mybot",
+    });
+    const adapter = createTelegramAdapter({
+      botToken: "token",
+      mode: "webhook",
+      logger: mockLogger,
+      userName: "mybot",
+      ...(options.mentionOnReply === undefined
+        ? {}
+        : { mentionOnReply: options.mentionOnReply }),
+    });
+    await adapter.initialize(chat);
+
+    await adapter.handleWebhook(
+      new Request("https://example.com/webhook", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          update_id: 1,
+          message: sampleMessage({
+            chat: { id: -100123, type: "supergroup", title: "General" },
+            text: "and the second one?",
+            reply_to_message: sampleMessage({
+              message_id: 5,
+              chat: { id: -100123, type: "supergroup", title: "General" },
+              from: options.replyFromBot
+                ? {
+                    id: BOT_USER_ID,
+                    is_bot: true,
+                    first_name: "Bot",
+                    username: "mybot",
+                  }
+                : {
+                    id: 777,
+                    is_bot: false,
+                    first_name: "Someone",
+                    username: "someone",
+                  },
+            }),
+          }),
+        }),
+      })
+    );
+
+    const processMessage = chat.processMessage as ReturnType<typeof vi.fn>;
+    const call = processMessage.mock.calls[0] as
+      | [unknown, string, { isMention?: boolean }]
+      | undefined;
+    return call?.[2];
+  }
+
+  it("counts a reply to the bot as a mention when enabled", async () => {
+    const parsed = await deliverReply({
+      mentionOnReply: true,
+      replyFromBot: true,
+    });
+    expect(parsed?.isMention).toBe(true);
+  });
+
+  it("ignores a reply to somebody else", async () => {
+    const parsed = await deliverReply({
+      mentionOnReply: true,
+      replyFromBot: false,
+    });
+    expect(parsed?.isMention).toBe(false);
+  });
+
+  it("stays off by default so existing bots keep mention-only behaviour", async () => {
+    const parsed = await deliverReply({ replyFromBot: true });
+    expect(parsed?.isMention).toBe(false);
+  });
+});

--- a/packages/adapter-telegram/src/index.test.ts
+++ b/packages/adapter-telegram/src/index.test.ts
@@ -6257,6 +6257,9 @@ describe("mentionOnReply", () => {
   async function deliverReply(options: {
     mentionOnReply?: boolean;
     replyFromBot: boolean;
+    fromBot?: boolean;
+    messageThreadId?: number;
+    replyToMessageId?: number;
   }) {
     mockFetch.mockResolvedValue(
       telegramOk({
@@ -6291,8 +6294,21 @@ describe("mentionOnReply", () => {
           message: sampleMessage({
             chat: { id: -100123, type: "supergroup", title: "General" },
             text: "and the second one?",
+            ...(options.messageThreadId === undefined
+              ? {}
+              : { message_thread_id: options.messageThreadId }),
+            ...(options.fromBot
+              ? {
+                  from: {
+                    id: BOT_USER_ID,
+                    is_bot: true,
+                    first_name: "Bot",
+                    username: "mybot",
+                  },
+                }
+              : {}),
             reply_to_message: sampleMessage({
-              message_id: 5,
+              message_id: options.replyToMessageId ?? 5,
               chat: { id: -100123, type: "supergroup", title: "General" },
               from: options.replyFromBot
                 ? {
@@ -6339,5 +6355,140 @@ describe("mentionOnReply", () => {
   it("stays off by default so existing bots keep mention-only behaviour", async () => {
     const parsed = await deliverReply({ replyFromBot: true });
     expect(parsed?.isMention).toBe(false);
+  });
+
+  it("ignores a forum topic's implicit reply to the bot's topic-creation message", async () => {
+    // In forum topics every message carries reply_to_message pointing at the
+    // topic-creation service message, whose message_id equals
+    // message_thread_id. When the bot created the topic that must not turn
+    // every message in the topic into a mention.
+    const parsed = await deliverReply({
+      mentionOnReply: true,
+      replyFromBot: true,
+      messageThreadId: 5,
+      replyToMessageId: 5,
+    });
+    expect(parsed?.isMention).toBe(false);
+  });
+
+  it("counts an explicit reply to the bot inside a forum topic", async () => {
+    const parsed = await deliverReply({
+      mentionOnReply: true,
+      replyFromBot: true,
+      messageThreadId: 5,
+      replyToMessageId: 42,
+    });
+    expect(parsed?.isMention).toBe(true);
+  });
+
+  it("does not flag the bot's own reply to one of its messages", async () => {
+    // The Bot API echoes outbound sends back; the echoed message replies to
+    // the bot's earlier message but is authored by the bot itself, and must
+    // not be parsed (and cached) as a mention.
+    const parsed = await deliverReply({
+      mentionOnReply: true,
+      replyFromBot: true,
+      fromBot: true,
+    });
+    expect(parsed?.isMention).toBe(false);
+  });
+
+  it("recovers bot identity while polling after a failed startup getMe", async () => {
+    // Without a lazy retry, a transient getMe outage at cold start leaves
+    // _botUserId unset for the process lifetime and mentionOnReply silently
+    // never fires in polling mode.
+    let getMeCalls = 0;
+    let getUpdatesCalls = 0;
+    mockFetch.mockImplementation((input, init) => {
+      const url = String(input);
+      if (url.includes("/getMe")) {
+        getMeCalls += 1;
+        if (getMeCalls === 1) {
+          return Promise.reject(new Error("getMe outage"));
+        }
+        return Promise.resolve(
+          telegramOk({
+            id: BOT_USER_ID,
+            is_bot: true,
+            first_name: "Bot",
+            username: "mybot",
+          })
+        );
+      }
+      if (url.includes("/getUpdates")) {
+        getUpdatesCalls += 1;
+        if (getUpdatesCalls === 1) {
+          return Promise.resolve(
+            telegramOk([
+              {
+                update_id: 10,
+                message: sampleMessage({
+                  chat: { id: -100123, type: "supergroup", title: "General" },
+                  text: "and the second one?",
+                  reply_to_message: sampleMessage({
+                    message_id: 5,
+                    chat: {
+                      id: -100123,
+                      type: "supergroup",
+                      title: "General",
+                    },
+                    from: {
+                      id: BOT_USER_ID,
+                      is_bot: true,
+                      first_name: "Bot",
+                      username: "mybot",
+                    },
+                  }),
+                }),
+              },
+            ])
+          );
+        }
+        return new Promise<Response>((_resolve, reject) => {
+          const signal = init?.signal;
+          if (signal?.aborted) {
+            reject(createAbortError());
+            return;
+          }
+          signal?.addEventListener(
+            "abort",
+            () => {
+              reject(createAbortError());
+            },
+            { once: true }
+          );
+        });
+      }
+      return Promise.resolve(telegramOk(true));
+    });
+
+    const adapter = createTelegramAdapter({
+      botToken: "token",
+      mode: "webhook",
+      logger: mockLogger,
+      userName: "mybot",
+      mentionOnReply: true,
+    });
+    const chat = createMockChat();
+
+    await adapter.initialize(chat);
+    expect(adapter.botUserId).toBeUndefined();
+
+    await adapter.startPolling({
+      limit: 1,
+      timeout: 1,
+      allowedUpdates: ["message"],
+      retryDelayMs: 0,
+    });
+    const processMessage = chat.processMessage as ReturnType<typeof vi.fn>;
+    await waitForCondition(() => processMessage.mock.calls.length > 0);
+    await adapter.stopPolling();
+
+    expect(getMeCalls).toBe(2);
+    expect(adapter.botUserId).toBe(String(BOT_USER_ID));
+    const parsed = processMessage.mock.calls[0]?.[2] as
+      | { isMention?: boolean }
+      | undefined;
+    expect(parsed?.isMention).toBe(true);
   });
 });

--- a/packages/adapter-telegram/src/index.ts
+++ b/packages/adapter-telegram/src/index.ts
@@ -336,6 +336,7 @@ export class TelegramAdapter
   protected readonly staticBotToken?: string;
   protected readonly apiBaseUrl: string;
   protected readonly secretToken?: string;
+  protected readonly mentionOnReply: boolean;
   private botIdentityPromise: Promise<void> | null = null;
   private webhookScope?: string;
   private warnedNoVerification = false;
@@ -400,6 +401,8 @@ export class TelegramAdapter
     this.allowUnverifiedWebhooks =
       config.allowUnverifiedWebhooks ??
       process.env.TELEGRAM_ALLOW_UNVERIFIED_WEBHOOKS === "true";
+    this.mentionOnReply =
+      config.mentionOnReply ?? process.env.TELEGRAM_MENTION_ON_REPLY === "true";
     const allowedUserIds =
       config.allowedUserIds ??
       process.env.TELEGRAM_ALLOWED_USER_IDS?.split(",");
@@ -3094,6 +3097,19 @@ export class TelegramAdapter
   }
 
   protected isBotMentioned(message: TelegramMessage, text: string): boolean {
+    // Replying to one of the bot's own messages addresses it as directly as an
+    // @mention does — it is how Telegram users continue a conversation without
+    // repeating the handle. Opt-in, and checked before the empty-text guard so
+    // a reply carrying only a photo or a document still counts.
+    if (
+      this.mentionOnReply &&
+      this._botUserId &&
+      message.reply_to_message?.from &&
+      String(message.reply_to_message.from.id) === this._botUserId
+    ) {
+      return true;
+    }
+
     if (!text) {
       return false;
     }

--- a/packages/adapter-telegram/src/index.ts
+++ b/packages/adapter-telegram/src/index.ts
@@ -3101,11 +3101,21 @@ export class TelegramAdapter
     // @mention does — it is how Telegram users continue a conversation without
     // repeating the handle. Opt-in, and checked before the empty-text guard so
     // a reply carrying only a photo or a document still counts.
+    //
+    // Two payload shapes look like a reply to the bot but are not one:
+    // - In forum topics every message carries reply_to_message pointing at the
+    //   topic-creation service message (its message_id equals
+    //   message_thread_id), authored by whoever created the topic — the bot,
+    //   when it did. Only an explicit reply to a different message counts.
+    // - The Bot API echoes the bot's own outbound replies back in send
+    //   responses; the bot replying to itself is not a user addressing it.
     if (
       this.mentionOnReply &&
       this._botUserId &&
       message.reply_to_message?.from &&
-      String(message.reply_to_message.from.id) === this._botUserId
+      String(message.reply_to_message.from.id) === this._botUserId &&
+      message.reply_to_message.message_id !== message.message_thread_id &&
+      !(message.from && String(message.from.id) === this._botUserId)
     ) {
       return true;
     }
@@ -3420,6 +3430,21 @@ export class TelegramAdapter
         );
 
         consecutiveFailures = 0;
+
+        // A failed startup getMe leaves _botUserId unset, which silently
+        // disables identity-based checks (text_mention, mentionOnReply).
+        // Webhook mode retries lazily per update; do the same here now that a
+        // successful getUpdates proves the API is reachable again.
+        if (updates.length > 0 && !this.webhookScope) {
+          try {
+            await this.ensureBotIdentity();
+          } catch (error) {
+            this.logger.warn(
+              "Telegram polling could not resolve bot identity",
+              { error: String(error) }
+            );
+          }
+        }
 
         for (const update of updates) {
           offset = update.update_id + 1;

--- a/packages/adapter-telegram/src/types.ts
+++ b/packages/adapter-telegram/src/types.ts
@@ -22,6 +22,17 @@ export interface TelegramAdapterConfig {
   /** Optional long-polling configuration for getUpdates flow. */
   longPolling?: TelegramLongPollingConfig;
   /**
+   * Treat a reply to one of the bot's own messages as a mention.
+   *
+   * Telegram users continue a conversation by replying rather than repeating
+   * the handle, so a bot that only reacts to `@name` looks unresponsive in a
+   * group. Off by default: turning it on changes which messages report
+   * `isMention`, and a bot that deliberately answers mentions only should keep
+   * the stricter behaviour. Defaults to the `TELEGRAM_MENTION_ON_REPLY`
+   * environment variable when set to `"true"`.
+   */
+  mentionOnReply?: boolean;
+  /**
    * Adapter runtime mode:
    * - auto: choose webhook vs polling based on webhook registration/runtime (default)
    * - webhook: webhook-only mode

--- a/packages/chat/src/adapters/index.ts
+++ b/packages/chat/src/adapters/index.ts
@@ -1010,6 +1010,10 @@ export const ADAPTERS = {
           "Set to true to accept unverified webhooks for local fixtures."
         ),
         env("TELEGRAM_BOT_USERNAME", "Bot username for mention detection."),
+        env(
+          "TELEGRAM_MENTION_ON_REPLY",
+          'Set to "true" to treat a reply to the bot as a mention.'
+        ),
         urlEnv("TELEGRAM_API_BASE_URL", "Override the Telegram API base URL."),
       ],
       required: [secretEnv("TELEGRAM_BOT_TOKEN", "Telegram bot token.")],


### PR DESCRIPTION
Based on #833.

In a group a bot only sees messages that address it, and people address a bot by replying to it as often as by typing its handle. The adapter reported `isMention` for the handle but not for the reply, so a bot went quiet the moment the conversation moved to replies.

`mentionOnReply` turns that on. **Off by default** — the flag changes which messages report `isMention`, and a bot that deliberately answers only explicit mentions should keep the stricter behaviour. It also reads `TELEGRAM_MENTION_ON_REPLY`, so a deployment can set it without code, and the key is declared in the adapters catalog.

The check runs before the empty-text guard, so a reply carrying only a photo or a document counts too.
