### PR TITLE
fix(adapters): validate external request targets

### DIFF
--- a/.changeset/validate-external-targets.md
+++ b/.changeset/validate-external-targets.md
@@ -1,0 +1,8 @@
+---
+"@chat-adapter/instagram": patch
+"@chat-adapter/slack": patch
+"@chat-adapter/teams": patch
+"@chat-adapter/x": patch
+---
+
+Validate external request targets before sending credentials, message content, or attachment requests.

--- a/apps/docs/content/adapters/official/teams.mdx
+++ b/apps/docs/content/adapters/official/teams.mdx
@@ -310,7 +310,7 @@ Use the low-level Teams subpaths when your app already owns routing, state, sess
 | `@chat-adapter/teams/modals` | Runtime-free Task Module Adaptive Card helpers and submit parsing |
 
 <Callout type="warn">
-  The webhook subpath parses Activities only. It does not verify Microsoft Bot Framework JWTs. For production request validation, use `createTeamsAdapter` or the Microsoft Teams SDK request pipeline before handing the Activity to these helpers.
+  The webhook subpath parses Activities only. It does not verify Microsoft Bot Framework JWTs. Authenticate the request with the Microsoft Teams SDK request pipeline before handing the Activity to these helpers, or use `createTeamsAdapter`. The Connector helpers restrict `serviceUrl` to Microsoft-owned hosts, but that does not authenticate the Activity.
 </Callout>
 
 ### Webhooks
@@ -322,6 +322,8 @@ import { postTeamsMessage } from "@chat-adapter/teams/api";
 import { readTeamsWebhook } from "@chat-adapter/teams/webhook";
 
 export async function POST(request: Request) {
+  // Authenticate the Bot Framework JWT before parsing the request. This
+  // example assumes your routing layer already performed that verification.
   const payload = await readTeamsWebhook(request, {
     botAppId: process.env.TEAMS_APP_ID,
   });

--- a/apps/docs/content/adapters/official/xchat.mdx
+++ b/apps/docs/content/adapters/official/xchat.mdx
@@ -88,22 +88,13 @@ bot.onNewMention(async (thread, message) => {
 });
 ```
 
-X sends two kinds of webhook requests: a **CRC challenge** (GET) answered with an HMAC-SHA256 of the token keyed by your app's consumer secret, and **event delivery** (POST) verified by the adapter via the `x-twitter-webhooks-signature` header. Handle the CRC challenge at the route level; it needs no adapter state:
+X sends two kinds of webhook requests: a **CRC challenge** (GET) answered with an HMAC-SHA256 of the token keyed by your app's consumer secret, and **event delivery** (POST) verified by the adapter via the `x-twitter-webhooks-signature` header. Route both methods through the adapter so it can constrain CRC tokens before signing them:
 
 ```typescript title="app/api/webhooks/xchat/route.ts" lineNumbers
-import { createHmac } from "node:crypto";
 import { bot } from "@/lib/bot";
 
 export async function GET(request: Request) {
-  const url = new URL(request.url);
-  const crcToken = url.searchParams.get("crc_token");
-  if (!crcToken) {
-    return new Response("Missing crc_token", { status: 400 });
-  }
-  const hash = createHmac("sha256", process.env.X_CONSUMER_SECRET!)
-    .update(crcToken)
-    .digest("base64");
-  return Response.json({ response_token: `sha256=${hash}` });
+  return bot.webhooks.xchat(request);
 }
 
 export async function POST(request: Request) {

--- a/packages/adapter-instagram/src/fetch.test.ts
+++ b/packages/adapter-instagram/src/fetch.test.ts
@@ -1,0 +1,70 @@
+import type { IncomingMessage } from "node:http";
+import { Readable } from "node:stream";
+import { NetworkError } from "@chat-adapter/shared";
+import { describe, expect, it, vi } from "vitest";
+import { downloadInstagramAttachment } from "./fetch";
+
+function response(
+  body: string,
+  status = 200,
+  headers: IncomingMessage["headers"] = {},
+  statusMessage = "OK"
+): IncomingMessage {
+  return Object.assign(Readable.from([Buffer.from(body)]), {
+    headers,
+    statusCode: status,
+    statusMessage,
+  }) as IncomingMessage;
+}
+
+describe("Instagram attachment fetch", () => {
+  it.each([
+    "https://scontent.cdninstagram.com/file",
+    "https://lookaside.fbsbx.com/file",
+    "https://scontent.xx.fbcdn.net/file",
+  ])("downloads from Meta CDN URL %s", async (url) => {
+    const transport = vi.fn(async () => response("media"));
+
+    await expect(downloadInstagramAttachment(url, transport)).resolves.toEqual(
+      Buffer.from("media")
+    );
+  });
+
+  it.each([
+    "https://example.com/file",
+    "https://cdninstagram.com.attacker.example/file",
+    "https://scontent.cdninstagram.com./file",
+    "http://scontent.cdninstagram.com/file",
+    "https://127.0.0.1/file",
+  ])("rejects untrusted attachment URL %s", async (url) => {
+    const transport = vi.fn(async () => response("media"));
+
+    await expect(downloadInstagramAttachment(url, transport)).rejects.toThrow(
+      NetworkError
+    );
+    expect(transport).not.toHaveBeenCalled();
+  });
+
+  it("rejects redirects away from Meta CDN hosts", async () => {
+    const transport = vi.fn(async () =>
+      response("", 302, { location: "https://example.com/file" })
+    );
+
+    await expect(
+      downloadInstagramAttachment(
+        "https://scontent.cdninstagram.com/file",
+        transport
+      )
+    ).rejects.toThrow("Refusing to fetch an untrusted attachment URL");
+    expect(transport).toHaveBeenCalledOnce();
+  });
+
+  it("uses Instagram network errors", async () => {
+    await expect(
+      downloadInstagramAttachment("https://example.com/file")
+    ).rejects.toMatchObject({
+      adapter: "instagram",
+      message: "Refusing to fetch an untrusted attachment URL",
+    });
+  });
+});

--- a/packages/adapter-instagram/src/fetch.ts
+++ b/packages/adapter-instagram/src/fetch.ts
@@ -1,0 +1,33 @@
+import {
+  type AttachmentTransport,
+  downloadAttachment,
+  NetworkError,
+} from "@chat-adapter/shared";
+
+const INSTAGRAM_CDN_HOSTS = [
+  "cdninstagram.com",
+  "fbcdn.net",
+  "fbsbx.com",
+] as const;
+
+export async function downloadInstagramAttachment(
+  url: string,
+  transport?: AttachmentTransport
+): Promise<Buffer> {
+  try {
+    return await downloadAttachment(url, {
+      adapter: "instagram",
+      hosts: INSTAGRAM_CDN_HOSTS,
+      transport,
+    });
+  } catch (error) {
+    if (error instanceof NetworkError) {
+      throw error;
+    }
+    throw new NetworkError(
+      "instagram",
+      "Failed to download Instagram attachment",
+      error instanceof Error ? error : undefined
+    );
+  }
+}

--- a/packages/adapter-instagram/src/index.ts
+++ b/packages/adapter-instagram/src/index.ts
@@ -34,6 +34,7 @@ import {
   Message,
 } from "chat";
 import { cardToInstagram, decodeInstagramCallbackData } from "./cards";
+import { downloadInstagramAttachment } from "./fetch";
 import { InstagramFormatConverter } from "./markdown";
 import type {
   InstagramAdapterConfig,
@@ -878,23 +879,7 @@ export class InstagramAdapter
   }
 
   protected async downloadAttachment(url: string): Promise<Buffer> {
-    let response: Response;
-    try {
-      response = await fetch(url);
-    } catch (error) {
-      throw new NetworkError(
-        "instagram",
-        "Failed to download Instagram attachment",
-        error instanceof Error ? error : undefined
-      );
-    }
-    if (!response.ok) {
-      throw new NetworkError(
-        "instagram",
-        `Failed to download Instagram attachment: ${response.status}`
-      );
-    }
-    return Buffer.from(await response.arrayBuffer());
+    return downloadInstagramAttachment(url);
   }
 
   protected async fetchUserProfile(

--- a/packages/adapter-slack/src/index.test.ts
+++ b/packages/adapter-slack/src/index.test.ts
@@ -8450,7 +8450,7 @@ describe("decodeEphemeralMessageId edge cases", () => {
     });
   });
 
-  it("handles non-JSON base64 as legacy responseUrl format", () => {
+  it("rejects the legacy non-JSON responseUrl format", () => {
     const adapter = createSlackAdapter({
       botToken: "xoxb-test",
       signingSecret: "s",
@@ -8463,11 +8463,31 @@ describe("decodeEphemeralMessageId edge cases", () => {
       }
     ).decodeEphemeralMessageId;
     const result = decode.call(adapter, encoded);
-    expect(result).toEqual({
-      messageTs: "1234567890.123456",
-      responseUrl: "https://hooks.slack.com/respond",
-      userId: "",
+    expect(result).toBeNull();
+  });
+
+  it.each([
+    "http://hooks.slack.com/respond",
+    "https://hooks.slack.com.attacker.example/respond",
+    "https://user@hooks.slack.com/respond",
+    "https://hooks.slack.com:444/respond",
+    "https://attacker.example/respond",
+  ])("rejects untrusted response_url %s", (responseUrl) => {
+    const adapter = createSlackAdapter({
+      botToken: "xoxb-test",
+      signingSecret: "s",
+      logger: mockLogger,
     });
+    const encoded = `ephemeral:1234567890.123456:${btoa(
+      JSON.stringify({ responseUrl, userId: "U123" })
+    )}`;
+    const decode = (
+      adapter as unknown as Record<string, unknown> & {
+        decodeEphemeralMessageId: (id: string) => unknown;
+      }
+    ).decodeEphemeralMessageId;
+
+    expect(decode.call(adapter, encoded)).toBeNull();
   });
 
   it("returns null for invalid base64", () => {
@@ -8525,6 +8545,57 @@ describe("editMessage via response_url", () => {
     );
     expect(callBody.text).toContain("```");
     expect(callBody).not.toHaveProperty("markdown_text");
+    fetchSpy.mockRestore();
+  });
+
+  it("rejects an untrusted encoded response_url before fetching", async () => {
+    const adapter = createSlackAdapter({
+      botToken: "xoxb-test",
+      signingSecret: "s",
+      logger: mockLogger,
+    });
+    const data = JSON.stringify({
+      responseUrl: "https://attacker.example/respond",
+      userId: "U123",
+    });
+    const ephemeralId = `ephemeral:1234567890.123456:${btoa(data)}`;
+    const fetchSpy = vi.spyOn(global, "fetch");
+
+    await expect(
+      adapter.editMessage(
+        "slack:C123:1234567890.000000",
+        ephemeralId,
+        "private message"
+      )
+    ).rejects.toThrow("Invalid Slack ephemeral message ID");
+    expect(fetchSpy).not.toHaveBeenCalled();
+    fetchSpy.mockRestore();
+  });
+
+  it("defends the response_url fetch sink against untrusted callers", async () => {
+    const adapter = createSlackAdapter({
+      botToken: "xoxb-test",
+      signingSecret: "s",
+      logger: mockLogger,
+    });
+    const sendToResponseUrl = (
+      adapter as unknown as {
+        sendToResponseUrl: (
+          url: string,
+          action: "delete"
+        ) => Promise<Record<string, unknown>>;
+      }
+    ).sendToResponseUrl;
+    const fetchSpy = vi.spyOn(global, "fetch");
+
+    await expect(
+      sendToResponseUrl.call(
+        adapter,
+        "https://hooks.slack.com.attacker.example/respond",
+        "delete"
+      )
+    ).rejects.toThrow("untrusted Slack response_url");
+    expect(fetchSpy).not.toHaveBeenCalled();
     fetchSpy.mockRestore();
   });
 });

--- a/packages/adapter-slack/src/index.ts
+++ b/packages/adapter-slack/src/index.ts
@@ -94,6 +94,10 @@ import { verifySlackRequest } from "./webhook/index";
 const SLACK_USER_ID_PATTERN = /^[A-Z0-9_]+$/;
 // Enterprise Grid users can have W-prefixed IDs anywhere a U-prefixed ID appears
 const SLACK_USER_ID_EXACT_PATTERN = /^[UW][A-Z0-9]+$/;
+const SLACK_RESPONSE_URL_HOSTS = new Set([
+  "hooks.slack-gov.com",
+  "hooks.slack.com",
+]);
 
 // Reserved user ID Slack uses for platform-generated messages (e.g.
 // "@user archived the channel") that carry no bot_id or system subtype.
@@ -116,6 +120,21 @@ function timingSafeStringEqual(a: string, b: string): boolean {
     return false;
   }
   return timingSafeEqual(aBuf, bBuf);
+}
+
+function isTrustedSlackResponseUrl(value: string): boolean {
+  try {
+    const url = new URL(value);
+    return (
+      url.protocol === "https:" &&
+      url.username === "" &&
+      url.password === "" &&
+      url.port === "" &&
+      SLACK_RESPONSE_URL_HOSTS.has(url.hostname.toLowerCase())
+    );
+  } catch {
+    return false;
+  }
 }
 
 /**
@@ -5029,6 +5048,9 @@ export class SlackAdapter implements Adapter<SlackThreadId, unknown> {
         raw: { ephemeral: true, ...result },
       };
     }
+    if (messageId.startsWith("ephemeral:")) {
+      throw new ValidationError("slack", "Invalid Slack ephemeral message ID");
+    }
 
     const { channel } = this.decodeThreadId(threadId);
 
@@ -5274,6 +5296,9 @@ export class SlackAdapter implements Adapter<SlackThreadId, unknown> {
     if (ephemeral) {
       await this.sendToResponseUrl(ephemeral.responseUrl, "delete");
       return;
+    }
+    if (messageId.startsWith("ephemeral:")) {
+      throw new ValidationError("slack", "Invalid Slack ephemeral message ID");
     }
     const { channel } = this.decodeThreadId(threadId);
 
@@ -6766,6 +6791,12 @@ export class SlackAdapter implements Adapter<SlackThreadId, unknown> {
     responseUrl: string,
     userId: string
   ): string {
+    if (!isTrustedSlackResponseUrl(responseUrl)) {
+      throw new ValidationError(
+        "slack",
+        "Refusing to encode an untrusted Slack response_url"
+      );
+    }
     const data = JSON.stringify({ responseUrl, userId });
     return `ephemeral:${messageTs}:${btoa(data)}`;
   }
@@ -6789,8 +6820,17 @@ export class SlackAdapter implements Adapter<SlackThreadId, unknown> {
     try {
       const decoded = atob(encodedData);
       try {
-        const data = JSON.parse(decoded);
-        if (data.responseUrl && data.userId) {
+        const data: unknown = JSON.parse(decoded);
+        if (
+          data &&
+          typeof data === "object" &&
+          "responseUrl" in data &&
+          typeof data.responseUrl === "string" &&
+          isTrustedSlackResponseUrl(data.responseUrl) &&
+          "userId" in data &&
+          typeof data.userId === "string" &&
+          data.userId.length > 0
+        ) {
           return {
             messageTs,
             responseUrl: data.responseUrl,
@@ -6798,7 +6838,7 @@ export class SlackAdapter implements Adapter<SlackThreadId, unknown> {
           };
         }
       } catch {
-        return { messageTs, responseUrl: decoded, userId: "" };
+        return null;
       }
       return null;
     } catch {
@@ -6815,6 +6855,13 @@ export class SlackAdapter implements Adapter<SlackThreadId, unknown> {
     action: "replace" | "delete",
     options?: { message?: AdapterPostableMessage; threadTs?: string }
   ): Promise<Record<string, unknown>> {
+    if (!isTrustedSlackResponseUrl(responseUrl)) {
+      throw new ValidationError(
+        "slack",
+        "Refusing to send content to an untrusted Slack response_url"
+      );
+    }
+
     let payload: Record<string, unknown>;
 
     if (action === "delete") {

--- a/packages/adapter-teams/src/api/client.ts
+++ b/packages/adapter-teams/src/api/client.ts
@@ -56,6 +56,36 @@ export class TeamsApiError extends Error {
 const DEFAULT_BOT_SCOPE = "https://api.botframework.com/.default";
 const DEFAULT_TENANT_ID = "botframework.com";
 const LEADING_SLASH_PATTERN = /^\/+/;
+const LOOPBACK_HOST_PATTERN = /^(?:localhost|127(?:\.\d{1,3}){3}|\[::1\])$/i;
+const TRUSTED_CONNECTOR_HOSTS = new Set([
+  "msteams.botframework.azure.cn",
+  "smba.infra.dod.teams.microsoft.us",
+  "smba.infra.gcc.teams.microsoft.com",
+  "smba.infra.gov.teams.microsoft.us",
+  "smba.trafficmanager.net",
+]);
+
+function getTrustedConnectorUrl(serviceUrl: string): URL {
+  let url: URL;
+  try {
+    url = new URL(serviceUrl);
+  } catch {
+    throw new TeamsApiError("Teams Connector serviceUrl must be a valid URL");
+  }
+
+  const isHttpsConnector =
+    url.protocol === "https:" &&
+    TRUSTED_CONNECTOR_HOSTS.has(url.hostname.toLowerCase());
+  const isLocalEmulator =
+    url.protocol === "http:" && LOOPBACK_HOST_PATTERN.test(url.hostname);
+  if (!(isHttpsConnector || isLocalEmulator)) {
+    throw new TeamsApiError(
+      "Refusing to send a Teams bot token to an untrusted Connector serviceUrl"
+    );
+  }
+
+  return url;
+}
 
 export async function resolveTeamsCredential(
   credential: TeamsCredential | undefined
@@ -137,11 +167,17 @@ export async function callTeamsConnectorApi<T = unknown>(
   options: TeamsConnectorOptions
 ): Promise<TeamsApiResponse<T>> {
   const request = options.fetch ?? fetch;
-  const token = await resolveTeamsAccessToken(options);
+  const serviceUrl = getTrustedConnectorUrl(options.serviceUrl);
   const url = new URL(
     options.path.replace(LEADING_SLASH_PATTERN, ""),
-    ensureTrailingSlash(options.serviceUrl)
+    ensureTrailingSlash(serviceUrl.href)
   );
+  if (url.origin !== serviceUrl.origin) {
+    throw new TeamsApiError(
+      "Refusing to send a Teams bot token outside the Connector serviceUrl origin"
+    );
+  }
+  const token = await resolveTeamsAccessToken(options);
 
   const response = await request(url, {
     body: options.body === undefined ? undefined : JSON.stringify(options.body),

--- a/packages/adapter-teams/src/api/index.test.ts
+++ b/packages/adapter-teams/src/api/index.test.ts
@@ -71,12 +71,12 @@ describe("Teams api primitives", () => {
       credentials,
       fetch: request,
       markdownText: "hello",
-      serviceUrl: "https://smba.example/teams/",
+      serviceUrl: "https://smba.trafficmanager.net/teams/",
     });
 
     expect(posted.id).toBe("activity-id");
     expect(String(request.mock.calls[1]?.[0])).toBe(
-      "https://smba.example/teams/v3/conversations/19%3Aabc%40thread.tacv2/activities"
+      "https://smba.trafficmanager.net/teams/v3/conversations/19%3Aabc%40thread.tacv2/activities"
     );
     expect(request.mock.calls[1]?.[1]?.headers).toMatchObject({
       authorization: "Bearer token",
@@ -95,12 +95,12 @@ describe("Teams api primitives", () => {
       credentials,
       fetch: request,
       replyToId: "root",
-      serviceUrl: "https://smba.example/teams/",
+      serviceUrl: "https://smba.trafficmanager.net/teams/",
       text: "reply",
     });
 
     expect(String(request.mock.calls[1]?.[0])).toBe(
-      "https://smba.example/teams/v3/conversations/conversation/activities/root"
+      "https://smba.trafficmanager.net/teams/v3/conversations/conversation/activities/root"
     );
   });
 
@@ -123,7 +123,7 @@ describe("Teams api primitives", () => {
       credentials,
       fetch: request,
       messageId: "activity",
-      serviceUrl: "https://smba.example/",
+      serviceUrl: "https://smba.trafficmanager.net/",
       text: "updated",
     });
     await deleteTeamsMessage({
@@ -131,19 +131,19 @@ describe("Teams api primitives", () => {
       credentials,
       fetch: request,
       messageId: "activity",
-      serviceUrl: "https://smba.example/",
+      serviceUrl: "https://smba.trafficmanager.net/",
     });
     await sendTeamsTyping({
       conversationId: "conversation",
       credentials,
       fetch: request,
-      serviceUrl: "https://smba.example/",
+      serviceUrl: "https://smba.trafficmanager.net/",
     });
     await createTeamsConversation({
       credentials,
       fetch: request,
       members: [{ id: "user" }],
-      serviceUrl: "https://smba.example/",
+      serviceUrl: "https://smba.trafficmanager.net/",
       tenantId: "tenant",
     });
 
@@ -166,7 +166,7 @@ describe("Teams api primitives", () => {
         conversationId: "conversation",
         credentials,
         fetch: request,
-        serviceUrl: "https://smba.example/",
+        serviceUrl: "https://smba.trafficmanager.net/",
         text: "hello",
       })
     ).rejects.toMatchObject({
@@ -182,18 +182,37 @@ describe("Teams api primitives", () => {
       conversationId: "c",
       credentials: { accessToken: () => "direct" },
       fetch: request,
-      serviceUrl: "https://smba.example",
+      serviceUrl: "https://smba.trafficmanager.net",
       text: "hi",
     });
 
     expect(posted.id).toBe("");
     expect(request).toHaveBeenCalledTimes(1);
     expect(String(request.mock.calls[0]?.[0])).toBe(
-      "https://smba.example/v3/conversations/c/activities"
+      "https://smba.trafficmanager.net/v3/conversations/c/activities"
     );
     expect(request.mock.calls[0]?.[1]?.headers).toMatchObject({
       authorization: "Bearer direct",
     });
+  });
+
+  it.each([
+    "https://attacker.example/",
+    "https://attacker.trafficmanager.net/",
+  ])("rejects untrusted service URL %s before acquiring a token", async (serviceUrl) => {
+    const request = vi.fn();
+
+    await expect(
+      postTeamsMessage({
+        conversationId: "conversation",
+        credentials,
+        fetch: request,
+        serviceUrl,
+        text: "hello",
+      })
+    ).rejects.toThrow("untrusted Connector serviceUrl");
+
+    expect(request).not.toHaveBeenCalled();
   });
 
   it("falls back to the default tenant when none is provided", async () => {
@@ -259,7 +278,7 @@ describe("Teams api primitives", () => {
       fetch: request,
       isGroup: true,
       members: [{ id: "user" }],
-      serviceUrl: "https://smba.example/",
+      serviceUrl: "https://smba.trafficmanager.net/",
     });
 
     const body = JSON.parse(request.mock.calls[1]?.[1]?.body as string);

--- a/packages/adapter-teams/src/graph/client.ts
+++ b/packages/adapter-teams/src/graph/client.ts
@@ -8,6 +8,30 @@ import type { TeamsGraphOptions } from "./types";
 const DEFAULT_GRAPH_SCOPE = "https://graph.microsoft.com/.default";
 const DEFAULT_GRAPH_URL = "https://graph.microsoft.com/v1.0/";
 const LEADING_SLASH_PATTERN = /^\/+/;
+const TRUSTED_GRAPH_HOSTS = new Set([
+  "dod-graph.microsoft.us",
+  "graph.microsoft.com",
+  "graph.microsoft.de",
+  "graph.microsoft.us",
+  "microsoftgraph.chinacloudapi.cn",
+]);
+
+function getTrustedGraphUrl(pathOrUrl: string, graphUrl: string): URL {
+  const url = pathOrUrl.startsWith("http")
+    ? new URL(pathOrUrl)
+    : new URL(pathOrUrl.replace(LEADING_SLASH_PATTERN, ""), graphUrl);
+
+  if (
+    url.protocol !== "https:" ||
+    !TRUSTED_GRAPH_HOSTS.has(url.hostname.toLowerCase())
+  ) {
+    throw new TeamsApiError(
+      "Refusing to send a Microsoft Graph token to an untrusted URL"
+    );
+  }
+
+  return url;
+}
 
 export async function resolveGraphAccessToken(
   options: TeamsGraphOptions
@@ -23,13 +47,11 @@ export async function callTeamsGraphApi<T = unknown>(
   options: TeamsGraphOptions
 ): Promise<T> {
   const request = options.fetch ?? fetch;
+  const url = getTrustedGraphUrl(
+    pathOrUrl,
+    options.graphUrl ?? DEFAULT_GRAPH_URL
+  );
   const token = await resolveGraphAccessToken(options);
-  const url = pathOrUrl.startsWith("http")
-    ? new URL(pathOrUrl)
-    : new URL(
-        pathOrUrl.replace(LEADING_SLASH_PATTERN, ""),
-        options.graphUrl ?? DEFAULT_GRAPH_URL
-      );
 
   const response = await request(url, {
     headers: {

--- a/packages/adapter-teams/src/graph/index.test.ts
+++ b/packages/adapter-teams/src/graph/index.test.ts
@@ -138,6 +138,19 @@ describe("Teams graph primitives", () => {
     );
   });
 
+  it("rejects untrusted pagination URLs before acquiring a token", async () => {
+    const request = vi.fn();
+
+    await expect(
+      paginateTeamsGraph("https://attacker.example/v1.0/next", {
+        credentials,
+        fetch: request,
+      })
+    ).rejects.toThrow("untrusted URL");
+
+    expect(request).not.toHaveBeenCalled();
+  });
+
   it("throws TeamsApiError when Graph responds with an error", async () => {
     const request = vi
       .fn()

--- a/packages/adapter-x/README.md
+++ b/packages/adapter-x/README.md
@@ -312,7 +312,7 @@ export async function POST(request: Request) {
 }
 ```
 
-Do not sign the token in your own handler. The challenge and the POST signature use the same key, algorithm, and `sha256=` prefix, so a handler that HMACs an arbitrary `crc_token` becomes a signing oracle: a caller can pass a forged event body as the token and replay the response as `x-twitter-webhooks-signature`. The adapter constrains the token before signing it.
+Do not sign the token in your own handler. The challenge and the POST signature use the same key, algorithm, and `sha256=` prefix, so a handler that HMACs an arbitrary `crc_token` becomes a signing oracle: a caller can pass a forged event body as the token and replay the response as `x-twitter-webhooks-signature`. Route GET through the adapter as shown above; it rejects malformed CRC tokens before signing them.
 
 ### Configuration
 

--- a/packages/adapter-x/src/chat/index.test.ts
+++ b/packages/adapter-x/src/chat/index.test.ts
@@ -1,3 +1,4 @@
+import { createHmac } from "node:crypto";
 import type { ChatInstance } from "chat";
 import { describe, expect, it, vi } from "vitest";
 
@@ -280,16 +281,50 @@ describe("parseMessage", () => {
 });
 
 describe("handleWebhook", () => {
-  // CRC challenges (GET) are handled at the route level, not by the adapter.
-  // The adapter only handles POST requests.
-
-  it("should return 405 for GET requests", async () => {
-    const adapter = createTestAdapter();
-    const request = new Request("https://example.com/webhook", {
-      method: "GET",
+  it("answers CRC challenges with the constrained token HMAC", async () => {
+    const consumerSecret = "test-secret";
+    const adapter = new XchatAdapter({
+      accessToken: "test-token",
+      consumerSecret,
+      userId: TEST_USER_ID,
+      userName: "test-bot",
+      logger: mockLogger,
     });
+    const crcToken = "abcdefghijklmnop";
+    const request = new Request(
+      `https://example.com/webhook?crc_token=${crcToken}`,
+      { method: "GET" }
+    );
     const response = await adapter.handleWebhook(request);
-    expect(response.status).toBe(405);
+    const body = (await response.json()) as { response_token: string };
+
+    expect(response.status).toBe(200);
+    expect(body.response_token).toBe(
+      `sha256=${createHmac("sha256", consumerSecret)
+        .update(crcToken, "utf8")
+        .digest("base64")}`
+    );
+  });
+
+  it("rejects a webhook-shaped CRC token without signing it", async () => {
+    const adapter = new XchatAdapter({
+      accessToken: "test-token",
+      consumerSecret: "test-secret",
+      userId: TEST_USER_ID,
+      userName: "test-bot",
+      logger: mockLogger,
+    });
+    const forgedBody = JSON.stringify({
+      data: { event_type: "chat.received" },
+    });
+    const request = new Request(
+      `https://example.com/webhook?crc_token=${encodeURIComponent(forgedBody)}`,
+      { method: "GET" }
+    );
+    const response = await adapter.handleWebhook(request);
+
+    expect(response.status).toBe(400);
+    expect(await response.text()).not.toContain("response_token");
   });
 
   it("should return 400 for invalid JSON body", async () => {

--- a/packages/adapter-x/src/chat/index.ts
+++ b/packages/adapter-x/src/chat/index.ts
@@ -65,6 +65,7 @@ import {
   Message,
   parseMarkdown,
 } from "chat";
+import { createCrcChallengeResponse } from "../crc";
 import { cardToXChat, type XchatUrlCardSpec } from "./cards";
 import { XchatFormatConverter } from "./markdown";
 import type {
@@ -997,9 +998,10 @@ export class XchatAdapter implements Adapter<XchatThreadId, XchatRawMessage> {
     request: Request,
     options?: WebhookOptions
   ): Promise<Response> {
+    if (request.method === "GET") {
+      return createCrcChallengeResponse(request, this.consumerSecret);
+    }
     if (request.method !== "POST") {
-      // CRC challenges (GET) should be handled at the route level,
-      // not here — they don't need adapter initialization or crypto.
       return new Response("Method not allowed", { status: 405 });
     }
 

--- a/packages/adapter-x/src/crc.ts
+++ b/packages/adapter-x/src/crc.ts
@@ -1,0 +1,24 @@
+import { createHmac } from "node:crypto";
+
+const CRC_TOKEN_PATTERN = /^[A-Za-z0-9+/=_-]{16,128}$/;
+const SIGNATURE_PREFIX = "sha256=";
+
+export function createCrcChallengeResponse(
+  request: Request,
+  consumerSecret?: string
+): Response {
+  if (!consumerSecret) {
+    return new Response("Consumer secret is not configured", { status: 500 });
+  }
+
+  const crcToken = new URL(request.url).searchParams.get("crc_token");
+  if (!(crcToken && CRC_TOKEN_PATTERN.test(crcToken))) {
+    return new Response("Invalid crc_token", { status: 400 });
+  }
+
+  const hash = createHmac("sha256", consumerSecret)
+    .update(crcToken, "utf8")
+    .digest("base64");
+
+  return Response.json({ response_token: `${SIGNATURE_PREFIX}${hash}` });
+}

--- a/packages/adapter-x/src/index.ts
+++ b/packages/adapter-x/src/index.ts
@@ -40,6 +40,7 @@ import {
   Message,
 } from "chat";
 import { cardToXText } from "./cards";
+import { createCrcChallengeResponse } from "./crc";
 import { XFormatConverter } from "./markdown";
 import type {
   XAccessToken,
@@ -63,11 +64,6 @@ import type {
 const DEFAULT_API_BASE_URL = "https://api.x.com";
 const SIGNATURE_HEADER = "x-twitter-webhooks-signature";
 const SIGNATURE_PREFIX = "sha256=";
-// X's CRC token is an opaque base64 string. Restricting the challenge to this
-// shape stops the endpoint from signing arbitrary bytes: a webhook body is JSON
-// (contains `{` and `"`, absent from base64) so it can never match, and a CRC
-// response can't double as a POST signature for a forged event.
-const CRC_TOKEN_PATTERN = /^[A-Za-z0-9+/=_-]{16,128}$/;
 const SENT_ID_LIMIT = 1000;
 const DM_EVENT_FIELDS = "id,text,sender_id,created_at,dm_conversation_id";
 const LIKE_EMOJI = new Set(["❤️", "♥️", "❤"]);
@@ -246,16 +242,7 @@ export class XAdapter implements Adapter<XThreadId, XRawMessage> {
    * keyed by the consumer secret, base64 encoded.
    */
   protected handleCrcChallenge(request: Request): Response {
-    const crcToken = new URL(request.url).searchParams.get("crc_token");
-    if (!(crcToken && CRC_TOKEN_PATTERN.test(crcToken))) {
-      return new Response("Invalid crc_token", { status: 400 });
-    }
-
-    const hash = createHmac("sha256", this.consumerSecret)
-      .update(crcToken, "utf8")
-      .digest("base64");
-
-    return Response.json({ response_token: `${SIGNATURE_PREFIX}${hash}` });
+    return createCrcChallengeResponse(request, this.consumerSecret);
   }
 
   protected verifySignature(request: Request, body: string): boolean {


### PR DESCRIPTION
Adapters now reject untrusted destinations before sending credentials, message content, or attachment requests.

Teams Connector and Graph calls stay on known Microsoft hosts, Instagram downloads stay on trusted Meta hosts, and Slack response URLs are checked before use.

XChat now handles CRC challenges itself and rejects tokens that could be reused to forge webhook signatures.