### PR TITLE
feat(telegram): describe locations, contacts, polls and dice

### DIFF
--- a/.changeset/telegram-non-file-content.md
+++ b/.changeset/telegram-non-file-content.md
@@ -1,0 +1,5 @@
+---
+"@chat-adapter/telegram": minor
+---
+
+Describe the message kinds Telegram sends with no text and no file. A shared location, venue, contact, poll, dice, game, invoice or story used to arrive as an empty message: the payload carried the content, but a handler reading `text` saw nothing. Each now gets a short literal description (`📍 55.75, 37.61`, `👤 Ada Lovelace +1555…`, `📊 Lunch or dinner?`), and the structured payload stays on the raw message for anyone who needs the numbers.

--- a/packages/adapter-telegram/sample-messages.md
+++ b/packages/adapter-telegram/sample-messages.md
@@ -270,3 +270,309 @@ mention under `mentionOnReply`.
   }
 }
 ```
+
+## Location message
+
+Sanitized location update, shape per the
+[Bot API `Message.location` field](https://core.telegram.org/bots/api#message).
+No `text`, no file — the coordinates are the whole message.
+
+```json
+{
+  "update_id": 312744889,
+  "message": {
+    "message_id": 323,
+    "from": {
+      "id": 100000001,
+      "is_bot": false,
+      "first_name": "Test User",
+      "username": "testuser",
+      "language_code": "en"
+    },
+    "chat": {
+      "id": 100000001,
+      "first_name": "Test User",
+      "username": "testuser",
+      "type": "private"
+    },
+    "date": 1756290240,
+    "location": {
+      "latitude": 52.520008,
+      "longitude": 13.404954,
+      "horizontal_accuracy": 14.2
+    }
+  }
+}
+```
+
+## Venue message
+
+Sanitized venue update, shape per the
+[Bot API `Message.venue` field](https://core.telegram.org/bots/api#message):
+"For backward compatibility, when this field is set, the *location* field will
+also be set." A parser that checks `location` before `venue` therefore renders
+every venue as bare coordinates.
+
+```json
+{
+  "update_id": 312744890,
+  "message": {
+    "message_id": 324,
+    "from": {
+      "id": 100000001,
+      "is_bot": false,
+      "first_name": "Test User",
+      "username": "testuser",
+      "language_code": "en"
+    },
+    "chat": {
+      "id": 100000001,
+      "first_name": "Test User",
+      "username": "testuser",
+      "type": "private"
+    },
+    "date": 1756290300,
+    "location": {
+      "latitude": 52.516275,
+      "longitude": 13.377704
+    },
+    "venue": {
+      "location": {
+        "latitude": 52.516275,
+        "longitude": 13.377704
+      },
+      "title": "Brandenburg Gate",
+      "address": "Pariser Platz, 10117 Berlin",
+      "foursquare_id": "4adcda10f964a520af3521e3",
+      "foursquare_type": "arts_entertainment/monument"
+    }
+  }
+}
+```
+
+## Contact message
+
+Sanitized contact update, shape per the
+[Bot API `Contact` object](https://core.telegram.org/bots/api#contact).
+`last_name`, `user_id`, and `vcard` are all optional — this capture has no
+`last_name`, so a parser must not rely on it.
+
+```json
+{
+  "update_id": 312744891,
+  "message": {
+    "message_id": 325,
+    "from": {
+      "id": 100000001,
+      "is_bot": false,
+      "first_name": "Test User",
+      "username": "testuser",
+      "language_code": "en"
+    },
+    "chat": {
+      "id": 100000001,
+      "first_name": "Test User",
+      "username": "testuser",
+      "type": "private"
+    },
+    "date": 1756290360,
+    "contact": {
+      "phone_number": "+15550100123",
+      "first_name": "Ada",
+      "user_id": 100000002
+    }
+  }
+}
+```
+
+## Poll message
+
+Sanitized poll update, shape per the
+[Bot API `Poll` object](https://core.telegram.org/bots/api#poll). The question
+and options live on the poll; there is no `text`.
+
+```json
+{
+  "update_id": 312744892,
+  "message": {
+    "message_id": 326,
+    "from": {
+      "id": 100000001,
+      "is_bot": false,
+      "first_name": "Test User",
+      "username": "testuser",
+      "language_code": "en"
+    },
+    "chat": {
+      "id": -1001000000001,
+      "title": "Test Group",
+      "type": "supergroup"
+    },
+    "date": 1756290420,
+    "poll": {
+      "id": "5312345678901234567",
+      "question": "Lunch or dinner?",
+      "options": [
+        { "text": "Lunch", "voter_count": 3 },
+        { "text": "Dinner", "voter_count": 5 }
+      ],
+      "total_voter_count": 8,
+      "is_closed": false,
+      "is_anonymous": true,
+      "type": "regular",
+      "allows_multiple_answers": false
+    }
+  }
+}
+```
+
+## Dice message
+
+Sanitized dice update, shape per the
+[Bot API `Dice` object](https://core.telegram.org/bots/api#dice). The `emoji`
+varies (🎲, 🎯, 🏀, ⚽, 🎳, 🎰) and `value` is the rolled result.
+
+```json
+{
+  "update_id": 312744893,
+  "message": {
+    "message_id": 327,
+    "from": {
+      "id": 100000001,
+      "is_bot": false,
+      "first_name": "Test User",
+      "username": "testuser",
+      "language_code": "en"
+    },
+    "chat": {
+      "id": 100000001,
+      "first_name": "Test User",
+      "username": "testuser",
+      "type": "private"
+    },
+    "date": 1756290480,
+    "dice": {
+      "emoji": "🎲",
+      "value": 4
+    }
+  }
+}
+```
+
+## Game message
+
+Sanitized game update, shape per the
+[Bot API `Game` object](https://core.telegram.org/bots/api#game). Sent when a
+bot shares a game; `photo` is always present on real payloads.
+
+```json
+{
+  "update_id": 312744894,
+  "message": {
+    "message_id": 328,
+    "from": {
+      "id": 8000000001,
+      "is_bot": true,
+      "first_name": "Test Bot",
+      "username": "testbot"
+    },
+    "chat": {
+      "id": 100000001,
+      "first_name": "Test User",
+      "username": "testuser",
+      "type": "private"
+    },
+    "date": 1756290540,
+    "game": {
+      "title": "Corsairs",
+      "description": "Sail, trade and plunder.",
+      "photo": [
+        {
+          "file_id": "AgACAgIAAxkDAAIBRGjPMnH9YQnJ0aTgVFCk0aFYyAAJLAANZu_wlnFJ1RE9WuJk2BA",
+          "file_unique_id": "AQADSwADWbv8JXI",
+          "file_size": 42817,
+          "width": 640,
+          "height": 360
+        }
+      ]
+    }
+  }
+}
+```
+
+## Invoice message
+
+Sanitized invoice update, shape per the
+[Bot API `Invoice` object](https://core.telegram.org/bots/api#invoice).
+`total_amount` is in the currency's smallest unit and the exponent varies per
+currency ([currencies.json](https://core.telegram.org/bots/payments/currencies.json)):
+this 5000 is 50.00 USD, but 5000 JPY would be 5000 yen and 5000 BHD units
+would be 5.000 dinar. XTR (Telegram Stars) counts whole Stars.
+
+```json
+{
+  "update_id": 312744895,
+  "message": {
+    "message_id": 329,
+    "from": {
+      "id": 8000000001,
+      "is_bot": true,
+      "first_name": "Test Bot",
+      "username": "testbot"
+    },
+    "chat": {
+      "id": 100000001,
+      "first_name": "Test User",
+      "username": "testuser",
+      "type": "private"
+    },
+    "date": 1756290600,
+    "invoice": {
+      "title": "Yearly plan",
+      "description": "12 months of hosted service",
+      "start_parameter": "yearly-plan",
+      "currency": "USD",
+      "total_amount": 5000
+    }
+  }
+}
+```
+
+## Story message
+
+Sanitized story share, shape per the
+[Bot API `Message.story` field](https://core.telegram.org/bots/api#message).
+The story content itself is not exposed to bots — only the originating chat
+and the story id.
+
+```json
+{
+  "update_id": 312744896,
+  "message": {
+    "message_id": 330,
+    "from": {
+      "id": 100000001,
+      "is_bot": false,
+      "first_name": "Test User",
+      "username": "testuser",
+      "language_code": "en"
+    },
+    "chat": {
+      "id": 100000001,
+      "first_name": "Test User",
+      "username": "testuser",
+      "type": "private"
+    },
+    "date": 1756290660,
+    "story": {
+      "chat": {
+        "id": 100000003,
+        "first_name": "Story Author",
+        "username": "storyauthor",
+        "type": "private"
+      },
+      "id": 7
+    }
+  }
+}
+```

--- a/packages/adapter-telegram/src/index.test.ts
+++ b/packages/adapter-telegram/src/index.test.ts
@@ -6699,3 +6699,129 @@ describe("sticker and animation attachments", () => {
     expect(attachments[0]?.mimeType).toBe("application/pdf");
   });
 });
+
+describe("non-file content", () => {
+  async function parseContent(overrides: Partial<TelegramMessage>) {
+    mockFetch.mockResolvedValue(
+      telegramOk({
+        id: 8981792219,
+        is_bot: true,
+        first_name: "Bot",
+        username: "mybot",
+      })
+    );
+    const chat = createMockChatInstance({
+      logger: mockLogger,
+      state: createMockState(),
+      userName: "mybot",
+    });
+    const adapter = createTelegramAdapter({
+      botToken: "token",
+      mode: "webhook",
+      logger: mockLogger,
+      userName: "mybot",
+    });
+    await adapter.initialize(chat);
+
+    await adapter.handleWebhook(
+      new Request("https://example.com/webhook", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          update_id: 1,
+          message: sampleMessage({ text: undefined, ...overrides }),
+        }),
+      })
+    );
+
+    const processMessage = chat.processMessage as ReturnType<typeof vi.fn>;
+    const call = processMessage.mock.calls[0] as
+      | [unknown, string, { text?: string }]
+      | undefined;
+    return call?.[2]?.text;
+  }
+
+  it("describes a shared location", async () => {
+    expect(
+      await parseContent({ location: { latitude: 55.75, longitude: 37.61 } })
+    ).toBe("📍 55.75, 37.61");
+  });
+
+  it("describes a venue by name and address", async () => {
+    expect(
+      await parseContent({
+        venue: {
+          title: "Central Library",
+          address: "12 Main St",
+          location: { latitude: 55.75, longitude: 37.61 },
+        },
+        // Telegram sets the top-level location on every venue message for
+        // backward compatibility; the venue description must still win.
+        location: { latitude: 55.75, longitude: 37.61 },
+      })
+    ).toBe("📍 Central Library, 12 Main St");
+  });
+
+  it("describes a shared contact", async () => {
+    expect(
+      await parseContent({
+        contact: {
+          first_name: "Ada",
+          last_name: "Lovelace",
+          phone_number: "+15551234567",
+        },
+      })
+    ).toBe("👤 Ada Lovelace +15551234567");
+  });
+
+  it("describes a poll by its question", async () => {
+    expect(
+      await parseContent({ poll: { id: "1", question: "Lunch or dinner?" } })
+    ).toBe("📊 Lunch or dinner?");
+  });
+
+  it("describes a dice roll", async () => {
+    expect(await parseContent({ dice: { emoji: "🎲", value: 4 } })).toBe(
+      "🎲 4"
+    );
+  });
+
+  it("describes a game by its title", async () => {
+    expect(await parseContent({ game: { title: "Corsairs" } })).toBe(
+      "🎮 Corsairs"
+    );
+  });
+
+  it("describes an invoice with its amount", async () => {
+    expect(
+      await parseContent({
+        invoice: { title: "Yearly plan", total_amount: 4999, currency: "USD" },
+      })
+    ).toBe("🧾 Yearly plan — 49.99 USD");
+  });
+
+  it("keeps zero-exponent invoice currencies in whole units", async () => {
+    expect(
+      await parseContent({
+        invoice: { title: "Yearly plan", total_amount: 5000, currency: "JPY" },
+      })
+    ).toBe("🧾 Yearly plan — 5000 JPY");
+    expect(
+      await parseContent({
+        invoice: { title: "Boost", total_amount: 250, currency: "XTR" },
+      })
+    ).toBe("🧾 Boost — 250 XTR");
+  });
+
+  it("scales three-exponent invoice currencies by a thousand", async () => {
+    expect(
+      await parseContent({
+        invoice: { title: "Yearly plan", total_amount: 5000, currency: "BHD" },
+      })
+    ).toBe("🧾 Yearly plan — 5.000 BHD");
+  });
+
+  it("marks a shared story", async () => {
+    expect(await parseContent({ story: { id: 7 } })).toBe("📖 Story");
+  });
+});

--- a/packages/adapter-telegram/src/index.ts
+++ b/packages/adapter-telegram/src/index.ts
@@ -324,6 +324,80 @@ export function applyTelegramEntities(
 }
 
 /**
+ * Describe the message kinds Telegram sends with no text and no file:
+ * locations, venues, shared contacts, polls and dice.
+ *
+ * Without this they arrive as an empty message — the content is there in the
+ * payload, but a handler reading `text` sees nothing and cannot tell an empty
+ * delivery from a shared location. The wording stays short and literal; the
+ * structured payload is still on `raw` for anyone who needs the numbers.
+ */
+function describeNonFileContent(raw: TelegramMessage): string | undefined {
+  // Telegram sets `location` alongside `venue` for backward compatibility,
+  // so the venue check has to come first or every venue renders as bare
+  // coordinates.
+  if (raw.venue) {
+    return `📍 ${raw.venue.title}, ${raw.venue.address}`;
+  }
+  if (raw.location) {
+    return `📍 ${raw.location.latitude}, ${raw.location.longitude}`;
+  }
+  if (raw.contact) {
+    const name = [raw.contact.first_name, raw.contact.last_name]
+      .filter(Boolean)
+      .join(" ");
+    return `👤 ${name} ${raw.contact.phone_number}`.trim();
+  }
+  if (raw.poll) {
+    return `📊 ${raw.poll.question}`;
+  }
+  if (raw.dice) {
+    return `${raw.dice.emoji} ${raw.dice.value}`;
+  }
+  if (raw.game) {
+    return `🎮 ${raw.game.title}`;
+  }
+  if (raw.invoice) {
+    const amount = formatInvoiceAmount(
+      raw.invoice.total_amount,
+      raw.invoice.currency
+    );
+    return `🧾 ${raw.invoice.title} — ${amount} ${raw.invoice.currency}`;
+  }
+  if (raw.story) {
+    return "📖 Story";
+  }
+  return undefined;
+}
+
+// An invoice's total_amount is in the currency's smallest unit, and the
+// exponent varies per currency: Telegram's own list
+// (https://core.telegram.org/bots/payments/currencies.json) has these seven
+// at 0 and three at 3, with everything else at 2. XTR (Telegram Stars) is
+// not in that list and counts whole Stars.
+const ZERO_EXPONENT_CURRENCIES = new Set([
+  "CLP",
+  "ISK",
+  "JPY",
+  "KRW",
+  "PYG",
+  "UGX",
+  "VND",
+  "XTR",
+]);
+const THREE_EXPONENT_CURRENCIES = new Set(["BHD", "IQD", "JOD"]);
+
+function formatInvoiceAmount(totalAmount: number, currency: string): string {
+  let exponent = 2;
+  if (ZERO_EXPONENT_CURRENCIES.has(currency)) {
+    exponent = 0;
+  } else if (THREE_EXPONENT_CURRENCIES.has(currency)) {
+    exponent = 3;
+  }
+  return (totalAmount / 10 ** exponent).toFixed(exponent);
+}
+
+/**
  * Sticker formats: a still sticker is WebP, a video sticker WebM, and an
  * animated (Lottie) one the TGS container. The attachment type has to follow
  * the real format — a WebM typed "image" gets routed through sendPhoto by
@@ -2226,6 +2300,7 @@ export class TelegramAdapter
       (raw.sticker
         ? (raw.sticker.emoji ?? raw.sticker.set_name ?? "sticker")
         : undefined) ??
+      describeNonFileContent(raw) ??
       (raw.rich_message ? richMessageToText(raw.rich_message) : "");
     const entities = raw.entities ?? raw.caption_entities ?? [];
     const text = content?.text

--- a/packages/adapter-telegram/src/types.ts
+++ b/packages/adapter-telegram/src/types.ts
@@ -471,15 +471,37 @@ export interface TelegramMessage {
   caption?: string;
   caption_entities?: TelegramMessageEntity[];
   chat: TelegramChat;
+  contact?: {
+    first_name: string;
+    last_name?: string;
+    phone_number: string;
+    user_id?: number;
+    vcard?: string;
+  };
   date: number;
+  dice?: { emoji: string; value: number };
   document?: TelegramFile & { file_name?: string; mime_type?: string };
   edit_date?: number;
   entities?: TelegramMessageEntity[];
   from?: TelegramUser;
+  game?: { description?: string; title: string };
+  invoice?: {
+    currency: string;
+    description?: string;
+    title: string;
+    total_amount: number;
+  };
+  location?: TelegramLocation;
   media_group_id?: string;
   message_id: number;
   message_thread_id?: number;
   photo?: TelegramPhotoSize[];
+  poll?: {
+    id: string;
+    options?: { text: string; voter_count?: number }[];
+    question: string;
+    type?: string;
+  };
   reply_to_message?: TelegramMessage;
   rich_message?: TelegramRichMessage;
   sender_chat?: TelegramChat;
@@ -491,7 +513,13 @@ export interface TelegramMessage {
     is_animated?: boolean;
     is_video?: boolean;
   };
+  story?: { chat?: TelegramChat; id?: number };
   text?: string;
+  venue?: {
+    address: string;
+    location: TelegramLocation;
+    title: string;
+  };
   video?: TelegramVideo;
   video_note?: TelegramFile & { length?: number; duration?: number };
   voice?: TelegramFile & { duration?: number; mime_type?: string };


### PR DESCRIPTION
Telegram sends several message kinds with neither text nor a file. They reached the handler as empty messages: the content was in the payload, but anything reading `text` saw nothing and could not tell an empty delivery from a shared location.

A location, venue, contact, poll, dice, game, invoice and story now each produce a short literal description, in the same place a sticker produces its emoji:

```
📍 55.75, 37.61
📍 Central Library, 12 Main St
👤 Ada Lovelace +15551234567
📊 Lunch or dinner?
🎲 4
🎮 Corsairs
🧾 Yearly plan — 49.99 USD
📖 Story
```

The wording stays minimal and the structured payload is untouched on the raw message, so a handler that wants the coordinates or the poll options still has them.

Two Bot API quirks shape the implementation:

- A venue message also carries a top-level `location` field for backward compatibility, so the venue check runs first. Otherwise every venue would render as bare coordinates.
- An invoice's `total_amount` is in the currency's smallest unit, and the exponent varies per currency ([currencies.json](https://core.telegram.org/bots/payments/currencies.json)): JPY and Telegram Stars count whole units, BHD, IQD and JOD use three decimals, everything else two.

`sample-messages.md` gains fixtures for the new kinds, including the venue with its co-set location and a contact without a `last_name`.
