### PR TITLE
fix(adapters): restrict attachment credentials to trusted hosts

### DIFF
--- a/.changeset/slimy-signs-wish.md
+++ b/.changeset/slimy-signs-wish.md
@@ -1,0 +1,6 @@
+---
+"@chat-adapter/slack": patch
+"@chat-adapter/whatsapp": patch
+---
+
+prevent attachment downloads from sending credentials to untrusted hosts

--- a/packages/adapter-slack/src/api/client.ts
+++ b/packages/adapter-slack/src/api/client.ts
@@ -1,3 +1,5 @@
+import { isSlackAuthUrl } from "../file";
+
 export type SlackBotToken = string | (() => Promise<string> | string);
 
 export type SlackFetch = typeof fetch;
@@ -319,12 +321,12 @@ export async function uploadSlackFiles(
 export async function fetchSlackFile(
   options: SlackFileFetchOptions
 ): Promise<Response> {
-  const token = await resolveSlackBotToken(options.token);
   const request = options.fetch ?? fetch;
+  const token = isSlackAuthUrl(options.url, options.apiUrl)
+    ? await resolveSlackBotToken(options.token)
+    : undefined;
   const response = await request(options.url, {
-    headers: {
-      authorization: `Bearer ${token}`,
-    },
+    headers: token ? { authorization: `Bearer ${token}` } : undefined,
   });
   if (!response.ok) {
     throw new SlackApiError(

--- a/packages/adapter-slack/src/api/index.test.ts
+++ b/packages/adapter-slack/src/api/index.test.ts
@@ -316,6 +316,41 @@ describe("Slack api primitives", () => {
     expect(request.mock.calls[0][1].headers.authorization).toBe("Bearer xoxb");
   });
 
+  it.each([
+    "https://docs.google.com/document/d/external",
+    "http://files.slack.com/files-pri/T/F/report.txt",
+    "https://files.slack.com.attacker.example/report.txt",
+    "https://files.slack.com@attacker.example/report.txt",
+  ])("fetches external URL %s without bearer auth", async (url) => {
+    const response = new Response("file", { status: 200 });
+    const request = vi.fn().mockResolvedValue(response);
+    const token = vi.fn().mockResolvedValue("xoxb");
+
+    const result = await fetchSlackFile({
+      fetch: request,
+      token,
+      url,
+    });
+
+    expect(result).toBe(response);
+    expect(token).not.toHaveBeenCalled();
+    expect(request).toHaveBeenCalledWith(url, { headers: undefined });
+  });
+
+  it("authenticates file URLs on the configured API origin", async () => {
+    const response = new Response("file", { status: 200 });
+    const request = vi.fn().mockResolvedValue(response);
+
+    await fetchSlackFile({
+      apiUrl: "https://slack-gov.com/api/",
+      fetch: request,
+      token: "xoxb",
+      url: "https://slack-gov.com/files-pri/T/F/report.txt",
+    });
+
+    expect(request.mock.calls[0][1].headers.authorization).toBe("Bearer xoxb");
+  });
+
   it("fetches thread replies with cursor metadata", async () => {
     const request = vi.fn().mockResolvedValue(
       jsonResponse({

--- a/packages/adapter-slack/src/file.ts
+++ b/packages/adapter-slack/src/file.ts
@@ -1,0 +1,20 @@
+const origins = new Set([
+  "https://files.slack.com",
+  "https://files.slack-gov.com",
+  "https://slack-files.com",
+  "https://slack-files-gov.com",
+  "https://slack.com",
+  "https://slack-gov.com",
+]);
+
+export function isSlackAuthUrl(url: string, apiUrl?: string): boolean {
+  try {
+    const origin = new URL(url).origin;
+    return (
+      origins.has(origin) ||
+      (apiUrl !== undefined && origin === new URL(apiUrl).origin)
+    );
+  } catch {
+    return false;
+  }
+}

--- a/packages/adapter-slack/src/index.test.ts
+++ b/packages/adapter-slack/src/index.test.ts
@@ -1259,6 +1259,49 @@ describe("parseMessage", () => {
     expect(message.attachments?.[0].height).toBe(600);
   });
 
+  it("downloads external message files without resolving the bot token", async () => {
+    const token = vi.fn().mockResolvedValue("xoxb-test");
+    const adapter = createSlackAdapter({
+      botToken: token,
+      signingSecret: "test-secret",
+      logger: mockLogger,
+    });
+    const message = adapter.parseMessage({
+      type: "message",
+      user: "U123",
+      channel: "C456",
+      text: "External file",
+      ts: "1234567890.123456",
+      files: [
+        {
+          id: "F123",
+          mimetype: "application/vnd.slack-remote",
+          url_private: "https://docs.google.com/document/d/external",
+        },
+      ],
+    });
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(new ArrayBuffer(8), {
+        status: 200,
+        headers: { "content-type": "application/octet-stream" },
+      })
+    );
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = fetchMock as unknown as typeof globalThis.fetch;
+
+    try {
+      await message.attachments?.[0].fetchData?.();
+
+      expect(token).not.toHaveBeenCalled();
+      expect(fetchMock).toHaveBeenCalledWith(
+        "https://docs.google.com/document/d/external",
+        { headers: undefined }
+      );
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
   it("handles different file types", () => {
     const createEvent = (mimetype: string) => ({
       type: "message",
@@ -2653,6 +2696,52 @@ describe("installationProvider", () => {
         expect.objectContaining({
           headers: { Authorization: "Bearer xoxb-rehydrate-token" },
         })
+      );
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  it("rehydrateAttachment does not send installation tokens off Slack", async () => {
+    const mockProvider = {
+      getInstallation: vi.fn().mockResolvedValue({
+        botToken: "xoxb-rehydrate-token",
+        botUserId: "U_BOT_REHYDRATE",
+      }),
+    };
+    const adapter = createSlackAdapter({
+      signingSecret: secret,
+      logger: mockLogger,
+      installationProvider: mockProvider,
+    });
+    await adapter.initialize(
+      createMockChatInstance({ state: createMockState() })
+    );
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(new ArrayBuffer(8), {
+        status: 200,
+        headers: { "content-type": "application/octet-stream" },
+      })
+    );
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = fetchMock as unknown as typeof globalThis.fetch;
+
+    try {
+      const rehydrated = adapter.rehydrateAttachment({
+        type: "file",
+        url: "https://attacker.example/file.txt",
+        fetchMetadata: {
+          url: "https://attacker.example/file.txt",
+          teamId: "T_REHYDRATE",
+        },
+      });
+
+      await rehydrated.fetchData?.();
+
+      expect(mockProvider.getInstallation).not.toHaveBeenCalled();
+      expect(fetchMock).toHaveBeenCalledWith(
+        "https://attacker.example/file.txt",
+        { headers: undefined }
       );
     } finally {
       globalThis.fetch = originalFetch;

--- a/packages/adapter-slack/src/index.ts
+++ b/packages/adapter-slack/src/index.ts
@@ -75,6 +75,7 @@ import {
   encryptToken,
   isEncryptedTokenData,
 } from "./crypto";
+import { isSlackAuthUrl } from "./file";
 import { SlackFormatConverter } from "./markdown";
 import {
   decodeModalMetadata,
@@ -3899,14 +3900,21 @@ export class SlackAdapter implements Adapter<SlackThreadId, unknown> {
       fetchMetadata: Object.keys(fetchMeta).length > 0 ? fetchMeta : undefined,
       fetchData: url
         ? async () =>
-            this.fetchSlackFile(url, ctxToken ?? (await this.getToken()))
+            this.fetchSlackFile(url, () => ctxToken ?? this.getToken())
         : undefined,
     };
   }
 
-  protected async fetchSlackFile(url: string, token: string): Promise<Buffer> {
+  protected async fetchSlackFile(
+    url: string,
+    token: SlackBotToken
+  ): Promise<Buffer> {
+    let value: string | undefined;
+    if (isSlackAuthUrl(url, this.slackApiUrl)) {
+      value = typeof token === "function" ? await token() : token;
+    }
     const response = await fetch(url, {
-      headers: { Authorization: `Bearer ${token}` },
+      headers: value ? { Authorization: `Bearer ${value}` } : undefined,
     });
     if (!response.ok) {
       throw new NetworkError(
@@ -3939,29 +3947,28 @@ export class SlackAdapter implements Adapter<SlackThreadId, unknown> {
     return {
       ...attachment,
       fetchData: async () => {
-        let token: string;
-        const installationId = isEnterpriseInstall ? enterpriseId : teamId;
-        if (installationId) {
-          // Route through resolveTokenForTeam so installationProvider (when
-          // configured) is honored — otherwise this falls back to internal
-          // state via getInstallation, matching the prior behavior.
-          const ctx = await this.resolveTokenForTeam(
-            installationId,
-            isEnterpriseInstall
-          );
-          if (!ctx) {
-            throw new AuthenticationError(
-              "slack",
-              `Installation not found for ${
-                isEnterpriseInstall ? "enterprise" : "team"
-              } ${installationId}`
+        return this.fetchSlackFile(url, async () => {
+          const installationId = isEnterpriseInstall ? enterpriseId : teamId;
+          if (installationId) {
+            // Route through resolveTokenForTeam so installationProvider (when
+            // configured) is honored — otherwise this falls back to internal
+            // state via getInstallation, matching the prior behavior.
+            const ctx = await this.resolveTokenForTeam(
+              installationId,
+              isEnterpriseInstall
             );
+            if (!ctx) {
+              throw new AuthenticationError(
+                "slack",
+                `Installation not found for ${
+                  isEnterpriseInstall ? "enterprise" : "team"
+                } ${installationId}`
+              );
+            }
+            return ctx.token;
           }
-          token = ctx.token;
-        } else {
-          token = await this.getToken();
-        }
-        return this.fetchSlackFile(url, token);
+          return this.getToken();
+        });
       },
     };
   }

--- a/packages/adapter-whatsapp/src/index.test.ts
+++ b/packages/adapter-whatsapp/src/index.test.ts
@@ -1,4 +1,5 @@
 import { createHmac } from "node:crypto";
+import { NetworkError } from "@chat-adapter/shared";
 import {
   createMockChatInstance,
   createMockLogger,
@@ -493,6 +494,103 @@ describe("parseMessage - media attachments", () => {
     };
     const message = adapter.parseMessage(raw);
     expect(message.attachments).toHaveLength(0);
+  });
+});
+
+describe("downloadMedia", () => {
+  it.each([
+    "https://attacker.example/media",
+    "http://lookaside.fbsbx.com/whatsapp/media",
+    "https://evilfbsbx.com/whatsapp/media",
+    "https://lookaside.fbsbx.com.attacker.example/whatsapp/media",
+    "https://lookaside.fbsbx.com:8443/whatsapp/media",
+  ])("rejects untrusted media URL %s", async (url) => {
+    const adapter = createTestAdapter();
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ url }), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        })
+      )
+      .mockResolvedValueOnce(new Response("leaked", { status: 200 }));
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = fetchMock as unknown as typeof globalThis.fetch;
+
+    try {
+      await expect(adapter.downloadMedia("media-123")).rejects.toBeInstanceOf(
+        NetworkError
+      );
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  it.each([
+    "https://lookaside.fbsbx.com/whatsapp/media",
+    "https://scontent.xx.fbcdn.net/whatsapp/media",
+  ])("downloads media from trusted Meta URL %s", async (url) => {
+    const adapter = createTestAdapter();
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ url }), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        })
+      )
+      .mockResolvedValueOnce(new Response("media", { status: 200 }));
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = fetchMock as unknown as typeof globalThis.fetch;
+
+    try {
+      const data = await adapter.downloadMedia("media-123");
+
+      expect(data.toString()).toBe("media");
+      expect(fetchMock.mock.calls[1][1]).toEqual({
+        headers: { Authorization: "Bearer test-token" },
+      });
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  it("downloads media from the configured Graph origin", async () => {
+    const adapter = new WhatsAppAdapter({
+      accessToken: "test-token",
+      apiUrl: "https://graph.example",
+      appSecret: "test-secret",
+      phoneNumberId: "123456789",
+      verifyToken: "test-verify-token",
+      userName: "test-bot",
+      logger: createMockLogger(),
+    });
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({ url: "https://graph.example/media/file" }),
+          {
+            status: 200,
+            headers: { "content-type": "application/json" },
+          }
+        )
+      )
+      .mockResolvedValueOnce(new Response("media", { status: 200 }));
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = fetchMock as unknown as typeof globalThis.fetch;
+
+    try {
+      await adapter.downloadMedia("media-123");
+
+      expect(fetchMock.mock.calls[1][1]).toEqual({
+        headers: { Authorization: "Bearer test-token" },
+      });
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
   });
 });
 

--- a/packages/adapter-whatsapp/src/index.ts
+++ b/packages/adapter-whatsapp/src/index.ts
@@ -5,6 +5,7 @@ import {
   extractCard,
   extractFiles,
   extractPostableAttachments,
+  NetworkError,
   type PlatformName,
   toBuffer,
   ValidationError,
@@ -71,6 +72,27 @@ const WHATSAPP_MESSAGE_LIMIT = 4096;
 
 /** Maximum caption length for WhatsApp media messages */
 const WHATSAPP_CAPTION_LIMIT = 1024;
+
+const WHATSAPP_MEDIA_HOSTS = ["fbcdn.net", "fbsbx.com"];
+
+function isWhatsAppMediaUrl(url: string, graphApiUrl: string): boolean {
+  try {
+    const mediaUrl = new URL(url);
+    if (mediaUrl.origin === new URL(graphApiUrl).origin) {
+      return true;
+    }
+    return (
+      mediaUrl.protocol === "https:" &&
+      mediaUrl.port === "" &&
+      WHATSAPP_MEDIA_HOSTS.some(
+        (host) =>
+          mediaUrl.hostname === host || mediaUrl.hostname.endsWith(`.${host}`)
+      )
+    );
+  } catch {
+    return false;
+  }
+}
 
 /** WhatsApp media message types supported for outbound sends */
 export type WhatsAppMediaType = "image" | "document" | "video" | "audio";
@@ -1148,6 +1170,13 @@ export class WhatsAppAdapter
 
     const mediaInfo: WhatsAppMediaResponse =
       (await metaResponse.json()) as WhatsAppMediaResponse;
+
+    if (!isWhatsAppMediaUrl(mediaInfo.url, this.graphApiUrl)) {
+      throw new NetworkError(
+        "whatsapp",
+        "Refusing to send the access token to an untrusted media URL"
+      );
+    }
 
     // Step 2: Download the actual file
     const dataResponse = await fetch(mediaInfo.url, {


### PR DESCRIPTION
## summary

- only send Slack bearer tokens to trusted Slack file origins or the configured API origin
- fetch external Slack file URLs without authentication, including rehydrated attachments
- reject WhatsApp media URLs outside trusted Meta CDN hosts or the configured Graph origin before sending credentials
- apply the Slack policy to both the adapter and lower-level API primitive

## test plan

- verify trusted Slack file URLs receive bearer authentication
- verify external and malformed Slack URLs receive no authentication
- verify rehydrated cross-tenant Slack attachments do not resolve or send installation tokens
- verify trusted Meta CDN and configured Graph URLs remain downloadable
- verify untrusted, malformed, HTTP, and host-confusion WhatsApp URLs are rejected