### PR TITLE
docs: add LINE community adapter

### DIFF
--- a/apps/docs/adapters.json
+++ b/apps/docs/adapters.json
@@ -452,5 +452,15 @@
     "packageName": "chat-adapter-weixin",
     "author": "wong2",
     "readme": "https://github.com/wong2/weixin-chat-adapter"
+  },
+  {
+    "name": "LINE",
+    "slug": "line",
+    "type": "platform",
+    "community": true,
+    "description": "Community LINE Messaging API adapter for Chat SDK with Flex Message cards, inbound media, action postbacks, and typing indicators.",
+    "packageName": "chat-adapter-line",
+    "author": "PunGrumpy",
+    "readme": "https://github.com/PunGrumpy/chat-adapter-line"
   }
 ]

--- a/apps/docs/content/adapters/community/line.mdx
+++ b/apps/docs/content/adapters/community/line.mdx
@@ -1,0 +1,156 @@
+---
+title: LINE
+description: Community LINE Messaging API adapter for Chat SDK with Flex Message cards, inbound media, action postbacks, and typing indicators.
+packageName: chat-adapter-line
+slug: line
+type: platform
+tagline: LINE Messaging API adapter for Chat SDK. Send text and Flex Message cards, receive media and postback actions, and verify signed webhooks.
+community: true
+mdxBody: true
+features:
+  postMessage: yes
+  editMessage: no
+  deleteMessage: no
+  fileUploads:
+    status: partial
+    label: Inbound only
+  streaming:
+    status: partial
+    label: Buffered chunks
+  scheduledMessages: no
+  cardFormat:
+    status: partial
+    label: LINE Flex Messages
+  buttons:
+    status: partial
+    label: Card postbacks
+  linkButtons: no
+  selectMenus: no
+  tables: no
+  fields: no
+  imagesInCards: no
+  modals: no
+  slashCommands: no
+  mentions: yes
+  addReactions: no
+  removeReactions: no
+  typingIndicator:
+    status: partial
+    label: DMs only
+  messageUpdatedEvents: no
+  messageDeletedEvents: no
+  directMessages: yes
+  ephemeralMessages: no
+  userLookup:
+    status: partial
+    label: DM profiles
+  customApiEndpoint: no
+  fetchMessages: no
+  fetchSingleMessage: no
+  fetchThreadInfo:
+    status: partial
+    label: Users and groups
+  fetchChannelMessages: no
+  listThreads: no
+  fetchChannelInfo:
+    status: partial
+    label: Group name
+  postChannelMessage: yes
+---
+
+## Install
+
+<PackageInstall package="chat-adapter-line chat" />
+
+## Quick start
+
+```typescript title="lib/bot.ts" lineNumbers
+import { Chat } from "chat";
+import { createLineAdapter } from "chat-adapter-line";
+
+const bot = new Chat({
+  userName: "mybot",
+  adapters: {
+    line: createLineAdapter(),
+  },
+});
+
+bot.onDirectMessage(async (thread, message) => {
+  await thread.post(`You said: ${message.text}`);
+});
+```
+
+When called with no arguments, `createLineAdapter()` reads `LINE_CHANNEL_ACCESS_TOKEN` and `LINE_CHANNEL_SECRET` from the environment.
+
+## LINE channel setup
+
+1. Create a provider and channel in the [LINE Developers Console](https://developers.line.biz/console/).
+2. Enable the Messaging API for the channel.
+3. Copy the channel access token and channel secret.
+4. Set the webhook URL to a public HTTPS endpoint, such as `https://your-domain.com/api/webhooks/line`.
+5. Subscribe to message and postback events.
+
+## Configuration
+
+<TypeTable
+  type={{
+    channelAccessToken: {
+      type: "string",
+      description:
+        "LINE channel access token. Falls back to `LINE_CHANNEL_ACCESS_TOKEN`.",
+    },
+    channelSecret: {
+      type: "string",
+      description:
+        "LINE channel secret. Falls back to `LINE_CHANNEL_SECRET`.",
+    },
+    userName: {
+      type: "string",
+      default: '"line-bot"',
+      description: "Bot display name used by Chat SDK.",
+    },
+    logger: {
+      type: "Logger",
+      description: "Custom Chat SDK logger. Defaults to `ConsoleLogger`.",
+    },
+  }}
+/>
+
+## Environment variables
+
+| Variable | Required | Description |
+| --- | --- | --- |
+| `LINE_CHANNEL_ACCESS_TOKEN` | Yes | LINE channel access token, unless you pass `channelAccessToken`. |
+| `LINE_CHANNEL_SECRET` | Yes | LINE channel secret, unless you pass `channelSecret`. |
+
+## Webhook setup
+
+```typescript title="app/api/webhooks/line/route.ts" lineNumbers
+import { bot } from "@/lib/bot";
+
+export async function POST(request: Request): Promise<Response> {
+  return bot.webhooks.line(request);
+}
+```
+
+LINE sends each webhook with an `x-line-signature` header. The adapter computes an HMAC-SHA256 digest with the channel secret and compares it with the header before parsing the body.
+
+## Messages and cards
+
+Text and Markdown output are converted to plain text. Chat SDK cards become LINE Flex Messages: the card title and text become the bubble body, and buttons become postback actions in the footer. Button clicks dispatch to Chat SDK action handlers.
+
+The adapter receives image, video, audio, and file messages as attachments. It doesn't upload outbound files; posting a message with files logs a warning and sends any text or card content.
+
+Streaming is buffered. The adapter sends a text message after it collects more than 500 characters, then sends the remaining text after the stream ends. It sends at most five messages per stream.
+
+## Thread IDs
+
+```text
+line:<channelId>:<sourceType>:<sourceId>
+```
+
+`sourceType` is `user`, `group`, or `room`. `sourceId` is the LINE user, group, or room ID.
+
+## Feature support
+
+<FeatureSupport />

--- a/apps/docs/content/adapters/community/meta.json
+++ b/apps/docs/content/adapters/community/meta.json
@@ -3,6 +3,7 @@
   "pages": [
     "---Platforms---",
     "webex",
+    "line",
     "baileys",
     "blooio",
     "zalo",

--- a/packages/integration-tests/src/documentation-test-utils.ts
+++ b/packages/integration-tests/src/documentation-test-utils.ts
@@ -240,6 +240,7 @@ export const VALID_DOC_PACKAGES = [
   "chat-adapter-sendblue",
   "@bitbasti/chat-adapter-webex",
   "chat-adapter-zalo",
+  "chat-adapter-line",
   "@larksuite/vercel-chat-adapter",
   "chat-adapter-weixin",
   "@agentor/chat-qq",


### PR DESCRIPTION
## Summary

- Add `chat-adapter-line` to the community adapter catalog.
- Add a hand-authored LINE adapter docs page with configuration, webhook, messaging, and feature-matrix details.
- Register `chat-adapter-line` as a valid docs code-example import.

## Validation

- `pnpm --filter @chat-adapter/integration-tests test -- src/docs-adapters.test.ts --coverage=false` — 467 tests passed
- `pnpm --filter @chat-adapter/integration-tests test -- src/docs-content.test.ts --coverage=false` — 91 tests passed
- `pnpm --filter @chat-adapter/integration-tests test -- src/docs-llms.test.ts --coverage=false` — 145 tests passed
- `pnpm exec biome check apps/docs/content/adapters/community/line.mdx apps/docs/content/adapters/community/meta.json apps/docs/adapters.json packages/integration-tests/src/documentation-test-utils.ts` — passed