### PR TITLE
fix(slack): use bot user ID for message authors

### DIFF
--- a/.changeset/fuzzy-cats-identify.md
+++ b/.changeset/fuzzy-cats-identify.md
@@ -1,0 +1,5 @@
+---
+"@chat-adapter/slack": patch
+---
+
+Use the Slack bot user ID for bot-authored messages when a bot profile is available.

--- a/packages/adapter-slack/src/index.test.ts
+++ b/packages/adapter-slack/src/index.test.ts
@@ -8659,6 +8659,12 @@ describe("isMessageFromSelf", () => {
     _botId: string | undefined;
     _botUserId: string | undefined;
     isMessageFromSelf: (event: Record<string, unknown>) => boolean;
+    requestContext: {
+      run<T>(
+        store: { token: string; botUserId?: string },
+        callback: () => T
+      ): T;
+    };
   }
 
   it("matches by bot user ID", () => {
@@ -8671,6 +8677,38 @@ describe("isMessageFromSelf", () => {
     const result = (
       adapter as unknown as AdapterWithPrivates
     ).isMessageFromSelf({ user: "U_BOT_123" });
+    expect(result).toBe(true);
+  });
+
+  it("matches by bot profile user ID", () => {
+    const adapter = createSlackAdapter({
+      botToken: "xoxb-test",
+      signingSecret: "s",
+      logger: mockLogger,
+    });
+    (adapter as unknown as AdapterWithPrivates)._botUserId = "U_BOT_123";
+    const result = (
+      adapter as unknown as AdapterWithPrivates
+    ).isMessageFromSelf({
+      bot_id: "B_BOT_456",
+      bot_profile: { user_id: "U_BOT_123" },
+    });
+    expect(result).toBe(true);
+  });
+
+  it("matches request bot user ID by bot profile", () => {
+    const adapter = createSlackAdapter({
+      signingSecret: "s",
+      logger: mockLogger,
+    }) as unknown as AdapterWithPrivates;
+    const result = adapter.requestContext.run(
+      { token: "xoxb-test", botUserId: "U_BOT_123" },
+      () =>
+        adapter.isMessageFromSelf({
+          bot_id: "B_BOT_456",
+          bot_profile: { user_id: "U_BOT_123" },
+        })
+    );
     expect(result).toBe(true);
   });
 

--- a/packages/adapter-slack/src/index.test.ts
+++ b/packages/adapter-slack/src/index.test.ts
@@ -1191,6 +1191,23 @@ describe("parseMessage", () => {
     expect(message.author.isBot).toBe(true);
   });
 
+  it("uses the bot user ID instead of the app bot ID", () => {
+    const event = {
+      type: "message",
+      bot_id: "B123",
+      bot_profile: { user_id: "U123" },
+      channel: "C456",
+      text: "Bot message",
+      ts: "1234567890.123456",
+      subtype: "bot_message",
+    };
+
+    const message = adapter.parseMessage(event);
+
+    expect(message.author.userId).toBe("U123");
+    expect(message.author.isBot).toBe(true);
+  });
+
   it("marks USLACK messages as system-authored", () => {
     const event = {
       type: "message",

--- a/packages/adapter-slack/src/index.ts
+++ b/packages/adapter-slack/src/index.ts
@@ -6746,21 +6746,23 @@ export class SlackAdapter implements Adapter<SlackThreadId, unknown> {
    *
    * Slack messages can come from:
    * - User messages: have `user` field (U_xxx format)
-   * - Bot messages: have `bot_id` field (B_xxx format)
+   * - Bot messages: have `bot_id` and may include a bot user ID
    *
    * We check both because:
-   * - _botUserId is the user ID (U_xxx) - matches event.user
+   * - _botUserId is the user ID (U_xxx) - matches event.user or bot_profile.user_id
    * - _botId is the bot ID (B_xxx) - matches event.bot_id
    */
   protected isMessageFromSelf(event: SlackEvent): boolean {
+    const userId = event.user || event.bot_profile?.user_id;
+
     // Check request context first (multi-workspace)
     const ctx = this.requestContext.getStore();
-    if (ctx?.botUserId && event.user === ctx.botUserId) {
+    if (ctx?.botUserId && userId === ctx.botUserId) {
       return true;
     }
 
     // Primary check: user ID match (for messages sent as the bot user)
-    if (this._botUserId && event.user === this._botUserId) {
+    if (this._botUserId && userId === this._botUserId) {
       return true;
     }
 

--- a/packages/adapter-slack/src/index.ts
+++ b/packages/adapter-slack/src/index.ts
@@ -780,6 +780,7 @@ export interface SlackEvent {
   /** Rich text blocks containing structured elements (links, mentions, etc.) */
   blocks?: SlackMessageBlock[];
   bot_id?: string;
+  bot_profile?: { user_id?: string };
   channel?: string;
   /** Channel type: "channel", "group", "mpim", or "im" (DM) */
   channel_type?: string;
@@ -4228,7 +4229,8 @@ export class SlackAdapter implements Adapter<SlackThreadId, unknown> {
       formatted,
       raw: event,
       author: {
-        userId: event.user || event.bot_id || "unknown",
+        userId:
+          event.user || event.bot_profile?.user_id || event.bot_id || "unknown",
         userName,
         fullName,
         email,
@@ -6201,7 +6203,8 @@ export class SlackAdapter implements Adapter<SlackThreadId, unknown> {
       formatted,
       raw: event,
       author: {
-        userId: event.user || event.bot_id || "unknown",
+        userId:
+          event.user || event.bot_profile?.user_id || event.bot_id || "unknown",
         userName,
         fullName,
         isBot: !!event.bot_id,


### PR DESCRIPTION
## Summary

Slack bot messages can include both an app-scoped bot_id and a user-scoped bot_profile.user_id. Use the user ID for normalized message authors when available so identity, self-message checks, and downstream user lookups operate on the same ID Slack uses for users.

## Test plan

- bunx vitest run packages/adapter-slack/src/index.test.ts packages/adapter-slack/src/markdown.test.ts (490 passed)
- bunx tsc -p packages/adapter-slack/tsconfig.json --noEmit
- bunx biome check on changed files

## Checklist

- [x] All commits are signed and verified
- [x] All commits are signed off for the DCO (git commit -s)
- [ ] pnpm validate passes (targeted package validation run)
- [x] Changeset added
- [x] Documentation updated (N/A; normalized identity correction only)