### PR TITLE
fix(slack): decode the bot self mention in incoming message text

### DIFF
--- a/.changeset/decode-slack-self-mention.md
+++ b/.changeset/decode-slack-self-mention.md
@@ -1,0 +1,5 @@
+---
+"@chat-adapter/slack": minor
+---
+
+Decode the bot's own mention in incoming Slack messages. The adapter now resolves `<@U_BOT>` to the bot's display name (`@<DisplayName>`) the same way it resolves every other user mention, instead of leaving the raw user-ID markup in place, and sets `isMention` on the parsed message by detecting the bot's ID in the raw event text. This keeps `message.text` self-describing for downstream consumers (LLM prompts, classifiers) while preserving mention detection, which previously depended on the raw ID markup surviving in the text.

--- a/packages/adapter-slack/src/index.test.ts
+++ b/packages/adapter-slack/src/index.test.ts
@@ -7245,6 +7245,61 @@ describe("resolveInlineMentions", () => {
     expect(message.isMention).toBe(true);
   });
 
+  it("falls back to the bot's user ID when users.info fails for its own mention", async () => {
+    const state = createMockState();
+    const chatInstance = createMockChatInstance({ state });
+    chatInstance.processMessage = vi.fn();
+
+    const adapter = createSlackAdapter({
+      botToken: "xoxb-test-token",
+      signingSecret: secret,
+      logger: mockLogger,
+      botUserId: "U_BOT",
+    });
+
+    const usersInfoMock = vi.fn().mockImplementation(async ({ user }: { user: string }) => {
+      if (user === "U_BOT") {
+        throw {
+          code: "slack_webapi_platform_error",
+          data: { error: "rate_limited" },
+        };
+      }
+      return {
+        ok: true,
+        user: {
+          name: "user",
+          profile: { display_name: "Test User", real_name: "Test User" },
+        },
+      };
+    });
+    mockClientMethod(adapter, "users.info", usersInfoMock);
+
+    await adapter.initialize(chatInstance);
+
+    const body = JSON.stringify({
+      type: "event_callback",
+      team_id: "T123",
+      event: {
+        type: "app_mention",
+        user: "U_SENDER",
+        channel: "C456",
+        text: "<@U_BOT> help me",
+        ts: "1234567890.777777",
+      },
+    });
+    const request = createWebhookRequest(body, secret);
+    await adapter.handleWebhook(request);
+
+    const factory = (chatInstance.processMessage as ReturnType<typeof vi.fn>)
+      .mock.calls[0][2];
+    const message = await factory();
+
+    // Lookup failure degrades to the raw user ID with a mention prefix —
+    // the raw angle-bracket markup never resurfaces in the rendered text.
+    expect(message.text).toBe("@U_BOT help me");
+    expect(message.isMention).toBe(true);
+  });
+
   it("resolves request-scoped self mention in multi-workspace mode", async () => {
     const state = createMockState();
     const chatInstance = createMockChatInstance({ state });

--- a/packages/adapter-slack/src/index.test.ts
+++ b/packages/adapter-slack/src/index.test.ts
@@ -7245,6 +7245,74 @@ describe("resolveInlineMentions", () => {
     expect(message.isMention).toBe(true);
   });
 
+  it("flags the bot's own mention in rich text table cells", async () => {
+    const state = createMockState();
+    const chatInstance = createMockChatInstance({ state });
+    chatInstance.processMessage = vi.fn();
+
+    const adapter = createSlackAdapter({
+      botToken: "xoxb-test-token",
+      signingSecret: secret,
+      logger: mockLogger,
+      botUserId: "U_BOT",
+    });
+
+    mockClientMethod(
+      adapter,
+      "users.info",
+      vi.fn().mockImplementation(async ({ user }: { user: string }) => ({
+        ok: true,
+        user: {
+          name: user === "U_BOT" ? "testbot" : "sender",
+          profile: {
+            display_name: user === "U_BOT" ? "Test Bot" : "Sender",
+          },
+        },
+      }))
+    );
+
+    await adapter.initialize(chatInstance);
+
+    const body = JSON.stringify({
+      type: "event_callback",
+      team_id: "T123",
+      event: {
+        type: "message",
+        user: "U_SENDER",
+        channel: "C456",
+        text: "",
+        ts: "1234567890.676767",
+        blocks: [
+          {
+            type: "table",
+            rows: [
+              [
+                {
+                  type: "rich_text",
+                  elements: [
+                    {
+                      type: "rich_text_section",
+                      elements: [{ type: "user", user_id: "U_BOT" }],
+                    },
+                  ],
+                },
+              ],
+            ],
+          },
+        ],
+      },
+    });
+    const request = createWebhookRequest(body, secret);
+    await adapter.handleWebhook(request);
+
+    const factory = (chatInstance.processMessage as ReturnType<typeof vi.fn>)
+      .mock.calls[0][2];
+    const message = await factory();
+
+    expect(message.text).toBe("@Test Bot");
+    expect(message.isMention).toBe(true);
+  });
+
   it("falls back to the bot's user ID when users.info fails for its own mention", async () => {
     const state = createMockState();
     const chatInstance = createMockChatInstance({ state });

--- a/packages/adapter-slack/src/index.test.ts
+++ b/packages/adapter-slack/src/index.test.ts
@@ -7257,21 +7257,22 @@ describe("resolveInlineMentions", () => {
       botUserId: "U_BOT",
     });
 
-    const usersInfoMock = vi.fn().mockImplementation(async ({ user }: { user: string }) => {
-      if (user === "U_BOT") {
-        throw {
-          code: "slack_webapi_platform_error",
-          data: { error: "rate_limited" },
+    const usersInfoMock = vi
+      .fn()
+      .mockImplementation(async ({ user }: { user: string }) => {
+        if (user === "U_BOT") {
+          // The Slack SDK surfaces API failures as error-like objects; lookupUser
+          // catches any rejection, so the shape is irrelevant to the fallback.
+          throw new Error("rate_limited");
+        }
+        return {
+          ok: true,
+          user: {
+            name: "user",
+            profile: { display_name: "Test User", real_name: "Test User" },
+          },
         };
-      }
-      return {
-        ok: true,
-        user: {
-          name: "user",
-          profile: { display_name: "Test User", real_name: "Test User" },
-        },
-      };
-    });
+      });
     mockClientMethod(adapter, "users.info", usersInfoMock);
 
     await adapter.initialize(chatInstance);

--- a/packages/adapter-slack/src/index.test.ts
+++ b/packages/adapter-slack/src/index.test.ts
@@ -7135,10 +7135,7 @@ describe("resolveInlineMentions", () => {
         callback: () => Promise<T>
       ): Promise<T>;
     };
-    resolveInlineMentions(
-      text: string,
-      skipSelfMention: boolean
-    ): Promise<string>;
+    resolveInlineMentions(text: string): Promise<string>;
   }
 
   it("resolves user mentions in incoming messages via webhook", async () => {
@@ -7200,7 +7197,7 @@ describe("resolveInlineMentions", () => {
     expect(message.text).toContain("@John");
   });
 
-  it("skips self-mention resolution in incoming webhooks", async () => {
+  it("resolves the bot's own mention and flags it in incoming webhooks", async () => {
     const state = createMockState();
     const chatInstance = createMockChatInstance({ state });
     chatInstance.processMessage = vi.fn();
@@ -7212,11 +7209,13 @@ describe("resolveInlineMentions", () => {
       botUserId: "U_BOT",
     });
 
-    // users.info should NOT be called for the bot's own mention
-    const usersInfoMock = vi.fn().mockResolvedValue({
+    const usersInfoMock = vi.fn().mockImplementation(async (_id: string) => ({
       ok: true,
-      user: { name: "sender", profile: { display_name: "Sender" } },
-    });
+      user: {
+        name: "user",
+        profile: { display_name: "Test User", real_name: "Test User" },
+      },
+    }));
     mockClientMethod(adapter, "users.info", usersInfoMock);
 
     await adapter.initialize(chatInstance);
@@ -7239,11 +7238,14 @@ describe("resolveInlineMentions", () => {
       .mock.calls[0][2];
     const message = await factory();
 
-    // Bot mention should NOT be resolved (kept as-is for mention detection)
-    expect(message.text).toContain("@U_BOT");
+    // The bot's own mention is decoded to its display name like any other
+    // mention, and the message is flagged as a mention from the raw event
+    // text (the ID markup no longer exists after resolution).
+    expect(message.text).toBe("@Test User help me");
+    expect(message.isMention).toBe(true);
   });
 
-  it("skips request-scoped self mention resolution in multi-workspace mode", async () => {
+  it("resolves request-scoped self mention in multi-workspace mode", async () => {
     const state = createMockState();
     const chatInstance = createMockChatInstance({ state });
     const adapter = createSlackAdapter({
@@ -7271,11 +7273,10 @@ describe("resolveInlineMentions", () => {
         token: "xoxb-multi-token",
         botUserId: "U_BOT_MULTI",
       },
-      () => mentionAdapter.resolveInlineMentions("<@U_BOT_MULTI> help me", true)
+      () => mentionAdapter.resolveInlineMentions("<@U_BOT_MULTI> help me")
     );
 
-    expect(result).toBe("<@U_BOT_MULTI> help me");
-    expect(usersInfoMock).not.toHaveBeenCalled();
+    expect(result).toBe("<@U_BOT_MULTI|Workspace Bot> help me");
   });
 
   it("resolves bare channel mentions in incoming messages", async () => {

--- a/packages/adapter-slack/src/index.ts
+++ b/packages/adapter-slack/src/index.ts
@@ -196,6 +196,10 @@ interface SlackMentionNames {
   users: Map<string, string>;
 }
 
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?${}()|[\]\\]/g, "\\$&");
+}
+
 /**
  * Collect the user and channel IDs referenced by `<@U…>` / `<#C…>` tokens.
  * Parses by splitting on angle brackets to avoid ReDoS.
@@ -3996,45 +4000,25 @@ export class SlackAdapter implements Adapter<SlackThreadId, unknown> {
   /**
    * Resolve inline user mentions in Slack mrkdwn text.
    * Converts <@U123> to <@U123|displayName> so that toAst/extractPlainText
-   * renders them as @displayName instead of @U123.
-   *
-   * @param skipSelfMention - When true, skips the bot's own user ID so that
-   *   mention detection (which looks for @botUserId in the text) continues to
-   *   work. Uses the effective request-scoped bot user ID in multi-workspace
-   *   mode, not only the adapter's default bot user ID. Set to false when
-   *   parsing historical/channel messages where mention detection doesn't
-   *   apply.
+   * renders them as @displayName instead of @U123. The bot's own mention is
+   * decoded too — parseSlackMessage detects it from the raw event text and
+   * flags the message with `isMention`.
    */
-  protected async resolveInlineMentions(
-    text: string,
-    skipSelfMention: boolean
-  ): Promise<string> {
+  protected async resolveInlineMentions(text: string): Promise<string> {
     const userIds = new Set<string>();
     const channelIds = new Set<string>();
     collectMentionIds(text, userIds, channelIds);
-    const names = await this.lookupMentionNames(
-      userIds,
-      channelIds,
-      skipSelfMention
-    );
+    const names = await this.lookupMentionNames(userIds, channelIds);
     return applyMentionNames(text, names);
   }
 
   /**
    * Look up display names for collected mention IDs in one parallel wave.
-   * Mutates `userIds`: the bot's own ID is removed when `skipSelfMention` is
-   * set — detectMention needs @botUserId to stay in the text (see
-   * `resolveInlineMentions`).
    */
   private async lookupMentionNames(
     userIds: Set<string>,
-    channelIds: Set<string>,
-    skipSelfMention: boolean
+    channelIds: Set<string>
   ): Promise<SlackMentionNames> {
-    const currentBotUserId = this.botUserId;
-    if (skipSelfMention && currentBotUserId) {
-      userIds.delete(currentBotUserId);
-    }
     if (userIds.size === 0 && channelIds.size === 0) {
       return { channels: new Map(), users: new Map() };
     }
@@ -4053,7 +4037,8 @@ export class SlackAdapter implements Adapter<SlackThreadId, unknown> {
         })
       ),
     ]);
-    return { channels: new Map(channelLookups), users: new Map(userLookups) };
+    const userNameMap = new Map(userLookups);
+    return { channels: new Map(channelLookups), users: userNameMap };
   }
 
   /**
@@ -4174,11 +4159,9 @@ export class SlackAdapter implements Adapter<SlackThreadId, unknown> {
 
   protected async parseSlackMessage(
     event: SlackEvent,
-    threadId: string,
-    options?: { skipSelfMention?: boolean }
+    threadId: string
   ): Promise<Message<unknown>> {
     const isMe = this.isMessageFromSelf(event);
-    const skipSelfMention = options?.skipSelfMention ?? true;
 
     const rawText = event.text || "";
 
@@ -4218,9 +4201,22 @@ export class SlackAdapter implements Adapter<SlackThreadId, unknown> {
       }
     }
 
-    // Resolve inline @mentions to display names
-    const text = await this.resolveInlineMentions(rawText, skipSelfMention);
-    const formatted = await this.resolvedContent(event, text, skipSelfMention);
+    // Resolve inline @mentions to display names. The bot's own mention is
+    // decoded like any other, so detect it here from the raw event text —
+    // after resolution the ID markup is gone, and detectMention's username
+    // pattern cannot reliably match the bot's resolved display name.
+    const text = await this.resolveInlineMentions(rawText);
+    const formatted = await this.resolvedContent(event, text);
+
+    const selfMentionPattern = this.botUserId
+      ? new RegExp(
+          `<@!?${escapeRegExp(this.botUserId)}(?:\\|[^>]*)?>|(?<!\\w)@${escapeRegExp(this.botUserId)}(?![\\w-])`,
+          "i"
+        )
+      : undefined;
+    const isSelfMentioned = selfMentionPattern
+      ? selfMentionPattern.test(rawText)
+      : false;
 
     return new Message({
       id: event.ts || "",
@@ -4228,6 +4224,7 @@ export class SlackAdapter implements Adapter<SlackThreadId, unknown> {
       text: toPlainText(formatted),
       formatted,
       raw: event,
+      isMention: isSelfMentioned || undefined,
       author: {
         userId:
           event.user || event.bot_profile?.user_id || event.bot_id || "unknown",
@@ -6243,8 +6240,7 @@ export class SlackAdapter implements Adapter<SlackThreadId, unknown> {
    */
   protected async resolvedContent(
     event: SlackEvent,
-    text: string,
-    skipSelfMention: boolean
+    text: string
   ): Promise<FormattedContent> {
     const { leading, trailing } = eventTables(event);
     const attachments = authorAttachments(event).map(attachmentContent);
@@ -6273,11 +6269,7 @@ export class SlackAdapter implements Adapter<SlackThreadId, unknown> {
         );
       }
     }
-    const names = await this.lookupMentionNames(
-      userIds,
-      channelIds,
-      skipSelfMention
-    );
+    const names = await this.lookupMentionNames(userIds, channelIds);
 
     const resolveTable = (data: SlackTableData): SlackTableData => ({
       ...data,
@@ -6490,9 +6482,7 @@ export class SlackAdapter implements Adapter<SlackThreadId, unknown> {
       slackMessages.map((msg) => {
         const threadTs = msg.thread_ts || msg.ts || "";
         const threadId = `slack:${channel}:${threadTs}`;
-        return this.parseSlackMessage(msg, threadId, {
-          skipSelfMention: false,
-        });
+        return this.parseSlackMessage(msg, threadId);
       })
     );
 
@@ -6539,9 +6529,7 @@ export class SlackAdapter implements Adapter<SlackThreadId, unknown> {
       chronological.map((msg) => {
         const threadTs = msg.thread_ts || msg.ts || "";
         const threadId = `slack:${channel}:${threadTs}`;
-        return this.parseSlackMessage(msg, threadId, {
-          skipSelfMention: false,
-        });
+        return this.parseSlackMessage(msg, threadId);
       })
     );
 
@@ -6607,9 +6595,7 @@ export class SlackAdapter implements Adapter<SlackThreadId, unknown> {
         selected.map(async (msg) => {
           const threadTs = msg.ts || "";
           const threadId = `slack:${channel}:${threadTs}`;
-          const rootMessage = await this.parseSlackMessage(msg, threadId, {
-            skipSelfMention: false,
-          });
+          const rootMessage = await this.parseSlackMessage(msg, threadId);
 
           return {
             id: threadId,

--- a/packages/adapter-slack/src/index.ts
+++ b/packages/adapter-slack/src/index.ts
@@ -705,6 +705,37 @@ function attachmentContent(
   return { parts, tables };
 }
 
+function mentionIds(
+  tables: SlackEventTables,
+  attachments: SlackAttachmentContent[]
+): { channelIds: Set<string>; userIds: Set<string> } {
+  const userIds = new Set<string>();
+  const channelIds = new Set<string>();
+  const scan = (data: SlackTableData) => {
+    for (const row of data.rows) {
+      for (const cell of row) {
+        collectMentionIds(cell, userIds, channelIds);
+      }
+    }
+  };
+  for (const data of [...tables.leading, ...tables.trailing]) {
+    scan(data);
+  }
+  for (const attachment of attachments) {
+    for (const data of attachment.tables) {
+      scan(data);
+    }
+    for (const part of attachment.parts) {
+      collectMentionIds(
+        "mrkdwn" in part ? part.mrkdwn : part.literal,
+        userIds,
+        channelIds
+      );
+    }
+  }
+  return { channelIds, userIds };
+}
+
 /**
  * Render one line of plain-text Slack content to phrasing nodes. Control
  * sequences are honored the same way `slackMrkdwnToMarkdown` renders them
@@ -4207,16 +4238,21 @@ export class SlackAdapter implements Adapter<SlackThreadId, unknown> {
     // pattern cannot reliably match the bot's resolved display name.
     const text = await this.resolveInlineMentions(rawText);
     const formatted = await this.resolvedContent(event, text);
+    const { userIds } = mentionIds(
+      eventTables(event),
+      authorAttachments(event).map(attachmentContent)
+    );
 
-    const selfMentionPattern = this.botUserId
+    const botUserId = this.botUserId;
+    const selfMentionPattern = botUserId
       ? new RegExp(
-          `<@!?${escapeRegExp(this.botUserId)}(?:\\|[^>]*)?>|(?<!\\w)@${escapeRegExp(this.botUserId)}(?![\\w-])`,
+          `<@!?${escapeRegExp(botUserId)}(?:\\|[^>]*)?>|(?<!\\w)@${escapeRegExp(botUserId)}(?![\\w-])`,
           "i"
         )
       : undefined;
-    const isSelfMentioned = selfMentionPattern
-      ? selfMentionPattern.test(rawText)
-      : false;
+    const isSelfMentioned = Boolean(
+      selfMentionPattern?.test(rawText) || (botUserId && userIds.has(botUserId))
+    );
 
     return new Message({
       id: event.ts || "",
@@ -6244,31 +6280,10 @@ export class SlackAdapter implements Adapter<SlackThreadId, unknown> {
   ): Promise<FormattedContent> {
     const { leading, trailing } = eventTables(event);
     const attachments = authorAttachments(event).map(attachmentContent);
-
-    const userIds = new Set<string>();
-    const channelIds = new Set<string>();
-    const collectTable = (data: SlackTableData) => {
-      for (const row of data.rows) {
-        for (const cell of row) {
-          collectMentionIds(cell, userIds, channelIds);
-        }
-      }
-    };
-    for (const data of [...leading, ...trailing]) {
-      collectTable(data);
-    }
-    for (const attachment of attachments) {
-      for (const data of attachment.tables) {
-        collectTable(data);
-      }
-      for (const part of attachment.parts) {
-        collectMentionIds(
-          "mrkdwn" in part ? part.mrkdwn : part.literal,
-          userIds,
-          channelIds
-        );
-      }
-    }
+    const { channelIds, userIds } = mentionIds(
+      { leading, trailing },
+      attachments
+    );
     const names = await this.lookupMentionNames(userIds, channelIds);
 
     const resolveTable = (data: SlackTableData): SlackTableData => ({

--- a/packages/integration-tests/src/replay-multi-workspace-slack.test.ts
+++ b/packages/integration-tests/src/replay-multi-workspace-slack.test.ts
@@ -112,7 +112,7 @@ describe("Slack Multi-Workspace Replay Tests", () => {
     );
   });
 
-  it("should skip bot self lookup for plain message mentions in multi-workspace installs", async () => {
+  it("should resolve and detect bot self mentions in plain message events in multi-workspace installs", async () => {
     mockClient.users.info.mockImplementation(async ({ user }) => {
       if (user === team1.mention.event.user) {
         return {
@@ -177,11 +177,9 @@ describe("Slack Multi-Workspace Replay Tests", () => {
     await tracker.waitForAll();
 
     expect(capturedMention).not.toBeNull();
+    expect(capturedMention?.message.isMention).toBe(true);
     expect(capturedMention?.message.text).toBe(
-      `@${team1.botUserId} hello from a plain message`
-    );
-    expect(mockClient.users.info).not.toHaveBeenCalledWith(
-      expect.objectContaining({ user: team1.botUserId })
+      "@Workspace Bot hello from a plain message"
     );
     expect(mockClient.chat.postMessage).toHaveBeenCalledWith(
       expect.objectContaining({

--- a/packages/integration-tests/src/slack.test.ts
+++ b/packages/integration-tests/src/slack.test.ts
@@ -111,7 +111,7 @@ describe("Slack Integration", () => {
 
       expect(handlerMock).toHaveBeenCalledWith(
         TEST_THREAD_ID,
-        `@${SLACK_BOT_USER_ID} hello bot!`
+        "@Test User hello bot!"
       );
 
       expect(mockClient.chat.postMessage).toHaveBeenCalledWith(
@@ -550,9 +550,7 @@ describe("Slack Integration", () => {
       });
       await tracker.waitForAll();
 
-      expect(conversationLog).toContain(
-        `mention: @${SLACK_BOT_USER_ID} hey bot!`
-      );
+      expect(conversationLog).toContain("mention: @Test User hey bot!");
       expect(mockClient.chat.postMessage).toHaveBeenCalledWith(
         expect.objectContaining({
           text: "Hi! I'm now listening to this thread. How can I help?",
@@ -721,12 +719,12 @@ describe("Slack Integration", () => {
 
       // Verify thread isolation
       expect(threadResponses[thread1Id]).toEqual([
-        `@${SLACK_BOT_USER_ID} Thread 1 start`,
+        "@Test User Thread 1 start",
         "Thread 1 message",
       ]);
 
       expect(threadResponses[thread2Id]).toEqual([
-        `@${SLACK_BOT_USER_ID} Thread 2 start`,
+        "@Test User Thread 2 start",
         "Thread 2 message",
       ]);
     });


### PR DESCRIPTION
## Problem

When a Slack message mentions the bot, the adapter resolves every mention in the text to a display name — except the bot's own. `<@U_BOT>` stays in `message.text` as raw user-ID markup while other mentions become `@<DisplayName>`.

Downstream consumers therefore see inconsistent text. For LLM-based consumers this is actively harmful: small models classify differently depending on whether the mention arrived as self-describing `@<DisplayName>` text or as cryptic `<@U_BOT>` markup, and there is no way for a consumer to tell a real mention from a lookalike string without re-implementing Slack's mrkdwn rules.

The reason the bot's own mention was left raw is detection coupling: `Chat.detectMention` matched `@botUserId` / `<@botUserId>` in the text, so resolving the markup would have hidden the mention from detection.

## Changes

- `resolveInlineMentions` now decodes the bot's own mention like any other: `<@U_BOT>` resolves to `@<DisplayName>` (via the same `users.info` lookup and cache as all other mentions).
- Because resolution renders the ID markup away, detection moves to where the ID is still known: `parseSlackMessage` tests the raw event text for the bot's mention (labeled, unlabeled, and bare `@ID` forms) and sets `isMention` on the parsed message. `Chat.detectMention` remains as the fallback for username-style mentions on the rendered text.
- The `skipSelfMention` option is removed; the history/thread fetch paths that passed `skipSelfMention: false` now behave identically to live events, which also fixes an inconsistency where edited messages (`parseSlackMessageSync`) never resolved mentions at all.

## Behavior change

`message.text` for a message that mentions the bot changes from `<@U_BOT> hello` to `@Vercel Bot hello` (the bot's resolved display name). Mention detection is preserved: `isMention` is set from the raw event text, and the labeled form is matched by the new detection patterns. Apps matching the raw `<@U_BOT>` markup in `message.text` should match the resolved display name or read `message.raw` instead.

## Relation to #355

#355 intentionally introduced the self-mention skip: in multi-workspace installs, the request-scoped bot ID was being resolved before mention detection ran, which broke `onNewMention` for those workspaces. This PR preserves that guarantee without the markup coupling — the multi-workspace replay test from that scenario is updated and still asserts that a plain `message` event containing the bot's mention sets `isMention: true` and routes to `onNewMention`. Detection additionally covers the labeled form (`<@U_BOT|Name>`) that resolution now produces.
