### PR TITLE
fix(slack): clear Agent Session typing status

### DIFF
--- a/.changeset/clear-slack-agent-typing.md
+++ b/.changeset/clear-slack-agent-typing.md
@@ -1,0 +1,5 @@
+---
+"@chat-adapter/slack": patch
+---
+
+Reactivate Slack Agent Sessions when `startTyping` receives an empty status.

--- a/packages/adapter-slack/src/index.test.ts
+++ b/packages/adapter-slack/src/index.test.ts
@@ -6166,7 +6166,7 @@ describe("agent_view DM threading", () => {
     expect(threadId).toBe("slack:D1:");
   });
 
-  it("sets status on an agent_view DM thread", async () => {
+  it("updates the Agent Session lifecycle on an agent_view DM thread", async () => {
     const adapter = createSlackAdapter({
       agentView: true,
       botToken: "xoxb-test-token",
@@ -6179,15 +6179,29 @@ describe("agent_view DM threading", () => {
     await adapter.startTyping("slack:D1:1771.99", "Thinking...", {
       initiatorUserId: "U1",
     });
+    await adapter.startTyping("slack:D1:1771.99", "", {
+      initiatorUserId: "U1",
+    });
 
     const client = getClient(adapter);
-    expect(client.apiCall).toHaveBeenCalledWith(
+    expect(client.apiCall).toHaveBeenNthCalledWith(
+      1,
       "agents.sessions.setStatus",
       expect.objectContaining({
         channel_id: "D1",
         initiator_user_id: "U1",
         thread_ts: "1771.99",
         status: "processing",
+      })
+    );
+    expect(client.apiCall).toHaveBeenNthCalledWith(
+      2,
+      "agents.sessions.setStatus",
+      expect.objectContaining({
+        channel_id: "D1",
+        initiator_user_id: "U1",
+        thread_ts: "1771.99",
+        status: "active",
       })
     );
   });

--- a/packages/adapter-slack/src/index.ts
+++ b/packages/adapter-slack/src/index.ts
@@ -5403,13 +5403,14 @@ export class SlackAdapter implements Adapter<SlackThreadId, unknown> {
       return;
     }
     if (this.agentView) {
+      const sessionStatus = status === "" ? "active" : "processing";
       this.logger.debug("Slack API: agents.sessions.setStatus", {
         channel,
         threadTs,
-        status: "processing",
+        status: sessionStatus,
       });
       try {
-        await this.setSessionStatus(channel, threadTs, "processing", {
+        await this.setSessionStatus(channel, threadTs, sessionStatus, {
           initiatorUserId: options?.initiatorUserId,
         });
       } catch (error) {


### PR DESCRIPTION
## Summary

- map non-empty `startTyping` statuses to the Slack Agent Session `processing` state
- map an empty `startTyping` status to `active`, allowing generic Chat SDK callers to end typing without posting a message
- preserve the legacy `assistant.threads.setStatus` path and `initiator_user_id` propagation

This fixes the regression reported in mastra-ai/mastra#22670. Mastra already clears typing through the generic `startTyping(threadId, "")` contract, so the platform-specific lifecycle translation belongs in the Slack adapter.

## Test plan

- `pnpm --filter @chat-adapter/slack exec vitest run src/index.test.ts`
- `pnpm --filter @chat-adapter/slack typecheck`
- `pnpm --filter @chat-adapter/slack build`
- `pnpm --filter @chat-adapter/slack test`
- `pnpm check`