### PR TITLE
fix(chat): preserve thread id when editing channel messages

### DIFF
--- a/.changeset/fine-doors-joke.md
+++ b/.changeset/fine-doors-joke.md
@@ -1,0 +1,5 @@
+---
+"chat": patch
+---
+
+preserve adapter-returned thread ids when editing channel messages

--- a/packages/chat/src/channel.test.ts
+++ b/packages/chat/src/channel.test.ts
@@ -865,8 +865,10 @@ describe("ChannelImpl.post error cases", () => {
     });
 
     const result = await channel.post("Hello!");
+    const edited = await result.edit("Updated!");
 
     expect(result.threadId).toBe("slack:C123:new-thread");
+    expect(edited.threadId).toBe("slack:C123:new-thread");
   });
 
   it("should return a SentMessage with edit/delete capabilities", async () => {

--- a/packages/chat/src/channel.ts
+++ b/packages/chat/src/channel.ts
@@ -527,7 +527,7 @@ export class ChannelImpl<TState = Record<string, unknown>>
         }
         editPostable = await self.processCallbackUrls(editPostable);
         await adapter.editMessage(threadId, messageId, editPostable);
-        return self.createSentMessage(messageId, editPostable);
+        return self.createSentMessage(messageId, editPostable, threadId);
       },
 
       async delete(): Promise<void> {


### PR DESCRIPTION
## summary

- preserve adapter-returned thread ids on messages returned by channel message edits
- prevent edited messages from falling back to the parent channel id
- add regression coverage for adapters that return a thread id when posting a channel message