### PR TITLE
chore: add .vercel.approvers with vercel/ai-sdk team

### DIFF
--- a/.vercel.approvers
+++ b/.vercel.approvers
@@ -1,1 +1,1 @@
-@vercel/ai-sdk:team
+@vercel/chat-sdk:team

--- a/.vercel.approvers
+++ b/.vercel.approvers
@@ -1,0 +1,1 @@
+@vercel/ai-sdk:team


### PR DESCRIPTION
Adds a `.vercel.approvers` file designating the **@vercel/ai-sdk** team as approvers for this repository.

Format follows the convention used in other Vercel repos (e.g. `vercel/vercel`):


```
@vercel/ai-sdk:team
```