### PR TITLE
fix(teams): hydrate incoming users without Graph

### DIFF
--- a/.changeset/calm-teams-listen.md
+++ b/.changeset/calm-teams-listen.md
@@ -1,0 +1,5 @@
+---
+"@chat-adapter/teams": patch
+---
+
+hydrate live Teams sender email without requiring Microsoft Graph permissions

--- a/apps/docs/content/adapters/official/teams.mdx
+++ b/apps/docs/content/adapters/official/teams.mdx
@@ -244,6 +244,8 @@ console.log(user?.fullName); // "Alice Smith"
 
 The adapter caches each user's Azure AD object ID from incoming activities, so `getUser` only works for users who have previously interacted with the bot.
 
+Live incoming message authors include `email` when the Teams conversation members API resolves the sender. This lookup uses the bot's access to the current conversation and does not require Microsoft Graph permissions. Lookup failures leave `message.author.email` undefined without preventing message delivery. Edited-message events and messages returned by `fetchMessages` are not hydrated with an email.
+
 ### Targeted / ephemeral messages
 
 Teams targeted messages are available in public preview. Use `thread.postEphemeral()` or `channel.postEphemeral()` to send a native Teams message that only the selected conversation member can see:

--- a/packages/adapter-teams/README.md
+++ b/packages/adapter-teams/README.md
@@ -226,7 +226,7 @@ console.log(user?.email);    // "alice@contoso.com"
 console.log(user?.fullName); // "Alice Smith"
 ```
 
-Incoming message authors also include `email` when Graph resolves the sender. The adapter uses the activity's Azure AD object ID first and falls back to its cached ID, so missing permissions or lookup failures leave `message.author.email` undefined without preventing message delivery. This applies to live incoming messages only — authors on edited-message events and messages returned by `fetchMessages` are not hydrated with an email. Resolved profiles are cached in the state adapter for 1 hour (failed lookups for 5 minutes), so busy conversations don't trigger a Graph call per message.
+Incoming message authors also include `email` when the Teams conversation members API resolves the sender. This lookup uses the bot's access to the current conversation and does not require Microsoft Graph permissions. Lookup failures leave `message.author.email` undefined without preventing message delivery. This applies to live incoming messages only. Authors on edited-message events and messages returned by `fetchMessages` are not hydrated with an email. Resolved profiles are cached in the state adapter for 1 hour, so busy conversations don't trigger a lookup per message.
 
 The adapter caches each user's Azure AD object ID from incoming activities for later `getUser` calls. `getUser` returns `null` if the user hasn't been seen or the Graph call fails.
 

--- a/packages/adapter-teams/src/index.test.ts
+++ b/packages/adapter-teams/src/index.test.ts
@@ -1597,12 +1597,13 @@ describe("TeamsAdapter", () => {
     });
 
     it("dispatches the message when conversation member lookup fails", async () => {
-      const { adapter, chat, getMemberById } = await setup(
+      const { adapter, chat, getMemberById, mockApp } = await setup(
         new Error("Forbidden")
       );
 
       await adapter.handleIncoming(activity("activity-aad-id"), getMemberById);
 
+      expect(mockApp.graph.call).not.toHaveBeenCalled();
       expect(chat.processMessage).toHaveBeenCalledOnce();
       const message = vi.mocked(chat.processMessage).mock.calls[0]?.[2];
       expect(message?.author.email).toBeUndefined();

--- a/packages/adapter-teams/src/index.test.ts
+++ b/packages/adapter-teams/src/index.test.ts
@@ -1464,8 +1464,14 @@ describe("TeamsAdapter", () => {
 
   describe("incoming sender email", () => {
     class IncomingMessageTestAdapter extends TeamsAdapter {
-      handleIncoming(activity: Record<string, unknown>) {
-        return this.handleMessageActivity({ activity } as never);
+      handleIncoming(
+        activity: Record<string, unknown>,
+        getMemberById: ReturnType<typeof vi.fn>
+      ) {
+        return this.handleMessageActivity({
+          activity,
+          api: { conversations: { getMemberById } },
+        } as never);
       }
     }
 
@@ -1483,7 +1489,7 @@ describe("TeamsAdapter", () => {
     });
 
     const setup = async (
-      graphResult: Record<string, unknown> | Error,
+      userResult: Record<string, unknown> | Error,
       cachedAadObjectId?: string
     ) => {
       const adapter = new IncomingMessageTestAdapter({
@@ -1507,37 +1513,71 @@ describe("TeamsAdapter", () => {
       mockApp.initialize = vi.fn(async () => undefined);
       mockApp.graph = {
         call: vi.fn(async () => {
-          if (graphResult instanceof Error) {
-            throw graphResult;
+          if (userResult instanceof Error) {
+            throw userResult;
           }
-          return graphResult;
+          return userResult;
         }),
       };
+      const getMemberById = vi.fn(async () => {
+        if (userResult instanceof Error) {
+          throw userResult;
+        }
+        return userResult;
+      });
       await adapter.initialize(chat);
-      return { adapter, chat, mockApp, state };
+      return { adapter, chat, getMemberById, mockApp, state };
     };
 
-    it("hydrates email from the activity AAD object ID without cached state", async () => {
-      const { adapter, chat, mockApp, state } = await setup({
-        displayName: "Alice",
-        mail: "alice@example.com",
+    it("hydrates email from the conversation member without Graph", async () => {
+      const { adapter, chat, getMemberById, mockApp, state } = await setup({
+        email: "alice@example.com",
+        name: "Alice",
         userPrincipalName: "alice@contoso.com",
       });
 
-      await adapter.handleIncoming(activity("activity-aad-id"));
+      await adapter.handleIncoming(activity("activity-aad-id"), getMemberById);
 
       expect(state.get).not.toHaveBeenCalledWith(
         "teams:aadObjectId:29:user-123"
       );
-      expect(mockApp.graph.call).toHaveBeenCalledWith(expect.anything(), {
-        "user-id": "activity-aad-id",
+      expect(getMemberById).toHaveBeenCalledWith(
+        "19:abc@thread.tacv2",
+        "29:user-123"
+      );
+      expect(mockApp.graph.call).not.toHaveBeenCalled();
+      const message = vi.mocked(chat.processMessage).mock.calls[0]?.[2];
+      expect(message?.author.email).toBe("alice@example.com");
+    });
+
+    it("falls back to the conversation member user principal name", async () => {
+      const { adapter, chat, getMemberById } = await setup({
+        name: "Alice",
+        userPrincipalName: "alice@contoso.com",
       });
+
+      await adapter.handleIncoming(activity("activity-aad-id"), getMemberById);
+
+      const message = vi.mocked(chat.processMessage).mock.calls[0]?.[2];
+      expect(message?.author.email).toBe("alice@contoso.com");
+    });
+
+    it("replaces a failed Graph lookup cached for the sender", async () => {
+      const { adapter, chat, getMemberById, state } = await setup({
+        email: "alice@example.com",
+        name: "Alice",
+      });
+      state.cache.set("teams:userInfo:activity-aad-id", "unresolvable");
+
+      await adapter.handleIncoming(activity("activity-aad-id"), getMemberById);
+
+      expect(getMemberById).toHaveBeenCalledOnce();
       const message = vi.mocked(chat.processMessage).mock.calls[0]?.[2];
       expect(message?.author.email).toBe("alice@example.com");
     });
 
     it("falls back to the cached AAD object ID", async () => {
-      const { adapter, chat, mockApp } = await setup(
+      const { adapter, chat, getMemberById, mockApp } = await setup(
         {
           displayName: "Alice",
           mail: null,
@@ -1546,56 +1586,61 @@ describe("TeamsAdapter", () => {
         "cached-aad-id"
       );
 
-      await adapter.handleIncoming(activity());
+      await adapter.handleIncoming(activity(), getMemberById);
 
       expect(mockApp.graph.call).toHaveBeenCalledWith(expect.anything(), {
         "user-id": "cached-aad-id",
       });
+      expect(getMemberById).not.toHaveBeenCalled();
       const message = vi.mocked(chat.processMessage).mock.calls[0]?.[2];
       expect(message?.author.email).toBe("alice@contoso.com");
     });
 
-    it("dispatches the message when Graph lookup fails", async () => {
-      const { adapter, chat } = await setup(new Error("Forbidden"));
+    it("dispatches the message when conversation member lookup fails", async () => {
+      const { adapter, chat, getMemberById } = await setup(
+        new Error("Forbidden")
+      );
 
-      await adapter.handleIncoming(activity("activity-aad-id"));
+      await adapter.handleIncoming(activity("activity-aad-id"), getMemberById);
 
       expect(chat.processMessage).toHaveBeenCalledOnce();
       const message = vi.mocked(chat.processMessage).mock.calls[0]?.[2];
       expect(message?.author.email).toBeUndefined();
     });
 
-    it("caches the Graph lookup across messages", async () => {
-      const { adapter, chat, mockApp } = await setup({
-        displayName: "Alice",
-        mail: "alice@example.com",
+    it("caches the conversation member lookup across messages", async () => {
+      const { adapter, chat, getMemberById } = await setup({
+        email: "alice@example.com",
+        name: "Alice",
         userPrincipalName: "alice@contoso.com",
       });
 
-      await adapter.handleIncoming(activity("activity-aad-id"));
-      await adapter.handleIncoming(activity("activity-aad-id"));
+      await adapter.handleIncoming(activity("activity-aad-id"), getMemberById);
+      await adapter.handleIncoming(activity("activity-aad-id"), getMemberById);
 
-      expect(mockApp.graph.call).toHaveBeenCalledOnce();
+      expect(getMemberById).toHaveBeenCalledOnce();
       const message = vi.mocked(chat.processMessage).mock.calls[1]?.[2];
       expect(message?.author.email).toBe("alice@example.com");
     });
 
-    it("caches failed Graph lookups without retrying", async () => {
-      const { adapter, chat, mockApp } = await setup(new Error("Forbidden"));
+    it("does not let a failed conversation lookup suppress retries", async () => {
+      const { adapter, chat, getMemberById } = await setup(
+        new Error("Forbidden")
+      );
 
-      await adapter.handleIncoming(activity("activity-aad-id"));
-      await adapter.handleIncoming(activity("activity-aad-id"));
+      await adapter.handleIncoming(activity("activity-aad-id"), getMemberById);
+      await adapter.handleIncoming(activity("activity-aad-id"), getMemberById);
 
-      expect(mockApp.graph.call).toHaveBeenCalledOnce();
+      expect(getMemberById).toHaveBeenCalledTimes(2);
       expect(chat.processMessage).toHaveBeenCalledTimes(2);
       const message = vi.mocked(chat.processMessage).mock.calls[1]?.[2];
       expect(message?.author.email).toBeUndefined();
     });
 
     it("hydrates email on the DM path and completes processing", async () => {
-      const { adapter, chat } = await setup({
-        displayName: "Alice",
-        mail: "alice@example.com",
+      const { adapter, chat, getMemberById } = await setup({
+        email: "alice@example.com",
+        name: "Alice",
         userPrincipalName: "alice@contoso.com",
       });
       // DM handling blocks on a waitUntil-driven promise for native
@@ -1609,10 +1654,13 @@ describe("TeamsAdapter", () => {
         }
       );
 
-      await adapter.handleIncoming({
-        ...activity("activity-aad-id"),
-        conversation: { id: "a:1dm-conversation" },
-      });
+      await adapter.handleIncoming(
+        {
+          ...activity("activity-aad-id"),
+          conversation: { id: "a:1dm-conversation" },
+        },
+        getMemberById
+      );
 
       expect(chat.processMessage).toHaveBeenCalledOnce();
       const message = vi.mocked(chat.processMessage).mock.calls[0]?.[2];

--- a/packages/adapter-teams/src/index.ts
+++ b/packages/adapter-teams/src/index.ts
@@ -373,7 +373,8 @@ export class TeamsAdapter implements Adapter<TeamsThreadId, unknown> {
 
     const message = this.parseTeamsMessage(activity, threadId);
     const user = activity.from?.aadObjectId
-      ? await this.getUserByAadObjectId(
+      ? await this.getIncomingUser(
+          ctx,
           message.author.userId,
           activity.from.aadObjectId
         )
@@ -945,6 +946,45 @@ export class TeamsAdapter implements Adapter<TeamsThreadId, unknown> {
         userId,
         error,
       });
+      return null;
+    }
+  }
+
+  private async getIncomingUser(
+    ctx: IActivityContext<IMessageActivity>,
+    userId: string,
+    aadObjectId: string
+  ): Promise<UserInfo | null> {
+    const cacheKey = `teams:userInfo:${aadObjectId}`;
+    const cached = await this.readCachedUserInfo(cacheKey);
+    if (cached && cached !== USER_INFO_NEGATIVE_SENTINEL) {
+      return { ...cached, userId };
+    }
+
+    try {
+      const member = await ctx.api.conversations.getMemberById(
+        ctx.activity.conversation.id,
+        userId
+      );
+      const userInfo: UserInfo = {
+        avatarUrl: undefined,
+        email: member.email ?? member.userPrincipalName ?? undefined,
+        fullName: member.name ?? aadObjectId,
+        isBot: false,
+        userId,
+        userName:
+          member.userPrincipalName ?? member.email ?? member.name ?? userId,
+      };
+      this.chat
+        ?.getState()
+        .set(cacheKey, JSON.stringify(userInfo), USER_INFO_CACHE_TTL_MS)
+        .catch(() => {});
+      return userInfo;
+    } catch (error) {
+      this.logger.warn(
+        "Failed to fetch user info from Teams conversation members API",
+        { userId, error }
+      );
       return null;
     }
   }


### PR DESCRIPTION
## Summary

Changes live incoming Teams author hydration to `ctx.api.conversations.getMemberById`, so the normal path no longer requires Microsoft Graph's `User.Read.All` permission or tenant admin consent. Explicit `getUser()` lookups remain Graph-backed.

## Test Plan

- `pnpm --filter @chat-adapter/teams test` (264 passed)
- `pnpm --filter @chat-adapter/teams exec vitest run src/index.test.ts -t 'incoming sender email'` (8 passed)
- `pnpm --filter @chat-adapter/teams typecheck`
- `pnpm --filter @chat-adapter/teams... build`
- `pnpm check`
- `git diff --check`
- built and packed `@chat-adapter/teams`; inspected the artifact for both the Connector lookup and preserved Graph lookup

The regression tests assert the exact activity conversation and sender IDs, Graph isolation on Connector success and failure, cache behavior, the missing-AAD fallback, and the DM path. A live Microsoft Teams tenant was not available for runtime verification.

## Checklist

- [x] All commits are signed and verified
- [x] All commits are signed off for the DCO (`git commit -s`)
- [ ] `pnpm validate` passes
- [x] Changeset added (or N/A — see [CONTRIBUTING.md](./CONTRIBUTING.md))
- [x] Documentation updated (or N/A)
