### PR TITLE
fix(telegram): require webhook verification by default

### DIFF
--- a/.changeset/tangy-apes-sort.md
+++ b/.changeset/tangy-apes-sort.md
@@ -1,5 +1,5 @@
 ---
-"@chat-adapter/telegram": patch
+"@chat-adapter/telegram": minor
 ---
 
 require webhook verification by default with an explicit unverified opt-in

--- a/.changeset/tangy-apes-sort.md
+++ b/.changeset/tangy-apes-sort.md
@@ -1,0 +1,5 @@
+---
+"@chat-adapter/telegram": patch
+---
+
+require webhook verification by default with an explicit unverified opt-in

--- a/apps/docs/content/adapters/official/telegram.mdx
+++ b/apps/docs/content/adapters/official/telegram.mdx
@@ -67,7 +67,7 @@ features:
 ## Quick start
 
 <Callout type="info">
-The adapter auto-detects `TELEGRAM_ALLOWED_USER_IDS`, `TELEGRAM_BOT_TOKEN`, `TELEGRAM_WEBHOOK_SECRET_TOKEN`, and `TELEGRAM_BOT_USERNAME` from the environment.
+The adapter auto-detects `TELEGRAM_ALLOWED_USER_IDS`, `TELEGRAM_BOT_TOKEN`, `TELEGRAM_WEBHOOK_SECRET_TOKEN`, `TELEGRAM_ALLOW_UNVERIFIED_WEBHOOKS`, and `TELEGRAM_BOT_USERNAME` from the environment.
 </Callout>
 
 ```typescript title="lib/bot.ts" lineNumbers
@@ -130,6 +130,12 @@ const telegram = createTelegramAdapter({
 
 <TypeTable
   type={{
+    allowUnverifiedWebhooks: {
+      type: "boolean",
+      default: "false",
+      description:
+        "Accept webhook requests without secret-token verification. Auto-detected from `TELEGRAM_ALLOW_UNVERIFIED_WEBHOOKS=true`. Use only for local development or behind a trusted verifying proxy.",
+    },
     allowedUserIds: {
       type: "Array<number | string>",
       description:
@@ -143,7 +149,7 @@ const telegram = createTelegramAdapter({
     secretToken: {
       type: "string",
       description:
-        "Optional webhook secret. Auto-detected from `TELEGRAM_WEBHOOK_SECRET_TOKEN`.",
+        "Webhook secret required in webhook mode unless unverified webhooks are explicitly allowed. Auto-detected from `TELEGRAM_WEBHOOK_SECRET_TOKEN`.",
     },
     mode: {
       type: '"auto" | "webhook" | "polling"',
@@ -181,7 +187,7 @@ const telegram = createTelegramAdapter({
   }}
 />
 
-`botToken` is required — either via config or env var.
+`botToken` is always required. Webhook mode also requires `secretToken` unless `allowUnverifiedWebhooks` is explicitly enabled. Polling mode does not require webhook verification.
 
 ## Authentication
 
@@ -255,7 +261,8 @@ Pass `{ raw: "..." }` only if you need to ship a fully pre-escaped MarkdownV2 st
 
 ### Notes
 
-- Verified webhook updates with an integer `update_id` are deduplicated for 24 hours through the configured state adapter. Configure `secretToken` and use shared durable state across serverless instances. If state is unavailable, the adapter returns 503 so Telegram retries without dispatching.
+- Accepted webhook updates with an integer `update_id` are deduplicated for 24 hours through the configured state adapter. Use shared durable state across serverless instances. If state is unavailable, the adapter returns 503 so Telegram retries without dispatching.
+- Webhook mode requires `secretToken` unless `allowUnverifiedWebhooks` is explicitly enabled. Polling mode does not require webhook verification.
 - Telegram does not expose full historical message APIs to bots. `fetchMessages` returns adapter-cached messages from the current process.
 - `listThreads` is not available for Telegram chats.
 - Telegram callback data is limited to 64 bytes — keep `Button` `id`/`value` payloads short.

--- a/packages/adapter-telegram/README.md
+++ b/packages/adapter-telegram/README.md
@@ -29,7 +29,7 @@ Visit the [adapters directory](https://chat-sdk.dev/adapters) to see other avail
 
 ## Usage
 
-The adapter auto-detects `TELEGRAM_BOT_TOKEN`, `TELEGRAM_WEBHOOK_SECRET_TOKEN`, `TELEGRAM_BOT_USERNAME`, and `TELEGRAM_API_BASE_URL` from environment variables:
+The adapter auto-detects `TELEGRAM_BOT_TOKEN`, `TELEGRAM_WEBHOOK_SECRET_TOKEN`, `TELEGRAM_ALLOW_UNVERIFIED_WEBHOOKS`, `TELEGRAM_BOT_USERNAME`, and `TELEGRAM_API_BASE_URL` from environment variables:
 
 ```typescript
 import { Chat } from "chat";
@@ -67,7 +67,7 @@ Connect does not forward Telegram webhooks. Keep
 without an inbound webhook. `TELEGRAM_BOT_TOKEN` is not needed when using the
 Connect helper. The adapter derives webhook deduplication scope from Telegram's
 stable bot identity, so token rotation does not split update claims. If bot
-identity lookup fails at startup, the next verified webhook retries it.
+identity lookup fails at startup, the next accepted webhook retries it.
 
 ## Webhook route
 
@@ -151,9 +151,10 @@ Most options are auto-detected from environment variables when not provided. `na
 
 | Option | Required | Description |
 |--------|----------|-------------|
+| `allowUnverifiedWebhooks` | No | Accept webhook requests without secret-token verification. Auto-detected from `TELEGRAM_ALLOW_UNVERIFIED_WEBHOOKS=true`. Use only for local development or behind a trusted verifying proxy |
 | `allowedUserIds` | No | Telegram user IDs allowed to trigger the adapter. Auto-detected from `TELEGRAM_ALLOWED_USER_IDS` (comma-separated). All users are allowed when omitted or empty |
 | `botToken` | No* | Telegram bot token. Auto-detected from `TELEGRAM_BOT_TOKEN` |
-| `secretToken` | No | Optional webhook secret token. Auto-detected from `TELEGRAM_WEBHOOK_SECRET_TOKEN` |
+| `secretToken` | Webhook* | Webhook secret token. Auto-detected from `TELEGRAM_WEBHOOK_SECRET_TOKEN` |
 | `mode` | No | Adapter mode: `auto` (default), `webhook`, or `polling` |
 | `longPolling` | No | Optional long polling config for `getUpdates` (`timeout`, `limit`, `allowedUpdates`, `deleteWebhook`, `dropPendingUpdates`, `retryDelayMs`) |
 | `userName` | No | Bot username used for mention detection. Auto-detected from `TELEGRAM_BOT_USERNAME` or `getMe` |
@@ -162,7 +163,7 @@ Most options are auto-detected from environment variables when not provided. `na
 | `apiUrl` | No | Telegram API base URL. Auto-detected from `TELEGRAM_API_BASE_URL`. Use `apiUrl` for cross-adapter consistency; the legacy `apiBaseUrl` alias is still accepted |
 | `logger` | No | Logger instance (defaults to `ConsoleLogger("info")`) |
 
-*`botToken` is required — either via config or env vars.
+*`botToken` is always required. Webhook mode also requires `secretToken` unless `allowUnverifiedWebhooks` is explicitly enabled. Polling mode does not require webhook verification.
 
 ## Environment variables
 
@@ -174,6 +175,8 @@ TELEGRAM_BOT_USERNAME=mybot
 # Optional (self-hosted API gateway)
 TELEGRAM_API_BASE_URL=https://api.telegram.org
 ```
+
+Set `TELEGRAM_ALLOW_UNVERIFIED_WEBHOOKS=true` only for local development or when a trusted upstream verifies every request before it reaches the adapter.
 
 ## Features
 
@@ -253,7 +256,8 @@ Behavior change in 4.27.0: previous versions used Telegram's legacy `Markdown` p
 
 ## Notes
 
-- Verified webhook updates with an integer `update_id` are deduplicated for 24 hours through the configured state adapter. Configure `secretToken` and use shared durable state across serverless instances. If state is unavailable, the adapter returns 503 so Telegram retries without dispatching.
+- Accepted webhook updates with an integer `update_id` are deduplicated for 24 hours through the configured state adapter. Use shared durable state across serverless instances. If state is unavailable, the adapter returns 503 so Telegram retries without dispatching.
+- Webhook mode requires `secretToken` unless `allowUnverifiedWebhooks` is explicitly enabled. Polling mode does not require webhook verification.
 - Telegram does not expose full historical message APIs to bots. `fetchMessages` / `fetchChannelMessages` return adapter-cached messages from the current process.
 - `listThreads` is not available for Telegram chats.
 - Polling and webhooks are mutually exclusive in Telegram.

--- a/packages/adapter-telegram/src/index.test.ts
+++ b/packages/adapter-telegram/src/index.test.ts
@@ -31,6 +31,7 @@ import {
 } from "./markdown";
 
 const mockFetch = vi.fn<typeof fetch>();
+process.env.TELEGRAM_ALLOW_UNVERIFIED_WEBHOOKS = "true";
 const SERVERLESS_ENV_KEYS = [
   "VERCEL",
   "AWS_LAMBDA_FUNCTION_NAME",
@@ -205,6 +206,38 @@ describe("createTelegramAdapter", () => {
     );
   });
 
+  it("requires verification in webhook mode", () => {
+    expect(() =>
+      createTelegramAdapter({
+        allowUnverifiedWebhooks: false,
+        botToken: "token",
+        mode: "webhook",
+        logger: mockLogger,
+      })
+    ).toThrow("secretToken is required in webhook mode");
+  });
+
+  it("allows explicit unverified webhook mode", () => {
+    expect(
+      createTelegramAdapter({
+        allowUnverifiedWebhooks: true,
+        botToken: "token",
+        mode: "webhook",
+        logger: mockLogger,
+      })
+    ).toBeInstanceOf(TelegramAdapter);
+  });
+
+  it("allows polling mode without webhook verification", () => {
+    expect(
+      createTelegramAdapter({
+        botToken: "token",
+        mode: "polling",
+        logger: mockLogger,
+      })
+    ).toBeInstanceOf(TelegramAdapter);
+  });
+
   it("uses env vars when config is omitted", () => {
     process.env.TELEGRAM_BOT_TOKEN = "token-from-env";
 
@@ -252,6 +285,21 @@ describe("constructor env var resolution", () => {
     process.env.TELEGRAM_WEBHOOK_SECRET_TOKEN = "env-secret";
     const adapter = new TelegramAdapter();
     expect(adapter).toBeInstanceOf(TelegramAdapter);
+  });
+
+  it("should resolve allowUnverifiedWebhooks from TELEGRAM_ALLOW_UNVERIFIED_WEBHOOKS", () => {
+    process.env.TELEGRAM_BOT_TOKEN = "env-bot-token";
+    process.env.TELEGRAM_ALLOW_UNVERIFIED_WEBHOOKS = "true";
+    const adapter = new TelegramAdapter({ mode: "webhook" });
+    expect(adapter).toBeInstanceOf(TelegramAdapter);
+  });
+
+  it("should reject TELEGRAM_ALLOW_UNVERIFIED_WEBHOOKS=false in webhook mode", () => {
+    process.env.TELEGRAM_BOT_TOKEN = "env-bot-token";
+    process.env.TELEGRAM_ALLOW_UNVERIFIED_WEBHOOKS = "false";
+    expect(() => new TelegramAdapter({ mode: "webhook" })).toThrow(
+      "secretToken is required in webhook mode"
+    );
   });
 
   it("should resolve userName from TELEGRAM_BOT_USERNAME env var", () => {
@@ -755,7 +803,7 @@ describe("TelegramAdapter", () => {
     );
   });
 
-  it("does not let unverified updates claim IDs", async () => {
+  it("deduplicates explicitly allowed unverified updates", async () => {
     mockFetch.mockResolvedValue(
       telegramOk({
         id: 999,
@@ -791,8 +839,8 @@ describe("TelegramAdapter", () => {
       request({ update_id: 1, message: sampleMessage() })
     );
 
-    expect(chat.processMessage).toHaveBeenCalledTimes(1);
-    expect(state.setIfNotExists).not.toHaveBeenCalled();
+    expect(chat.processMessage).not.toHaveBeenCalled();
+    expect(state.setIfNotExists).toHaveBeenCalledTimes(2);
   });
 
   it("scopes webhook update claims by bot identity", async () => {
@@ -894,13 +942,15 @@ describe("TelegramAdapter", () => {
 
   it("combines an incoming media group into one ordered message", async () => {
     vi.useFakeTimers();
-    mockFetch.mockResolvedValue(
-      telegramOk({
-        id: 999,
-        is_bot: true,
-        first_name: "Bot",
-        username: "mybot",
-      })
+    mockFetch.mockImplementation(() =>
+      Promise.resolve(
+        telegramOk({
+          id: 999,
+          is_bot: true,
+          first_name: "Bot",
+          username: "mybot",
+        })
+      )
     );
 
     const state = createMockState();
@@ -958,7 +1008,7 @@ describe("TelegramAdapter", () => {
     ];
 
     for (const [index, message] of messages.entries()) {
-      await adapters[index].handleWebhook(
+      const response = await adapters[index].handleWebhook(
         new Request("https://example.com/webhook", {
           method: "POST",
           headers: { "content-type": "application/json" },
@@ -966,6 +1016,7 @@ describe("TelegramAdapter", () => {
         }),
         { waitUntil }
       );
+      expect(response.status).toBe(200);
     }
 
     const processMessages = chats.map(
@@ -1022,6 +1073,7 @@ describe("TelegramAdapter", () => {
     }
 
     const adapter = new TestTelegramAdapter({
+      allowUnverifiedWebhooks: true,
       allowedUserIds: [456],
       botToken: "token",
       mode: "webhook",
@@ -1455,6 +1507,47 @@ describe("TelegramAdapter", () => {
     expect(response.status).toBe(401);
   });
 
+  it("rejects unverified callback queries before dispatch", async () => {
+    const adapter = createTelegramAdapter({
+      allowUnverifiedWebhooks: false,
+      botToken: "token",
+      mode: "auto",
+      logger: mockLogger,
+      userName: "mybot",
+    });
+    const chat = createMockChat();
+    (
+      adapter as unknown as {
+        chat: ChatInstance;
+      }
+    ).chat = chat;
+
+    const response = await adapter.handleWebhook(
+      new Request("https://example.com/webhook", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          update_id: 2,
+          callback_query: {
+            id: "callback-1",
+            from: {
+              id: 456,
+              is_bot: false,
+              first_name: "User",
+              username: "user",
+            },
+            message: sampleMessage(),
+            chat_instance: "ci_1",
+            data: encodeTelegramCallbackData("eve_input", "request-123"),
+          },
+        }),
+      })
+    );
+
+    expect(response.status).toBe(401);
+    expect(chat).not.toHaveDispatched("processAction");
+  });
+
   it("returns 400 for invalid webhook JSON", async () => {
     const adapter = createTelegramAdapter({
       botToken: "token",
@@ -1832,6 +1925,38 @@ describe("TelegramAdapter", () => {
     expect(String(mockFetch.mock.calls[1]?.[0])).toContain("/getWebhookInfo");
     expect(adapter.runtimeMode).toBe("webhook");
     expect(adapter.isPolling).toBe(false);
+  });
+
+  it("auto mode requires verification when a webhook is registered", async () => {
+    mockFetch
+      .mockResolvedValueOnce(
+        telegramOk({
+          id: 999,
+          is_bot: true,
+          first_name: "Bot",
+          username: "mybot",
+        })
+      )
+      .mockResolvedValueOnce(
+        telegramOk({
+          allowed_updates: [],
+          has_custom_certificate: false,
+          pending_update_count: 0,
+          url: "https://example.com/webhook/telegram",
+        })
+      );
+
+    const adapter = createTelegramAdapter({
+      allowUnverifiedWebhooks: false,
+      botToken: "token",
+      mode: "auto",
+      logger: mockLogger,
+      userName: "mybot",
+    });
+
+    await expect(adapter.initialize(createMockChat())).rejects.toThrow(
+      "secretToken is required in webhook mode"
+    );
   });
 
   it("auto mode stays in webhook mode on serverless runtime", async () => {
@@ -5772,6 +5897,7 @@ describe("sleep abort support", () => {
 
   const makeAdapter = () =>
     new SleepTestAdapter({
+      allowUnverifiedWebhooks: true,
       botToken: "token",
       mode: "webhook",
       logger: mockLogger,
@@ -5840,6 +5966,7 @@ describe("mention regex caching", () => {
 
   it("matches with the cached regex and recompiles when the username changes", () => {
     const adapter = new MentionTestAdapter({
+      allowUnverifiedWebhooks: true,
       botToken: "token",
       mode: "webhook",
       userName: "first_bot",

--- a/packages/adapter-telegram/src/index.ts
+++ b/packages/adapter-telegram/src/index.ts
@@ -83,6 +83,8 @@ import type {
 
 const TELEGRAM_API_BASE = "https://api.telegram.org";
 const TELEGRAM_SECRET_TOKEN_HEADER = "x-telegram-bot-api-secret-token";
+const TELEGRAM_WEBHOOK_VERIFICATION_ERROR =
+  "secretToken is required in webhook mode. Set TELEGRAM_WEBHOOK_SECRET_TOKEN or provide secretToken. To accept unverified webhooks, set allowUnverifiedWebhooks: true or TELEGRAM_ALLOW_UNVERIFIED_WEBHOOKS=true.";
 const MESSAGE_ID_PATTERN = /^([^:]+):(\d+)$/;
 const trimTrailingSlashes = (url: string): string => {
   let end = url.length;
@@ -277,6 +279,7 @@ export class TelegramAdapter
   readonly persistThreadHistory = true;
 
   protected readonly allowedUserIds?: Set<string>;
+  protected readonly allowUnverifiedWebhooks: boolean;
   protected readonly botTokenProvider: () => Promise<string>;
   protected readonly staticBotToken?: string;
   protected readonly apiBaseUrl: string;
@@ -342,6 +345,9 @@ export class TelegramAdapter
     );
     this.secretToken =
       config.secretToken ?? process.env.TELEGRAM_WEBHOOK_SECRET_TOKEN;
+    this.allowUnverifiedWebhooks =
+      config.allowUnverifiedWebhooks ??
+      process.env.TELEGRAM_ALLOW_UNVERIFIED_WEBHOOKS === "true";
     const allowedUserIds =
       config.allowedUserIds ??
       process.env.TELEGRAM_ALLOWED_USER_IDS?.split(",");
@@ -373,6 +379,15 @@ export class TelegramAdapter
       throw new ValidationError(
         "telegram",
         `Invalid mode: ${this.mode}. Expected "auto", "webhook", or "polling".`
+      );
+    }
+    if (
+      this.mode === "webhook" &&
+      !(this.secretToken || this.allowUnverifiedWebhooks)
+    ) {
+      throw new ValidationError(
+        "telegram",
+        TELEGRAM_WEBHOOK_VERIFICATION_ERROR
       );
     }
   }
@@ -437,6 +452,16 @@ export class TelegramAdapter
     const runtimeMode = await this.resolveRuntimeMode();
     this._runtimeMode = runtimeMode;
 
+    if (
+      runtimeMode === "webhook" &&
+      !(this.secretToken || this.allowUnverifiedWebhooks)
+    ) {
+      throw new ValidationError(
+        "telegram",
+        TELEGRAM_WEBHOOK_VERIFICATION_ERROR
+      );
+    }
+
     if (runtimeMode === "polling") {
       const pollingConfig = this.longPolling;
 
@@ -482,6 +507,12 @@ export class TelegramAdapter
     request: Request,
     options?: WebhookOptions
   ): Promise<Response> {
+    if (!(this.secretToken || this.allowUnverifiedWebhooks)) {
+      this.logger.warn(
+        "Telegram webhook rejected because verification is not configured"
+      );
+      return new Response("Webhook verification required", { status: 401 });
+    }
     if (this.secretToken) {
       const headerToken = request.headers.get(TELEGRAM_SECRET_TOKEN_HEADER);
       let valid = false;
@@ -503,9 +534,7 @@ export class TelegramAdapter
       }
     } else if (!this.warnedNoVerification) {
       this.warnedNoVerification = true;
-      this.logger.warn(
-        "Telegram webhook verification is disabled. Set TELEGRAM_WEBHOOK_SECRET_TOKEN or secretToken to verify incoming requests."
-      );
+      this.logger.warn("Telegram webhook verification is explicitly disabled");
     }
 
     let update: TelegramUpdate;
@@ -522,7 +551,7 @@ export class TelegramAdapter
       return new Response("OK", { status: 200 });
     }
 
-    if (this.secretToken && Number.isInteger(update.update_id)) {
+    if (Number.isInteger(update.update_id)) {
       let webhookScope = this.webhookScope;
       if (!webhookScope) {
         try {

--- a/packages/adapter-telegram/src/types.ts
+++ b/packages/adapter-telegram/src/types.ts
@@ -10,6 +10,7 @@ import type { Logger } from "chat";
 export interface TelegramAdapterConfig {
   /** Telegram user IDs allowed to trigger the adapter. Defaults to TELEGRAM_ALLOWED_USER_IDS env var (comma-separated). All users are allowed when omitted or empty. */
   allowedUserIds?: Array<number | string>;
+  allowUnverifiedWebhooks?: boolean;
   /** Optional custom API base URL (defaults to https://api.telegram.org). Defaults to TELEGRAM_API_BASE_URL env var. */
   apiBaseUrl?: string;
   /** Override the Telegram API base URL. Alias for apiBaseUrl — apiUrl takes precedence if both are set. Defaults to TELEGRAM_API_BASE_URL env var. */
@@ -35,7 +36,7 @@ export interface TelegramAdapterConfig {
    * post-and-edit regardless of this setting.
    */
   nativeStreaming?: boolean;
-  /** Optional webhook secret token checked against x-telegram-bot-api-secret-token. Defaults to TELEGRAM_WEBHOOK_SECRET_TOKEN env var. */
+  /** Webhook secret token checked against x-telegram-bot-api-secret-token. Required in webhook mode unless unverified webhooks are explicitly allowed. Defaults to TELEGRAM_WEBHOOK_SECRET_TOKEN env var. */
   secretToken?: string;
   /**
    * Minimum interval between edits on the post-and-edit streaming path.

--- a/packages/chat/src/adapters/index.ts
+++ b/packages/chat/src/adapters/index.ts
@@ -1003,7 +1003,11 @@ export const ADAPTERS = {
         ),
         secretEnv(
           "TELEGRAM_WEBHOOK_SECRET_TOKEN",
-          "Optional webhook secret token."
+          "Webhook secret token required in webhook mode."
+        ),
+        env(
+          "TELEGRAM_ALLOW_UNVERIFIED_WEBHOOKS",
+          "Set to true to accept unverified webhooks for local fixtures."
         ),
         env("TELEGRAM_BOT_USERNAME", "Bot username for mention detection."),
         urlEnv("TELEGRAM_API_BASE_URL", "Override the Telegram API base URL."),

--- a/packages/integration-tests/src/replay-telegram.test.ts
+++ b/packages/integration-tests/src/replay-telegram.test.ts
@@ -53,6 +53,7 @@ describe("Replay Tests - Telegram", () => {
     });
 
     adapter = createTelegramAdapter({
+      allowUnverifiedWebhooks: true,
       botToken: TELEGRAM_BOT_TOKEN,
       logger: mockLogger,
       mode: "webhook",


### PR DESCRIPTION
## summary

- require `secretToken` when Telegram resolves to webhook mode
- reject unverified messages and callback queries before dispatch
- add `allowUnverifiedWebhooks` as an explicit escape hatch for local fixtures or trusted upstream verification
- preserve polling without requiring webhook credentials
- deduplicate every accepted webhook update
- update adapter docs, configuration metadata, and integration fixtures