### PR TITLE
fix(adapters): harden webhook tenant isolation

### DIFF
--- a/.changeset/harden-webhook-tenancy.md
+++ b/.changeset/harden-webhook-tenancy.md
@@ -1,8 +1,8 @@
 ---
-"@chat-adapter/gchat": patch
+"@chat-adapter/gchat": minor
 "@chat-adapter/slack": patch
 "@chat-adapter/teams": patch
 "chat": patch
 ---
 
-Harden webhook tenant isolation, bot identity, pagination, logging, and recording.
+Harden webhook tenant isolation, require explicit Google Chat bot identity for reliable mention handling, use native Google Chat pagination, isolate Slack caches, and bound recording storage.

--- a/.changeset/harden-webhook-tenancy.md
+++ b/.changeset/harden-webhook-tenancy.md
@@ -1,0 +1,8 @@
+---
+"@chat-adapter/gchat": patch
+"@chat-adapter/slack": patch
+"@chat-adapter/teams": patch
+"chat": patch
+---
+
+Harden webhook tenant isolation, bot identity, pagination, logging, and recording.

--- a/apps/docs/content/adapters/official/gchat.mdx
+++ b/apps/docs/content/adapters/official/gchat.mdx
@@ -95,6 +95,11 @@ bot.onNewMention(async (thread, message) => {
       description:
         "Service account credentials JSON. Auto-detected from `GOOGLE_CHAT_CREDENTIALS`.",
     },
+    botUserId: {
+      type: "string",
+      description:
+        "Canonical users/... resource name of this Chat app. Required for exact self-message and mention detection; auto-detected from `GOOGLE_CHAT_BOT_USER_ID`.",
+    },
     useApplicationDefaultCredentials: {
       type: "boolean",
       description:
@@ -143,6 +148,8 @@ bot.onNewMention(async (thread, message) => {
 />
 
 One of `googleChatProjectNumber`, `endpointUrl`, `pubsubAudience`, or `disableSignatureVerification: true` is required — the constructor throws otherwise. Configure the verifier(s) for each transport you actually receive.
+
+Set `botUserId` (or `GOOGLE_CHAT_BOT_USER_ID`) to the canonical `sender.name` from a verified message authored by your Chat app, such as `users/123456789`. The adapter never learns this identity from inbound mentions. When it is omitted, all `BOT` senders are conservatively treated as self to prevent reply loops.
 
 ## Authentication
 

--- a/apps/docs/content/adapters/official/gchat.mdx
+++ b/apps/docs/content/adapters/official/gchat.mdx
@@ -151,6 +151,8 @@ One of `googleChatProjectNumber`, `endpointUrl`, `pubsubAudience`, or `disableSi
 
 Set `botUserId` (or `GOOGLE_CHAT_BOT_USER_ID`) to the canonical `sender.name` from a verified message authored by your Chat app, such as `users/123456789`. The adapter never learns this identity from inbound mentions. When it is omitted, all `BOT` senders are conservatively treated as self to prevent reply loops.
 
+Apps upgrading from an earlier release that rely on mention handlers must configure `botUserId` to preserve mention handling. Without it, bot mention annotations are left unchanged and the default `onNewMention` detection may no longer match them.
+
 ## Authentication
 
 ### 1. Create a GCP project

--- a/examples/nextjs-chat/.env.example
+++ b/examples/nextjs-chat/.env.example
@@ -13,6 +13,8 @@ BOT_USERNAME=mybot
 
 # Google Chat (optional)
 # GOOGLE_CHAT_CREDENTIALS={"type":"service_account",...}
+# Canonical sender.name from a verified message authored by your Chat app.
+# GOOGLE_CHAT_BOT_USER_ID=users/123456789
 
 # Discord (optional)
 # DISCORD_BOT_TOKEN=your-bot-token
@@ -73,3 +75,9 @@ BOT_USERNAME=mybot
 
 # Redis (for production state persistence)
 # REDIS_URL=redis://localhost:6379
+
+# Preview branch webhook proxy (optional)
+# Required to view or update /settings. Use a long, randomly generated value.
+# PREVIEW_BRANCH_SECRET=replace-with-a-random-secret
+# Optional comma-separated exact hostnames. Defaults to any *.vercel.app host.
+# PREVIEW_BRANCH_ALLOWED_HOSTS=my-feature-git-main-team.vercel.app

--- a/examples/nextjs-chat/README.md
+++ b/examples/nextjs-chat/README.md
@@ -132,12 +132,16 @@ pnpm recording:export <session-id>
 
 See `packages/integration-tests/fixtures/replay/README.md` for the full workflow.
 
+Only successful, adapter-verified webhook deliveries are recorded. Individual records are limited to 256 KiB and each session retains at most 500 entries.
+
 ## Preview branch testing
 
 Test PRs with real webhook traffic by proxying requests from production to a preview deployment:
 
 1. Deploy a preview branch to Vercel
-2. Go to `/settings` on the production deployment
-3. Enter the preview branch URL and save
+2. Set `PREVIEW_BRANCH_SECRET` on the production deployment to a long, random value
+3. Optionally set `PREVIEW_BRANCH_ALLOWED_HOSTS` to a comma-separated list of exact preview hostnames (otherwise any `*.vercel.app` hostname is accepted)
+4. Go to `/settings` on the production deployment
+5. Enter the operator secret, load the setting, then enter the preview branch URL and save
 
-All webhook requests are proxied until the URL is cleared.
+The settings API requires the operator secret as a bearer token. Only HTTPS Vercel deployments or explicitly allowed hosts are accepted, and all webhook requests are proxied until the URL is cleared.

--- a/examples/nextjs-chat/package.json
+++ b/examples/nextjs-chat/package.json
@@ -6,6 +6,7 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
+    "test": "vitest run",
     "typecheck": "tsc --noEmit",
     "recording:list": "tsx src/lib/recorder.ts --list",
     "recording:export": "tsx src/lib/recorder.ts"
@@ -45,6 +46,7 @@
     "dotenv": "^17.2.3",
     "postcss": "^8.5.26",
     "tsx": "^4.21.0",
-    "typescript": "^5.7.2"
+    "typescript": "^5.7.2",
+    "vitest": "^4.0.18"
   }
 }

--- a/examples/nextjs-chat/src/app/api/settings/preview-branch/route.ts
+++ b/examples/nextjs-chat/src/app/api/settings/preview-branch/route.ts
@@ -1,5 +1,5 @@
-import { timingSafeEqual } from "node:crypto";
 import { createClient } from "redis";
+import { authorizePreviewBranchRequest } from "@/lib/authorization";
 import {
   PREVIEW_BRANCH_KEY,
   parseAllowedPreviewBranchUrl,
@@ -33,33 +33,8 @@ async function getRedisClient() {
   return redisClient;
 }
 
-function authorize(request: Request): Response | null {
-  const secret = process.env.PREVIEW_BRANCH_SECRET;
-  if (!secret) {
-    return Response.json(
-      { error: "PREVIEW_BRANCH_SECRET is not configured" },
-      { status: 503 }
-    );
-  }
-
-  const authorization = request.headers.get("authorization");
-  const provided = authorization?.startsWith("Bearer ")
-    ? authorization.slice("Bearer ".length)
-    : "";
-  const expectedBytes = Buffer.from(secret);
-  const providedBytes = Buffer.from(provided);
-  if (
-    expectedBytes.length !== providedBytes.length ||
-    !timingSafeEqual(expectedBytes, providedBytes)
-  ) {
-    return Response.json({ error: "Unauthorized" }, { status: 401 });
-  }
-
-  return null;
-}
-
 export async function GET(request: Request): Promise<Response> {
-  const unauthorized = authorize(request);
+  const unauthorized = authorizePreviewBranchRequest(request);
   if (unauthorized) {
     return unauthorized;
   }
@@ -79,7 +54,7 @@ export async function GET(request: Request): Promise<Response> {
 }
 
 export async function POST(request: Request): Promise<Response> {
-  const unauthorized = authorize(request);
+  const unauthorized = authorizePreviewBranchRequest(request);
   if (unauthorized) {
     return unauthorized;
   }

--- a/examples/nextjs-chat/src/app/api/settings/preview-branch/route.ts
+++ b/examples/nextjs-chat/src/app/api/settings/preview-branch/route.ts
@@ -1,7 +1,11 @@
+import { timingSafeEqual } from "node:crypto";
 import { createClient } from "redis";
+import {
+  PREVIEW_BRANCH_KEY,
+  parseAllowedPreviewBranchUrl,
+} from "@/lib/preview-branch";
 
 const REDIS_URL = process.env.REDIS_URL || "";
-const PREVIEW_BRANCH_KEY = "chat-sdk:cache:preview-branch-url";
 
 // Redis client singleton
 let redisClient: ReturnType<typeof createClient> | null = null;
@@ -29,7 +33,37 @@ async function getRedisClient() {
   return redisClient;
 }
 
-export async function GET(): Promise<Response> {
+function authorize(request: Request): Response | null {
+  const secret = process.env.PREVIEW_BRANCH_SECRET;
+  if (!secret) {
+    return Response.json(
+      { error: "PREVIEW_BRANCH_SECRET is not configured" },
+      { status: 503 }
+    );
+  }
+
+  const authorization = request.headers.get("authorization");
+  const provided = authorization?.startsWith("Bearer ")
+    ? authorization.slice("Bearer ".length)
+    : "";
+  const expectedBytes = Buffer.from(secret);
+  const providedBytes = Buffer.from(provided);
+  if (
+    expectedBytes.length !== providedBytes.length ||
+    !timingSafeEqual(expectedBytes, providedBytes)
+  ) {
+    return Response.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  return null;
+}
+
+export async function GET(request: Request): Promise<Response> {
+  const unauthorized = authorize(request);
+  if (unauthorized) {
+    return unauthorized;
+  }
+
   try {
     const client = await getRedisClient();
     const value = await client.get(PREVIEW_BRANCH_KEY);
@@ -45,26 +79,46 @@ export async function GET(): Promise<Response> {
 }
 
 export async function POST(request: Request): Promise<Response> {
+  const unauthorized = authorize(request);
+  if (unauthorized) {
+    return unauthorized;
+  }
+
   try {
-    const body = await request.json();
-    const { url } = body;
+    const body: unknown = await request.json();
+    if (!(body && typeof body === "object" && "url" in body)) {
+      return Response.json({ error: "Missing URL" }, { status: 400 });
+    }
+    const { url } = body as { url: unknown };
 
     const client = await getRedisClient();
 
-    if (url) {
-      // Validate URL
-      try {
-        new URL(url);
-      } catch {
-        return Response.json({ error: "Invalid URL" }, { status: 400 });
+    if (typeof url === "string" && url.length > 0) {
+      const allowedUrl = parseAllowedPreviewBranchUrl(url);
+      if (!allowedUrl) {
+        return Response.json(
+          {
+            error:
+              "URL must be an HTTPS Vercel deployment or a configured allowed host",
+          },
+          { status: 400 }
+        );
       }
-      await client.set(PREVIEW_BRANCH_KEY, url);
-    } else {
+      await client.set(PREVIEW_BRANCH_KEY, allowedUrl.origin);
+      return Response.json({ success: true, url: allowedUrl.origin });
+    }
+    if (url === null || url === "") {
       // Clear the preview branch URL
       await client.del(PREVIEW_BRANCH_KEY);
+      return Response.json({ success: true, url: null });
     }
 
-    return Response.json({ success: true, url: url || null });
+    return Response.json(
+      { error: "URL must be a string or null" },
+      {
+        status: 400,
+      }
+    );
   } catch (error) {
     console.error("[settings] Error setting preview branch URL:", error);
     return Response.json(

--- a/examples/nextjs-chat/src/app/api/webhooks/[platform]/route.ts
+++ b/examples/nextjs-chat/src/app/api/webhooks/[platform]/route.ts
@@ -16,16 +16,18 @@ export async function POST(
     return new Response(`Unknown platform: ${platform}`, { status: 404 });
   }
 
-  // Record webhook if enabled (no-op if disabled)
-  if (recorder.isEnabled) {
-    await recorder.recordWebhook(platform, request.clone());
-  }
+  const recordingRequest = recorder.isEnabled ? request.clone() : null;
 
   // Handle the webhook with waitUntil for background processing
   // Next.js after() ensures work completes after the response is sent
-  return webhookHandler(request, {
+  const response = await webhookHandler(request, {
     waitUntil: (task) => after(() => task),
   });
+  // Only successful, adapter-verified deliveries are eligible for recording.
+  if (recordingRequest && response.ok) {
+    await recorder.recordWebhook(platform, recordingRequest);
+  }
+  return response;
 }
 
 // GET handler — serves as health check, but also forwards to webhook handler

--- a/examples/nextjs-chat/src/app/settings/page.tsx
+++ b/examples/nextjs-chat/src/app/settings/page.tsx
@@ -1,34 +1,47 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useState } from "react";
 
 export default function SettingsPage() {
+  const [operatorSecret, setOperatorSecret] = useState("");
+  const [authenticated, setAuthenticated] = useState(false);
   const [previewBranchUrl, setPreviewBranchUrl] = useState("");
   const [savedUrl, setSavedUrl] = useState<string | null>(null);
   const [status, setStatus] = useState<"idle" | "loading" | "saving" | "error">(
-    "loading"
+    "idle"
   );
   const [error, setError] = useState<string | null>(null);
 
-  // Load current setting on mount
-  useEffect(() => {
-    fetch("/api/settings/preview-branch")
-      .then((res) => res.json())
-      .then((data) => {
-        if (data.error) {
-          setError(data.error);
-          setStatus("error");
-        } else {
-          setPreviewBranchUrl(data.url || "");
-          setSavedUrl(data.url);
-          setStatus("idle");
-        }
-      })
-      .catch((err) => {
-        setError(err.message);
-        setStatus("error");
+  const authorizationHeaders = {
+    Authorization: `Bearer ${operatorSecret}`,
+  };
+
+  const handleLoad = async () => {
+    setStatus("loading");
+    setError(null);
+
+    try {
+      const res = await fetch("/api/settings/preview-branch", {
+        headers: authorizationHeaders,
       });
-  }, []);
+      const data = await res.json();
+      if (!res.ok || data.error) {
+        setAuthenticated(false);
+        setError(data.error || "Unable to load settings");
+        setStatus("error");
+        return;
+      }
+
+      setAuthenticated(true);
+      setPreviewBranchUrl(data.url || "");
+      setSavedUrl(data.url);
+      setStatus("idle");
+    } catch (err) {
+      setAuthenticated(false);
+      setError(err instanceof Error ? err.message : "Unknown error");
+      setStatus("error");
+    }
+  };
 
   const handleSave = async () => {
     setStatus("saving");
@@ -37,13 +50,16 @@ export default function SettingsPage() {
     try {
       const res = await fetch("/api/settings/preview-branch", {
         method: "POST",
-        headers: { "Content-Type": "application/json" },
+        headers: {
+          ...authorizationHeaders,
+          "Content-Type": "application/json",
+        },
         body: JSON.stringify({ url: previewBranchUrl || null }),
       });
 
       const data = await res.json();
 
-      if (data.error) {
+      if (!res.ok || data.error) {
         setError(data.error);
         setStatus("error");
       } else {
@@ -64,13 +80,16 @@ export default function SettingsPage() {
     try {
       const res = await fetch("/api/settings/preview-branch", {
         method: "POST",
-        headers: { "Content-Type": "application/json" },
+        headers: {
+          ...authorizationHeaders,
+          "Content-Type": "application/json",
+        },
         body: JSON.stringify({ url: null }),
       });
 
       const data = await res.json();
 
-      if (data.error) {
+      if (!res.ok || data.error) {
         setError(data.error);
         setStatus("error");
       } else {
@@ -101,9 +120,63 @@ export default function SettingsPage() {
           webhook traffic.
         </p>
 
-        {status === "loading" ? (
-          <p>Loading...</p>
-        ) : (
+        <div style={{ marginBottom: "1rem" }}>
+          <label
+            htmlFor="operator-secret"
+            style={{
+              display: "block",
+              marginBottom: "0.5rem",
+              fontWeight: 500,
+            }}
+          >
+            Operator Secret
+          </label>
+          <div style={{ display: "flex", gap: "0.5rem" }}>
+            <input
+              autoComplete="current-password"
+              id="operator-secret"
+              onChange={(event) => {
+                setOperatorSecret(event.target.value);
+                setAuthenticated(false);
+              }}
+              placeholder="PREVIEW_BRANCH_SECRET"
+              style={{
+                width: "100%",
+                padding: "0.5rem",
+                fontSize: "1rem",
+                border: "1px solid #ccc",
+                borderRadius: "4px",
+                boxSizing: "border-box",
+              }}
+              type="password"
+              value={operatorSecret}
+            />
+            <button
+              disabled={!operatorSecret || status === "loading"}
+              onClick={handleLoad}
+              style={{
+                padding: "0.5rem 1rem",
+                fontSize: "1rem",
+                whiteSpace: "nowrap",
+              }}
+              type="button"
+            >
+              {status === "loading" ? "Loading..." : "Load settings"}
+            </button>
+          </div>
+          <p style={{ color: "#666", fontSize: "0.875rem" }}>
+            This secret stays in this browser tab and is sent only in the
+            authorization header.
+          </p>
+        </div>
+
+        {error && (
+          <p role="alert" style={{ color: "red", marginBottom: "1rem" }}>
+            {error}
+          </p>
+        )}
+
+        {authenticated ? (
           <>
             <div style={{ marginBottom: "1rem" }}>
               <label
@@ -132,10 +205,6 @@ export default function SettingsPage() {
                 value={previewBranchUrl}
               />
             </div>
-
-            {error && (
-              <p style={{ color: "red", marginBottom: "1rem" }}>{error}</p>
-            )}
 
             <div style={{ display: "flex", gap: "0.5rem" }}>
               <button
@@ -205,6 +274,17 @@ export default function SettingsPage() {
               </p>
             )}
           </>
+        ) : (
+          <p
+            style={{
+              marginTop: "1rem",
+              padding: "0.75rem",
+              backgroundColor: "#f8f9fa",
+              borderRadius: "4px",
+            }}
+          >
+            Enter the operator secret to view or change this setting.
+          </p>
         )}
       </section>
 

--- a/examples/nextjs-chat/src/lib/authorization.ts
+++ b/examples/nextjs-chat/src/lib/authorization.ts
@@ -1,0 +1,28 @@
+import { timingSafeEqual } from "node:crypto";
+
+export function authorizePreviewBranchRequest(
+  request: Request
+): Response | null {
+  const secret = process.env.PREVIEW_BRANCH_SECRET;
+  if (!secret) {
+    return Response.json(
+      { error: "PREVIEW_BRANCH_SECRET is not configured" },
+      { status: 503 }
+    );
+  }
+
+  const authorization = request.headers.get("authorization");
+  const provided = authorization?.startsWith("Bearer ")
+    ? authorization.slice("Bearer ".length)
+    : "";
+  const expectedBytes = Buffer.from(secret);
+  const providedBytes = Buffer.from(provided);
+  if (
+    expectedBytes.length !== providedBytes.length ||
+    !timingSafeEqual(expectedBytes, providedBytes)
+  ) {
+    return Response.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  return null;
+}

--- a/examples/nextjs-chat/src/lib/preview-branch.ts
+++ b/examples/nextjs-chat/src/lib/preview-branch.ts
@@ -1,0 +1,37 @@
+export const PREVIEW_BRANCH_KEY = "chat-sdk:cache:preview-branch-url";
+
+function configuredAllowedHosts(): Set<string> {
+  return new Set(
+    (process.env.PREVIEW_BRANCH_ALLOWED_HOSTS ?? "")
+      .split(",")
+      .map((host) => host.trim().toLowerCase())
+      .filter(Boolean)
+  );
+}
+
+export function parseAllowedPreviewBranchUrl(value: string): URL | null {
+  let url: URL;
+  try {
+    url = new URL(value);
+  } catch {
+    return null;
+  }
+
+  if (
+    url.protocol !== "https:" ||
+    url.username !== "" ||
+    url.password !== "" ||
+    url.port !== ""
+  ) {
+    return null;
+  }
+
+  const hostname = url.hostname.toLowerCase();
+  const allowedHosts = configuredAllowedHosts();
+  const hostnameAllowed =
+    allowedHosts.size > 0
+      ? allowedHosts.has(hostname)
+      : hostname.endsWith(".vercel.app");
+
+  return hostnameAllowed ? url : null;
+}

--- a/examples/nextjs-chat/src/lib/preview.test.ts
+++ b/examples/nextjs-chat/src/lib/preview.test.ts
@@ -1,0 +1,88 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { authorizePreviewBranchRequest } from "./authorization";
+import { parseAllowedPreviewBranchUrl } from "./preview-branch";
+
+const previousSecret = process.env.PREVIEW_BRANCH_SECRET;
+const previousHosts = process.env.PREVIEW_BRANCH_ALLOWED_HOSTS;
+
+function restore(name: string, value: string | undefined): void {
+  if (value === undefined) {
+    Reflect.deleteProperty(process.env, name);
+    return;
+  }
+  process.env[name] = value;
+}
+
+afterEach(() => {
+  restore("PREVIEW_BRANCH_SECRET", previousSecret);
+  restore("PREVIEW_BRANCH_ALLOWED_HOSTS", previousHosts);
+});
+
+describe("preview branch boundary", () => {
+  it("allows only trusted HTTPS origins", () => {
+    Reflect.deleteProperty(process.env, "PREVIEW_BRANCH_ALLOWED_HOSTS");
+
+    expect(
+      parseAllowedPreviewBranchUrl("https://chat-example.vercel.app/path")
+        ?.origin
+    ).toBe("https://chat-example.vercel.app");
+    expect(
+      parseAllowedPreviewBranchUrl("https://chat-example.vercel.app.evil.test")
+    ).toBeNull();
+    expect(
+      parseAllowedPreviewBranchUrl("http://chat-example.vercel.app")
+    ).toBeNull();
+    expect(
+      parseAllowedPreviewBranchUrl("https://user@chat-example.vercel.app")
+    ).toBeNull();
+    expect(
+      parseAllowedPreviewBranchUrl("https://chat-example.vercel.app:8443")
+    ).toBeNull();
+  });
+
+  it("uses configured hosts as an exact allowlist", () => {
+    process.env.PREVIEW_BRANCH_ALLOWED_HOSTS = "preview.example.com";
+
+    expect(
+      parseAllowedPreviewBranchUrl("https://preview.example.com/path")?.origin
+    ).toBe("https://preview.example.com");
+    expect(
+      parseAllowedPreviewBranchUrl("https://child.preview.example.com")
+    ).toBeNull();
+  });
+
+  it("fails closed when the management secret is absent or incorrect", () => {
+    Reflect.deleteProperty(process.env, "PREVIEW_BRANCH_SECRET");
+    expect(
+      authorizePreviewBranchRequest(
+        new Request("https://example.com", {
+          headers: { authorization: "Bearer test-secret" },
+        })
+      )?.status
+    ).toBe(503);
+
+    process.env.PREVIEW_BRANCH_SECRET = "test-secret";
+    expect(
+      authorizePreviewBranchRequest(new Request("https://example.com"))?.status
+    ).toBe(401);
+    expect(
+      authorizePreviewBranchRequest(
+        new Request("https://example.com", {
+          headers: { authorization: "Bearer wrong-secret" },
+        })
+      )?.status
+    ).toBe(401);
+  });
+
+  it("accepts the exact management secret", () => {
+    process.env.PREVIEW_BRANCH_SECRET = "test-secret";
+
+    expect(
+      authorizePreviewBranchRequest(
+        new Request("https://example.com", {
+          headers: { authorization: "Bearer test-secret" },
+        })
+      )
+    ).toBeNull();
+  });
+});

--- a/examples/nextjs-chat/src/lib/recorder.test.ts
+++ b/examples/nextjs-chat/src/lib/recorder.test.ts
@@ -1,0 +1,73 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { readBoundedResponseBody, sanitizeHeaderValue } from "./recorder";
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("recording boundary", () => {
+  it.each([
+    "authorization",
+    "cookie",
+    "linear-signature",
+    "x-discord-gateway-token",
+    "x-hub-signature-256",
+    "x-notion-signature",
+    "x-slack-signature",
+    "x-slack-socket-token",
+    "x-telegram-bot-api-secret-token",
+    "x-twilio-signature",
+    "x-twitter-webhooks-signature",
+  ])("fully redacts %s", (name) => {
+    expect(sanitizeHeaderValue(name, "reusable-secret-value")).toBe(
+      "[REDACTED]"
+    );
+  });
+
+  it("preserves non-sensitive headers", () => {
+    expect(sanitizeHeaderValue("content-type", "application/json")).toBe(
+      "application/json"
+    );
+  });
+
+  it("rejects oversized response bodies while streaming", async () => {
+    const cancel = vi.fn();
+    const chunk = new Uint8Array(128 * 1024);
+    const stream = new ReadableStream<Uint8Array>({
+      cancel,
+      start(controller) {
+        controller.enqueue(chunk);
+        controller.enqueue(chunk);
+        controller.enqueue(chunk);
+      },
+    });
+
+    await expect(
+      readBoundedResponseBody(new Response(stream))
+    ).resolves.toBeNull();
+    expect(cancel).toHaveBeenCalledOnce();
+  });
+
+  it("rejects an oversized declared response before reading", async () => {
+    const getReader = vi.fn();
+    const response = {
+      body: { getReader },
+      headers: new Headers({ "content-length": String(300 * 1024) }),
+    } as unknown as Response;
+
+    await expect(readBoundedResponseBody(response)).resolves.toBeNull();
+    expect(getReader).not.toHaveBeenCalled();
+  });
+
+  it("stops recording a stalled response body", async () => {
+    vi.useFakeTimers();
+    const cancel = vi.fn();
+    const response = new Response(new ReadableStream<Uint8Array>({ cancel }));
+
+    const body = readBoundedResponseBody(response);
+    await vi.advanceTimersByTimeAsync(5000);
+
+    await expect(body).resolves.toBeNull();
+    expect(cancel).toHaveBeenCalledOnce();
+  });
+});

--- a/examples/nextjs-chat/src/lib/recorder.ts
+++ b/examples/nextjs-chat/src/lib/recorder.ts
@@ -64,27 +64,15 @@ export type RecordEntry =
   | FetchRecord
   | GatewayRecord;
 
-// Headers that contain sensitive data - values will be redacted
-const SENSITIVE_HEADERS = new Set([
-  "authorization",
-  "cookie",
-  "set-cookie",
-  "x-api-key",
-  "x-auth-token",
-  "x-access-token",
-  "x-refresh-token",
-  "x-csrf-token",
-  "x-xsrf-token",
-]);
+const SENSITIVE_HEADER_PATTERN =
+  /authorization|cookie|token|secret|signature|api-key|csrf|xsrf/i;
 
 /**
  * Sanitize header values by redacting sensitive information.
  */
-function sanitizeHeaderValue(key: string, value: string): string {
-  if (SENSITIVE_HEADERS.has(key.toLowerCase())) {
-    // Keep first few chars for debugging (e.g., "Bearer ey...")
-    const prefix = value.slice(0, 10);
-    return `${prefix}...[REDACTED]`;
+export function sanitizeHeaderValue(key: string, value: string): string {
+  if (SENSITIVE_HEADER_PATTERN.test(key)) {
+    return "[REDACTED]";
   }
   return value;
 }
@@ -92,6 +80,7 @@ function sanitizeHeaderValue(key: string, value: string): string {
 const RECORDING_TTL_SECONDS = 1 * 60 * 60; // 1 hour
 const MAX_RECORD_BYTES = 256 * 1024;
 const MAX_RECORDS_PER_SESSION = 500;
+const RECORDING_READ_TIMEOUT_MS = 5000;
 
 const DEFAULT_FETCH_URL_PATTERNS: RegExp[] = [
   /graph\.microsoft\.com/,
@@ -100,33 +89,65 @@ const DEFAULT_FETCH_URL_PATTERNS: RegExp[] = [
   /chat\.googleapis\.com/,
 ];
 
-async function readBoundedRequestBody(
-  request: Request
+async function readBoundedBody(
+  stream: ReadableStream<Uint8Array> | null,
+  contentLength: string | null
 ): Promise<string | null> {
-  const declaredLength = Number(request.headers.get("content-length"));
+  const declaredLength = contentLength ? Number(contentLength) : 0;
   if (Number.isFinite(declaredLength) && declaredLength > MAX_RECORD_BYTES) {
     return null;
   }
-  if (!request.body) {
+  if (!stream) {
     return "";
   }
 
-  const reader = request.body.getReader();
+  const reader = stream.getReader();
   const decoder = new TextDecoder();
   let totalBytes = 0;
   let body = "";
-  while (true) {
-    const { done, value } = await reader.read();
-    if (done) {
-      return body + decoder.decode();
+  let timedOut = false;
+  let timeoutId: ReturnType<typeof setTimeout> | undefined;
+  const timeout = new Promise<null>((resolve) => {
+    timeoutId = setTimeout(() => {
+      timedOut = true;
+      reader.cancel().catch(() => {});
+      resolve(null);
+    }, RECORDING_READ_TIMEOUT_MS);
+  });
+
+  try {
+    while (true) {
+      const result = await Promise.race([reader.read(), timeout]);
+      if (timedOut || result === null) {
+        return null;
+      }
+      if (result.done) {
+        return body + decoder.decode();
+      }
+      totalBytes += result.value.byteLength;
+      if (totalBytes > MAX_RECORD_BYTES) {
+        reader.cancel().catch(() => {});
+        return null;
+      }
+      body += decoder.decode(result.value, { stream: true });
     }
-    totalBytes += value.byteLength;
-    if (totalBytes > MAX_RECORD_BYTES) {
-      await reader.cancel();
-      return null;
-    }
-    body += decoder.decode(value, { stream: true });
+  } catch {
+    return null;
+  } finally {
+    clearTimeout(timeoutId);
   }
+}
+
+async function readBoundedRequestBody(
+  request: Request
+): Promise<string | null> {
+  return readBoundedBody(request.body, request.headers.get("content-length"));
+}
+
+export async function readBoundedResponseBody(
+  response: Response
+): Promise<string | null> {
+  return readBoundedBody(response.body, response.headers.get("content-length"));
 }
 
 class Recorder {
@@ -225,7 +246,8 @@ class Recorder {
 
     let recordedResponse = response;
     if (recordedResponse && recordedResponse instanceof Response) {
-      recordedResponse = await recordedResponse.clone().text();
+      recordedResponse =
+        (await readBoundedResponseBody(recordedResponse.clone())) ?? undefined;
     }
 
     const record: ApiCallRecord = {
@@ -394,7 +416,7 @@ class Recorder {
         if (response) {
           try {
             const cloned = response.clone();
-            responseBody = await cloned.text();
+            responseBody = (await readBoundedResponseBody(cloned)) ?? undefined;
             const respHeaders: Record<string, string> = {};
             cloned.headers.forEach((value, key) => {
               respHeaders[key] = sanitizeHeaderValue(key, value);

--- a/examples/nextjs-chat/src/lib/recorder.ts
+++ b/examples/nextjs-chat/src/lib/recorder.ts
@@ -90,6 +90,8 @@ function sanitizeHeaderValue(key: string, value: string): string {
 }
 
 const RECORDING_TTL_SECONDS = 1 * 60 * 60; // 1 hour
+const MAX_RECORD_BYTES = 256 * 1024;
+const MAX_RECORDS_PER_SESSION = 500;
 
 const DEFAULT_FETCH_URL_PATTERNS: RegExp[] = [
   /graph\.microsoft\.com/,
@@ -97,6 +99,35 @@ const DEFAULT_FETCH_URL_PATTERNS: RegExp[] = [
   /\.slack\.com/,
   /chat\.googleapis\.com/,
 ];
+
+async function readBoundedRequestBody(
+  request: Request
+): Promise<string | null> {
+  const declaredLength = Number(request.headers.get("content-length"));
+  if (Number.isFinite(declaredLength) && declaredLength > MAX_RECORD_BYTES) {
+    return null;
+  }
+  if (!request.body) {
+    return "";
+  }
+
+  const reader = request.body.getReader();
+  const decoder = new TextDecoder();
+  let totalBytes = 0;
+  let body = "";
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) {
+      return body + decoder.decode();
+    }
+    totalBytes += value.byteLength;
+    if (totalBytes > MAX_RECORD_BYTES) {
+      await reader.cancel();
+      return null;
+    }
+    body += decoder.decode(value, { stream: true });
+  }
+}
 
 class Recorder {
   private readonly redis: RedisClientType | null = null;
@@ -156,10 +187,14 @@ class Recorder {
 
     const headers: Record<string, string> = {};
     request.headers.forEach((value, key) => {
-      headers[key] = value;
+      headers[key] = sanitizeHeaderValue(key, value);
     });
 
-    const body = await request.clone().text();
+    const body = await readBoundedRequestBody(request.clone());
+    if (body === null) {
+      console.warn("[recorder] Skipping oversized webhook record");
+      return;
+    }
 
     const record: WebhookRecord = {
       type: "webhook",
@@ -236,7 +271,13 @@ class Recorder {
 
     try {
       await this.ensureConnected();
-      await this.redis.rPush(this.redisKey, JSON.stringify(record));
+      const serialized = JSON.stringify(record);
+      if (Buffer.byteLength(serialized) > MAX_RECORD_BYTES) {
+        console.warn("[recorder] Skipping oversized record");
+        return;
+      }
+      await this.redis.rPush(this.redisKey, serialized);
+      await this.redis.lTrim(this.redisKey, -MAX_RECORDS_PER_SESSION, -1);
       await this.redis.expire(this.redisKey, RECORDING_TTL_SECONDS);
     } catch (err) {
       console.error("[recorder] Failed to record:", err);

--- a/examples/nextjs-chat/src/proxy.ts
+++ b/examples/nextjs-chat/src/proxy.ts
@@ -1,12 +1,13 @@
 import type { NextRequest } from "next/server";
 import { NextResponse } from "next/server";
 import { createClient } from "redis";
+import {
+  PREVIEW_BRANCH_KEY,
+  parseAllowedPreviewBranchUrl,
+} from "@/lib/preview-branch";
 
 // Redis URL from environment
 const REDIS_URL = process.env.REDIS_URL || "";
-
-// Key for storing the preview branch URL
-const PREVIEW_BRANCH_KEY = "chat-sdk:cache:preview-branch-url";
 
 // Redis client singleton
 let redisClient: ReturnType<typeof createClient> | null = null;
@@ -71,10 +72,17 @@ export async function proxy(request: NextRequest) {
     return NextResponse.next();
   }
 
+  const allowedPreviewBranchUrl =
+    parseAllowedPreviewBranchUrl(previewBranchUrl);
+  if (!allowedPreviewBranchUrl) {
+    console.error("[proxy] Ignoring an untrusted preview branch URL");
+    return NextResponse.next();
+  }
+
   // Rewrite the request to the preview branch URL
   const targetUrl = new URL(
     pathname + request.nextUrl.search,
-    previewBranchUrl
+    allowedPreviewBranchUrl
   );
 
   console.warn(`[proxy] Proxying ${pathname} to ${targetUrl.hostname}`);

--- a/examples/nextjs-chat/vitest.config.ts
+++ b/examples/nextjs-chat/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineProject } from "vitest/config";
+
+export default defineProject({
+  test: {
+    environment: "node",
+  },
+});

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "build": "turbo build",
     "build:validate": "SLACK_BOT_TOKEN=xoxb-mock SLACK_SIGNING_SECRET=mock TEAMS_APP_ID=mock TEAMS_APP_PASSWORD=mock TEAMS_APP_TENANT_ID=mock GOOGLE_CHAT_CREDENTIALS='{\"type\":\"service_account\",\"project_id\":\"mock\",\"private_key\":\"-----BEGIN RSA PRIVATE KEY-----\\nMOCK\\n-----END RSA PRIVATE KEY-----\",\"client_email\":\"mock@mock.iam.gserviceaccount.com\"}' REDIS_URL=redis://localhost:6379 RECORDING_ENABLED=false turbo build",
     "dev": "turbo dev",
-    "test": "turbo test --filter='!example-nextjs-chat' --filter='!docs'",
+    "test": "turbo test --filter='!docs'",
     "test:workspace": "vitest run",
     "typecheck": "turbo typecheck",
     "knip": "knip",

--- a/packages/adapter-gchat/README.md
+++ b/packages/adapter-gchat/README.md
@@ -177,6 +177,7 @@ Most options are auto-detected from environment variables when not provided.
 | Option | Required | Description |
 |--------|----------|-------------|
 | `credentials` | No* | Service account credentials JSON. Auto-detected from `GOOGLE_CHAT_CREDENTIALS` |
+| `botUserId` | No | Canonical `users/...` resource name of this Chat app. Required for exact self-message and mention detection. Auto-detected from `GOOGLE_CHAT_BOT_USER_ID` |
 | `useApplicationDefaultCredentials` | No | Use Application Default Credentials. Auto-detected from `GOOGLE_CHAT_USE_ADC` |
 | `pubsubTopic` | No | Pub/Sub topic for Workspace Events. Auto-detected from `GOOGLE_CHAT_PUBSUB_TOPIC` |
 | `pubsubAudience` | No† | Expected JWT audience for Pub/Sub webhook verification. Auto-detected from `GOOGLE_CHAT_PUBSUB_AUDIENCE` |
@@ -192,6 +193,8 @@ Most options are auto-detected from environment variables when not provided.
 
 *Either `credentials`, `GOOGLE_CHAT_CREDENTIALS` env var, `useApplicationDefaultCredentials`, or `GOOGLE_CHAT_USE_ADC=true` is required.
 
+Use the canonical `sender.name` from a verified message authored by your Chat app for `botUserId`. The adapter does not learn its identity from inbound mentions. Without this value it conservatively treats every `BOT` sender as self to prevent reply loops.
+
 †One of `googleChatProjectNumber`, `endpointUrl`, `pubsubAudience`, or `disableSignatureVerification: true` is required — the constructor throws otherwise. Configure the verifier(s) for each transport you actually receive; requests of a shape whose verifier is unconfigured are rejected with HTTP 401.
 
 §Required alongside `pubsubAudience`. The audience is your public push endpoint, so anyone can have Google mint a validly signed token naming it from their own project. Only the `email` claim identifies the caller, which is why [Google requires checking it](https://docs.cloud.google.com/pubsub/docs/authenticate-push-subscriptions) in addition to `aud`. Without it, Pub/Sub pushes are rejected with HTTP 401 rather than trusted on their audience alone.
@@ -202,6 +205,7 @@ Most options are auto-detected from environment variables when not provided.
 
 ```bash
 GOOGLE_CHAT_CREDENTIALS={"type":"service_account",...}
+GOOGLE_CHAT_BOT_USER_ID=users/123456789
 
 # Optional: for receiving all messages
 GOOGLE_CHAT_PUBSUB_TOPIC=projects/your-project/topics/chat-events

--- a/packages/adapter-gchat/README.md
+++ b/packages/adapter-gchat/README.md
@@ -195,6 +195,8 @@ Most options are auto-detected from environment variables when not provided.
 
 Use the canonical `sender.name` from a verified message authored by your Chat app for `botUserId`. The adapter does not learn its identity from inbound mentions. Without this value it conservatively treats every `BOT` sender as self to prevent reply loops.
 
+Apps upgrading from an earlier release that rely on mention handlers must configure `botUserId` to preserve mention handling. Without it, bot mention annotations are left unchanged and the default `onNewMention` detection may no longer match them.
+
 †One of `googleChatProjectNumber`, `endpointUrl`, `pubsubAudience`, or `disableSignatureVerification: true` is required — the constructor throws otherwise. Configure the verifier(s) for each transport you actually receive; requests of a shape whose verifier is unconfigured are rejected with HTTP 401.
 
 §Required alongside `pubsubAudience`. The audience is your public push endpoint, so anyone can have Google mint a validly signed token naming it from their own project. Only the `email` claim identifies the caller, which is why [Google requires checking it](https://docs.cloud.google.com/pubsub/docs/authenticate-push-subscriptions) in addition to `aud`. Without it, Pub/Sub pushes are rejected with HTTP 401 rather than trusted on their audience alone.

--- a/packages/adapter-gchat/src/index.test.ts
+++ b/packages/adapter-gchat/src/index.test.ts
@@ -140,6 +140,7 @@ function makePubSubPushMessage(
 
 /** Helper: create an initialized adapter with mocks */
 async function createInitializedAdapter(opts?: {
+  botUserId?: string;
   pubsubTopic?: string;
   userName?: string;
   endpointUrl?: string;
@@ -151,6 +152,7 @@ async function createInitializedAdapter(opts?: {
   const adapter = createGoogleChatAdapter({
     credentials: TEST_CREDENTIALS,
     logger: mockLogger,
+    botUserId: opts?.botUserId,
     pubsubTopic: opts?.pubsubTopic,
     userName: opts?.userName,
     endpointUrl: opts?.endpointUrl,
@@ -285,8 +287,9 @@ describe("GoogleChatAdapter", () => {
       expect(adapter).toBeInstanceOf(GoogleChatAdapter);
     });
 
-    it("should restore bot user ID from state on initialize", async () => {
+    it("should use the configured bot user ID instead of persisted state", async () => {
       const adapter = createGoogleChatAdapter({
+        botUserId: "users/BOT_CONFIGURED",
         credentials: TEST_CREDENTIALS,
         logger: mockLogger,
       });
@@ -296,15 +299,14 @@ describe("GoogleChatAdapter", () => {
 
       await adapter.initialize(mockChat);
 
-      expect(adapter.botUserId).toBe("users/BOT999");
+      expect(adapter.botUserId).toBe("users/BOT_CONFIGURED");
     });
 
-    it("should not overwrite existing botUserId on initialize", async () => {
+    it("should not restore an untrusted learned bot ID from state", async () => {
       const adapter = createGoogleChatAdapter({
         credentials: TEST_CREDENTIALS,
         logger: mockLogger,
       });
-      (adapter as any).botUserId = "users/EXISTING";
 
       const mockState = createMockStateAdapter();
       mockState.storage.set("gchat:botUserId", "users/OTHERFROMSTATE");
@@ -312,7 +314,7 @@ describe("GoogleChatAdapter", () => {
 
       await adapter.initialize(mockChat);
 
-      expect(adapter.botUserId).toBe("users/EXISTING");
+      expect(adapter.botUserId).toBeUndefined();
     });
   });
 
@@ -357,6 +359,15 @@ describe("GoogleChatAdapter", () => {
       process.env.GOOGLE_CHAT_PUBSUB_TOPIC = "projects/test/topics/test";
       const adapter = new GoogleChatAdapter();
       expect(adapter).toBeInstanceOf(GoogleChatAdapter);
+    });
+
+    it("should resolve botUserId from GOOGLE_CHAT_BOT_USER_ID", () => {
+      process.env.GOOGLE_CHAT_CREDENTIALS = JSON.stringify(TEST_CREDENTIALS);
+      process.env.GOOGLE_CHAT_BOT_USER_ID = "users/BOT_ENV";
+
+      const adapter = new GoogleChatAdapter();
+
+      expect(adapter.botUserId).toBe("users/BOT_ENV");
     });
 
     it("should resolve impersonateUser from GOOGLE_CHAT_IMPERSONATE_USER env var", () => {
@@ -658,7 +669,10 @@ describe("GoogleChatAdapter", () => {
 
   describe("normalizeBotMentions (via parseMessage)", () => {
     it("should replace bot mention with adapter userName", async () => {
-      const { adapter } = await createInitializedAdapter({ userName: "mybot" });
+      const { adapter } = await createInitializedAdapter({
+        botUserId: "users/BOT123",
+        userName: "mybot",
+      });
       const event = makeMessageEvent({
         messageText: "@Chat SDK Demo hello",
         annotations: [
@@ -684,7 +698,7 @@ describe("GoogleChatAdapter", () => {
       expect(msg.text).not.toContain("@Chat SDK Demo");
     });
 
-    it("should learn bot user ID from annotations", async () => {
+    it("should not learn bot user ID from inbound annotations", async () => {
       const { adapter } = await createInitializedAdapter();
 
       expect(adapter.botUserId).toBeUndefined();
@@ -708,14 +722,16 @@ describe("GoogleChatAdapter", () => {
         ],
       });
 
-      adapter.parseMessage(event);
+      const message = adapter.parseMessage(event);
 
-      expect(adapter.botUserId).toBe("users/LEARNED_BOT_ID");
+      expect(adapter.botUserId).toBeUndefined();
+      expect(message.text).toBe("@BotName hi");
     });
 
-    it("should not overwrite botUserId once learned", async () => {
-      const { adapter } = await createInitializedAdapter();
-      (adapter as any).botUserId = "users/FIRST_BOT";
+    it("should ignore mentions of other bots", async () => {
+      const { adapter } = await createInitializedAdapter({
+        botUserId: "users/FIRST_BOT",
+      });
 
       const event = makeMessageEvent({
         messageText: "@AnotherBot hi",
@@ -736,16 +752,61 @@ describe("GoogleChatAdapter", () => {
         ],
       });
 
-      adapter.parseMessage(event);
+      const message = adapter.parseMessage(event);
 
       expect(adapter.botUserId).toBe("users/FIRST_BOT");
+      expect(message.text).toBe("@AnotherBot hi");
+    });
+
+    it("should normalize only this app when another bot is mentioned first", async () => {
+      const { adapter } = await createInitializedAdapter({
+        botUserId: "users/OUR_BOT",
+        userName: "ourbot",
+      });
+      const event = makeMessageEvent({
+        messageText: "@OtherBot @OurBot hi",
+        annotations: [
+          {
+            type: "USER_MENTION",
+            startIndex: 0,
+            length: 9,
+            userMention: {
+              user: {
+                name: "users/OTHER_BOT",
+                displayName: "OtherBot",
+                type: "BOT",
+              },
+              type: "MENTION",
+            },
+          },
+          {
+            type: "USER_MENTION",
+            startIndex: 10,
+            length: 7,
+            userMention: {
+              user: {
+                name: "users/OUR_BOT",
+                displayName: "OurBot",
+                type: "BOT",
+              },
+              type: "MENTION",
+            },
+          },
+        ],
+      });
+
+      const message = adapter.parseMessage(event);
+
+      expect(message.text).toBe("@OtherBot @ourbot hi");
+      expect(adapter.botUserId).toBe("users/OUR_BOT");
     });
   });
 
   describe("isMessageFromSelf (via parseMessage)", () => {
     it("should detect self messages when botUserId is known", async () => {
-      const { adapter } = await createInitializedAdapter();
-      (adapter as any).botUserId = "users/BOT123";
+      const { adapter } = await createInitializedAdapter({
+        botUserId: "users/BOT123",
+      });
 
       const event = makeMessageEvent({
         senderName: "users/BOT123",
@@ -758,8 +819,9 @@ describe("GoogleChatAdapter", () => {
     });
 
     it("should not mark other bots as self", async () => {
-      const { adapter } = await createInitializedAdapter();
-      (adapter as any).botUserId = "users/BOT123";
+      const { adapter } = await createInitializedAdapter({
+        botUserId: "users/BOT123",
+      });
 
       const event = makeMessageEvent({
         senderName: "users/OTHER_BOT",
@@ -771,7 +833,7 @@ describe("GoogleChatAdapter", () => {
       expect(msg.author.isMe).toBe(false);
     });
 
-    it("should return false when botUserId is unknown", async () => {
+    it("should fail closed for bot senders when botUserId is unknown", async () => {
       const { adapter } = await createInitializedAdapter();
 
       const event = makeMessageEvent({
@@ -780,7 +842,7 @@ describe("GoogleChatAdapter", () => {
       });
 
       const msg = adapter.parseMessage(event);
-      expect(msg.author.isMe).toBe(false);
+      expect(msg.author.isMe).toBe(true);
     });
   });
 
@@ -1403,8 +1465,9 @@ describe("GoogleChatAdapter", () => {
     });
 
     it("should detect self messages when botUserId matches", async () => {
-      const { adapter } = await createInitializedAdapter();
-      (adapter as any).botUserId = "users/MYBOT";
+      const { adapter } = await createInitializedAdapter({
+        botUserId: "users/MYBOT",
+      });
 
       const notification: WorkspaceEventNotification = {
         eventType: "google.workspace.chat.message.v1.created",
@@ -2303,7 +2366,7 @@ describe("GoogleChatAdapter", () => {
   });
 
   describe("fetchMessages (forward direction)", () => {
-    it("should fetch all messages forward and paginate", async () => {
+    it("should fetch one bounded forward page", async () => {
       const { adapter } = await createInitializedAdapter();
       const threadId = adapter.encodeThreadId({
         spaceName: "spaces/ABC123",
@@ -2327,15 +2390,8 @@ describe("GoogleChatAdapter", () => {
               sender: { name: "users/2", displayName: "B", type: "HUMAN" },
               thread: { name: "spaces/ABC123/threads/T1" },
             },
-            {
-              name: "spaces/ABC123/messages/msg3",
-              text: "Third",
-              createTime: "2024-01-03T00:00:00Z",
-              sender: { name: "users/1", displayName: "A", type: "HUMAN" },
-              thread: { name: "spaces/ABC123/threads/T1" },
-            },
           ],
-          nextPageToken: undefined,
+          nextPageToken: "page-2",
         },
       });
       (adapter as any).chatApi = {
@@ -2347,12 +2403,18 @@ describe("GoogleChatAdapter", () => {
         limit: 2,
       });
 
-      // Oldest first, limited to 2
       expect(result.messages).toHaveLength(2);
       expect(result.messages[0].text).toBe("First");
       expect(result.messages[1].text).toBe("Second");
-      // Should have cursor since there are more messages
-      expect(result.nextCursor).toBe("spaces/ABC123/messages/msg2");
+      expect(result.nextCursor).toBe("page-2");
+      expect(mockList).toHaveBeenCalledOnce();
+      expect(mockList).toHaveBeenCalledWith(
+        expect.objectContaining({
+          orderBy: "createTime asc",
+          pageSize: 2,
+          pageToken: undefined,
+        })
+      );
     });
 
     it("should support cursor-based forward pagination", async () => {
@@ -2366,13 +2428,6 @@ describe("GoogleChatAdapter", () => {
         data: {
           messages: [
             {
-              name: "spaces/ABC123/messages/msg1",
-              text: "First",
-              createTime: "2024-01-01T00:00:00Z",
-              sender: { name: "users/1", displayName: "A", type: "HUMAN" },
-              thread: { name: "spaces/ABC123/threads/T1" },
-            },
-            {
               name: "spaces/ABC123/messages/msg2",
               text: "Second",
               createTime: "2024-01-02T00:00:00Z",
@@ -2393,16 +2448,18 @@ describe("GoogleChatAdapter", () => {
         spaces: { messages: { list: mockList } },
       };
 
-      // Start after msg1
       const result = await adapter.fetchMessages(threadId, {
         direction: "forward",
         limit: 10,
-        cursor: "spaces/ABC123/messages/msg1",
+        cursor: "page-2",
       });
 
       expect(result.messages).toHaveLength(2);
       expect(result.messages[0].text).toBe("Second");
       expect(result.messages[1].text).toBe("Third");
+      expect(mockList).toHaveBeenCalledWith(
+        expect.objectContaining({ pageToken: "page-2" })
+      );
     });
   });
 

--- a/packages/adapter-gchat/src/index.ts
+++ b/packages/adapter-gchat/src/index.ts
@@ -207,7 +207,7 @@ interface SpaceSubscriptionInfo {
 export class GoogleChatAdapter implements Adapter<GoogleChatThreadId, unknown> {
   readonly name = "gchat";
   readonly userName: string;
-  /** Bot's user ID (e.g., "users/123...") - learned from annotations */
+  /** Authenticated Chat app user resource name (e.g., "users/123..."). */
   botUserId?: string;
 
   protected readonly chatApi: chat_v1.Chat;
@@ -269,6 +269,8 @@ export class GoogleChatAdapter implements Adapter<GoogleChatThreadId, unknown> {
   ) {
     this.logger = config.logger ?? new ConsoleLogger("info").child("gchat");
     this.userName = config.userName || "bot";
+    this.botUserId =
+      config.botUserId ?? process.env.GOOGLE_CHAT_BOT_USER_ID ?? undefined;
     // Initialize with null state - will be updated in initialize()
     this.userInfoCache = new UserInfoCache(null, this.logger);
     this.pubsubTopic =
@@ -422,16 +424,10 @@ export class GoogleChatAdapter implements Adapter<GoogleChatThreadId, unknown> {
     this.state = chat.getState();
     // Update userInfoCache to use the state adapter for persistence
     this.userInfoCache = new UserInfoCache(this.state, this.logger);
-
-    // Restore persisted bot user ID from state (for serverless environments)
     if (!this.botUserId) {
-      const savedBotUserId = await this.state.get<string>("gchat:botUserId");
-      if (savedBotUserId) {
-        this.botUserId = savedBotUserId;
-        this.logger.debug("Restored bot user ID from state", {
-          botUserId: this.botUserId,
-        });
-      }
+      this.logger.warn(
+        "Google Chat botUserId is not configured. BOT senders will be treated as self to prevent reply loops, and bot mentions cannot be normalized. Set GOOGLE_CHAT_BOT_USER_ID."
+      );
     }
   }
 
@@ -900,7 +896,9 @@ export class GoogleChatAdapter implements Adapter<GoogleChatThreadId, unknown> {
     options?: WebhookOptions
   ): Promise<Response> {
     const body = await request.text();
-    this.logger.debug("GChat webhook raw body", { body });
+    this.logger.debug("GChat webhook received", {
+      bodyLength: Buffer.byteLength(body),
+    });
 
     let parsed: unknown;
     try {
@@ -2104,13 +2102,9 @@ export class GoogleChatAdapter implements Adapter<GoogleChatThreadId, unknown> {
   /**
    * Fetch messages in forward direction (oldest first).
    *
-   * GChat API defaults to createTime ASC (oldest first), which is what we want.
-   * For forward pagination, we:
-   * 1. If no cursor: Fetch ALL messages (already in chronological order)
-   * 2. If cursor: Cursor is a message name, skip to after that message
-   *
-   * Note: This is less efficient than backward for large message histories,
-   * as it requires fetching all messages to find the cursor position.
+   * GChat supports ascending creation time with native page tokens. Use the
+   * API token as the opaque Chat SDK cursor so each call fetches one bounded
+   * page and a deleted message cannot reset iteration to page one.
    */
   protected async fetchMessagesForward(
     api: chat_v1.Chat,
@@ -2127,50 +2121,14 @@ export class GoogleChatAdapter implements Adapter<GoogleChatThreadId, unknown> {
       cursor,
     });
 
-    // Fetch all messages (GChat defaults to createTime ASC = oldest first)
-    const allRawMessages: chat_v1.Schema$Message[] = [];
-    let pageToken: string | undefined;
-
-    do {
-      const response = await api.spaces.messages.list({
-        parent: spaceName,
-        pageSize: 1000, // Max page size for efficiency
-        pageToken,
-        filter,
-        // Default orderBy is createTime ASC (oldest first) - what we want
-      });
-
-      const pageMessages = response.data.messages || [];
-      allRawMessages.push(...pageMessages);
-      pageToken = response.data.nextPageToken ?? undefined;
-    } while (pageToken);
-
-    // Messages are already in chronological order (oldest first) from API
-
-    this.logger.debug(
-      "GChat API: fetched all messages for forward pagination",
-      {
-        totalCount: allRawMessages.length,
-      }
-    );
-
-    // Find starting position based on cursor
-    let startIndex = 0;
-    if (cursor) {
-      // Cursor is a message name - find the index after it
-      const cursorIndex = allRawMessages.findIndex(
-        (msg) => msg.name === cursor
-      );
-      if (cursorIndex >= 0) {
-        startIndex = cursorIndex + 1;
-      }
-    }
-
-    // Get the requested slice
-    const selectedMessages = allRawMessages.slice(
-      startIndex,
-      startIndex + limit
-    );
+    const response = await api.spaces.messages.list({
+      parent: spaceName,
+      pageSize: Math.min(Math.max(limit, 1), 1000),
+      pageToken: cursor,
+      filter,
+      orderBy: "createTime asc",
+    });
+    const selectedMessages = response.data.messages || [];
 
     const messages = await Promise.all(
       selectedMessages.map((msg) =>
@@ -2178,21 +2136,9 @@ export class GoogleChatAdapter implements Adapter<GoogleChatThreadId, unknown> {
       )
     );
 
-    // Determine nextCursor - use message name of last returned message
-    let nextCursor: string | undefined;
-    if (
-      startIndex + limit < allRawMessages.length &&
-      selectedMessages.length > 0
-    ) {
-      const lastMsg = selectedMessages.at(-1);
-      if (lastMsg?.name) {
-        nextCursor = lastMsg.name;
-      }
-    }
-
     return {
       messages,
-      nextCursor,
+      nextCursor: response.data.nextPageToken ?? undefined,
     };
   }
 
@@ -2745,7 +2691,7 @@ export class GoogleChatAdapter implements Adapter<GoogleChatThreadId, unknown> {
    * Google Chat uses the bot's display name (e.g., "@Chat SDK Demo") but the
    * Chat SDK expects "@{userName}" format. This method replaces bot mentions
    * with the adapter's userName so mention detection works properly.
-   * Also learns the bot's user ID from annotations for isMe detection.
+   * Only annotations matching the configured bot user ID are rewritten.
    */
   protected normalizeBotMentions(message: GoogleChatMessage): string {
     let text = message.text || "";
@@ -2758,21 +2704,10 @@ export class GoogleChatAdapter implements Adapter<GoogleChatThreadId, unknown> {
         annotation.userMention?.user?.type === "BOT"
       ) {
         const botUser = annotation.userMention.user;
-        const botDisplayName = botUser.displayName;
-
-        // Learn our bot's user ID from mentions and persist to state
-        if (botUser.name && !this.botUserId) {
-          this.botUserId = botUser.name;
-          this.logger.info("Learned bot user ID from mention", {
-            botUserId: this.botUserId,
-          });
-          // Persist to state for serverless environments
-          this.state
-            ?.set("gchat:botUserId", this.botUserId)
-            .catch((err) =>
-              this.logger.error("Failed to persist botUserId", { error: err })
-            );
+        if (botUser.name !== this.botUserId) {
+          continue;
         }
+        const botDisplayName = botUser.displayName;
 
         // Replace the bot mention with @{userName}
         // Pub/Sub messages don't include displayName, so use startIndex/length
@@ -2805,12 +2740,8 @@ export class GoogleChatAdapter implements Adapter<GoogleChatThreadId, unknown> {
   /**
    * Check if a message is from this bot.
    *
-   * Bot user ID is learned dynamically from message annotations when the bot
-   * is @mentioned. Until we learn the ID, we cannot reliably determine isMe.
-   *
-   * This is safer than the previous approach of assuming all BOT messages are
-   * from self, which would incorrectly filter messages from other bots in
-   * multi-bot spaces (especially via Pub/Sub).
+   * A configured bot user ID permits exact matching in multi-bot spaces.
+   * Without it, fail closed for BOT senders to prevent self-reply loops.
    */
   protected isMessageFromSelf(message: GoogleChatMessage): boolean {
     const senderId = message.sender?.name;
@@ -2820,15 +2751,14 @@ export class GoogleChatAdapter implements Adapter<GoogleChatThreadId, unknown> {
       return senderId === this.botUserId;
     }
 
-    // If we don't know our bot ID yet, we can't reliably determine isMe.
-    // Log a debug message and return false - better to process a self-message
-    // than to incorrectly filter out messages from other bots.
+    // Fail closed when identity is unavailable: processing an unknown BOT
+    // sender could reprocess this app's own replies indefinitely.
     if (!this.botUserId && message.sender?.type === "BOT") {
       this.logger.debug(
-        "Cannot determine isMe - bot user ID not yet learned. " +
-          "Bot ID is learned from @mentions. Assuming message is not from self.",
+        "Cannot distinguish BOT sender without botUserId; treating it as self.",
         { senderId }
       );
+      return true;
     }
 
     return false;

--- a/packages/adapter-gchat/src/types.ts
+++ b/packages/adapter-gchat/src/types.ts
@@ -17,6 +17,12 @@ export interface GoogleChatAdapterBaseConfig {
   /** Override the Google Chat API root URL. Defaults to GOOGLE_CHAT_API_URL env var. */
   apiUrl?: string;
   /**
+   * Authenticated resource name of this Chat app, for example `users/123456`.
+   * Used to distinguish this app from other bots in messages and mentions.
+   * Defaults to GOOGLE_CHAT_BOT_USER_ID.
+   */
+  botUserId?: string;
+  /**
    * Explicit opt-in to disable webhook signature verification. Required to
    * accept incoming webhooks when neither `googleChatProjectNumber` nor
    * `pubsubAudience` is configured. Without this flag set the constructor

--- a/packages/adapter-slack/src/index.test.ts
+++ b/packages/adapter-slack/src/index.test.ts
@@ -2782,6 +2782,38 @@ describe("installationProvider", () => {
     );
   });
 
+  it("drops slash commands when no installation is found", async () => {
+    const mockProvider = {
+      getInstallation: vi.fn().mockResolvedValue(null),
+    };
+    const chatInstance = createMockChatInstance({ state: createMockState() });
+    const adapter = createSlackAdapter({
+      signingSecret: secret,
+      logger: mockLogger,
+      installationProvider: mockProvider,
+    });
+    await adapter.initialize(chatInstance);
+
+    const params = new URLSearchParams({
+      command: "/test",
+      team_id: "T_UNKNOWN",
+      channel_id: "C_SLASH",
+      user_id: "U_SLASHER",
+    });
+    const response = await adapter.handleWebhook(
+      createWebhookRequest(params.toString(), secret, {
+        contentType: "application/x-www-form-urlencoded",
+      })
+    );
+
+    expect(response.status).toBe(200);
+    expect(mockProvider.getInstallation).toHaveBeenCalledWith(
+      "T_UNKNOWN",
+      false
+    );
+    expect(chatInstance.processSlashCommand).not.toHaveBeenCalled();
+  });
+
   it("uses enterprise_id for slash commands in Enterprise Grid", async () => {
     const mockProvider = {
       getInstallation: vi.fn().mockResolvedValue({
@@ -2913,6 +2945,40 @@ describe("installationProvider", () => {
       "T_INTER_PROVIDER",
       false
     );
+  });
+
+  it("drops interactive payloads when no installation is found", async () => {
+    const mockProvider = {
+      getInstallation: vi.fn().mockResolvedValue(null),
+    };
+    const chatInstance = createMockChatInstance({ state: createMockState() });
+    const adapter = createSlackAdapter({
+      signingSecret: secret,
+      logger: mockLogger,
+      installationProvider: mockProvider,
+    });
+    await adapter.initialize(chatInstance);
+
+    const payload = JSON.stringify({
+      type: "block_actions",
+      team: { id: "T_UNKNOWN" },
+      user: { id: "U123", username: "testuser" },
+      channel: { id: "C_INTER", name: "general" },
+      message: { ts: "1234567890.123456" },
+      actions: [{ type: "button", action_id: "test_action", value: "v" }],
+    });
+    const response = await adapter.handleWebhook(
+      createWebhookRequest(`payload=${encodeURIComponent(payload)}`, secret, {
+        contentType: "application/x-www-form-urlencoded",
+      })
+    );
+
+    expect(response.status).toBe(200);
+    expect(mockProvider.getInstallation).toHaveBeenCalledWith(
+      "T_UNKNOWN",
+      false
+    );
+    expect(chatInstance.processAction).not.toHaveBeenCalled();
   });
 
   it("uses enterprise_id for interactive payloads in Enterprise Grid", async () => {
@@ -11656,19 +11722,46 @@ describe("socket mode - multi-workspace token resolution", () => {
     expect(resolveSpy).toHaveBeenCalledWith("T_SOCK_2", false);
     expect(chatInstance).toHaveDispatched("processAction");
   });
+
+  it("drops socket interactive payloads with no installation", async () => {
+    const { chatInstance, routing, resolveSpy } =
+      await createMultiWorkspaceAdapter();
+    const ack = vi.fn().mockResolvedValue(undefined);
+
+    await routing.routeSocketEvent(
+      {
+        type: "block_actions",
+        team: { id: "T_UNKNOWN" },
+        actions: [{ type: "button", action_id: "test_action", value: "v" }],
+        channel: { id: "C123", name: "test" },
+        message: { ts: "1234567890.123456" },
+        user: { id: "U_USER", username: "testuser" },
+      },
+      "interactive",
+      ack
+    );
+
+    expect(resolveSpy).toHaveBeenCalledWith("T_UNKNOWN", false);
+    expect(chatInstance).not.toHaveDispatched("processAction");
+    expect(ack).toHaveBeenCalledOnce();
+  });
 });
 
 // ============================================================================
-// Enterprise Grid: installation-scoped user caches
+// Enterprise Grid: installation-scoped caches
 // ============================================================================
 
-describe("installation-scoped user caches", () => {
+describe("installation-scoped caches", () => {
   interface CacheTestAdapter {
-    _client: { users: { info: unknown } };
+    _client: {
+      conversations: { info: unknown };
+      users: { info: unknown };
+    };
     handleUserChange(event: {
       type: string;
       user: { id: string };
     }): Promise<void>;
+    lookupChannel(channelId: string): Promise<string>;
     lookupUser(userId: string): Promise<{ displayName: string } | null>;
     requestContext: {
       run<T>(ctx: { token: string; installationId?: string }, fn: () => T): T;
@@ -11698,7 +11791,11 @@ describe("installation-scoped user caches", () => {
       },
     });
     internals._client.users.info = usersInfoMock;
-    return { internals, state, usersInfoMock };
+    const conversationsInfoMock = vi.fn().mockResolvedValue({
+      channel: { name: "general" },
+    });
+    internals._client.conversations.info = conversationsInfoMock;
+    return { conversationsInfoMock, internals, state, usersInfoMock };
   }
 
   it("scopes the user profile cache by installation", async () => {
@@ -11718,6 +11815,36 @@ describe("installation-scoped user caches", () => {
     expect(await state.get("slack:user:T_A:U1")).not.toBeNull();
     expect(await state.get("slack:user:T_B:U1")).not.toBeNull();
     expect(await state.get("slack:user:U1")).toBeNull();
+  });
+
+  it("scopes the channel-name cache by installation", async () => {
+    const { conversationsInfoMock, internals, state } =
+      await createCacheAdapter();
+    conversationsInfoMock
+      .mockResolvedValueOnce({ channel: { name: "team-a-private" } })
+      .mockResolvedValueOnce({ channel: { name: "team-b-general" } });
+
+    await expect(
+      internals.requestContext.run(
+        { token: "xoxb-team-a", installationId: "T_A" },
+        () => internals.lookupChannel("C1")
+      )
+    ).resolves.toBe("team-a-private");
+    await expect(
+      internals.requestContext.run(
+        { token: "xoxb-team-b", installationId: "T_B" },
+        () => internals.lookupChannel("C1")
+      )
+    ).resolves.toBe("team-b-general");
+
+    expect(conversationsInfoMock).toHaveBeenCalledTimes(2);
+    expect(await state.get("slack:channel:T_A:C1")).toEqual({
+      name: "team-a-private",
+    });
+    expect(await state.get("slack:channel:T_B:C1")).toEqual({
+      name: "team-b-general",
+    });
+    expect(await state.get("slack:channel:C1")).toBeNull();
   });
 
   it("uses unscoped keys without a request context (single-workspace)", async () => {

--- a/packages/adapter-slack/src/index.test.ts
+++ b/packages/adapter-slack/src/index.test.ts
@@ -11757,6 +11757,12 @@ describe("installation-scoped caches", () => {
       conversations: { info: unknown };
       users: { info: unknown };
     };
+    enrichLinks(
+      links: Array<{ url: string; title?: string }>,
+      channelId?: string,
+      messageTs?: string
+    ): Promise<Array<{ url: string; title?: string }>>;
+    handleMessageChanged(event: SlackEvent): void;
     handleUserChange(event: {
       type: string;
       user: { id: string };
@@ -11903,6 +11909,84 @@ describe("installation-scoped caches", () => {
 
     expect(await state.getList("slack:user-by-name:T_A:alice")).toContain("U1");
     expect(await state.getList("slack:user-by-name:alice")).toHaveLength(0);
+  });
+
+  it("scopes unfurl metadata by installation and channel", async () => {
+    const { internals, state } = await createCacheAdapter();
+    const message = {
+      type: "message",
+      subtype: "message_changed",
+      hidden: true,
+      channel: "C1",
+      ts: "1234567890.123456",
+      message: {
+        type: "message",
+        channel: "C1",
+        ts: "1111111111.111111",
+        attachments: [
+          {
+            from_url: "https://example.com/shared",
+            title: "Team A",
+          },
+        ],
+      },
+    } satisfies SlackEvent;
+
+    internals.requestContext.run(
+      { token: "xoxb-team-a", installationId: "T_A" },
+      () => internals.handleMessageChanged(message)
+    );
+    internals.requestContext.run(
+      { token: "xoxb-team-b", installationId: "T_B" },
+      () =>
+        internals.handleMessageChanged({
+          ...message,
+          channel: "C2",
+          message: {
+            ...message.message,
+            channel: "C2",
+            attachments: [
+              {
+                from_url: "https://example.com/shared",
+                title: "Team B",
+              },
+            ],
+          },
+        })
+    );
+
+    await vi.waitFor(async () => {
+      expect(
+        await state.get("slack:unfurls:T_A:C1:1111111111.111111")
+      ).not.toBeNull();
+      expect(
+        await state.get("slack:unfurls:T_B:C2:1111111111.111111")
+      ).not.toBeNull();
+    });
+    expect(await state.get("slack:unfurls:1111111111.111111")).toBeNull();
+
+    await expect(
+      internals.requestContext.run(
+        { token: "xoxb-team-a", installationId: "T_A" },
+        () =>
+          internals.enrichLinks(
+            [{ url: "https://example.com/shared" }],
+            "C1",
+            "1111111111.111111"
+          )
+      )
+    ).resolves.toEqual([expect.objectContaining({ title: "Team A" })]);
+    await expect(
+      internals.requestContext.run(
+        { token: "xoxb-team-b", installationId: "T_B" },
+        () =>
+          internals.enrichLinks(
+            [{ url: "https://example.com/shared" }],
+            "C2",
+            "1111111111.111111"
+          )
+      )
+    ).resolves.toEqual([expect.objectContaining({ title: "Team B" })]);
   });
 
   it("resolves outgoing mentions from the installation-scoped index", async () => {

--- a/packages/adapter-slack/src/index.ts
+++ b/packages/adapter-slack/src/index.ts
@@ -1773,14 +1773,12 @@ export class SlackAdapter implements Adapter<SlackThreadId, unknown> {
   }
 
   /**
-   * Scope prefix for per-user state keys (profile cache, display-name
-   * reverse index). In multi-workspace deployments these must not be shared
-   * across installations: profiles fetched with one workspace's token would
-   * bleed into another, and display names collide across workspaces, so
-   * mention resolution could pick a user from the wrong org. Single-workspace
-   * mode (and code running outside a webhook context) uses the unscoped key.
+   * Scope prefix for installation-owned cache keys. In multi-workspace
+   * deployments user profiles, display-name indexes, and channel names must
+   * not be shared across installations. Single-workspace mode (and code
+   * running outside a webhook context) uses the unscoped key.
    */
-  protected userCacheScope(): string {
+  protected installationCacheScope(): string {
     const installationId = this.requestContext.getStore()?.installationId;
     return installationId ? `${installationId}:` : "";
   }
@@ -1790,7 +1788,7 @@ export class SlackAdapter implements Adapter<SlackThreadId, unknown> {
    * Returns null when the API call fails.
    */
   protected async lookupUser(userId: string): Promise<CachedUser | null> {
-    const cacheKey = `slack:user:${this.userCacheScope()}${userId}`;
+    const cacheKey = `slack:user:${this.installationCacheScope()}${userId}`;
 
     // Check cache first (via state adapter for serverless compatibility)
     if (this.chat) {
@@ -1842,7 +1840,7 @@ export class SlackAdapter implements Adapter<SlackThreadId, unknown> {
 
         // Build reverse index: display name → user IDs (skip if already present)
         const normalizedName = displayName.toLowerCase();
-        const reverseKey = `slack:user-by-name:${this.userCacheScope()}${normalizedName}`;
+        const reverseKey = `slack:user-by-name:${this.installationCacheScope()}${normalizedName}`;
         const existing = await this.chat.getState().getList<string>(reverseKey);
         if (!existing.includes(userId)) {
           await this.chat.getState().appendToList(reverseKey, userId, {
@@ -1869,7 +1867,7 @@ export class SlackAdapter implements Adapter<SlackThreadId, unknown> {
    * Returns channel name, or falls back to channel ID.
    */
   protected async lookupChannel(channelId: string): Promise<string> {
-    const cacheKey = `slack:channel:${channelId}`;
+    const cacheKey = `slack:channel:${this.installationCacheScope()}${channelId}`;
 
     // Check cache first (via state adapter for serverless compatibility)
     if (this.chat) {
@@ -1975,7 +1973,9 @@ export class SlackAdapter implements Adapter<SlackThreadId, unknown> {
       this.logger.warn("Webhook verifier rejected request", { error });
       return new Response("Invalid signature", { status: 401 });
     }
-    this.logger.debug("Slack webhook raw body", { body });
+    this.logger.debug("Slack webhook received", {
+      bodyLength: Buffer.byteLength(body),
+    });
 
     // Check if this is a form-urlencoded payload
     const contentType = request.headers.get("content-type") || "";
@@ -2006,6 +2006,7 @@ export class SlackAdapter implements Adapter<SlackThreadId, unknown> {
           }
         }
         this.logger.warn("Could not resolve token for interactive payload");
+        return new Response("", { status: 200 });
       }
       return this.handleInteractivePayload(body, options);
     }
@@ -2085,6 +2086,7 @@ export class SlackAdapter implements Adapter<SlackThreadId, unknown> {
           isEnterpriseInstall,
         });
       }
+      return new Response("", { status: 200 });
     }
     return this.handleSlashCommand(params, options);
   }
@@ -2803,7 +2805,7 @@ export class SlackAdapter implements Adapter<SlackThreadId, unknown> {
             this.logger.warn(
               "Could not resolve token for socket interactive payload"
             );
-            result = dispatch();
+            result = new Response("", { status: 200 });
           }
         }
         const response = result instanceof Promise ? await result : result;
@@ -3742,7 +3744,7 @@ export class SlackAdapter implements Adapter<SlackThreadId, unknown> {
     try {
       await this.chat
         .getState()
-        .delete(`slack:user:${this.userCacheScope()}${event.user.id}`);
+        .delete(`slack:user:${this.installationCacheScope()}${event.user.id}`);
     } catch (error) {
       this.logger.warn("Failed to invalidate user cache", {
         userId: event.user.id,
@@ -4479,7 +4481,7 @@ export class SlackAdapter implements Adapter<SlackThreadId, unknown> {
     // Look up user IDs for each mentioned name
     for (const name of mentions.keys()) {
       const userIds = await state.getList<string>(
-        `slack:user-by-name:${this.userCacheScope()}${name}`
+        `slack:user-by-name:${this.installationCacheScope()}${name}`
       );
       // Dedup
       const unique = [...new Set(userIds)];

--- a/packages/adapter-slack/src/index.ts
+++ b/packages/adapter-slack/src/index.ts
@@ -1783,6 +1783,10 @@ export class SlackAdapter implements Adapter<SlackThreadId, unknown> {
     return installationId ? `${installationId}:` : "";
   }
 
+  protected unfurlCacheKey(channelId: string, messageTs: string): string {
+    return `slack:unfurls:${this.installationCacheScope()}${channelId}:${messageTs}`;
+  }
+
   /**
    * Look up user info from Slack API with caching via state adapter.
    * Returns null when the API call fails.
@@ -3240,7 +3244,11 @@ export class SlackAdapter implements Adapter<SlackThreadId, unknown> {
       if (Object.keys(unfurls).length > 0) {
         this.chat
           .getState()
-          .set(`slack:unfurls:${inner.ts}`, unfurls, 60 * 60 * 1000)
+          .set(
+            this.unfurlCacheKey(event.channel, inner.ts),
+            unfurls,
+            60 * 60 * 1000
+          )
           .catch((error) => {
             this.logger.error("Failed to cache unfurl metadata", { error });
           });
@@ -4229,7 +4237,11 @@ export class SlackAdapter implements Adapter<SlackThreadId, unknown> {
       attachments: (event.files || []).map((file) =>
         this.createAttachment(file, event.team_id ?? event.team)
       ),
-      links: await this.enrichLinks(this.extractLinks(event), event.ts),
+      links: await this.enrichLinks(
+        this.extractLinks(event),
+        event.channel,
+        event.ts
+      ),
     });
   }
 
@@ -4246,9 +4258,10 @@ export class SlackAdapter implements Adapter<SlackThreadId, unknown> {
 
   protected async enrichLinks(
     links: LinkPreview[],
+    channelId?: string,
     messageTs?: string
   ): Promise<LinkPreview[]> {
-    if (!(this.chat && messageTs) || links.length === 0) {
+    if (!(this.chat && channelId && messageTs) || links.length === 0) {
       return links;
     }
 
@@ -4266,7 +4279,7 @@ export class SlackAdapter implements Adapter<SlackThreadId, unknown> {
     while (true) {
       try {
         stored = await state.get<Record<string, SlackUnfurl>>(
-          `slack:unfurls:${messageTs}`
+          this.unfurlCacheKey(channelId, messageTs)
         );
       } catch {
         return links;

--- a/packages/adapter-teams/src/bridge-adapter.ts
+++ b/packages/adapter-teams/src/bridge-adapter.ts
@@ -36,7 +36,9 @@ export class BridgeHttpAdapter implements IHttpServerAdapter {
     options?: WebhookOptions
   ): Promise<Response> {
     const body = await request.text();
-    this.logger.debug("Teams webhook raw body", { body });
+    this.logger.debug("Teams webhook received", {
+      bodyLength: Buffer.byteLength(body),
+    });
 
     let parsedBody: unknown;
     try {

--- a/packages/chat/src/adapters/index.ts
+++ b/packages/chat/src/adapters/index.ts
@@ -348,6 +348,10 @@ export const ADAPTERS = {
         },
       ],
       optional: [
+        env(
+          "GOOGLE_CHAT_BOT_USER_ID",
+          "Canonical users/... resource name of this Chat app."
+        ),
         env("GOOGLE_CHAT_PUBSUB_TOPIC", "Pub/Sub topic for Workspace Events."),
         env(
           "GOOGLE_CHAT_IMPERSONATE_USER",

--- a/packages/chat/src/chat.ts
+++ b/packages/chat/src/chat.ts
@@ -2284,9 +2284,6 @@ export class Chat<
       adapter: adapter.name,
       threadId,
       messageId: message.id,
-      text: message.text,
-      author: message.author.userName,
-      authorUserId: message.author.userId,
       isBot: message.author.isBot,
       isMe: message.author.isMe,
     });

--- a/packages/integration-tests/src/replay-fetch-messages-gchat.test.ts
+++ b/packages/integration-tests/src/replay-fetch-messages-gchat.test.ts
@@ -73,13 +73,13 @@ describe("fetchMessages Replay Tests - Google Chat", () => {
       direction: "forward",
     });
 
-    // Forward direction: fetches all messages (pageSize: 1000 for efficiency)
-    // No orderBy = defaults to createTime ASC (oldest first)
+    // Forward direction uses one bounded ascending API page.
     expect(ctx.mockChatApi.spaces.messages.list).toHaveBeenCalledWith({
       parent: GCHAT_SPACE,
-      pageSize: 1000,
+      pageSize: 25,
       pageToken: undefined,
       filter: `thread.name = "${GCHAT_THREAD}"`,
+      orderBy: "createTime asc",
     });
   });
 
@@ -287,13 +287,13 @@ describe("allMessages Replay Tests - Google Chat", () => {
       // Just iterate
     }
 
-    // allMessages uses forward direction with limit 100 internally
-    // GChat forward fetches with pageSize 1000 (max efficiency)
+    // allMessages uses bounded forward pages of 100.
     expect(ctx.mockChatApi.spaces.messages.list).toHaveBeenCalledWith({
       parent: GCHAT_SPACE,
-      pageSize: 1000,
+      pageSize: 100,
       pageToken: undefined,
       filter: `thread.name = "${GCHAT_THREAD}"`,
+      orderBy: "createTime asc",
     });
   });
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -271,13 +271,13 @@ importers:
         version: 8.5.26
       tsx:
         specifier: ^4.21.0
-        version: 4.21.0
+        version: 4.22.3
       typescript:
         specifier: ^5.7.2
         version: 5.9.3
       vitest:
         specifier: ^4.0.18
-        version: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@25.3.2)(jiti@2.7.0)(lightningcss@1.30.2)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0)
+        version: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@25.3.2)(jiti@2.7.0)(lightningcss@1.30.2)(terser@5.48.0)(tsx@4.22.3)(yaml@2.9.0)
 
   examples/nuxt-chat:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -275,6 +275,9 @@ importers:
       typescript:
         specifier: ^5.7.2
         version: 5.9.3
+      vitest:
+        specifier: ^4.0.18
+        version: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@25.3.2)(jiti@2.7.0)(lightningcss@1.30.2)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0)
 
   examples/nuxt-chat:
     dependencies:


### PR DESCRIPTION
Multi-workspace Slack now ignores commands and interactions when their installation cannot be found, and channel names stay isolated per workspace.

Google Chat no longer learns its identity from incoming mentions, and forward history reads use bounded native pagination.

Webhook logs avoid message content. The example app protects preview routing, records only successful verified deliveries, and caps recording size and retention.