### PR TITLE
fix(chat): allow link button IDs in JSX

### DIFF
--- a/.changeset/smart-links-smile.md
+++ b/.changeset/smart-links-smile.md
@@ -1,0 +1,5 @@
+---
+"chat": patch
+---
+
+Allow JSX link buttons to include an explicit action ID.

--- a/packages/chat/src/jsx-runtime.test.tsx
+++ b/packages/chat/src/jsx-runtime.test.tsx
@@ -140,7 +140,11 @@ describe("chat-sdk JSX runtime with actual JSX syntax", () => {
       const element = (
         <Card>
           <Actions>
-            <LinkButton style="primary" url="https://example.com">
+            <LinkButton
+              id="visit-site"
+              style="primary"
+              url="https://example.com"
+            >
               Visit Site
             </LinkButton>
           </Actions>
@@ -154,6 +158,7 @@ describe("chat-sdk JSX runtime with actual JSX syntax", () => {
         const linkBtn = result.children[0].children[0];
         expect(linkBtn.type).toBe("link-button");
         if (linkBtn.type === "link-button") {
+          expect(linkBtn.id).toBe("visit-site");
           expect(linkBtn.url).toBe("https://example.com");
           expect(linkBtn.label).toBe("Visit Site");
           expect(linkBtn.style).toBe("primary");

--- a/packages/chat/src/jsx-runtime.ts
+++ b/packages/chat/src/jsx-runtime.ts
@@ -546,7 +546,7 @@ function isButtonProps(props: CardJSXProps): props is ButtonProps {
  * Type guard to check if props match LinkButtonProps
  */
 function isLinkButtonProps(props: CardJSXProps): props is LinkButtonProps {
-  return "url" in props && typeof props.url === "string" && !("id" in props);
+  return "url" in props && typeof props.url === "string";
 }
 
 /**


### PR DESCRIPTION

- Accept the documented optional `id` prop in the `LinkButton` JSX runtime guard.
- Preserve the action ID in the resulting `LinkButtonElement`.


## Discovery

We found this when Omniagent’s Slack sign-in card used the documented `<LinkButton id="…" url="…">` API and Chat SDK’s preview renderer threw `LinkButton requires a 'url' prop` despite receiving one.

## Root cause

The `!('id' in props)` check was introduced when `LinkButton` did not support IDs, as a structural distinction from `Button`. Stable link-button IDs were later added in #598 across `LinkButtonProps`, `LinkButtonOptions`, `LinkButtonElement`, JSX resolution, adapters, and the public documentation, but the old JSX guard was not updated.

Component identity is already established by `type === LinkButton` before this guard runs. Requiring a string `url` is therefore sufficient and restores the intended API without changing button dispatch or adapter behavior.