### PR TITLE
Create a new branch for this commit and start a pull request

### DIFF
--- a/packages/adapter-discord/package.json
+++ b/packages/adapter-discord/package.json
@@ -31,7 +31,7 @@
     "chat": "workspace:*",
     "discord-api-types": "^0.37.119",
     "discord-interactions": "^4.4.0",
-    "discord.js": "^14.25.1"
+    "discord.js": "^14.27.0"
   },
   "devDependencies": {
     "@chat-adapter/tests": "workspace:*",


### PR DESCRIPTION
undici@6.21.3 is within the affected range for CVE-2026-1526 / GHSA-vrm6-8vpv-qv8q, which concerns unbounded memory consumption during WebSocket permessage-deflate decompression. A malicious WebSocket server may send a highly compressed frame that expands to a very large amount of memory, potentially causing a Node.js process to crash or become unresponsive.
The vulnerable WebSocket code path is reachable when @chat-adapter/discord enables its optional Discord Gateway listener. The package also supports HTTP Interactions/Webhooks; an HTTP-only deployment does not, by itself, exercise the WebSocket decompression path described by this CVE.
This report intentionally distinguishes dependency presence and vulnerable-path reachability from a full production denial-of-service demonstration. The attached PoC is local-only and bounded to 4 MiB. It confirms negotiation and decompression through the affected version without sending a decompression bomb or attempting memory exhaustion.
