### PR TITLE
fix(slack): bound structured stream chunk fields

### DIFF
--- a/.changeset/tidy-tasks-slack.md
+++ b/.changeset/tidy-tasks-slack.md
@@ -1,0 +1,5 @@
+---
+"@chat-adapter/slack": patch
+---
+
+Split oversized Slack task updates and truncate structured stream fields to Slack's 256-character limit.

--- a/packages/adapter-slack/src/index.test.ts
+++ b/packages/adapter-slack/src/index.test.ts
@@ -10728,6 +10728,57 @@ describe("stream with empty threadTs", () => {
       expect.objectContaining({ token: "xoxb-test-token" })
     );
   });
+
+  it("bounds structured stream fields to Slack's 256-character limit", async () => {
+    const adapter = createSlackAdapter({
+      botToken: "xoxb-test-token",
+      signingSecret: "test-signing-secret",
+      logger: mockLogger,
+    });
+    const append = vi.fn().mockResolvedValue({ ok: true });
+    const stop = vi.fn().mockResolvedValue({
+      ok: true,
+      ts: "1234567890.111111",
+    });
+    mockClientMethod(
+      adapter,
+      "chatStream",
+      vi.fn().mockReturnValue({ append, stop })
+    );
+
+    async function* chunkStream() {
+      yield {
+        title: "p".repeat(300),
+        type: "plan_update" as const,
+      };
+      yield {
+        details: "d".repeat(600),
+        id: "i".repeat(300),
+        output: "o".repeat(600),
+        status: "in_progress" as const,
+        title: "t".repeat(300),
+        type: "task_update" as const,
+      };
+    }
+
+    await adapter.stream("slack:C123:1234567890.000000", chunkStream(), {
+      recipientUserId: "U123",
+      recipientTeamId: "T123",
+    });
+
+    const chunks = append.mock.calls.flatMap(
+      (call) => (call[0] as { chunks?: Record<string, string>[] }).chunks ?? []
+    );
+    expect(chunks).toHaveLength(4);
+    expect(chunks[0]?.title).toHaveLength(256);
+    for (const chunk of chunks.slice(1)) {
+      expect(chunk.id?.length).toBeLessThanOrEqual(256);
+      expect(chunk.title?.length).toBeLessThanOrEqual(256);
+      expect(chunk.details?.length ?? 0).toBeLessThanOrEqual(256);
+      expect(chunk.output?.length ?? 0).toBeLessThanOrEqual(256);
+    }
+    expect(new Set(chunks.slice(1).map((chunk) => chunk.id)).size).toBe(3);
+  });
 });
 
 describe("native stream rotation", () => {

--- a/packages/adapter-slack/src/index.ts
+++ b/packages/adapter-slack/src/index.ts
@@ -428,6 +428,65 @@ function tableContinuation(text: string): string {
   return `${rows[separatorAt - 1]}\n${rows[separatorAt]}\n`;
 }
 
+const SLACK_STREAM_CHUNK_FIELD_LIMIT = 256;
+
+function truncateStreamChunkField(value: string, limit: number): string {
+  if (value.length <= limit) {
+    return value;
+  }
+  let end = limit - 3;
+  const lastCode = value.charCodeAt(end - 1);
+  if (lastCode >= 0xd800 && lastCode <= 0xdbff) {
+    end -= 1;
+  }
+  return `${value.slice(0, end)}...`;
+}
+
+function splitStreamChunkField(value: string): string[] {
+  if (value.length <= SLACK_STREAM_CHUNK_FIELD_LIMIT) {
+    return [value];
+  }
+  const parts: string[] = [];
+  let offset = 0;
+  while (offset < value.length) {
+    let end = Math.min(offset + SLACK_STREAM_CHUNK_FIELD_LIMIT, value.length);
+    const lastCode = value.charCodeAt(end - 1);
+    if (lastCode >= 0xd800 && lastCode <= 0xdbff) {
+      end -= 1;
+    }
+    parts.push(value.slice(offset, end));
+    offset = end;
+  }
+  return parts;
+}
+
+function normalizeTaskChunks(
+  chunk: Extract<StreamChunk, { type: "task_update" }>,
+  previousParts: number
+): Extract<StreamChunk, { type: "task_update" }>[] {
+  const details = chunk.details ? splitStreamChunkField(chunk.details) : [];
+  const output = chunk.output ? splitStreamChunkField(chunk.output) : [];
+  const total = Math.max(previousParts, details.length, output.length, 1);
+  return Array.from({ length: total }, (_, index) => {
+    const suffix = index === 0 ? "" : `:part:${index + 1}`;
+    const titleSuffix = total === 1 ? "" : ` (${index + 1}/${total})`;
+    return {
+      ...(details[index] ? { details: details[index] } : {}),
+      id: `${truncateStreamChunkField(
+        chunk.id,
+        SLACK_STREAM_CHUNK_FIELD_LIMIT - suffix.length
+      )}${suffix}`,
+      ...(output[index] ? { output: output[index] } : {}),
+      status: chunk.status,
+      title: `${truncateStreamChunkField(
+        chunk.title,
+        SLACK_STREAM_CHUNK_FIELD_LIMIT - titleSuffix.length
+      )}${titleSuffix}`,
+      type: "task_update" as const,
+    };
+  });
+}
+
 export type {
   SlackAdapterConfig,
   SlackAdapterMode,
@@ -6117,7 +6176,10 @@ export class SlackAdapter implements Adapter<SlackThreadId, unknown> {
      * structured chunks are skipped — task cards only exist on the native
      * streaming surface.
      */
-    const sendStructuredChunk = async (chunk: StreamChunk): Promise<void> => {
+    const taskPartCounts = new Map<string, number>();
+    const sendStructuredChunk = async (
+      chunk: Exclude<StreamChunk, { type: "markdown_text" }>
+    ): Promise<void> => {
       // Flush any buffered markdown before sending the structured chunk
       await flushCommitted();
 
@@ -6134,14 +6196,32 @@ export class SlackAdapter implements Adapter<SlackThreadId, unknown> {
       await sendDelta("", true);
 
       try {
+        const chunks =
+          chunk.type === "plan_update"
+            ? [
+                {
+                  ...chunk,
+                  title: truncateStreamChunkField(
+                    chunk.title,
+                    SLACK_STREAM_CHUNK_FIELD_LIMIT
+                  ),
+                },
+              ]
+            : normalizeTaskChunks(chunk, taskPartCounts.get(chunk.id) ?? 0);
+        if (chunk.type === "task_update") {
+          taskPartCounts.set(chunk.id, chunks.length);
+        }
         await segment.streamer.append({
-          chunks: [chunk] as ChatAppendStreamArguments["chunks"],
+          chunks: chunks as ChatAppendStreamArguments["chunks"],
           token,
         });
         markSegmentStarted();
         // Sending chunks flushes the streamer's text buffer as well.
         lastFlushed = lastAppended;
-        rememberStructuredChunk(chunk);
+        // Remember the bounded chunks so a segment rotation replays them as sent.
+        for (const normalized of chunks) {
+          rememberStructuredChunk(normalized);
+        }
       } catch (error) {
         disableStructuredChunks(chunk.type, error);
       }


### PR DESCRIPTION
## Summary

Slack limits structured task and plan fields to 256 characters. Truncate IDs, titles, and plan titles safely, and split oversized task details/output into stable continuation chunks so large tool results do not make native streaming fail. Preserve the prior part count on subsequent task updates so existing continuation cards can be updated consistently.

## Test plan

- bunx vitest run packages/adapter-slack/src/index.test.ts (444 passed)
- bunx tsc -p packages/adapter-slack/tsconfig.json --noEmit
- bunx biome check on changed files

## Checklist

- [x] All commits are signed and verified
- [x] All commits are signed off for the DCO (git commit -s)
- [ ] pnpm validate passes (targeted package validation run)
- [x] Changeset added
- [x] Documentation updated (N/A; automatic enforcement of Slack platform limits)