### PR TITLE
fix(docs): stop the vendor-official badge clipping adapter card titles

### DIFF
--- a/apps/docs/app/[lang]/adapters/components/adapter-card.tsx
+++ b/apps/docs/app/[lang]/adapters/components/adapter-card.tsx
@@ -80,24 +80,22 @@ export const AdapterCard = ({
     <a className="no-underline" href={href}>
       <Card className="group h-full gap-0 overflow-hidden py-0 shadow-none transition-colors hover:bg-accent/50">
         <CardHeader className="flex h-full flex-col gap-4 p-6!">
-          <div className="flex w-full items-center justify-between">
-            <div className="flex items-center gap-2.5">
-              {Icon ? <Icon className="size-5" /> : null}
-              <CardTitle className="font-medium">{name}</CardTitle>
+          <div className="flex w-full flex-wrap items-center justify-between gap-x-3 gap-y-2">
+            <div className="flex min-w-0 items-center gap-2.5">
+              {Icon ? <Icon className="size-5 shrink-0" /> : null}
+              <CardTitle className="break-words font-medium">{name}</CardTitle>
             </div>
             {badge ? (
-              <CardAction>
-                <Badge className="shrink-0" variant="secondary">
+              <CardAction className="shrink-0">
+                <Badge variant="secondary">
                   <VerifiedIcon className="size-4 text-primary" />
                   {badge === "official" ? "Official" : "Vendor official"}
                 </Badge>
               </CardAction>
             ) : null}
             {beta ? (
-              <CardAction>
-                <Badge className="shrink-0" variant="secondary">
-                  Beta
-                </Badge>
+              <CardAction className="shrink-0">
+                <Badge variant="secondary">Beta</Badge>
               </CardAction>
             ) : null}
           </div>

--- a/apps/docs/app/[lang]/adapters/components/adapter-card.tsx
+++ b/apps/docs/app/[lang]/adapters/components/adapter-card.tsx
@@ -80,7 +80,7 @@ export const AdapterCard = ({
     <a className="no-underline" href={href}>
       <Card className="group h-full gap-0 overflow-hidden py-0 shadow-none transition-colors hover:bg-accent/50">
         <CardHeader className="flex h-full flex-col gap-4 p-6!">
-          <div className="flex w-full flex-wrap items-center justify-between gap-x-3 gap-y-2">
+          <div className="flex w-full flex-col items-start gap-2 md:flex-row md:items-center md:justify-between md:gap-3">
             <div className="flex min-w-0 items-center gap-2.5">
               {Icon ? <Icon className="size-5 shrink-0" /> : null}
               <CardTitle className="break-words font-medium">{name}</CardTitle>


### PR DESCRIPTION
## Summary

On phones the `Vendor official` badge on the adapters listing sat on top of the card title and cut it off — `Liveblocks` rendered as `Liveblo`, `Sendblue` as `Sendb`, `AgentPhone` as `AgentP` — and the badge itself ran past the card's right edge.

Root cause is a size collision, not a z-index or spacing issue:

- `@vercel/geistdocs`' Geist breakpoints put `sm` at **401px**, not 640px, so `grid gap-4 sm:grid-cols-2` goes two-up on **every modern phone** (Pixel 7 = 412px, iPhone 16 Pro Max = 430px). Each card is then ~175px wide, leaving ~125px of content width inside `p-6`.
- The `Vendor official` badge is 115px and, via `badgeVariants`, `whitespace-nowrap shrink-0` — so it claimed almost the entire row.
- The header row was a non-wrapping `justify-between` flex row, and the docs CSS applies a global `min-width: 0` reset, which defeats flexbox's automatic minimum size. The title's flex item was squeezed to 51px while its text needed 80px, so the name spilled to the right underneath the opaque badge and `overflow-hidden` on the `Card` clipped the remainder.

## Approach

The header row now switches placement on the **breakpoint**, not on the title:

- **Below `md` (601px)** the header stacks — title, then badge on its own line, left-aligned — for every card.
- **At `md` and above** every card puts the badge inline to the right, exactly as it does today.

`md` is the point where the narrowest card can hold the widest badge with room to spare. The two-column band opens at 401px with only ~123px of row width, less than the 115px `Vendor official` badge plus a gap; by 601px the row is ~228px. Above `md` a long title wraps within its own flex item rather than pushing the badge out, so the badge keeps its position.

Supporting changes in the same row:

- `shrink-0` on `CardAction`. The `Badge` already had it, but its wrapper did not, so the wrapper was shrinking to a smaller box than its own content.
- `min-w-0` + `break-words` on the title, so a long single-word name breaks rather than spilling.
- `shrink-0` on the platform logo, which was being squashed out of square on narrow cards — the Microsoft Teams mark rendered **12x20** instead of 20x20, and Google Chat 14.5x20.

One file, five class-list changes; no data, copy, or component-API changes.

<details>
<summary>Why not <code>flex-wrap</code> (the first commit in this PR)</summary>

Letting the row wrap fixes the clipping, but wrapping is content-driven: with the 44px `Beta` badge, `Slack` (42px) and `Discord` (57px) still fit inline while `Google Chat` (93px) and `Microsoft Teams` (124px) pushed the badge to the next line. Between ~430px and ~560px a single grid row showed both placements side by side. The second commit replaces it with the breakpoint switch above.

</details>

## Test plan

Ran `pnpm --filter docs dev` and measured `/adapters` in a real browser at **320, 360, 375, 390, 400, 401, 412, 430, 470, 500, 560, 600, 601, 640, 700, 768, 900, 960, 961, 1024, 1280 and 1440px**, asserting per card that placement mode is uniform across the page, the badge sits a constant distance from the card edge, the header row does not overflow, the title does not spill, the badge stays inside the card's content box, and every logo renders 20x20.

| | `main` | `flex-wrap` (1st commit) | this PR |
| --- | --- | --- | --- |
| widths mixing inline + stacked badges | 0 (all clipped instead) | 430–560px | **none** |
| distinct badge offsets from card edge | — | — | **25px, all 32 cards, all 22 widths** |
| cards with a clipped title or badge @412px | 13 | 0 | **0** |
| worst header-row overflow | 68px | 0 | **0** |
| worst title spill | 29px | 0 | **0** |
| squashed logos | 5+ | 0 | **0** |

Also confirmed visually at 430px (uniform stacked badges where the mixed placement was reported), 640px (uniform inline badges, including the one title that wraps to two lines) and 1440px (three-column layout unchanged from `main`), plus on the PR's own preview deployment.

One known sub-pixel residual: at exactly 401px — the two-column breakpoint boundary, where cards are 169px — `PostgreSQL` plus its 20px logo needs 0.89px more than the row, so the final glyph loses under a pixel to `overflow-hidden`. `wrap-anywhere` removes it but renders the name as `PostgreSQ` / `L`, which is a worse outcome for an invisible gain, so `break-words` is kept.

Also ran `npx ultracite check apps/docs/app` (clean) and `tsc --noEmit` for `apps/docs` (clean).

## Checklist

- [x] All commits are signed and verified
- [x] All commits are signed off for the DCO (`git commit -s`)
- [ ] `pnpm validate` passes — not run in full; it builds every package and needs adapter credentials. Ran the parts that cover this change: `ultracite check apps/docs/app` and `tsc --noEmit` in `apps/docs`, both clean.
- [x] Changeset added (or N/A) — N/A, `apps/docs` is private and CONTRIBUTING lists documentation changes as not needing one.
- [x] Documentation updated (or N/A) — N/A, no content change.

> [!NOTE]
> The commits are GPG-verified, but they were authored through a Vercel Devbox, so the author identity is `vercel[bot]` with `Signed-off-by`/`Co-Authored-By` trailers for @aldosch. If the DCO check wants the sign-off to match the author line, say so and I'll push a remediation commit (`allowRemediationCommits.individual` is enabled).
