### PR TITLE
fix(teams): infer missing conversation types

### DIFF
--- a/.changeset/fuzzy-teams-route.md
+++ b/.changeset/fuzzy-teams-route.md
@@ -1,0 +1,5 @@
+---
+"@chat-adapter/teams": patch
+---
+
+Fall back to Teams activity group metadata when the explicit conversation type is missing.

--- a/apps/docs/content/adapters/official/teams.mdx
+++ b/apps/docs/content/adapters/official/teams.mdx
@@ -223,7 +223,7 @@ The Teams SDK reads a generic `CLIENT_SECRET` environment variable and prefers i
 
 ### Conversation routing
 
-Incoming thread IDs preserve the Teams conversation type when the legacy ID-prefix heuristic would route it incorrectly. This keeps correctly classified IDs stable while selecting the buffered fallback for group chats whose IDs begin with `a:`. Thread IDs created by older adapter versions remain supported.
+Incoming thread IDs preserve the Teams conversation type when the legacy ID-prefix heuristic would route it incorrectly. When Teams omits `conversationType`, the adapter falls back to `conversation.isGroup` and the activity's team context. This keeps correctly classified IDs stable while selecting the buffered fallback for group chats whose IDs begin with `a:`. Thread IDs created by older adapter versions remain supported.
 
 ### Incoming attachments
 

--- a/packages/adapter-teams/README.md
+++ b/packages/adapter-teams/README.md
@@ -207,7 +207,7 @@ TEAMS_API_URL=...        # Optional, for GCC-High or sovereign-cloud deployments
 
 ## Conversation routing
 
-Incoming thread IDs preserve the Teams conversation type when the legacy ID-prefix heuristic would route it incorrectly. This keeps correctly classified IDs stable while selecting the buffered fallback for group chats whose IDs begin with `a:`. Thread IDs created by older adapter versions remain supported.
+Incoming thread IDs preserve the Teams conversation type when the legacy ID-prefix heuristic would route it incorrectly. When Teams omits `conversationType`, the adapter falls back to `conversation.isGroup` and the activity's team context. This keeps correctly classified IDs stable while selecting the buffered fallback for group chats whose IDs begin with `a:`. Thread IDs created by older adapter versions remain supported.
 
 ## Incoming attachments
 

--- a/packages/adapter-teams/src/index.test.ts
+++ b/packages/adapter-teams/src/index.test.ts
@@ -160,6 +160,70 @@ describe("Teams conversation type routing", () => {
     expect(personal).toBe(legacyPersonal);
     expect(channel).toBe(legacyChannel);
   });
+
+  it("falls back to isGroup when conversationType is missing", () => {
+    const groupMessage = contractAdapter.parseMessage({
+      conversation: { id: "a:group-chat-id", isGroup: true },
+      from: { id: "user-1", name: "Alice" },
+      id: "group-message",
+      serviceUrl: TEST_SERVICE_URL,
+      text: "hello",
+      type: "message",
+    });
+    const channelMessage = contractAdapter.parseMessage({
+      channelData: { team: { id: "team-id" } },
+      conversation: { id: "a:channel-id", isGroup: true },
+      from: { id: "user-1", name: "Alice" },
+      id: "channel-message",
+      serviceUrl: TEST_SERVICE_URL,
+      text: "hello",
+      type: "message",
+    });
+    const personalMessage = contractAdapter.parseMessage({
+      conversation: { id: "19:personal-id", isGroup: false },
+      from: { id: "user-1", name: "Alice" },
+      id: "personal-message",
+      serviceUrl: TEST_SERVICE_URL,
+      text: "hello",
+      type: "message",
+    });
+
+    expect(contractAdapter.decodeThreadId(groupMessage.threadId)).toMatchObject(
+      {
+        conversationType: "groupChat",
+      }
+    );
+    expect(contractAdapter.isDM(groupMessage.threadId)).toBe(false);
+    expect(
+      contractAdapter.decodeThreadId(channelMessage.threadId)
+    ).toMatchObject({
+      conversationType: "channel",
+    });
+    expect(contractAdapter.isDM(channelMessage.threadId)).toBe(false);
+    expect(
+      contractAdapter.decodeThreadId(personalMessage.threadId)
+    ).toMatchObject({
+      conversationType: "personal",
+    });
+    expect(contractAdapter.isDM(personalMessage.threadId)).toBe(true);
+  });
+
+  it("prefers an explicit conversationType over isGroup", () => {
+    const message = contractAdapter.parseMessage({
+      conversation: {
+        conversationType: "personal",
+        id: "19:personal-id",
+        isGroup: true,
+      },
+      from: { id: "user-1", name: "Alice" },
+      id: "personal-message",
+      serviceUrl: TEST_SERVICE_URL,
+      text: "hello",
+      type: "message",
+    });
+
+    expect(contractAdapter.isDM(message.threadId)).toBe(true);
+  });
 });
 
 describe("ESM compatibility", () => {

--- a/packages/adapter-teams/src/index.ts
+++ b/packages/adapter-teams/src/index.ts
@@ -71,10 +71,10 @@ import {
   parseDialogSubmitValues,
 } from "./modals";
 import {
+  conversationTypeFromActivity,
   decodeThreadId,
   encodeThreadId,
   isDM,
-  parseConversationType,
 } from "./thread-id";
 import type {
   TeamsAdapterConfig,
@@ -269,9 +269,7 @@ export class TeamsAdapter implements Adapter<TeamsThreadId, unknown> {
 
     // Cache DM context for Graph API chat ID resolution
     const aadObjectId = (activity.from as { aadObjectId?: string }).aadObjectId;
-    const conversationType = parseConversationType(
-      activity.conversation?.conversationType
-    );
+    const conversationType = conversationTypeFromActivity(activity);
     const isPersonalConversation = conversationType
       ? conversationType === "personal"
       : !baseChannelId.startsWith("19:");
@@ -1740,9 +1738,7 @@ export class TeamsAdapter implements Adapter<TeamsThreadId, unknown> {
   private threadIdFromActivity(activity: Activity): string {
     return this.encodeThreadId({
       conversationId: activity.conversation?.id || "",
-      conversationType: parseConversationType(
-        activity.conversation?.conversationType
-      ),
+      conversationType: conversationTypeFromActivity(activity),
       serviceUrl: activity.serviceUrl || "",
     });
   }

--- a/packages/adapter-teams/src/thread-id.ts
+++ b/packages/adapter-teams/src/thread-id.ts
@@ -1,11 +1,30 @@
 import { ValidationError } from "@chat-adapter/shared";
+import type { Activity } from "@microsoft/teams.api";
 import type { TeamsThreadId } from "./types";
 
-export function parseConversationType(
+function parseConversationType(
   value: unknown
 ): TeamsThreadId["conversationType"] {
   if (value === "channel" || value === "groupChat" || value === "personal") {
     return value;
+  }
+  return undefined;
+}
+
+export function conversationTypeFromActivity(
+  activity: Activity
+): TeamsThreadId["conversationType"] {
+  const explicit = parseConversationType(
+    activity.conversation?.conversationType
+  );
+  if (explicit) {
+    return explicit;
+  }
+  if (activity.conversation?.isGroup === false) {
+    return "personal";
+  }
+  if (activity.conversation?.isGroup === true) {
+    return activity.channelData?.team?.id ? "channel" : "groupChat";
   }
   return undefined;
 }


### PR DESCRIPTION
## Summary

Teams can omit `conversationType` while still sending `conversation.isGroup`. Use `isGroup` and team context as a fallback so `a:`-prefixed group chats are not treated as DMs. An explicit `conversationType` still takes precedence.

## Test plan

- `pnpm validate`
- `pnpm --filter @chat-adapter/teams test`, 276 tests passed

## Checklist

- [x] All commits are signed and verified
- [x] All commits are signed off for the DCO with `git commit -s`
- [x] `pnpm validate` passes
- [x] Changeset added
- [x] Documentation updated