### PR TITLE
feat(cards): add button tooltips and a card width hint

### DIFF
--- a/.changeset/wide-cards-button-tooltips.md
+++ b/.changeset/wide-cards-button-tooltips.md
@@ -1,0 +1,6 @@
+---
+"chat": minor
+"@chat-adapter/teams": minor
+---
+
+Add `tooltip` to `Button` and `LinkButton`, and a `width` hint to `Card`. The Teams adapter renders them as the Adaptive Card action `tooltip` and the `msteams` full-width card property; other adapters ignore them.

--- a/.changeset/wide-cards-button-tooltips.md
+++ b/.changeset/wide-cards-button-tooltips.md
@@ -3,4 +3,4 @@
 "@chat-adapter/teams": minor
 ---
 
-Add `tooltip` to `Button` and `LinkButton`, and a `width` hint to `Card`. The Teams adapter renders them as the Adaptive Card action `tooltip` and the `msteams` full-width card property; other adapters ignore them.
+Add `tooltip` to `Button` and `LinkButton`, and a `width` hint to `Card`. The Teams adapter and the `@chat-adapter/teams/cards` subpath render them as the Adaptive Card action `tooltip` and the `msteams` full-width card property; other adapters ignore them. Emitted Adaptive Cards now declare schema version 1.5, which is the version that introduced action tooltips. Buttons with a `callbackUrl` keep their `tooltip` and other fields when the URL is swapped for a callback token.

--- a/apps/docs/content/docs/api/cards.mdx
+++ b/apps/docs/content/docs/api/cards.mdx
@@ -45,6 +45,10 @@ Card({
       description: 'Card content elements.',
       type: 'CardChild[]',
     },
+    width: {
+      description: 'Width hint for platforms that can render a card wider than the default (Teams). Other adapters ignore it.',
+      type: '"default" | "full"',
+    },
   }}
 />
 
@@ -107,6 +111,10 @@ Button({ id: "delete", label: "Delete", style: "danger", value: "item-123" })
       description: 'URL to POST action data to when this button is clicked.',
       type: 'string',
     },
+    tooltip: {
+      description: 'Hover text for the button, on platforms that render one (Teams).',
+      type: 'string',
+    },
   }}
 />
 
@@ -159,6 +167,10 @@ LinkButton({ id: "view_docs", url: "https://example.com", label: "View Docs" })
     style: {
       description: 'Visual style.',
       type: '"primary" | "danger" | "default"',
+    },
+    tooltip: {
+      description: 'Hover text for the button, on platforms that render one (Teams).',
+      type: 'string',
     },
   }}
 />

--- a/apps/docs/content/docs/api/cards.mdx
+++ b/apps/docs/content/docs/api/cards.mdx
@@ -112,7 +112,7 @@ Button({ id: "delete", label: "Delete", style: "danger", value: "item-123" })
       type: 'string',
     },
     tooltip: {
-      description: 'Hover text for the button, on platforms that render one (Teams).',
+      description: 'Hover text for the button. Rendered by Teams only; other adapters ignore it.',
       type: 'string',
     },
   }}
@@ -169,7 +169,7 @@ LinkButton({ id: "view_docs", url: "https://example.com", label: "View Docs" })
       type: '"primary" | "danger" | "default"',
     },
     tooltip: {
-      description: 'Hover text for the button, on platforms that render one (Teams).',
+      description: 'Hover text for the button. Rendered by Teams only; other adapters ignore it.',
       type: 'string',
     },
   }}

--- a/apps/docs/content/docs/cards.mdx
+++ b/apps/docs/content/docs/cards.mdx
@@ -131,7 +131,7 @@ Optional `callbackUrl` causes the action data to be POSTed to a URL when clicked
 <Button callbackUrl={webhook.url} id="approve" style="primary">Approve</Button>
 ```
 
-Optional `tooltip` is hover text for the button, on platforms that render one (Teams):
+Optional `tooltip` is hover text for the button. Teams renders it; other adapters ignore it:
 
 ```tsx title="lib/bot.tsx"
 <Button id="approve" tooltip="Approve the request">Approve</Button>
@@ -171,7 +171,7 @@ stable action identifier for routing or analytics.
 </LinkButton>
 ```
 
-Optional `tooltip` is hover text for the button, on platforms that render one (Teams):
+Optional `tooltip` is hover text for the button. Teams renders it; other adapters ignore it:
 
 ```tsx title="lib/bot.tsx"
 <LinkButton tooltip="Opens the order in your browser" url="https://example.com/order/1234">

--- a/apps/docs/content/docs/cards.mdx
+++ b/apps/docs/content/docs/cards.mdx
@@ -60,6 +60,14 @@ The top-level container. Accepts `title` and optional `subtitle`.
 </Card>
 ```
 
+Set `width="full"` to ask for a wider card on platforms that can render one. Teams renders it as a full-width Adaptive Card; other adapters ignore the hint.
+
+```tsx title="lib/bot.tsx"
+<Card title="Weekly digest" width="full">
+  {/* children */}
+</Card>
+```
+
 ### CardText
 
 Renders formatted text. Supports a subset of markdown.
@@ -123,6 +131,12 @@ Optional `callbackUrl` causes the action data to be POSTed to a URL when clicked
 <Button callbackUrl={webhook.url} id="approve" style="primary">Approve</Button>
 ```
 
+Optional `tooltip` is hover text for the button, on platforms that render one (Teams):
+
+```tsx title="lib/bot.tsx"
+<Button id="approve" tooltip="Approve the request">Approve</Button>
+```
+
 ### CardLink
 
 Inline hyperlink rendered as text. Unlike `LinkButton` (which must be inside `Actions`), `CardLink` can be placed directly in a card alongside other content.
@@ -153,6 +167,14 @@ stable action identifier for routing or analytics.
 
 ```tsx title="lib/bot.tsx"
 <LinkButton id="view_order" url="https://example.com/order/1234">
+  View Order
+</LinkButton>
+```
+
+Optional `tooltip` is hover text for the button, on platforms that render one (Teams):
+
+```tsx title="lib/bot.tsx"
+<LinkButton tooltip="Opens the order in your browser" url="https://example.com/order/1234">
   View Order
 </LinkButton>
 ```

--- a/packages/adapter-teams/AGENTS.md
+++ b/packages/adapter-teams/AGENTS.md
@@ -232,6 +232,9 @@ Adaptive Card v1.5 JSON. Notable mappings:
 - `<Actions>` / `<Button>` → `Action.Submit` (with `data` carrying the
   callback metadata).
 - `<LinkButton>` → `Action.OpenUrl`.
+- `tooltip` on either button → the action `tooltip` (Adaptive Card 1.5+,
+  which is why the emitted `version` is `1.5`).
+- `<Card width="full">` → `msteams: { width: "full" }`.
 - `<Select>` → `Input.ChoiceSet` (single, multi, or compact based on
   options).
 - `<Divider>` → `Container` with a top border.

--- a/packages/adapter-teams/src/cards-primitives/index.test.ts
+++ b/packages/adapter-teams/src/cards-primitives/index.test.ts
@@ -48,8 +48,43 @@ describe("Teams card primitives", () => {
         { text: "Deploy ✅", type: "TextBlock" },
       ],
       type: "AdaptiveCard",
-      version: "1.4",
+      version: "1.5",
     });
+  });
+
+  it("forwards the width hint and button tooltips", () => {
+    const card = cardToAdaptiveCard({
+      children: [
+        {
+          children: [
+            {
+              id: "approve",
+              label: "Approve",
+              tooltip: "Approve the request :white_check_mark:",
+              type: "button",
+            },
+            {
+              label: "Docs",
+              tooltip: "Opens the docs",
+              type: "link-button",
+              url: "https://example.com",
+            },
+          ],
+          type: "actions",
+        },
+      ],
+      type: "card",
+      width: "full",
+    });
+
+    expect(card.msteams).toEqual({ width: "full" });
+    expect(card.actions).toEqual([
+      expect.objectContaining({ tooltip: "Approve the request ✅" }),
+      expect.objectContaining({ tooltip: "Opens the docs" }),
+    ]);
+
+    const plain = cardToAdaptiveCard({ children: [], type: "card" });
+    expect(plain.msteams).toBeUndefined();
   });
 
   it("renders fallback text", () => {

--- a/packages/adapter-teams/src/cards-primitives/index.ts
+++ b/packages/adapter-teams/src/cards-primitives/index.ts
@@ -47,8 +47,9 @@ export function cardToAdaptiveCard(card: TeamsCardElement): TeamsAdaptiveCard {
     $schema: "http://adaptivecards.io/schemas/adaptive-card.json",
     ...(actions.length > 0 ? { actions } : {}),
     body,
+    ...(card.width === "full" ? { msteams: { width: "full" as const } } : {}),
     type: "AdaptiveCard",
-    version: "1.4",
+    version: "1.5",
   };
 }
 
@@ -147,6 +148,9 @@ function convertButton(button: TeamsButtonElement): unknown {
     ...(button.style === "danger" ? { style: "destructive" } : {}),
     ...(button.style === "primary" ? { style: "positive" } : {}),
     title: button.label,
+    ...(button.tooltip
+      ? { tooltip: convertTeamsEmojiPlaceholders(button.tooltip) }
+      : {}),
     type: "Action.Submit",
   };
 }
@@ -155,6 +159,9 @@ function convertLinkButton(button: TeamsLinkButtonElement): unknown {
   return {
     ...(button.style === "primary" ? { style: "positive" } : {}),
     title: button.label,
+    ...(button.tooltip
+      ? { tooltip: convertTeamsEmojiPlaceholders(button.tooltip) }
+      : {}),
     type: "Action.OpenUrl",
     url: button.url,
   };

--- a/packages/adapter-teams/src/cards-primitives/input.ts
+++ b/packages/adapter-teams/src/cards-primitives/input.ts
@@ -93,7 +93,7 @@ export function inputRequestToTeamsAdaptiveCard(
     actions,
     body,
     type: "AdaptiveCard",
-    version: "1.4",
+    version: "1.5",
   };
 }
 

--- a/packages/adapter-teams/src/cards-primitives/types.ts
+++ b/packages/adapter-teams/src/cards-primitives/types.ts
@@ -1,4 +1,5 @@
 export type TeamsButtonStyle = "danger" | "default" | "primary";
+export type TeamsCardWidth = "default" | "full";
 export type TeamsTextStyle = "bold" | "muted" | "plain";
 
 export interface TeamsCardElement {
@@ -7,6 +8,8 @@ export interface TeamsCardElement {
   subtitle?: string;
   title?: string;
   type: "card";
+  /** Width hint; "full" renders a full-width Adaptive Card in Teams */
+  width?: TeamsCardWidth;
 }
 
 export type TeamsCardChild =
@@ -49,6 +52,8 @@ export interface TeamsButtonElement {
   id: string;
   label: string;
   style?: TeamsButtonStyle;
+  /** Hover text rendered as the Adaptive Card action tooltip */
+  tooltip?: string;
   type: "button";
   value?: string;
 }
@@ -56,6 +61,8 @@ export interface TeamsButtonElement {
 export interface TeamsLinkButtonElement {
   label: string;
   style?: TeamsButtonStyle;
+  /** Hover text rendered as the Adaptive Card action tooltip */
+  tooltip?: string;
   type: "link-button";
   url: string;
 }
@@ -110,6 +117,7 @@ export interface TeamsAdaptiveCard {
   $schema: string;
   actions?: unknown[];
   body: unknown[];
+  msteams?: { width: "full" };
   type: "AdaptiveCard";
-  version: "1.4";
+  version: "1.5";
 }

--- a/packages/adapter-teams/src/cards.test.ts
+++ b/packages/adapter-teams/src/cards.test.ts
@@ -26,7 +26,7 @@ describe("cardToAdaptiveCard", () => {
     expect(adaptive.$schema).toBe(
       "http://adaptivecards.io/schemas/adaptive-card.json"
     );
-    expect(adaptive.version).toBe("1.4");
+    expect(adaptive.version).toBe("1.5");
     expect(adaptive.body).toBeInstanceOf(Array);
   });
 

--- a/packages/adapter-teams/src/cards.test.ts
+++ b/packages/adapter-teams/src/cards.test.ts
@@ -451,3 +451,55 @@ describe("cardToAdaptiveCard with CardLink", () => {
     });
   });
 });
+
+describe("cardToAdaptiveCard with Teams-specific hints", () => {
+  it("sets msteams width when the card asks for full width", () => {
+    const adaptive = cardToAdaptiveCard(Card({ title: "Wide", width: "full" }));
+
+    expect(adaptive.msteams).toEqual({ width: "full" });
+  });
+
+  it("leaves msteams unset by default", () => {
+    const adaptive = cardToAdaptiveCard(Card({ title: "Default" }));
+
+    expect(adaptive.msteams).toBeUndefined();
+  });
+
+  it("forwards button tooltips to the actions", () => {
+    const card = Card({
+      children: [
+        Actions([
+          Button({
+            id: "approve",
+            label: "Approve",
+            tooltip: "Approve the request",
+          }),
+          LinkButton({
+            url: "https://example.com/docs",
+            label: "View Docs",
+            tooltip: "Opens the docs",
+          }),
+        ]),
+      ],
+    });
+    const adaptive = cardToAdaptiveCard(card);
+
+    expect(adaptive.actions?.[0]).toMatchObject({
+      type: "Action.Submit",
+      tooltip: "Approve the request",
+    });
+    expect(adaptive.actions?.[1]).toMatchObject({
+      type: "Action.OpenUrl",
+      tooltip: "Opens the docs",
+    });
+  });
+
+  it("leaves tooltip unset when none is given", () => {
+    const card = Card({
+      children: [Actions([Button({ id: "ok", label: "OK" })])],
+    });
+    const adaptive = cardToAdaptiveCard(card);
+
+    expect(adaptive.actions?.[0]?.tooltip).toBeUndefined();
+  });
+});

--- a/packages/adapter-teams/src/cards.ts
+++ b/packages/adapter-teams/src/cards.ts
@@ -15,6 +15,8 @@ import type {
   ActionStyle,
   CardElementArray,
   ChoiceSetInputOptions,
+  OpenUrlActionOptions,
+  SubmitActionOptions,
 } from "@microsoft/teams.cards";
 import {
   AdaptiveCard,
@@ -54,7 +56,7 @@ const convertEmoji = createEmojiConverter("teams");
 
 const ADAPTIVE_CARD_SCHEMA =
   "http://adaptivecards.io/schemas/adaptive-card.json";
-const ADAPTIVE_CARD_VERSION = "1.4" as const;
+const ADAPTIVE_CARD_VERSION = "1.5" as const;
 
 /**
  * Sentinel action ID for auto-injected submit buttons.
@@ -105,11 +107,8 @@ export function cardToAdaptiveCard(card: CardElement): AdaptiveCard {
   const adaptiveCard = new AdaptiveCard(...body).withOptions({
     $schema: ADAPTIVE_CARD_SCHEMA,
     version: ADAPTIVE_CARD_VERSION,
+    ...(card.width === "full" ? { msteams: { width: "full" } } : {}),
   });
-
-  if (card.width === "full") {
-    adaptiveCard.withMsteams({ width: "full" });
-  }
 
   if (actions.length > 0) {
     adaptiveCard.withActions(...actions);
@@ -267,6 +266,29 @@ function convertRadioSelectToElement(
   return new ChoiceSetInput(...choices).withOptions(options);
 }
 
+/**
+ * Options shared by Action.Submit and Action.OpenUrl: title, style, tooltip.
+ */
+function actionOptions(
+  button: ButtonElement | LinkButtonElement
+): Pick<SubmitActionOptions, "title" | "style" | "tooltip"> {
+  const options: Pick<SubmitActionOptions, "title" | "style" | "tooltip"> = {
+    title: convertEmoji(button.label),
+  };
+
+  const style = mapButtonStyle(button.style, "teams") as
+    | ActionStyle
+    | undefined;
+  if (style) {
+    options.style = style;
+  }
+  if (button.tooltip) {
+    options.tooltip = convertEmoji(button.tooltip);
+  }
+
+  return options;
+}
+
 function convertButtonToAction(button: ButtonElement): SubmitAction {
   const data: Record<string, unknown> = {
     actionId: button.id,
@@ -278,44 +300,12 @@ function convertButtonToAction(button: ButtonElement): SubmitAction {
     data.msteams = { type: "task/fetch" };
   }
 
-  const options: {
-    title: string;
-    data: Record<string, unknown>;
-    style?: ActionStyle;
-    tooltip?: string;
-  } = {
-    title: convertEmoji(button.label),
-    data,
-  };
-
-  const style = mapButtonStyle(button.style, "teams") as
-    | ActionStyle
-    | undefined;
-  if (style) {
-    options.style = style;
-  }
-  if (button.tooltip) {
-    options.tooltip = convertEmoji(button.tooltip);
-  }
-
+  const options: SubmitActionOptions = { ...actionOptions(button), data };
   return new SubmitAction(options);
 }
 
 function convertLinkButtonToAction(button: LinkButtonElement): OpenUrlAction {
-  const options: { title: string; style?: ActionStyle; tooltip?: string } = {
-    title: convertEmoji(button.label),
-  };
-
-  const style = mapButtonStyle(button.style, "teams") as
-    | ActionStyle
-    | undefined;
-  if (style) {
-    options.style = style;
-  }
-  if (button.tooltip) {
-    options.tooltip = convertEmoji(button.tooltip);
-  }
-
+  const options: OpenUrlActionOptions = actionOptions(button);
   return new OpenUrlAction(button.url, options);
 }
 

--- a/packages/adapter-teams/src/cards.ts
+++ b/packages/adapter-teams/src/cards.ts
@@ -107,6 +107,10 @@ export function cardToAdaptiveCard(card: CardElement): AdaptiveCard {
     version: ADAPTIVE_CARD_VERSION,
   });
 
+  if (card.width === "full") {
+    adaptiveCard.withMsteams({ width: "full" });
+  }
+
   if (actions.length > 0) {
     adaptiveCard.withActions(...actions);
   }
@@ -278,6 +282,7 @@ function convertButtonToAction(button: ButtonElement): SubmitAction {
     title: string;
     data: Record<string, unknown>;
     style?: ActionStyle;
+    tooltip?: string;
   } = {
     title: convertEmoji(button.label),
     data,
@@ -289,12 +294,15 @@ function convertButtonToAction(button: ButtonElement): SubmitAction {
   if (style) {
     options.style = style;
   }
+  if (button.tooltip) {
+    options.tooltip = convertEmoji(button.tooltip);
+  }
 
   return new SubmitAction(options);
 }
 
 function convertLinkButtonToAction(button: LinkButtonElement): OpenUrlAction {
-  const options: { title: string; style?: ActionStyle } = {
+  const options: { title: string; style?: ActionStyle; tooltip?: string } = {
     title: convertEmoji(button.label),
   };
 
@@ -303,6 +311,9 @@ function convertLinkButtonToAction(button: LinkButtonElement): OpenUrlAction {
     | undefined;
   if (style) {
     options.style = style;
+  }
+  if (button.tooltip) {
+    options.tooltip = convertEmoji(button.tooltip);
   }
 
   return new OpenUrlAction(button.url, options);

--- a/packages/adapter-teams/src/modals-primitives/index.ts
+++ b/packages/adapter-teams/src/modals-primitives/index.ts
@@ -37,7 +37,7 @@ export function modalToAdaptiveCard(
     ],
     body: modal.children.flatMap(modalChildToAdaptiveElements),
     type: "AdaptiveCard",
-    version: "1.4",
+    version: "1.5",
   };
 }
 
@@ -96,7 +96,7 @@ export function toTeamsTaskModuleResponse(
         })),
       ],
       type: "AdaptiveCard",
-      version: "1.4",
+      version: "1.5",
     });
   }
 

--- a/packages/adapter-teams/src/modals.test.ts
+++ b/packages/adapter-teams/src/modals.test.ts
@@ -49,7 +49,7 @@ describe("modalToAdaptiveCard", () => {
     expect(card.$schema).toBe(
       "http://adaptivecards.io/schemas/adaptive-card.json"
     );
-    expect(card.version).toBe("1.4");
+    expect(card.version).toBe("1.5");
     expect(card.body).toBeInstanceOf(Array);
   });
 

--- a/packages/adapter-teams/src/modals.ts
+++ b/packages/adapter-teams/src/modals.ts
@@ -43,7 +43,7 @@ const convertEmoji = createEmojiConverter("teams");
 
 const ADAPTIVE_CARD_SCHEMA =
   "http://adaptivecards.io/schemas/adaptive-card.json";
-const ADAPTIVE_CARD_VERSION = "1.4" as const;
+const ADAPTIVE_CARD_VERSION = "1.5" as const;
 
 // ============================================================================
 // ModalElement -> Adaptive Card

--- a/packages/chat/src/callback-url.test.ts
+++ b/packages/chat/src/callback-url.test.ts
@@ -165,6 +165,44 @@ describe("processCardCallbackUrls", () => {
     expect(callbackBtn?.value).toMatch(CALLBACK_PREFIX_PATTERN);
   });
 
+  it("keeps every other button field when replacing the callback URL", async () => {
+    const card = Card({
+      title: "Test",
+      children: [
+        Actions([
+          Button({
+            id: "approve",
+            label: "Approve",
+            style: "primary",
+            disabled: true,
+            actionType: "modal",
+            tooltip: "Approve the request",
+            callbackUrl: "https://example.com/hook",
+          }),
+        ]),
+      ],
+    });
+
+    const result = await processCardCallbackUrls(card, state, {
+      id: "slack:C1",
+      type: "channel",
+    });
+    const actions = result.children.find((c) => c.type === "actions");
+    const button = actions?.children[0];
+
+    expect(button).toMatchObject({
+      type: "button",
+      id: "approve",
+      label: "Approve",
+      style: "primary",
+      disabled: true,
+      actionType: "modal",
+      tooltip: "Approve the request",
+    });
+    expect(button).not.toHaveProperty("callbackUrl");
+    expect(button?.value).toMatch(CALLBACK_PREFIX_PATTERN);
+  });
+
   it("processes buttons nested inside sections", async () => {
     const card = Card({
       title: "Test",

--- a/packages/chat/src/callback-url.ts
+++ b/packages/chat/src/callback-url.ts
@@ -72,14 +72,12 @@ async function processActionsElement(
           CALLBACK_TTL_MS
         );
 
+        // Keep every other button field so new ones (like tooltip) are not
+        // silently dropped; only the callback URL is replaced by the token.
+        const { callbackUrl: _callbackUrl, ...rest } = el;
         const processed: ButtonElement = {
-          type: "button",
-          id: el.id,
-          label: el.label,
-          style: el.style,
-          disabled: el.disabled,
+          ...rest,
           value: encodeCallbackValue(token),
-          actionType: el.actionType,
         };
         return processed;
       })

--- a/packages/chat/src/cards.test.ts
+++ b/packages/chat/src/cards.test.ts
@@ -40,6 +40,12 @@ describe("Card Builder Functions", () => {
       expect(card.children).toHaveLength(1);
     });
 
+    it("creates a card with a width hint", () => {
+      const card = Card({ title: "Wide", width: "full" });
+      expect(card.width).toBe("full");
+      expect(Card({ title: "Default" }).width).toBeUndefined();
+    });
+
     it("creates an empty card", () => {
       const card = Card();
       expect(card.type).toBe("card");
@@ -116,6 +122,16 @@ describe("Card Builder Functions", () => {
       expect(btn.style).toBe("danger");
       expect(btn.value).toBe("item-123");
     });
+
+    it("creates a button with a tooltip", () => {
+      const btn = Button({
+        id: "ok",
+        label: "OK",
+        tooltip: "Confirm the order",
+      });
+      expect(btn.tooltip).toBe("Confirm the order");
+      expect(Button({ id: "ok", label: "OK" }).tooltip).toBeUndefined();
+    });
   });
 
   describe("LinkButton", () => {
@@ -137,6 +153,15 @@ describe("Card Builder Functions", () => {
         style: "primary",
       });
       expect(btn.style).toBe("primary");
+    });
+
+    it("creates a link button with a tooltip", () => {
+      const btn = LinkButton({
+        url: "https://example.com",
+        label: "Visit Site",
+        tooltip: "Opens example.com",
+      });
+      expect(btn.tooltip).toBe("Opens example.com");
     });
   });
 

--- a/packages/chat/src/cards.ts
+++ b/packages/chat/src/cards.ts
@@ -57,6 +57,9 @@ export type ButtonStyle = "primary" | "danger" | "default";
 /** Text style options */
 export type TextStyle = "plain" | "bold" | "muted";
 
+/** Card width hint */
+export type CardWidth = "default" | "full";
+
 /** Button element for interactive actions */
 export interface ButtonElement {
   /** Whether this button triggers a regular action or opens a modal dialog. Default: "action" */
@@ -71,6 +74,8 @@ export interface ButtonElement {
   label: string;
   /** Visual style */
   style?: ButtonStyle;
+  /** Hover text for the button, on platforms that render one (Teams) */
+  tooltip?: string;
   type: "button";
   /** Optional payload value sent with action callback */
   value?: string;
@@ -84,6 +89,8 @@ export interface LinkButtonElement {
   label: string;
   /** Visual style */
   style?: ButtonStyle;
+  /** Hover text for the button, on platforms that render one (Teams) */
+  tooltip?: string;
   type: "link-button";
   /** URL to open when clicked */
   url: string;
@@ -264,6 +271,8 @@ export interface CardElement {
   /** Card title */
   title?: string;
   type: "card";
+  /** Width hint for platforms that can render a card wider than the default (Teams) */
+  width?: CardWidth;
 }
 
 /** Type guard for CardElement */
@@ -286,6 +295,7 @@ export interface CardOptions {
   imageUrl?: string;
   subtitle?: string;
   title?: string;
+  width?: CardWidth;
 }
 
 /**
@@ -305,6 +315,7 @@ export function Card(options: CardOptions = {}): CardElement {
     title: options.title,
     subtitle: options.subtitle,
     imageUrl: options.imageUrl,
+    width: options.width,
     children: options.children ?? [],
   };
 }
@@ -429,6 +440,8 @@ export interface ButtonOptions {
   label: string;
   /** Visual style */
   style?: ButtonStyle;
+  /** Hover text for the button, on platforms that render one (Teams) */
+  tooltip?: string;
   /** Optional payload value sent with action callback */
   value?: string;
 }
@@ -452,6 +465,7 @@ export function Button(options: ButtonOptions): ButtonElement {
     disabled: options.disabled,
     actionType: options.actionType,
     callbackUrl: options.callbackUrl,
+    tooltip: options.tooltip,
   };
 }
 
@@ -463,6 +477,8 @@ export interface LinkButtonOptions {
   label: string;
   /** Visual style */
   style?: ButtonStyle;
+  /** Hover text for the button, on platforms that render one (Teams) */
+  tooltip?: string;
   /** URL to open when clicked */
   url: string;
 }
@@ -483,6 +499,7 @@ export function LinkButton(options: LinkButtonOptions): LinkButtonElement {
     url: options.url,
     label: options.label,
     style: options.style,
+    tooltip: options.tooltip,
   };
 }
 
@@ -749,6 +766,7 @@ export function fromReactElement(element: unknown): AnyCardElement | null {
         title: props.title as string | undefined,
         subtitle: props.subtitle as string | undefined,
         imageUrl: props.imageUrl as string | undefined,
+        width: props.width as CardWidth | undefined,
         children: convertedChildren.filter(isCardChild),
       });
 
@@ -797,6 +815,7 @@ export function fromReactElement(element: unknown): AnyCardElement | null {
         value: props.value as string | undefined,
         actionType: props.actionType as "action" | "modal" | undefined,
         disabled: props.disabled as boolean | undefined,
+        tooltip: props.tooltip as string | undefined,
       });
     }
 
@@ -807,6 +826,7 @@ export function fromReactElement(element: unknown): AnyCardElement | null {
         url: props.url as string,
         label: (props.label as string | undefined) ?? label,
         style: props.style as ButtonStyle | undefined,
+        tooltip: props.tooltip as string | undefined,
       });
     }
 

--- a/packages/chat/src/cards.ts
+++ b/packages/chat/src/cards.ts
@@ -74,7 +74,7 @@ export interface ButtonElement {
   label: string;
   /** Visual style */
   style?: ButtonStyle;
-  /** Hover text for the button, on platforms that render one (Teams) */
+  /** Hover text for the button. Rendered by Teams only; other adapters ignore it */
   tooltip?: string;
   type: "button";
   /** Optional payload value sent with action callback */
@@ -89,7 +89,7 @@ export interface LinkButtonElement {
   label: string;
   /** Visual style */
   style?: ButtonStyle;
-  /** Hover text for the button, on platforms that render one (Teams) */
+  /** Hover text for the button. Rendered by Teams only; other adapters ignore it */
   tooltip?: string;
   type: "link-button";
   /** URL to open when clicked */
@@ -440,7 +440,7 @@ export interface ButtonOptions {
   label: string;
   /** Visual style */
   style?: ButtonStyle;
-  /** Hover text for the button, on platforms that render one (Teams) */
+  /** Hover text for the button. Rendered by Teams only; other adapters ignore it */
   tooltip?: string;
   /** Optional payload value sent with action callback */
   value?: string;
@@ -477,7 +477,7 @@ export interface LinkButtonOptions {
   label: string;
   /** Visual style */
   style?: ButtonStyle;
-  /** Hover text for the button, on platforms that render one (Teams) */
+  /** Hover text for the button. Rendered by Teams only; other adapters ignore it */
   tooltip?: string;
   /** URL to open when clicked */
   url: string;

--- a/packages/chat/src/index.ts
+++ b/packages/chat/src/index.ts
@@ -181,6 +181,7 @@ export type {
   CardChild,
   CardElement,
   CardOptions,
+  CardWidth,
   ChartDataPoint,
   ChartDefinition,
   ChartElement,

--- a/packages/chat/src/jsx-react.test.tsx
+++ b/packages/chat/src/jsx-react.test.tsx
@@ -20,6 +20,7 @@ import {
   Fields,
   fromReactElement,
   Image,
+  LinkButton,
   Section,
   Text,
 } from "./cards";
@@ -230,6 +231,25 @@ describe("fromReactElement - React JSX mode", () => {
             children: [{ type: "button", tooltip: "Approve the request" }],
           },
         ],
+      });
+    });
+  });
+
+  describe("LinkButton conversion", () => {
+    it("converts LinkButton with tooltip", () => {
+      const result = fromReactElement(
+        createReactElement(LinkButton, {
+          url: "https://example.com",
+          tooltip: "Opens example.com",
+          children: "Open",
+        })
+      );
+
+      expect(result).toMatchObject({
+        type: "link-button",
+        url: "https://example.com",
+        label: "Open",
+        tooltip: "Opens example.com",
       });
     });
   });

--- a/packages/chat/src/jsx-react.test.tsx
+++ b/packages/chat/src/jsx-react.test.tsx
@@ -120,6 +120,16 @@ describe("fromReactElement - React JSX mode", () => {
         expect(result.imageUrl).toBe("https://example.com/image.png");
       }
     });
+
+    it("converts Card with width", () => {
+      const reactCard = createReactElement(Card, {
+        title: "Test",
+        width: "full",
+      });
+
+      const result = fromReactElement(reactCard);
+      expect(result).toMatchObject({ type: "card", width: "full" });
+    });
   });
 
   describe("Text conversion", () => {
@@ -198,6 +208,29 @@ describe("fromReactElement - React JSX mode", () => {
           expect(btn.value).toBe("item-123");
         }
       }
+    });
+
+    it("converts Button with tooltip", () => {
+      const reactCard = createReactElement(Card, {
+        children: createReactElement(Actions, {
+          children: createReactElement(Button, {
+            id: "approve",
+            tooltip: "Approve the request",
+            children: "Approve",
+          }),
+        }),
+      });
+
+      const result = fromReactElement(reactCard);
+      expect(result).toMatchObject({
+        type: "card",
+        children: [
+          {
+            type: "actions",
+            children: [{ type: "button", tooltip: "Approve the request" }],
+          },
+        ],
+      });
     });
   });
 

--- a/packages/chat/src/jsx-runtime.test.ts
+++ b/packages/chat/src/jsx-runtime.test.ts
@@ -223,6 +223,32 @@ describe("toCardElement", () => {
     }
   });
 
+  it("converts tooltip on Button and LinkButton", () => {
+    const button = jsx(Button, { id: "ok", label: "OK", tooltip: "Confirm" });
+    const linkButton = jsx(LinkButton, {
+      url: "https://example.com",
+      label: "Visit Site",
+      tooltip: "Opens example.com",
+    });
+    const actions = jsxs(Actions, { children: [button, linkButton] });
+    const cardElement = jsxs(Card, { children: [actions] });
+    const card = toCardElement(cardElement);
+
+    expect(card?.children[0]).toMatchObject({
+      type: "actions",
+      children: [
+        { type: "button", tooltip: "Confirm" },
+        { type: "link-button", tooltip: "Opens example.com" },
+      ],
+    });
+  });
+
+  it("converts Card width", () => {
+    const card = toCardElement(jsxs(Card, { children: [], width: "full" }));
+    expect(card?.width).toBe("full");
+    expect(toCardElement(jsxs(Card, { children: [] }))?.width).toBeUndefined();
+  });
+
   it("converts Image elements", () => {
     const image = jsx(Image, {
       url: "https://example.com/img.png",

--- a/packages/chat/src/jsx-runtime.ts
+++ b/packages/chat/src/jsx-runtime.ts
@@ -41,6 +41,7 @@ import {
   type CardElement,
   CardLink,
   type CardOptions,
+  type CardWidth,
   Chart,
   type ChartDefinition,
   type ChartElement,
@@ -107,6 +108,7 @@ export interface CardProps {
   imageUrl?: string;
   subtitle?: string;
   title?: string;
+  width?: CardWidth;
 }
 
 /** Props for Text component in JSX */
@@ -124,6 +126,7 @@ export interface ButtonProps {
   id: string;
   label?: string;
   style?: ButtonStyle;
+  tooltip?: string;
   value?: string;
 }
 
@@ -133,6 +136,7 @@ export interface LinkButtonProps {
   id?: string;
   label?: string;
   style?: ButtonStyle;
+  tooltip?: string;
   url: string;
 }
 
@@ -587,7 +591,10 @@ function isFieldProps(props: CardJSXProps): props is FieldProps {
 function isCardProps(props: CardJSXProps): props is CardProps {
   return (
     !("id" in props || "url" in props || "callbackId" in props) &&
-    ("title" in props || "subtitle" in props || "imageUrl" in props)
+    ("title" in props ||
+      "subtitle" in props ||
+      "imageUrl" in props ||
+      "width" in props)
   );
 }
 
@@ -724,6 +731,7 @@ function resolveJSXElement(element: JSXElement): AnyCardElement {
       actionType: props.actionType,
       callbackUrl: props.callbackUrl,
       disabled: props.disabled,
+      tooltip: props.tooltip,
     });
   }
 
@@ -742,6 +750,7 @@ function resolveJSXElement(element: JSXElement): AnyCardElement {
       url: props.url,
       label,
       style: props.style,
+      tooltip: props.tooltip,
     });
   }
 
@@ -922,6 +931,7 @@ function resolveJSXElement(element: JSXElement): AnyCardElement {
     title: cardProps.title,
     subtitle: cardProps.subtitle,
     imageUrl: cardProps.imageUrl,
+    width: cardProps.width,
     children: processedChildren as CardChild[],
   });
 }

--- a/packages/chat/src/jsx-runtime.ts
+++ b/packages/chat/src/jsx-runtime.ts
@@ -126,6 +126,7 @@ export interface ButtonProps {
   id: string;
   label?: string;
   style?: ButtonStyle;
+  /** Hover text for the button. Rendered by Teams only; other adapters ignore it */
   tooltip?: string;
   value?: string;
 }
@@ -136,6 +137,7 @@ export interface LinkButtonProps {
   id?: string;
   label?: string;
   style?: ButtonStyle;
+  /** Hover text for the button. Rendered by Teams only; other adapters ignore it */
   tooltip?: string;
   url: string;
 }
@@ -586,19 +588,6 @@ function isFieldProps(props: CardJSXProps): props is FieldProps {
 }
 
 /**
- * Type guard to check if props match CardProps
- */
-function isCardProps(props: CardJSXProps): props is CardProps {
-  return (
-    !("id" in props || "url" in props || "callbackId" in props) &&
-    ("title" in props ||
-      "subtitle" in props ||
-      "imageUrl" in props ||
-      "width" in props)
-  );
-}
-
-/**
  * Type guard to check if props match ModalProps
  */
 function isModalProps(props: CardJSXProps): props is ModalProps {
@@ -925,8 +914,10 @@ function resolveJSXElement(element: JSXElement): AnyCardElement {
     });
   }
 
-  // Default: Card({ title, subtitle, imageUrl, children })
-  const cardProps = isCardProps(props) ? props : {};
+  // Default: Card({ title, subtitle, imageUrl, width, children }).
+  // Every other component is dispatched by identity above, so a cast is
+  // safe here and avoids a prop-name allowlist that silently drops new props.
+  const cardProps = props as CardProps;
   return Card({
     title: cardProps.title,
     subtitle: cardProps.subtitle,


### PR DESCRIPTION
Buttons can now show hover text, and a card can ask to be rendered wider than usual. Both are small hints: Teams renders them, and every other adapter leaves the card exactly as it was before.

### Button tooltips

`Button` and `LinkButton` take an optional `tooltip`. On Teams it appears when someone hovers over the button.

```tsx
<Card title="Deploy request">
  <Actions>
    <Button id="approve" style="primary" tooltip="Ships this build to production">
      Approve
    </Button>
    <LinkButton url="https://example.com/build/1234" tooltip="Opens the build log in your browser">
      View build
    </LinkButton>
  </Actions>
</Card>
```

The same option is available on the plain builder functions:

```ts
Button({ id: "approve", label: "Approve", tooltip: "Ships this build to production" })
```

Tooltips survive the `callbackUrl` flow too. When a button's callback URL is swapped for a token before the card is sent, every other field on the button is kept, so a tooltip on a callback button shows up just like one on a regular button.

### Full-width cards

`Card` takes an optional `width`, either `"default"` or `"full"`. Teams draws a `"full"` card wider than its usual size, which suits tables and digests. It does not stretch the card across the whole chat pane, that is how Teams defines full width.

```tsx
<Card title="Weekly digest" width="full">
  <Table headers={["Service", "Uptime"]} rows={[["api", "99.98%"], ["web", "99.95%"]]} />
</Card>
```

### What Teams receives

- `tooltip` becomes the `tooltip` on the Adaptive Card action, for both submit and open-URL buttons.
- `width="full"` becomes `msteams: { width: "full" }` on the card.
- The card now declares Adaptive Card version 1.5, which is the version that introduced action tooltips. Teams accepts cards up to 1.6 for bots, so nothing changes for existing cards beyond the version number.
- The runtime-free `@chat-adapter/teams/cards` helpers understand both new fields as well, so apps that build Teams cards without the full adapter get the same result.

### Why only Teams

Slack and Google Chat have no hover text for buttons. They do have screen-reader labels, but those replace the button text for assistive technology rather than adding to it, so mapping a tooltip onto them would change what a screen reader announces. The fields are documented as Teams-only for that reason.

### Small cleanup along the way

The JSX runtime used to decide whether a set of props belonged to a `Card` by checking for a fixed list of prop names. Any new `Card` prop that was not on that list was silently dropped. Since `Card` is the only component left once every other one has been matched, the props are now used directly and the list is gone.

Docs for both props are on the cards page and in the API reference.
