### PR TITLE
fix(linear): stabilize agent session event threads

### DIFF
--- a/.changeset/bright-bots-linear.md
+++ b/.changeset/bright-bots-linear.md
@@ -1,0 +1,5 @@
+---
+"@chat-adapter/linear": patch
+---
+
+Keep Linear agent-session events on one stable thread and handle sessions created by automation or without a root comment.

--- a/packages/adapter-linear/src/index.test.ts
+++ b/packages/adapter-linear/src/index.test.ts
@@ -397,6 +397,7 @@ function createAgentSessionPayload(overrides?: {
   activityId?: string;
   appUserId?: string;
   commentId?: string;
+  comment?: null;
   creator?: {
     avatarUrl?: string;
     email?: string;
@@ -444,11 +445,14 @@ function createAgentSessionPayload(overrides?: {
       issueId: overrides?.issueId ?? "issue-123",
       commentId: overrides?.commentId ?? "comment-root",
       sourceCommentId,
-      comment: {
-        id: overrides?.commentId ?? "comment-root",
-        body: overrides?.sourceCommentBody ?? "@test-bot Hello there",
-        userId: creator?.id,
-      },
+      comment:
+        overrides?.comment === null
+          ? null
+          : {
+              id: overrides?.commentId ?? "comment-root",
+              body: overrides?.sourceCommentBody ?? "@test-bot Hello there",
+              userId: creator?.id,
+            },
       creator,
       sourceMetadata: {
         type: "comment",
@@ -462,12 +466,20 @@ function createAgentSessionPayload(overrides?: {
     },
     agentActivity: {
       id: overrides?.activityId ?? "agent-activity-1",
+      sourceCommentId,
       body: overrides?.activityBody ?? "Hello from app actor",
       createdAt: "2025-06-01T12:00:00.000Z",
       updatedAt: "2025-06-01T12:00:00.000Z",
       content: {
         type: overrides?.action === "prompted" ? "prompt" : "prompt",
         body: overrides?.activityBody ?? "Hello from app actor",
+      },
+      user: {
+        id: "user-456",
+        name: "Test User",
+        email: undefined,
+        avatarUrl: undefined,
+        url: "https://linear.app/test/profiles/test-user",
       },
     },
     previousComments: [
@@ -1301,16 +1313,14 @@ describe("handleWebhook - agent session events", () => {
     expect(response.status).toBe(200);
     expect(chat.processMessage).toHaveBeenCalledTimes(1);
     const message = chat.processMessage.mock.calls[0][2];
-    expect(message.threadId).toBe(
-      "linear:issue-123:c:comment-root:s:agent-session-1"
-    );
+    expect(message.threadId).toBe("linear:issue-123:s:agent-session-1");
     expect(message.author.userId).toBe("user-456");
     expect(message.author.userName).toBe("test-user");
     expect(message.author.isBot).toBe(false);
     expect(message.author.isMe).toBe(false);
   });
 
-  it("routes prompted events to the same session thread without mention flag", async () => {
+  it("routes prompted events to the same stable session thread", async () => {
     const logger = createMockLogger();
     const adapter = createWebhookAdapter(logger, "agent-sessions");
     const chat = createMockChatInstance({ state: createMockState(), logger });
@@ -1325,10 +1335,13 @@ describe("handleWebhook - agent session events", () => {
     const response = await adapter.handleWebhook(request);
 
     expect(response.status).toBe(200);
-    expect(chat).not.toHaveDispatched("processMessage");
+    expect(chat.processMessage).toHaveBeenCalledTimes(1);
+    const message = chat.processMessage.mock.calls[0][2];
+    expect(message.threadId).toBe("linear:issue-123:s:agent-session-1");
+    expect(message.text).toBe("Can you elaborate?");
   });
 
-  it("falls back to the bot author when a created session has no creator", async () => {
+  it("uses an automation author when a created session has no creator", async () => {
     const logger = createMockLogger();
     const adapter = createWebhookAdapter(logger, "agent-sessions");
     const chat = createMockChatInstance({ state: createMockState(), logger });
@@ -1345,10 +1358,30 @@ describe("handleWebhook - agent session events", () => {
     expect(response.status).toBe(200);
     expect(chat.processMessage).toHaveBeenCalledTimes(1);
     const message = chat.processMessage.mock.calls[0][2];
-    expect(message.author.userId).toBe("bot-user-id");
-    expect(message.author.userName).toBe("test-bot");
+    expect(message.author.userId).toBe("linear-automation");
+    expect(message.author.userName).toBe("Linear automation");
     expect(message.author.isBot).toBe(true);
-    expect(message.author.isMe).toBe(true);
+    expect(message.author.isMe).toBe(false);
+  });
+
+  it("dispatches created sessions without a root comment", async () => {
+    const logger = createMockLogger();
+    const adapter = createWebhookAdapter(logger, "agent-sessions");
+    const chat = createMockChatInstance({ state: createMockState(), logger });
+    (adapter as unknown as { chat: typeof chat }).chat = chat;
+
+    const payload = createAgentSessionPayload({ comment: null });
+    const body = JSON.stringify(payload);
+    const response = await adapter.handleWebhook(
+      buildWebhookRequest(body, signPayload(body))
+    );
+
+    expect(response.status).toBe(200);
+    expect(chat.processMessage).toHaveBeenCalledTimes(1);
+    const message = chat.processMessage.mock.calls[0][2];
+    expect(message.id).toBe("agent-session-agent-session-1");
+    expect(message.text).toBe("");
+    expect(message.threadId).toBe("linear:issue-123:s:agent-session-1");
   });
 
   it("ignores comment webhooks in agent-session mode", async () => {
@@ -1441,9 +1474,7 @@ describe("handleWebhook - agent session events", () => {
     expect(sessionResponse.status).toBe(200);
     expect(chat.processMessage).toHaveBeenCalledTimes(1);
     const message = chat.processMessage.mock.calls[0][2];
-    expect(message.threadId).toBe(
-      "linear:issue-123:c:comment-abc:s:agent-session-1"
-    );
+    expect(message.threadId).toBe("linear:issue-123:s:agent-session-1");
   });
 
   it("ignores comment webhooks in multi-tenant agent-session mode", async () => {

--- a/packages/adapter-linear/src/index.test.ts
+++ b/packages/adapter-linear/src/index.test.ts
@@ -1341,6 +1341,31 @@ describe("handleWebhook - agent session events", () => {
     expect(message.text).toBe("Can you elaborate?");
   });
 
+  it("routes prompted events without a source comment", async () => {
+    const logger = createMockLogger();
+    const adapter = createWebhookAdapter(logger, "agent-sessions");
+    const chat = createMockChatInstance({ state: createMockState(), logger });
+    (adapter as unknown as { chat: typeof chat }).chat = chat;
+
+    const payload = createAgentSessionPayload({
+      action: "prompted",
+      activityBody: "Can you elaborate?",
+      activityId: "agent-activity-without-comment",
+      sourceCommentId: null,
+    });
+    const body = JSON.stringify(payload);
+    const response = await adapter.handleWebhook(
+      buildWebhookRequest(body, signPayload(body))
+    );
+
+    expect(response.status).toBe(200);
+    expect(chat.processMessage).toHaveBeenCalledTimes(1);
+    const message = chat.processMessage.mock.calls[0][2];
+    expect(message.id).toBe("agent-activity-without-comment");
+    expect(message.text).toBe("Can you elaborate?");
+    expect(message.threadId).toBe("linear:issue-123:s:agent-session-1");
+  });
+
   it("uses an automation author when a created session has no creator", async () => {
     const logger = createMockLogger();
     const adapter = createWebhookAdapter(logger, "agent-sessions");
@@ -1380,7 +1405,7 @@ describe("handleWebhook - agent session events", () => {
     expect(chat.processMessage).toHaveBeenCalledTimes(1);
     const message = chat.processMessage.mock.calls[0][2];
     expect(message.id).toBe("agent-session-agent-session-1");
-    expect(message.text).toBe("");
+    expect(message.text).toBe("Issue TEST-1\n\n@get-bot Hello there");
     expect(message.threadId).toBe("linear:issue-123:s:agent-session-1");
   });
 
@@ -2320,6 +2345,104 @@ describe("fetchMessages", () => {
     expect(
       expectAgentSessionCommentRawMessage(result.messages[1].raw).agentSessionId
     ).toBe("session-789");
+  });
+
+  it("should fetch activities for agent sessions without a root comment", async () => {
+    const adapter = createWebhookAdapter(undefined, "agent-sessions");
+    setDefaultOrganizationId(adapter, "org-xyz");
+    setBotUserId(adapter, "bot-id");
+
+    const activities = vi.fn().mockResolvedValue({
+      nodes: [
+        {
+          id: "response-activity",
+          sourceCommentId: undefined,
+          userId: "bot-id",
+          createdAt: new Date("2025-06-01T10:02:00.000Z"),
+          updatedAt: new Date("2025-06-01T10:02:00.000Z"),
+          content: { type: "response", body: "Agent response" },
+          user: Promise.resolve({
+            id: "bot-id",
+            displayName: "Test Bot",
+            name: "Test Bot",
+          }),
+        },
+        {
+          id: "prompt-activity",
+          sourceCommentId: undefined,
+          userId: "user-1",
+          createdAt: new Date("2025-06-01T10:00:00.000Z"),
+          updatedAt: new Date("2025-06-01T10:00:00.000Z"),
+          content: { type: "prompt", body: "User prompt" },
+          user: Promise.resolve({
+            id: "user-1",
+            displayName: "Alice",
+            name: "Alice Smith",
+          }),
+        },
+        {
+          id: "action-activity",
+          sourceCommentId: undefined,
+          userId: "bot-id",
+          createdAt: new Date("2025-06-01T10:01:00.000Z"),
+          updatedAt: new Date("2025-06-01T10:01:00.000Z"),
+          content: {
+            type: "action",
+            action: "Searching",
+            parameter: "Chat SDK",
+            result: "Found documentation",
+          },
+          user: Promise.resolve({
+            id: "bot-id",
+            displayName: "Test Bot",
+            name: "Test Bot",
+          }),
+        },
+      ],
+      pageInfo: {
+        hasNextPage: false,
+        hasPreviousPage: false,
+        endCursor: null,
+        startCursor: null,
+      },
+    });
+    const mockLinearClient = {
+      agentSession: vi.fn().mockResolvedValue({
+        id: "session-789",
+        issueId: "issue-abc",
+        url: "https://linear.app/session/session-789",
+        comment: Promise.resolve(undefined),
+        activities,
+      }),
+    };
+    (
+      adapter as unknown as { linearClient: typeof mockLinearClient }
+    ).linearClient = mockLinearClient as never;
+
+    const result = await adapter.fetchMessages(
+      "linear:issue-abc:s:session-789"
+    );
+
+    expect(activities).toHaveBeenCalledWith({ last: 50 });
+    expect(result.messages.map((message) => message.text)).toEqual([
+      "User prompt",
+      "Searching: Chat SDK\nFound documentation",
+      "Agent response",
+    ]);
+    expect(result.messages.map((message) => message.id)).toEqual([
+      "prompt-activity",
+      "action-activity",
+      "response-activity",
+    ]);
+    expect(result.messages[0].author.isBot).toBe(false);
+    expect(result.messages[0].author.isMe).toBe(false);
+    expect(result.messages[1].author.isBot).toBe(true);
+    expect(result.messages[1].author.isMe).toBe(true);
+    expect(
+      result.messages.every(
+        (message) => message.threadId === "linear:issue-abc:s:session-789"
+      )
+    ).toBe(true);
   });
 
   it("should surface root comment lookup failures", async () => {

--- a/packages/adapter-linear/src/index.ts
+++ b/packages/adapter-linear/src/index.ts
@@ -1165,16 +1165,14 @@ export class LinearAdapter
         return null;
       }
 
-      if (!agentSession.comment) {
-        this.logger.warn("Missing comment for agent session", {
-          agentSessionId: payload.agentSession.id,
-        });
-        return null;
-      }
+      const sessionComment = agentSession.comment ?? {
+        id: `agent-session-${agentSession.id}`,
+        body: "",
+      };
 
       const commentData: LinearCommentData = {
-        id: agentSession.comment.id,
-        body: agentSession.comment.body,
+        id: sessionComment.id,
+        body: sessionComment.body,
         issueId,
         user: agentSession.creator
           ? {
@@ -1187,9 +1185,9 @@ export class LinearAdapter
             }
           : {
               type: "bot",
-              id: this.botUserId,
-              displayName: this.userName,
-              fullName: this.userName,
+              id: "linear-automation",
+              displayName: "Linear automation",
+              fullName: "Linear automation",
               email: undefined,
               avatarUrl: undefined,
             },
@@ -2298,12 +2296,16 @@ export class LinearAdapter
     return new Message<LinearRawMessage>({
       id: raw.comment.id,
       isMention: raw.kind === "agent_session_comment", // Agent session comments are treated as mentions as they directly target the bot
-      threadId: this.encodeThreadId({
-        issueId: raw.comment.issueId,
-        commentId: raw.comment.id,
-        agentSessionId:
-          raw.kind === "agent_session_comment" ? raw.agentSessionId : undefined,
-      }),
+      threadId:
+        raw.kind === "agent_session_comment"
+          ? this.encodeThreadId({
+              issueId: raw.comment.issueId,
+              agentSessionId: raw.agentSessionId,
+            })
+          : this.encodeThreadId({
+              issueId: raw.comment.issueId,
+              commentId: raw.comment.id,
+            }),
       text,
       formatted,
       author: {

--- a/packages/adapter-linear/src/index.ts
+++ b/packages/adapter-linear/src/index.ts
@@ -9,7 +9,12 @@ import {
   isEncryptedTokenData,
   ValidationError,
 } from "@chat-adapter/shared";
-import type { AgentActivityPayload, Comment } from "@linear/sdk";
+import type {
+  AgentActivity,
+  AgentActivityPayload,
+  AgentSession,
+  Comment,
+} from "@linear/sdk";
 import { AgentActivityType, LinearClient } from "@linear/sdk";
 import {
   type AgentSessionEventWebhookPayload,
@@ -64,6 +69,19 @@ const COMMENT_THREAD_PATTERN = /^([^:]+):c:([^:]+)$/;
 const ISSUE_SESSION_THREAD_PATTERN = /^([^:]+):s:([^:]+)$/;
 const INSTALLATION_KEY_PREFIX = "linear:installation";
 const INSTALLATION_REFRESH_BUFFER_MS = 5 * 60 * 1000;
+
+function renderActivity(activity: AgentActivity): string {
+  const { content } = activity;
+  if ("body" in content) {
+    return content.body;
+  }
+
+  const action = content.action.trim() || "Action";
+  const parameter = content.parameter.trim();
+  const result = content.result?.trim();
+  const text = parameter ? `${action}: ${parameter}` : action;
+  return result ? `${text}\n${result}` : text;
+}
 
 function parseEnvClientCredentialScopes(value?: string): string[] | undefined {
   if (!value) {
@@ -1115,17 +1133,9 @@ export class LinearAdapter
         return null;
       }
 
-      if (!agentActivity.sourceCommentId) {
-        this.logger.warn("Missing source comment ID for agent activity", {
-          agentSessionId: payload.agentSession.id,
-          agentActivityId: agentActivity.id,
-        });
-        return null;
-      }
-
       const content = agentActivity.content as { type: "prompt"; body: string };
       const commentData: LinearCommentData = {
-        id: agentActivity.sourceCommentId,
+        id: agentActivity.sourceCommentId ?? agentActivity.id,
         body: content.body,
         issueId,
         user: {
@@ -1167,7 +1177,7 @@ export class LinearAdapter
 
       const sessionComment = agentSession.comment ?? {
         id: `agent-session-${agentSession.id}`,
-        body: "",
+        body: payload.promptContext ?? "",
       };
 
       const commentData: LinearCommentData = {
@@ -2050,9 +2060,10 @@ export class LinearAdapter
 
     const rootComment = await agentSession.comment;
     if (!rootComment) {
-      throw new AdapterError(
-        `Linear agent session ${thread.agentSessionId} is missing a root comment`,
-        "linear"
+      return await this.fetchAgentSessionActivities(
+        agentSession,
+        issueId,
+        options
       );
     }
 
@@ -2080,6 +2091,72 @@ export class LinearAdapter
       nextCursor: childrenConnection.pageInfo.hasNextPage
         ? (childrenConnection.pageInfo.endCursor ?? undefined)
         : undefined,
+    };
+  }
+
+  protected async fetchAgentSessionActivities(
+    agentSession: AgentSession,
+    issueId: string,
+    options?: FetchOptions
+  ): Promise<FetchResult<LinearRawMessage>> {
+    const forward = options?.direction === "forward";
+    const activitiesConnection = await agentSession.activities({
+      ...(forward
+        ? {
+            first: options?.limit ?? 50,
+            ...(options?.cursor ? { after: options.cursor } : {}),
+          }
+        : {
+            last: options?.limit ?? 50,
+            ...(options?.cursor ? { before: options.cursor } : {}),
+          }),
+    });
+    const activities = [...activitiesConnection.nodes].sort(
+      (first, second) => first.createdAt.getTime() - second.createdAt.getTime()
+    );
+    const messages = await Promise.all(
+      activities.map(async (activity) => {
+        const user = await activity.user;
+        const isBot = activity.content.type !== AgentActivityType.Prompt;
+        const fallback = isBot ? this.userName : "unknown";
+        const actor: LinearActorData = {
+          type: isBot ? "bot" : "user",
+          id:
+            user?.id ?? activity.userId ?? (isBot ? this.botUserId : "unknown"),
+          displayName: user?.displayName ?? user?.name ?? fallback,
+          fullName: user?.name ?? user?.displayName ?? fallback,
+          email: user?.email ?? undefined,
+          avatarUrl: user?.avatarUrl ?? undefined,
+        };
+
+        return this.parseMessage({
+          kind: "agent_session_comment",
+          organizationId: this.organizationId,
+          agentSessionId: agentSession.id,
+          comment: {
+            id: activity.sourceCommentId ?? activity.id,
+            body: renderActivity(activity),
+            issueId,
+            user: actor,
+            parentId: undefined,
+            createdAt: activity.createdAt.toISOString(),
+            updatedAt: activity.updatedAt.toISOString(),
+            url: agentSession.url ?? undefined,
+          },
+        });
+      })
+    );
+    const pageInfo = activitiesConnection.pageInfo;
+    let cursor: string | undefined;
+    if (forward && pageInfo.hasNextPage) {
+      cursor = pageInfo.endCursor ?? undefined;
+    } else if (!forward && pageInfo.hasPreviousPage) {
+      cursor = pageInfo.startCursor ?? undefined;
+    }
+
+    return {
+      messages,
+      nextCursor: cursor,
     };
   }
 


### PR DESCRIPTION
## Summary

Route every event in a Linear agent session to the stable issue/session thread instead of deriving a new thread from each source comment. Also accept sessions created without a root comment and attribute creator-less sessions to a distinct Linear automation identity instead of the bot itself, which previously caused automation-created sessions to be dropped as self-messages.

## Test plan

- bunx vitest run packages/adapter-linear/src/index.test.ts (164 passed)
- bunx tsc -p packages/adapter-linear/tsconfig.json --noEmit
- bunx biome check on changed files

## Checklist

- [x] All commits are signed and verified
- [x] All commits are signed off for the DCO (git commit -s)
- [ ] pnpm validate passes (targeted package validation run)
- [x] Changeset added
- [x] Documentation updated (N/A; documented stable session thread format is now used consistently)