### PR TITLE
fix(messenger): guard attachment downloads

### DIFF
--- a/.changeset/curly-bats-draw.md
+++ b/.changeset/curly-bats-draw.md
@@ -1,0 +1,8 @@
+---
+"@chat-adapter/shared": minor
+"@chat-adapter/messenger": patch
+---
+
+guard Messenger attachment downloads against SSRF and oversized responses
+
+`downloadAttachment` in `@chat-adapter/shared` accepts an optional `hosts` allowlist that restricts downloads, including redirect targets, to the given hosts and their subdomains. The Messenger adapter uses it to download attachment media only from Meta's `fbsbx.com` and `fbcdn.net` hosts, with the shared SSRF guard, 25 MB size cap, and 30 second timeout. External fallback and link-share URLs are rejected before any network request.

--- a/apps/docs/content/adapters/official/messenger.mdx
+++ b/apps/docs/content/adapters/official/messenger.mdx
@@ -185,6 +185,15 @@ Constraints:
 - Subtitles limited to 80 characters.
 - Button Template text limited to 640 characters.
 
+### Inbound attachments
+
+Inbound attachment URLs remain available as `attachment.url`. The adapter's
+`fetchData` function downloads media only from Meta's `fbsbx.com` and
+`fbcdn.net` hosts, refuses private and internal addresses (including after
+redirects), limits responses to 25 MB, and times out after 30 seconds.
+External fallback and link-share URLs are preserved but rejected before any
+network request.
+
 ### Read receipts
 
 Use `thread.markAsRead()` in a message handler to send Messenger's `mark_seen` sender action:

--- a/packages/adapter-messenger/README.md
+++ b/packages/adapter-messenger/README.md
@@ -159,6 +159,15 @@ export async function POST(request: Request) {
 | DMs | Yes (DM-only platform) |
 | Postbacks | Yes |
 
+### Inbound attachments
+
+Inbound attachment URLs remain available as `attachment.url`. The adapter's
+`fetchData` function downloads media only from Meta's `fbsbx.com` and
+`fbcdn.net` hosts, refuses private and internal addresses (including after
+redirects), limits responses to 25 MB, and times out after 30 seconds.
+External fallback and link-share URLs are preserved but rejected before any
+network request.
+
 ### Read receipts
 
 Use `thread.markAsRead()` in a message handler to send Messenger's `mark_seen` sender action:

--- a/packages/adapter-messenger/src/fetch.test.ts
+++ b/packages/adapter-messenger/src/fetch.test.ts
@@ -1,0 +1,91 @@
+import type { IncomingMessage } from "node:http";
+import { Readable } from "node:stream";
+import { NetworkError } from "@chat-adapter/shared";
+import { describe, expect, it, vi } from "vitest";
+import { download } from "./fetch";
+
+function response(
+  body: string,
+  status = 200,
+  headers: IncomingMessage["headers"] = {},
+  statusMessage = "OK"
+): IncomingMessage {
+  return Object.assign(Readable.from([Buffer.from(body)]), {
+    headers,
+    statusCode: status,
+    statusMessage,
+  }) as IncomingMessage;
+}
+
+describe("Messenger attachment fetch", () => {
+  it.each([
+    "https://cdn.fbsbx.com/file",
+    "https://lookaside.fbsbx.com/file",
+    "https://scontent.xx.fbcdn.net/file",
+    "https://SContent.XX.FBCDN.NET/file",
+  ])("downloads from Meta CDN URL %s", async (url) => {
+    const transport = vi.fn(async () => response("media"));
+
+    await expect(download(url, transport)).resolves.toEqual(
+      Buffer.from("media")
+    );
+  });
+
+  it.each([
+    "https://example.com/file",
+    "https://fbcdn.net.attacker.example/file",
+    "https://cdn.fbsbx.com./file",
+    "http://cdn.fbsbx.com/file",
+    "https://127.0.0.1/file",
+    "https://2130706433/file",
+  ])("rejects untrusted attachment URL %s", async (url) => {
+    const transport = vi.fn(async () => response("media"));
+
+    await expect(download(url, transport)).rejects.toThrow(NetworkError);
+    expect(transport).not.toHaveBeenCalled();
+  });
+
+  it("rejects redirects away from Meta CDN hosts", async () => {
+    const transport = vi.fn(async () =>
+      response("", 302, { location: "https://example.com/file" })
+    );
+
+    await expect(
+      download("https://cdn.fbsbx.com/file", transport)
+    ).rejects.toThrow("Refusing to fetch an untrusted attachment URL");
+    expect(transport).toHaveBeenCalledOnce();
+  });
+
+  it("normalizes transport failures", async () => {
+    const transport = vi.fn(async () => {
+      throw new Error("offline");
+    });
+
+    await expect(
+      download("https://cdn.fbsbx.com/file", transport)
+    ).rejects.toMatchObject({
+      adapter: "messenger",
+      message: "Failed to download Messenger attachment",
+    });
+  });
+
+  it("rejects unsuccessful responses", async () => {
+    const transport = vi.fn(async () =>
+      response("missing", 404, {}, "Not Found")
+    );
+
+    await expect(
+      download("https://cdn.fbsbx.com/file", transport)
+    ).rejects.toMatchObject({
+      adapter: "messenger",
+      message: "Failed to fetch file: 404 Not Found",
+    });
+  });
+
+  it("uses Messenger network errors", async () => {
+    await expect(download("https://example.com/file")).rejects.toMatchObject({
+      adapter: "messenger",
+      message: "Refusing to fetch an untrusted attachment URL",
+    });
+  });
+});

--- a/packages/adapter-messenger/src/fetch.ts
+++ b/packages/adapter-messenger/src/fetch.ts
@@ -1,0 +1,29 @@
+import {
+  type AttachmentTransport,
+  downloadAttachment,
+  NetworkError,
+} from "@chat-adapter/shared";
+
+const HOSTS = ["fbsbx.com", "fbcdn.net"] as const;
+
+export async function download(
+  url: string,
+  transport?: AttachmentTransport
+): Promise<Buffer> {
+  try {
+    return await downloadAttachment(url, {
+      adapter: "messenger",
+      hosts: HOSTS,
+      transport,
+    });
+  } catch (error) {
+    if (error instanceof NetworkError) {
+      throw error;
+    }
+    throw new NetworkError(
+      "messenger",
+      "Failed to download Messenger attachment",
+      error instanceof Error ? error : undefined
+    );
+  }
+}

--- a/packages/adapter-messenger/src/index.test.ts
+++ b/packages/adapter-messenger/src/index.test.ts
@@ -1449,67 +1449,55 @@ describe("MessengerAdapter", () => {
     });
 
     it("downloads attachment successfully", async () => {
-      const adapter = createAdapter();
+      class Adapter extends MessengerAdapter {
+        protected override downloadAttachment(url: string): Promise<Buffer> {
+          expect(url).toBe("https://cdn.fbsbx.com/img.jpg");
+          return Promise.resolve(Buffer.from("fake-image-data"));
+        }
+      }
+      const adapter = new Adapter({
+        appSecret: "test-app-secret",
+        pageAccessToken: "test-page-token",
+        verifyToken: "test-verify-token",
+        logger: mockLogger,
+      });
       const event = sampleMessagingEvent({
         message: {
           mid: "mid.dl",
           text: "photo",
           attachments: [
-            { type: "image", payload: { url: "https://example.com/img.jpg" } },
+            {
+              type: "image",
+              payload: { url: "https://cdn.fbsbx.com/img.jpg" },
+            },
           ],
         },
       });
 
       const parsed = adapter.parseMessage(event);
       const attachment = parsed.attachments[0];
-
-      const imageData = Buffer.from("fake-image-data");
-      mockFetch.mockResolvedValueOnce(new Response(imageData, { status: 200 }));
 
       const result = await attachment.fetchData?.();
-      expect(result).toBeInstanceOf(Buffer);
+      expect(result).toEqual(Buffer.from("fake-image-data"));
     });
 
-    it("throws NetworkError when attachment download fails", async () => {
+    it("rejects external fallback downloads before the network", async () => {
       const adapter = createAdapter();
+      const url = "https://169.254.169.254/latest/meta-data";
       const event = sampleMessagingEvent({
         message: {
-          mid: "mid.dlerr",
-          text: "photo",
-          attachments: [
-            { type: "image", payload: { url: "https://example.com/img.jpg" } },
-          ],
+          mid: "mid.fallback",
+          text: "link",
+          attachments: [{ type: "fallback", payload: { url } }],
         },
       });
 
-      const parsed = adapter.parseMessage(event);
-      const attachment = parsed.attachments[0];
+      const attachment = adapter.parseMessage(event).attachments[0];
+      mockFetch.mockResolvedValueOnce(new Response("secret", { status: 200 }));
 
-      mockFetch.mockRejectedValueOnce(new Error("Network failure"));
-
+      expect(attachment.url).toBe(url);
       await expect(attachment.fetchData?.()).rejects.toThrow(NetworkError);
-    });
-
-    it("throws NetworkError when attachment download returns non-ok", async () => {
-      const adapter = createAdapter();
-      const event = sampleMessagingEvent({
-        message: {
-          mid: "mid.dl404",
-          text: "photo",
-          attachments: [
-            { type: "image", payload: { url: "https://example.com/img.jpg" } },
-          ],
-        },
-      });
-
-      const parsed = adapter.parseMessage(event);
-      const attachment = parsed.attachments[0];
-
-      mockFetch.mockResolvedValueOnce(
-        new Response("Not Found", { status: 404 })
-      );
-
-      await expect(attachment.fetchData?.()).rejects.toThrow(NetworkError);
+      expect(mockFetch).not.toHaveBeenCalled();
     });
 
     it("maps location attachment type to file", () => {

--- a/packages/adapter-messenger/src/index.ts
+++ b/packages/adapter-messenger/src/index.ts
@@ -31,6 +31,7 @@ import {
   Message,
 } from "chat";
 import { cardToMessenger, decodeMessengerCallbackData } from "./cards";
+import { download } from "./fetch";
 import { MessengerFormatConverter } from "./markdown";
 import type {
   MessengerAdapterConfig,
@@ -698,25 +699,7 @@ export class MessengerAdapter
   }
 
   protected async downloadAttachment(url: string): Promise<Buffer> {
-    let response: Response;
-    try {
-      response = await fetch(url);
-    } catch (error) {
-      throw new NetworkError(
-        "messenger",
-        "Failed to download Messenger attachment",
-        error instanceof Error ? error : undefined
-      );
-    }
-
-    if (!response.ok) {
-      throw new NetworkError(
-        "messenger",
-        `Failed to download Messenger attachment: ${response.status}`
-      );
-    }
-
-    return Buffer.from(await response.arrayBuffer());
+    return await download(url);
   }
 
   protected async fetchUserProfile(

--- a/packages/adapter-shared/src/download.test.ts
+++ b/packages/adapter-shared/src/download.test.ts
@@ -131,6 +131,58 @@ describe("guarded attachment downloads", () => {
     ).rejects.toThrow("Refusing to fetch an internal attachment URL");
   });
 
+  it.each([
+    "https://fbsbx.com/file",
+    "https://cdn.fbsbx.com/file",
+    "https://SContent.XX.FBCDN.NET/file",
+  ])("accepts allowlisted host URL %s", (url) => {
+    expect(
+      validateAttachmentUrl(url, "test", ["fbsbx.com", "FBCDN.net"])
+    ).toBeInstanceOf(URL);
+  });
+
+  it.each([
+    "https://example.com/file",
+    "https://fbsbx.com.attacker.example/file",
+    "https://cdn.fbsbx.com./file",
+  ])("rejects off-allowlist URL %s", (url) => {
+    expect(() =>
+      validateAttachmentUrl(url, "test", ["fbsbx.com", "fbcdn.net"])
+    ).toThrow("Refusing to fetch an untrusted attachment URL");
+  });
+
+  it("applies the host allowlist to redirect targets", async () => {
+    const transport = vi.fn(async () =>
+      response("", 302, { location: "https://example.com/file" })
+    );
+
+    await expect(
+      downloadAttachment("https://cdn.fbsbx.com/file", {
+        adapter: "test",
+        hosts: ["fbsbx.com"],
+        transport,
+      })
+    ).rejects.toThrow("Refusing to fetch an untrusted attachment URL");
+    expect(transport).toHaveBeenCalledOnce();
+  });
+
+  it("follows redirects between allowlisted hosts", async () => {
+    const transport = vi
+      .fn<(url: URL, signal: AbortSignal) => Promise<IncomingMessage>>()
+      .mockResolvedValueOnce(
+        response("", 302, { location: "https://scontent.xx.fbcdn.net/file" })
+      )
+      .mockResolvedValueOnce(response("media"));
+
+    await expect(
+      downloadAttachment("https://lookaside.fbsbx.com/file", {
+        adapter: "test",
+        hosts: ["fbsbx.com", "fbcdn.net"],
+        transport,
+      })
+    ).resolves.toEqual(Buffer.from("media"));
+  });
+
   it("rejects redirects to internal addresses", async () => {
     const transport = vi.fn(async () =>
       response("", 302, {

--- a/packages/adapter-shared/src/download.ts
+++ b/packages/adapter-shared/src/download.ts
@@ -66,6 +66,12 @@ export interface DownloadAttachmentOptions {
   adapter: string;
   /** Extra request headers merged over the defaults. */
   headers?: Record<string, string>;
+  /**
+   * Optional host allowlist. When set, every fetched URL (including
+   * redirect targets) must be one of these hosts or a subdomain of one;
+   * anything else is refused as untrusted. Matching is case-insensitive.
+   */
+  hosts?: readonly string[];
   /** Maximum decoded body size in bytes. Defaults to 25 MB. */
   limit?: number;
   /** Maximum redirects to follow. Defaults to 5. */
@@ -148,7 +154,8 @@ export function createResolver(
 
 export function validateAttachmentUrl(
   value: string | URL,
-  adapter: string
+  adapter: string,
+  hosts?: readonly string[]
 ): URL {
   const url = value instanceof URL ? value : new URL(value);
   const hostname = url.hostname.replace(BRACKETS, "");
@@ -156,7 +163,14 @@ export function validateAttachmentUrl(
   if (family && blocked(hostname, family)) {
     throw refusal(adapter);
   }
-  if (url.protocol !== "https:") {
+  if (
+    url.protocol !== "https:" ||
+    (hosts &&
+      !hosts.some((host) => {
+        const allowed = host.toLowerCase();
+        return hostname === allowed || hostname.endsWith(`.${allowed}`);
+      }))
+  ) {
     throw new NetworkError(
       adapter,
       "Refusing to fetch an untrusted attachment URL"
@@ -260,6 +274,7 @@ export async function downloadAttachment(
   const {
     adapter,
     headers,
+    hosts,
     limit = LIMIT,
     redirects = REDIRECTS,
     timeoutMs = TIMEOUT,
@@ -267,7 +282,7 @@ export async function downloadAttachment(
   } = options;
   const send = transport ?? createTransport(adapter, headers);
   const signal = AbortSignal.timeout(timeoutMs);
-  let url = validateAttachmentUrl(value, adapter);
+  let url = validateAttachmentUrl(value, adapter, hosts);
   try {
     for (let hop = 0; hop <= redirects; hop += 1) {
       const response = await send(url, signal);
@@ -284,7 +299,7 @@ export async function downloadAttachment(
         if (hop === redirects) {
           throw new NetworkError(adapter, "Too many attachment redirects");
         }
-        url = validateAttachmentUrl(new URL(location, url), adapter);
+        url = validateAttachmentUrl(new URL(location, url), adapter, hosts);
         continue;
       }
       if (status < 200 || status >= 300) {


### PR DESCRIPTION
## summary

- restrict Messenger attachment downloads to Meta's `fbsbx.com` and `fbcdn.net` hosts while preserving external URLs on `attachment.url`
- reject untrusted URLs before connecting using HTTPS validation, connection-bound DNS checks, manual redirect validation, timeouts, and streamed size limits
- move the guarded downloader into `@chat-adapter/shared` and keep the Teams implementation behaviorally equivalent
- normalize malformed redirect locations and other download failures as typed `NetworkError` values
- document the inbound attachment policy for Messenger
- stacked on #850 and should merge after it

## test plan

- verified valid Meta image, audio, video, and file CDN hosts remain downloadable
- verified external hosts, private addresses, malformed URLs, unsafe ports, trailing dots, and suffix attacks are rejected
- verified mixed private and public DNS results fail closed
- verified redirects are revalidated and malformed or external destinations are rejected
- verified declared and streamed size limits and stalled body timeouts
- ran workspace build, affected package tests and typechecks, integration checks, Knip, Ultracite, and diff validation