### PR TITLE
fix(slack): pass team id to agent view prompt resolvers

### DIFF
--- a/.changeset/chatty-memes-play.md
+++ b/.changeset/chatty-memes-play.md
@@ -1,0 +1,5 @@
+---
+"@chat-adapter/slack": patch
+---
+
+pass workspace context to suggested prompt resolvers in Agent view

--- a/packages/adapter-slack/src/index.test.ts
+++ b/packages/adapter-slack/src/index.test.ts
@@ -7744,7 +7744,7 @@ describe("configured suggestedPrompts", () => {
     );
   });
 
-  it("passes active-view entities to the resolver under agentView", async () => {
+  it("passes team and active-view entities to the resolver under agentView", async () => {
     const resolver = vi.fn().mockResolvedValue(null);
     const { adapter } = await setup({
       agentView: true,
@@ -7766,6 +7766,7 @@ describe("configured suggestedPrompts", () => {
         entities: [
           expect.objectContaining({ kind: "channel", channelId: "C42" }),
         ],
+        teamId: "T123",
       })
     );
   });

--- a/packages/adapter-slack/src/index.ts
+++ b/packages/adapter-slack/src/index.ts
@@ -2228,7 +2228,11 @@ export class SlackAdapter implements Adapter<SlackThreadId, unknown> {
       } else if (event.type === "app_home_opened") {
         const homeEvent = event as SlackAppHomeOpenedEvent;
         if (this.agentView || homeEvent.tab === "home") {
-          this.handleAppHomeOpened(homeEvent, options);
+          const teamId =
+            payload.authorizations?.[0]?.team_id ||
+            payload.team_id ||
+            undefined;
+          this.handleAppHomeOpened(homeEvent, options, teamId);
         }
       } else if (event.type === "member_joined_channel") {
         this.handleMemberJoinedChannel(
@@ -3659,7 +3663,8 @@ export class SlackAdapter implements Adapter<SlackThreadId, unknown> {
    */
   protected handleAppHomeOpened(
     event: SlackAppHomeOpenedEvent,
-    options?: WebhookOptions
+    options?: WebhookOptions,
+    teamId?: string
   ): void {
     if (!this.chat) {
       this.logger.warn(
@@ -3675,6 +3680,7 @@ export class SlackAdapter implements Adapter<SlackThreadId, unknown> {
     if (this.agentView && event.tab === "messages") {
       const promptsTask = this.applyConfiguredSuggestedPrompts({
         channelId: event.channel,
+        ...(teamId ? { teamId } : {}),
         userId: event.user,
         ...(event.context
           ? { entities: normalizeAppContextEntities(event.context) }

--- a/packages/adapter-slack/src/types.ts
+++ b/packages/adapter-slack/src/types.ts
@@ -67,7 +67,7 @@ export interface SlackSuggestedPromptsContext {
   enterpriseId?: string;
   /** Active-view context entities (agent_view, when Slack folds context in). */
   entities?: AppContextEntity[];
-  /** Team the user opened the thread from (legacy assistant_view). */
+  /** Team the user opened the conversation from. */
   teamId?: string;
   /** Assistant thread root (legacy assistant_view; absent under agent_view). */
   threadTs?: string;


### PR DESCRIPTION
## summary

- pass the workspace `team_id` from `app_home_opened` events to dynamic `suggestedPrompts` resolvers
- prefer `authorizations[0].team_id` with the top-level `team_id` as a fallback
- add regression coverage for multi-workspace agent view apps
- fixes #874

## test plan

- reproduce the missing workspace context with Slack's documented event envelope
- verify the resolver receives the workspace id
- `pnpm build`
- `pnpm --filter @chat-adapter/slack test`
- `pnpm --filter @chat-adapter/integration-tests test`
- `pnpm typecheck`
- `pnpm exec ultracite check packages/adapter-slack/src/index.ts packages/adapter-slack/src/index.test.ts packages/adapter-slack/src/types.ts`