### PR TITLE
feat(telegram): parse stickers and animations

### DIFF
--- a/.changeset/telegram-sticker-animation.md
+++ b/.changeset/telegram-sticker-animation.md
@@ -1,0 +1,5 @@
+---
+"@chat-adapter/telegram": minor
+---
+
+Parse stickers and animations. A sticker used to arrive as an empty message — it carries no text — and an animation (Telegram GIF) was dropped entirely. A sticker now reports the emoji it stands for as its text and an image attachment typed by its real format (WebP, WebM or TGS), and an animation arrives as a video attachment.

--- a/.changeset/telegram-sticker-animation.md
+++ b/.changeset/telegram-sticker-animation.md
@@ -2,4 +2,4 @@
 "@chat-adapter/telegram": minor
 ---
 
-Parse stickers and animations. A sticker used to arrive as an empty message — it carries no text — and an animation (Telegram GIF) was dropped entirely. A sticker now reports the emoji it stands for as its text and an image attachment typed by its real format (WebP, WebM or TGS), and an animation arrives as a video attachment.
+Parse stickers and animations. A sticker used to arrive as an empty message, since it carries no text, and an animation (Telegram GIF) was dropped entirely. A sticker now reports the emoji it stands for as its text (falling back to the sticker set name, then to "sticker") plus an attachment matching its real format: an image for a still WebP sticker, a video for a WebM one, a file for a Lottie (TGS) one. An animation arrives as a single video attachment; the redundant `document` field Telegram sets alongside it for backward compatibility is no longer reported as a second attachment.

--- a/packages/adapter-telegram/sample-messages.md
+++ b/packages/adapter-telegram/sample-messages.md
@@ -57,6 +57,118 @@ Sanitized from a [captured Telegram webhook](https://gist.github.com/otnansirk/7
 }
 ```
 
+## Sticker message
+
+Sanitized sticker update, shape per the
+[Bot API `Sticker` object](https://core.telegram.org/bots/api#sticker). The
+message carries no `text`; `emoji` and `set_name` are both optional, so a
+parser must not rely on either. A still sticker is WebP; `is_video` marks a
+WebM one and `is_animated` a Lottie (TGS) one.
+
+```json
+{
+  "update_id": 312744887,
+  "message": {
+    "message_id": 321,
+    "from": {
+      "id": 100000001,
+      "is_bot": false,
+      "first_name": "Test User",
+      "username": "testuser",
+      "language_code": "en"
+    },
+    "chat": {
+      "id": 100000001,
+      "first_name": "Test User",
+      "username": "testuser",
+      "type": "private"
+    },
+    "date": 1756290120,
+    "sticker": {
+      "file_id": "CAACAgIAAxkBAAIBQWjPMV5rZ0dEUvO0kQABt3l0aFYyAAJKAANZu_wlnFJ1RE9WuJk2BA",
+      "file_unique_id": "AgADSgADWbv8JQ",
+      "type": "regular",
+      "width": 512,
+      "height": 512,
+      "is_animated": false,
+      "is_video": false,
+      "emoji": "😀",
+      "set_name": "TestPack",
+      "thumbnail": {
+        "file_id": "AAMCAgADGQEAAgFBaM8xXmtnR0RS87SRAAG3eXRoVjIAAkoAA1m7_CWcUnVET1a4mQEAB20AAzYE",
+        "file_unique_id": "AQADSgADWbv8JXI",
+        "file_size": 5304,
+        "width": 128,
+        "height": 128
+      },
+      "file_size": 36042
+    }
+  }
+}
+```
+
+## Animation (GIF) message
+
+Sanitized animation update, shape per the
+[Bot API `Message.animation` field](https://core.telegram.org/bots/api#message):
+"For backward compatibility, when this field is set, the *document* field will
+also be set." Both fields describe the same file (same `file_id`), so a parser
+that walks both produces a duplicate attachment.
+
+```json
+{
+  "update_id": 312744888,
+  "message": {
+    "message_id": 322,
+    "from": {
+      "id": 100000001,
+      "is_bot": false,
+      "first_name": "Test User",
+      "username": "testuser",
+      "language_code": "en"
+    },
+    "chat": {
+      "id": 100000001,
+      "first_name": "Test User",
+      "username": "testuser",
+      "type": "private"
+    },
+    "date": 1756290180,
+    "animation": {
+      "file_id": "CgACAgQAAxkBAAIBQmjPMbXhH2m0T3nQAAFrJ8x0aFYyAAK0AgACWbv8U5FQn0lmQnUsNgQ",
+      "file_unique_id": "AgADtAIAAlm7_FM",
+      "file_name": "cat.mp4",
+      "mime_type": "video/mp4",
+      "duration": 3,
+      "width": 480,
+      "height": 480,
+      "thumbnail": {
+        "file_id": "AAMCBAADGQEAAgFCaM8xteEfabRPedAAAWsnzHRoVjIAArQCAAJZu_xTkVCfSWZCdSwBAAdtAAM2BA",
+        "file_unique_id": "AQADtAIAAlm7_FNy",
+        "file_size": 12816,
+        "width": 320,
+        "height": 320
+      },
+      "file_size": 291345
+    },
+    "document": {
+      "file_id": "CgACAgQAAxkBAAIBQmjPMbXhH2m0T3nQAAFrJ8x0aFYyAAK0AgACWbv8U5FQn0lmQnUsNgQ",
+      "file_unique_id": "AgADtAIAAlm7_FM",
+      "file_name": "cat.mp4",
+      "mime_type": "video/mp4",
+      "thumbnail": {
+        "file_id": "AAMCBAADGQEAAgFCaM8xteEfabRPedAAAWsnzHRoVjIAArQCAAJZu_xTkVCfSWZCdSwBAAdtAAM2BA",
+        "file_unique_id": "AQADtAIAAlm7_FNy",
+        "file_size": 12816,
+        "width": 320,
+        "height": 320
+      },
+      "file_size": 291345
+    }
+  }
+}
+```
+
 ## Reply to a bot message in a group
 
 Sanitized from a captured webhook: a user replies to one of the bot's own

--- a/packages/adapter-telegram/src/index.test.ts
+++ b/packages/adapter-telegram/src/index.test.ts
@@ -6494,7 +6494,7 @@ describe("mentionOnReply", () => {
 });
 
 describe("sticker messages", () => {
-  it("represents a sticker by the emoji it stands for", async () => {
+  async function parseText(overrides: Partial<TelegramMessage>) {
     mockFetch.mockResolvedValue(
       telegramOk({
         id: 8981792219,
@@ -6522,14 +6522,7 @@ describe("sticker messages", () => {
         headers: { "content-type": "application/json" },
         body: JSON.stringify({
           update_id: 1,
-          message: sampleMessage({
-            text: undefined,
-            sticker: {
-              emoji: "😀",
-              file_id: "sticker-file",
-              file_unique_id: "sticker-unique",
-            },
-          }),
+          message: sampleMessage({ text: undefined, ...overrides }),
         }),
       })
     );
@@ -6538,7 +6531,42 @@ describe("sticker messages", () => {
     const call = processMessage.mock.calls[0] as
       | [unknown, string, { text?: string }]
       | undefined;
-    expect(call?.[2]?.text).toBe("😀");
+    return call?.[2]?.text;
+  }
+
+  it("represents a sticker by the emoji it stands for", async () => {
+    const text = await parseText({
+      sticker: {
+        emoji: "😀",
+        file_id: "sticker-file",
+        file_unique_id: "sticker-unique",
+      },
+    });
+
+    expect(text).toBe("😀");
+  });
+
+  it("falls back to the set name when the emoji is missing", async () => {
+    const text = await parseText({
+      sticker: {
+        set_name: "CorgiPack",
+        file_id: "sticker-file",
+        file_unique_id: "sticker-unique",
+      },
+    });
+
+    expect(text).toBe("CorgiPack");
+  });
+
+  it("never delivers a sticker as an empty message", async () => {
+    const text = await parseText({
+      sticker: {
+        file_id: "sticker-file",
+        file_unique_id: "sticker-unique",
+      },
+    });
+
+    expect(text).toBe("sticker");
   });
 });
 
@@ -6603,7 +6631,7 @@ describe("sticker and animation attachments", () => {
     expect(attachments[0]?.mimeType).toBe("image/webp");
   });
 
-  it("labels a video sticker by its real format", async () => {
+  it("carries a video sticker through as a video", async () => {
     const attachments = await parseMedia({
       sticker: {
         emoji: "🔥",
@@ -6613,12 +6641,37 @@ describe("sticker and animation attachments", () => {
       },
     });
 
+    expect(attachments).toHaveLength(1);
+    expect(attachments[0]?.type).toBe("video");
     expect(attachments[0]?.mimeType).toBe("video/webm");
   });
 
-  it("carries an animation through as a video", async () => {
+  it("carries a Lottie sticker through as a file", async () => {
+    const attachments = await parseMedia({
+      sticker: {
+        emoji: "🎉",
+        file_id: "sticker-file",
+        file_unique_id: "sticker-unique",
+        is_animated: true,
+      },
+    });
+
+    expect(attachments).toHaveLength(1);
+    expect(attachments[0]?.type).toBe("file");
+    expect(attachments[0]?.mimeType).toBe("application/x-tgsticker");
+  });
+
+  it("carries an animation through as a single video attachment", async () => {
+    // Telegram sets `document` alongside `animation` for backward
+    // compatibility — the same file must not surface twice.
     const attachments = await parseMedia({
       animation: {
+        file_id: "animation-file",
+        file_unique_id: "animation-unique",
+        mime_type: "video/mp4",
+        file_name: "cat.mp4",
+      },
+      document: {
         file_id: "animation-file",
         file_unique_id: "animation-unique",
         mime_type: "video/mp4",
@@ -6629,5 +6682,20 @@ describe("sticker and animation attachments", () => {
     expect(attachments).toHaveLength(1);
     expect(attachments[0]?.type).toBe("video");
     expect(attachments[0]?.mimeType).toBe("video/mp4");
+  });
+
+  it("still carries a plain document through as a file", async () => {
+    const attachments = await parseMedia({
+      document: {
+        file_id: "document-file",
+        file_unique_id: "document-unique",
+        mime_type: "application/pdf",
+        file_name: "report.pdf",
+      },
+    });
+
+    expect(attachments).toHaveLength(1);
+    expect(attachments[0]?.type).toBe("file");
+    expect(attachments[0]?.mimeType).toBe("application/pdf");
   });
 });

--- a/packages/adapter-telegram/src/index.test.ts
+++ b/packages/adapter-telegram/src/index.test.ts
@@ -6492,3 +6492,142 @@ describe("mentionOnReply", () => {
     expect(parsed?.isMention).toBe(true);
   });
 });
+
+describe("sticker messages", () => {
+  it("represents a sticker by the emoji it stands for", async () => {
+    mockFetch.mockResolvedValue(
+      telegramOk({
+        id: 8981792219,
+        is_bot: true,
+        first_name: "Bot",
+        username: "mybot",
+      })
+    );
+    const chat = createMockChatInstance({
+      logger: mockLogger,
+      state: createMockState(),
+      userName: "mybot",
+    });
+    const adapter = createTelegramAdapter({
+      botToken: "token",
+      mode: "webhook",
+      logger: mockLogger,
+      userName: "mybot",
+    });
+    await adapter.initialize(chat);
+
+    await adapter.handleWebhook(
+      new Request("https://example.com/webhook", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          update_id: 1,
+          message: sampleMessage({
+            text: undefined,
+            sticker: {
+              emoji: "😀",
+              file_id: "sticker-file",
+              file_unique_id: "sticker-unique",
+            },
+          }),
+        }),
+      })
+    );
+
+    const processMessage = chat.processMessage as ReturnType<typeof vi.fn>;
+    const call = processMessage.mock.calls[0] as
+      | [unknown, string, { text?: string }]
+      | undefined;
+    expect(call?.[2]?.text).toBe("😀");
+  });
+});
+
+describe("sticker and animation attachments", () => {
+  async function parseMedia(overrides: Partial<TelegramMessage>) {
+    mockFetch.mockResolvedValue(
+      telegramOk({
+        id: 8981792219,
+        is_bot: true,
+        first_name: "Bot",
+        username: "mybot",
+      })
+    );
+    const chat = createMockChatInstance({
+      logger: mockLogger,
+      state: createMockState(),
+      userName: "mybot",
+    });
+    const adapter = createTelegramAdapter({
+      botToken: "token",
+      mode: "webhook",
+      logger: mockLogger,
+      userName: "mybot",
+    });
+    await adapter.initialize(chat);
+
+    await adapter.handleWebhook(
+      new Request("https://example.com/webhook", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          update_id: 1,
+          message: sampleMessage({ text: undefined, ...overrides }),
+        }),
+      })
+    );
+
+    const processMessage = chat.processMessage as ReturnType<typeof vi.fn>;
+    const call = processMessage.mock.calls[0] as
+      | [
+          unknown,
+          string,
+          { attachments?: { type: string; mimeType?: string }[] },
+        ]
+      | undefined;
+    return call?.[2]?.attachments ?? [];
+  }
+
+  it("carries a sticker through as an image", async () => {
+    const attachments = await parseMedia({
+      sticker: {
+        emoji: "😀",
+        file_id: "sticker-file",
+        file_unique_id: "sticker-unique",
+        width: 512,
+        height: 512,
+      },
+    });
+
+    expect(attachments).toHaveLength(1);
+    expect(attachments[0]?.type).toBe("image");
+    expect(attachments[0]?.mimeType).toBe("image/webp");
+  });
+
+  it("labels a video sticker by its real format", async () => {
+    const attachments = await parseMedia({
+      sticker: {
+        emoji: "🔥",
+        file_id: "sticker-file",
+        file_unique_id: "sticker-unique",
+        is_video: true,
+      },
+    });
+
+    expect(attachments[0]?.mimeType).toBe("video/webm");
+  });
+
+  it("carries an animation through as a video", async () => {
+    const attachments = await parseMedia({
+      animation: {
+        file_id: "animation-file",
+        file_unique_id: "animation-unique",
+        mime_type: "video/mp4",
+        file_name: "cat.mp4",
+      },
+    });
+
+    expect(attachments).toHaveLength(1);
+    expect(attachments[0]?.type).toBe("video");
+    expect(attachments[0]?.mimeType).toBe("video/mp4");
+  });
+});

--- a/packages/adapter-telegram/src/index.ts
+++ b/packages/adapter-telegram/src/index.ts
@@ -323,6 +323,23 @@ export function applyTelegramEntities(
   return result;
 }
 
+/**
+ * Sticker formats: a still sticker is WebP, a video sticker WebM, and an
+ * animated (Lottie) one the TGS container.
+ */
+function stickerMimeType(sticker: {
+  is_animated?: boolean;
+  is_video?: boolean;
+}): string {
+  if (sticker.is_video) {
+    return "video/webm";
+  }
+  if (sticker.is_animated) {
+    return "application/x-tgsticker";
+  }
+  return "image/webp";
+}
+
 export class TelegramAdapter
   implements Adapter<TelegramThreadId, TelegramRawMessage>
 {
@@ -2200,6 +2217,10 @@ export class TelegramAdapter
       content?.text ??
       raw.text ??
       raw.caption ??
+      // A sticker carries no text, only the emoji it stands for. Without this
+      // a sticker reaches the handler as an empty message and looks like a
+      // delivery that lost its body.
+      raw.sticker?.emoji ??
       (raw.rich_message ? richMessageToText(raw.rich_message) : "");
     const entities = raw.entities ?? raw.caption_entities ?? [];
     const text = content?.text
@@ -2317,6 +2338,35 @@ export class TelegramAdapter
           width: raw.video_note.length,
           height: raw.video_note.length,
           fileUniqueId: raw.video_note.file_unique_id,
+        })
+      );
+    }
+
+    // An animation is Telegram's GIF: an MP4 without sound.
+    if (raw.animation) {
+      attachments.push(
+        this.createAttachment("video", raw.animation.file_id, {
+          size: raw.animation.file_size,
+          width: raw.animation.width,
+          height: raw.animation.height,
+          name: raw.animation.file_name,
+          mimeType: raw.animation.mime_type,
+          fileUniqueId: raw.animation.file_unique_id,
+        })
+      );
+    }
+
+    // Stickers are images (WebP, or WebM/TGS when animated). They arrive with
+    // no text at all, so without this a sticker reaches the handler as an
+    // empty message; the emoji it stands for becomes the message text.
+    if (raw.sticker) {
+      attachments.push(
+        this.createAttachment("image", raw.sticker.file_id, {
+          size: raw.sticker.file_size,
+          width: raw.sticker.width,
+          height: raw.sticker.height,
+          mimeType: stickerMimeType(raw.sticker),
+          fileUniqueId: raw.sticker.file_unique_id,
         })
       );
     }

--- a/packages/adapter-telegram/src/index.ts
+++ b/packages/adapter-telegram/src/index.ts
@@ -325,19 +325,21 @@ export function applyTelegramEntities(
 
 /**
  * Sticker formats: a still sticker is WebP, a video sticker WebM, and an
- * animated (Lottie) one the TGS container.
+ * animated (Lottie) one the TGS container. The attachment type has to follow
+ * the real format — a WebM typed "image" gets routed through sendPhoto by
+ * type-driven consumers, which Telegram rejects.
  */
-function stickerMimeType(sticker: {
+function stickerAttachmentFormat(sticker: {
   is_animated?: boolean;
   is_video?: boolean;
-}): string {
+}): { type: Attachment["type"]; mimeType: string } {
   if (sticker.is_video) {
-    return "video/webm";
+    return { type: "video", mimeType: "video/webm" };
   }
   if (sticker.is_animated) {
-    return "application/x-tgsticker";
+    return { type: "file", mimeType: "application/x-tgsticker" };
   }
-  return "image/webp";
+  return { type: "image", mimeType: "image/webp" };
 }
 
 export class TelegramAdapter
@@ -2219,8 +2221,11 @@ export class TelegramAdapter
       raw.caption ??
       // A sticker carries no text, only the emoji it stands for. Without this
       // a sticker reaches the handler as an empty message and looks like a
-      // delivery that lost its body.
-      raw.sticker?.emoji ??
+      // delivery that lost its body. The emoji itself is optional, so fall
+      // back to the sticker set's name, then to a plain label — never empty.
+      (raw.sticker
+        ? (raw.sticker.emoji ?? raw.sticker.set_name ?? "sticker")
+        : undefined) ??
       (raw.rich_message ? richMessageToText(raw.rich_message) : "");
     const entities = raw.entities ?? raw.caption_entities ?? [];
     const text = content?.text
@@ -2320,7 +2325,9 @@ export class TelegramAdapter
       );
     }
 
-    if (raw.document) {
+    // When a message carries an animation, Telegram also sets `document` for
+    // backward compatibility — it's the same file, so don't report it twice.
+    if (raw.document && !raw.animation) {
       attachments.push(
         this.createAttachment("file", raw.document.file_id, {
           size: raw.document.file_size,
@@ -2356,16 +2363,16 @@ export class TelegramAdapter
       );
     }
 
-    // Stickers are images (WebP, or WebM/TGS when animated). They arrive with
-    // no text at all, so without this a sticker reaches the handler as an
-    // empty message; the emoji it stands for becomes the message text.
+    // A still sticker is a WebP image; a video sticker is WebM and a Lottie
+    // one the TGS container, neither of which renders as an image.
     if (raw.sticker) {
+      const format = stickerAttachmentFormat(raw.sticker);
       attachments.push(
-        this.createAttachment("image", raw.sticker.file_id, {
+        this.createAttachment(format.type, raw.sticker.file_id, {
           size: raw.sticker.file_size,
           width: raw.sticker.width,
           height: raw.sticker.height,
-          mimeType: stickerMimeType(raw.sticker),
+          mimeType: format.mimeType,
           fileUniqueId: raw.sticker.file_unique_id,
         })
       );

--- a/packages/adapter-telegram/src/types.ts
+++ b/packages/adapter-telegram/src/types.ts
@@ -454,6 +454,13 @@ export interface TelegramRichMessage {
  * @see https://core.telegram.org/bots/api#message
  */
 export interface TelegramMessage {
+  animation?: TelegramFile & {
+    duration?: number;
+    width?: number;
+    height?: number;
+    mime_type?: string;
+    file_name?: string;
+  };
   audio?: TelegramFile & {
     duration?: number;
     performer?: string;
@@ -476,7 +483,13 @@ export interface TelegramMessage {
   reply_to_message?: TelegramMessage;
   rich_message?: TelegramRichMessage;
   sender_chat?: TelegramChat;
-  sticker?: TelegramFile & { emoji?: string };
+  sticker?: TelegramFile & {
+    emoji?: string;
+    width?: number;
+    height?: number;
+    is_animated?: boolean;
+    is_video?: boolean;
+  };
   text?: string;
   video?: TelegramVideo;
   video_note?: TelegramFile & { length?: number; duration?: number };

--- a/packages/adapter-telegram/src/types.ts
+++ b/packages/adapter-telegram/src/types.ts
@@ -485,6 +485,7 @@ export interface TelegramMessage {
   sender_chat?: TelegramChat;
   sticker?: TelegramFile & {
     emoji?: string;
+    set_name?: string;
     width?: number;
     height?: number;
     is_animated?: boolean;


### PR DESCRIPTION
Based on #834.

A sticker carries no text, so it reached the handler as an empty message and looked like a delivery that had lost its body. An animation — the MP4 Telegram sends for a GIF — was not declared on the message type and was dropped on the floor.

A sticker now reports the emoji it stands for as the message text, plus an image attachment typed by its real format: WebP for a still one, WebM for a video sticker, TGS for a Lottie one. An animation arrives as a video attachment alongside the other media types.
