### PR TITLE
feat(whatsapp): expose typed API errors

### DIFF
--- a/.changeset/upset-terms-hope.md
+++ b/.changeset/upset-terms-hope.md
@@ -1,0 +1,5 @@
+---
+"@chat-adapter/whatsapp": minor
+---
+
+export WhatsAppApiError with structured Meta error codes, details, and HTTP status

--- a/.changeset/upset-terms-hope.md
+++ b/.changeset/upset-terms-hope.md
@@ -2,4 +2,4 @@
 "@chat-adapter/whatsapp": minor
 ---
 
-export WhatsAppApiError with structured Meta error codes, details, and HTTP status
+export `WhatsAppApiError` for non-2xx Graph API responses. It carries Meta's numeric `errorCode`, `providerMessage`, `type`, `details`, `subcode`, `traceId`, the HTTP `status`, and the `raw` envelope, and maps `code` onto the shared `AdapterError` taxonomy (`RATE_LIMITED`, `AUTH_FAILED`, `PERMISSION_DENIED`, `NOT_FOUND`). Transport failures and unparseable response bodies now throw `NetworkError` instead of leaking raw fetch errors, and error messages carry Meta's message or a bounded excerpt instead of the full response body.

--- a/apps/docs/content/adapters/official/whatsapp.mdx
+++ b/apps/docs/content/adapters/official/whatsapp.mdx
@@ -316,6 +316,33 @@ await thread.post({
 });
 ```
 
+## API errors
+
+Failed Graph API requests throw `WhatsAppApiError`, exported from `@chat-adapter/whatsapp`. It extends `AdapterError`, so existing `instanceof AdapterError` checks continue to work.
+
+```typescript
+import { WhatsAppApiError } from "@chat-adapter/whatsapp";
+
+try {
+  await thread.post("Hello");
+} catch (error) {
+  if (error instanceof WhatsAppApiError) {
+    console.error(error.code, error.details, error.status);
+  }
+  throw error;
+}
+```
+
+- `code`: Meta's numeric error code as a string, such as `"130429"`, consistent with `AdapterError.code`
+- `details`: Meta's `error_data.details`, when present
+- `status`: HTTP response status
+- `subcode` and `traceId`: Meta's `error_subcode` and `fbtrace_id`, when present
+- `raw`: the full parsed response body, or the original text if it is not valid JSON
+
+Meta recommends using [error codes and details](https://developers.facebook.com/documentation/business-messaging/whatsapp/support/error-codes/) for error handling. Subcodes are optional and deprecated in the Cloud API. The adapter preserves its existing error message text, and missing or malformed provider fields remain undefined.
+
+This covers message sends, templates, reactions, read receipts, typing requests, media uploads, and media metadata requests. Binary download failures remain `NetworkError`s. A successful API response can still be followed by an asynchronous delivery failure; those webhook errors are not thrown as `WhatsAppApiError`.
+
 ## Feature support
 
 <FeatureSupport />

--- a/apps/docs/content/adapters/official/whatsapp.mdx
+++ b/apps/docs/content/adapters/official/whatsapp.mdx
@@ -318,7 +318,7 @@ await thread.post({
 
 ## API errors
 
-Failed Graph API requests throw `WhatsAppApiError`, exported from `@chat-adapter/whatsapp`. It extends `AdapterError`, so existing `instanceof AdapterError` checks continue to work.
+A non-2xx Graph API response throws `WhatsAppApiError`, exported from `@chat-adapter/whatsapp`. It extends `AdapterError`, so existing `instanceof AdapterError` checks continue to work.
 
 ```typescript
 import { WhatsAppApiError } from "@chat-adapter/whatsapp";
@@ -327,21 +327,23 @@ try {
   await thread.post("Hello");
 } catch (error) {
   if (error instanceof WhatsAppApiError) {
-    console.error(error.code, error.details, error.status);
+    console.error(error.code, error.errorCode, error.details, error.status);
   }
   throw error;
 }
 ```
 
-- `code`: Meta's numeric error code as a string, such as `"130429"`, consistent with `AdapterError.code`
+- `code`: the shared `AdapterError` code when the failure maps onto one: `RATE_LIMITED` (HTTP 429, or Meta throttling codes such as `130429` and `80007`), `AUTH_FAILED` (HTTP 401, or Meta codes `0` and `190`), `PERMISSION_DENIED` (HTTP 403, or Meta codes `3`, `10`, and `200` to `299`), `NOT_FOUND` (HTTP 404). Otherwise `undefined`.
+- `errorCode`: Meta's numeric error code, such as `130429`
+- `providerMessage` and `type`: Meta's `error.message` and `error.type`, when present
 - `details`: Meta's `error_data.details`, when present
 - `status`: HTTP response status
 - `subcode` and `traceId`: Meta's `error_subcode` and `fbtrace_id`, when present
-- `raw`: the full parsed response body, or the original text if it is not valid JSON
+- `raw`: the full parsed response body (see the `WhatsAppGraphErrorBody` type), or the original text if it is not valid JSON
 
-Meta recommends using [error codes and details](https://developers.facebook.com/documentation/business-messaging/whatsapp/support/error-codes/) for error handling. Subcodes are optional and deprecated in the Cloud API. The adapter preserves its existing error message text, and missing or malformed provider fields remain undefined.
+Meta recommends using [error codes and details](https://developers.facebook.com/documentation/business-messaging/whatsapp/support/error-codes/) for error handling. Subcodes are optional and deprecated in the Cloud API. Missing or malformed provider fields stay `undefined`, and numeric codes that a proxy serializes as strings are accepted. The error message combines the operation, the HTTP status, and Meta's `error.message`, or a bounded excerpt of a non-JSON body.
 
-This covers message sends, templates, reactions, read receipts, typing requests, media uploads, and media metadata requests. Binary download failures remain `NetworkError`s. A successful API response can still be followed by an asynchronous delivery failure; those webhook errors are not thrown as `WhatsAppApiError`.
+This covers non-2xx responses from message sends, templates, reactions, read receipts, typing requests, media uploads, and media metadata requests. Transport failures and unparseable response bodies throw `NetworkError`, as do binary media download failures. A 2xx response that reports `success: false` for a typing request or read receipt throws a plain `AdapterError`. A successful API response can still be followed by an asynchronous delivery failure; those webhook errors are not thrown as `WhatsAppApiError`.
 
 ## Feature support
 

--- a/packages/adapter-whatsapp/AGENTS.md
+++ b/packages/adapter-whatsapp/AGENTS.md
@@ -32,6 +32,8 @@ packages/adapter-whatsapp/
 │   ├── index.test.ts
 │   ├── cards.ts             # PostableMessage / Card → interactive payloads
 │   ├── cards.test.ts
+│   ├── errors.ts            # WhatsAppApiError (Meta Graph error envelope)
+│   ├── errors.test.ts
 │   ├── markdown.ts          # WhatsAppFormatConverter (mdast ↔ WA formatting)
 │   ├── markdown.test.ts
 │   └── types.ts             # Cloud API typings
@@ -77,6 +79,8 @@ Main exports from `src/index.ts`:
   `openDM`, `sendTemplate`.
 - Configuration: `WhatsAppAdapterConfig`, `WhatsAppThreadId`,
   `WhatsAppTemplateMessage`.
+- Errors: `WhatsAppApiError` (non-2xx Graph API responses) plus the
+  `WhatsAppGraphError` / `WhatsAppGraphErrorBody` envelope types.
 - Helpers: `cardToInteractive`, `cardToFallbackText`,
   `WhatsAppFormatConverter`, `decodeThreadId`, `encodeThreadId`,
   `isDM`.
@@ -282,8 +286,12 @@ in `sample-messages.md`.
 - Use named exports throughout. No default exports.
 - Cloud API typings live in `types.ts`. Extend them rather than
   pulling a third-party dependency.
-- Errors map to `@chat-adapter/shared` (`AuthenticationError`,
-  `AdapterRateLimitError`, `NetworkError`, `ValidationError`).
+- Every Graph API call goes through `graphFetchJson`. Non-2xx responses
+  throw `WhatsAppApiError` from `errors.ts`, which maps status and Meta
+  codes onto the shared `AdapterError.code` taxonomy; extend that mapping
+  rather than throwing `AdapterRateLimitError` / `AuthenticationError`
+  directly. Transport and JSON parse failures throw `NetworkError`, and
+  bad input throws `ValidationError`.
 - Top-level regex literals only.
 - Phone-number sanitization belongs in one helper — never inline
   `replace(/\\+/, "")` calls.

--- a/packages/adapter-whatsapp/README.md
+++ b/packages/adapter-whatsapp/README.md
@@ -250,6 +250,33 @@ await adapter.sendTemplate(threadId, {
 
 Templates must be created and approved in [WhatsApp Manager](https://business.facebook.com/wa/manage/message-templates/) before they can be sent. Quick reply button taps on a template arrive as button responses and are dispatched to your `onAction` handlers.
 
+## API errors
+
+Failed Graph API requests throw `WhatsAppApiError`, exported from `@chat-adapter/whatsapp`. It extends `AdapterError`, so existing `instanceof AdapterError` checks continue to work.
+
+```typescript
+import { WhatsAppApiError } from "@chat-adapter/whatsapp";
+
+try {
+  await thread.post("Hello");
+} catch (error) {
+  if (error instanceof WhatsAppApiError) {
+    console.error(error.code, error.details, error.status);
+  }
+  throw error;
+}
+```
+
+- `code`: Meta's numeric error code as a string, such as `"130429"`, consistent with `AdapterError.code`
+- `details`: Meta's `error_data.details`, when present
+- `status`: HTTP response status
+- `subcode` and `traceId`: Meta's `error_subcode` and `fbtrace_id`, when present
+- `raw`: the full parsed response body, or the original text if it is not valid JSON
+
+Meta recommends using [error codes and details](https://developers.facebook.com/documentation/business-messaging/whatsapp/support/error-codes/) for error handling. Subcodes are optional and deprecated in the Cloud API. The adapter preserves its existing error message text, and missing or malformed provider fields remain undefined.
+
+This covers message sends, templates, reactions, read receipts, typing requests, media uploads, and media metadata requests. Binary download failures remain `NetworkError`s. A successful API response can still be followed by an asynchronous delivery failure; those webhook errors are not thrown as `WhatsAppApiError`.
+
 ## User identity
 
 WhatsApp messages include a [business-scoped user ID](https://developers.facebook.com/documentation/business-messaging/whatsapp/business-scoped-user-ids/) in `from_user_id` and `contacts[].user_id`. Users with a username may omit the phone-based `from` and `wa_id` fields.

--- a/packages/adapter-whatsapp/README.md
+++ b/packages/adapter-whatsapp/README.md
@@ -252,7 +252,7 @@ Templates must be created and approved in [WhatsApp Manager](https://business.fa
 
 ## API errors
 
-Failed Graph API requests throw `WhatsAppApiError`, exported from `@chat-adapter/whatsapp`. It extends `AdapterError`, so existing `instanceof AdapterError` checks continue to work.
+A non-2xx Graph API response throws `WhatsAppApiError`, exported from `@chat-adapter/whatsapp`. It extends `AdapterError`, so existing `instanceof AdapterError` checks continue to work.
 
 ```typescript
 import { WhatsAppApiError } from "@chat-adapter/whatsapp";
@@ -261,21 +261,23 @@ try {
   await thread.post("Hello");
 } catch (error) {
   if (error instanceof WhatsAppApiError) {
-    console.error(error.code, error.details, error.status);
+    console.error(error.code, error.errorCode, error.details, error.status);
   }
   throw error;
 }
 ```
 
-- `code`: Meta's numeric error code as a string, such as `"130429"`, consistent with `AdapterError.code`
+- `code`: the shared `AdapterError` code when the failure maps onto one: `RATE_LIMITED` (HTTP 429, or Meta throttling codes such as `130429` and `80007`), `AUTH_FAILED` (HTTP 401, or Meta codes `0` and `190`), `PERMISSION_DENIED` (HTTP 403, or Meta codes `3`, `10`, and `200` to `299`), `NOT_FOUND` (HTTP 404). Otherwise `undefined`.
+- `errorCode`: Meta's numeric error code, such as `130429`
+- `providerMessage` and `type`: Meta's `error.message` and `error.type`, when present
 - `details`: Meta's `error_data.details`, when present
 - `status`: HTTP response status
 - `subcode` and `traceId`: Meta's `error_subcode` and `fbtrace_id`, when present
-- `raw`: the full parsed response body, or the original text if it is not valid JSON
+- `raw`: the full parsed response body (see the `WhatsAppGraphErrorBody` type), or the original text if it is not valid JSON
 
-Meta recommends using [error codes and details](https://developers.facebook.com/documentation/business-messaging/whatsapp/support/error-codes/) for error handling. Subcodes are optional and deprecated in the Cloud API. The adapter preserves its existing error message text, and missing or malformed provider fields remain undefined.
+Meta recommends using [error codes and details](https://developers.facebook.com/documentation/business-messaging/whatsapp/support/error-codes/) for error handling. Subcodes are optional and deprecated in the Cloud API. Missing or malformed provider fields stay `undefined`, and numeric codes that a proxy serializes as strings are accepted. The error message combines the operation, the HTTP status, and Meta's `error.message`, or a bounded excerpt of a non-JSON body.
 
-This covers message sends, templates, reactions, read receipts, typing requests, media uploads, and media metadata requests. Binary download failures remain `NetworkError`s. A successful API response can still be followed by an asynchronous delivery failure; those webhook errors are not thrown as `WhatsAppApiError`.
+This covers non-2xx responses from message sends, templates, reactions, read receipts, typing requests, media uploads, and media metadata requests. Transport failures and unparseable response bodies throw `NetworkError`, as do binary media download failures. A 2xx response that reports `success: false` for a typing request or read receipt throws a plain `AdapterError`. A successful API response can still be followed by an asynchronous delivery failure; those webhook errors are not thrown as `WhatsAppApiError`.
 
 ## User identity
 

--- a/packages/adapter-whatsapp/src/errors.test.ts
+++ b/packages/adapter-whatsapp/src/errors.test.ts
@@ -23,14 +23,56 @@ describe("WhatsAppApiError", () => {
     expect(error).toMatchObject({
       name: "WhatsAppApiError",
       adapter: "whatsapp",
-      code: "190",
+      code: "AUTH_FAILED",
+      errorCode: 190,
       status: 401,
+      providerMessage: "Invalid token",
+      type: "OAuthException",
       subcode: 463,
       details: raw.error.error_data.details,
       traceId: "trace123",
       raw,
-      message: `WhatsApp API error: 401 ${body}`,
+      message: "WhatsApp API error: 401 Invalid token",
     });
+  });
+
+  it.each([
+    { status: 400, code: 130_429, expected: "RATE_LIMITED" },
+    { status: 400, code: 80_007, expected: "RATE_LIMITED" },
+    { status: 429, code: 100, expected: "RATE_LIMITED" },
+    { status: 400, code: 190, expected: "AUTH_FAILED" },
+    { status: 401, code: 100, expected: "AUTH_FAILED" },
+    { status: 400, code: 10, expected: "PERMISSION_DENIED" },
+    { status: 400, code: 200, expected: "PERMISSION_DENIED" },
+    { status: 403, code: 100, expected: "PERMISSION_DENIED" },
+    { status: 404, code: 100, expected: "NOT_FOUND" },
+    { status: 400, code: 131_047, expected: undefined },
+    { status: 500, code: undefined, expected: undefined },
+  ])("maps status $status and Meta code $code to $expected", ({
+    status,
+    code,
+    expected,
+  }) => {
+    const error = new WhatsAppApiError(
+      "WhatsApp API error",
+      status,
+      JSON.stringify({ error: { code } })
+    );
+
+    expect(error.code).toBe(expected);
+    expect(error.errorCode).toBe(code);
+  });
+
+  it("accepts numeric strings from proxies in front of the Cloud API", () => {
+    const error = new WhatsAppApiError(
+      "WhatsApp API error",
+      400,
+      JSON.stringify({ error: { code: "130429", error_subcode: "2494055" } })
+    );
+
+    expect(error.code).toBe("RATE_LIMITED");
+    expect(error.errorCode).toBe(130_429);
+    expect(error.subcode).toBe(2_494_055);
   });
 
   it.each([
@@ -43,7 +85,24 @@ describe("WhatsAppApiError", () => {
     expect(error.raw).toBe(body);
     expect(error.status).toBe(502);
     expect(error.code).toBeUndefined();
+    expect(error.errorCode).toBeUndefined();
     expect(error.message).toBe(`WhatsApp API error: 502 ${body}`);
+  });
+
+  it("bounds a long non-JSON body in the message and keeps it whole in raw", () => {
+    const body = "x".repeat(2000);
+    const error = new WhatsAppApiError("WhatsApp API error", 502, body);
+
+    expect(error.raw).toBe(body);
+    expect(error.message).toBe(`WhatsApp API error: 502 ${"x".repeat(500)}…`);
+  });
+
+  it("falls back to the body when Meta omits a message", () => {
+    const body = JSON.stringify({ error: { code: 100 } });
+    const error = new WhatsAppApiError("WhatsApp API error", 400, body);
+
+    expect(error.providerMessage).toBeUndefined();
+    expect(error.message).toBe(`WhatsApp API error: 400 ${body}`);
   });
 
   it.each([
@@ -56,9 +115,11 @@ describe("WhatsAppApiError", () => {
     {
       error: {
         code: { value: 190 },
-        error_subcode: "463",
+        error_subcode: "4.5",
         error_data: { details: [] },
         fbtrace_id: 123,
+        message: ["nope"],
+        type: 7,
       },
     },
   ])("ignores invalid field shapes in %j", (raw) => {
@@ -70,6 +131,9 @@ describe("WhatsAppApiError", () => {
 
     expect(error.raw).toEqual(raw);
     expect(error.code).toBeUndefined();
+    expect(error.errorCode).toBeUndefined();
+    expect(error.providerMessage).toBeUndefined();
+    expect(error.type).toBeUndefined();
     expect(error.details).toBeUndefined();
     expect(error.subcode).toBeUndefined();
     expect(error.traceId).toBeUndefined();
@@ -82,7 +146,8 @@ describe("WhatsAppApiError", () => {
       JSON.stringify({ error: { code: 0 } })
     );
 
-    expect(error.code).toBe("0");
+    expect(error.errorCode).toBe(0);
+    expect(error.code).toBe("AUTH_FAILED");
     expect(error.details).toBeUndefined();
     expect(error.subcode).toBeUndefined();
     expect(error.traceId).toBeUndefined();

--- a/packages/adapter-whatsapp/src/errors.test.ts
+++ b/packages/adapter-whatsapp/src/errors.test.ts
@@ -1,0 +1,90 @@
+import { AdapterError } from "@chat-adapter/shared";
+import { describe, expect, it } from "vitest";
+import { WhatsAppApiError } from "./index";
+
+describe("WhatsAppApiError", () => {
+  it("preserves the error contract and raw Meta response", () => {
+    const raw = {
+      error: {
+        message: "Invalid token",
+        type: "OAuthException",
+        code: 190,
+        error_subcode: 463,
+        error_data: { details: "The access token has expired" },
+        fbtrace_id: "trace123",
+        extra: { retained: true },
+      },
+    };
+    const body = JSON.stringify(raw);
+    const error = new WhatsAppApiError("WhatsApp API error", 401, body);
+
+    expect(error).toBeInstanceOf(Error);
+    expect(error).toBeInstanceOf(AdapterError);
+    expect(error).toMatchObject({
+      name: "WhatsAppApiError",
+      adapter: "whatsapp",
+      code: "190",
+      status: 401,
+      subcode: 463,
+      details: raw.error.error_data.details,
+      traceId: "trace123",
+      raw,
+      message: `WhatsApp API error: 401 ${body}`,
+    });
+  });
+
+  it.each([
+    "",
+    "<html>Bad gateway</html>",
+    '{"error":',
+  ])("retains non-JSON response %j without masking the HTTP error", (body) => {
+    const error = new WhatsAppApiError("WhatsApp API error", 502, body);
+
+    expect(error.raw).toBe(body);
+    expect(error.status).toBe(502);
+    expect(error.code).toBeUndefined();
+    expect(error.message).toBe(`WhatsApp API error: 502 ${body}`);
+  });
+
+  it.each([
+    null,
+    [],
+    "unexpected",
+    { error: null },
+    { error: [] },
+    { error: "unexpected" },
+    {
+      error: {
+        code: { value: 190 },
+        error_subcode: "463",
+        error_data: { details: [] },
+        fbtrace_id: 123,
+      },
+    },
+  ])("ignores invalid field shapes in %j", (raw) => {
+    const error = new WhatsAppApiError(
+      "WhatsApp API error",
+      500,
+      JSON.stringify(raw)
+    );
+
+    expect(error.raw).toEqual(raw);
+    expect(error.code).toBeUndefined();
+    expect(error.details).toBeUndefined();
+    expect(error.subcode).toBeUndefined();
+    expect(error.traceId).toBeUndefined();
+  });
+
+  it("preserves error code zero without requiring optional fields", () => {
+    const error = new WhatsAppApiError(
+      "WhatsApp API error",
+      400,
+      JSON.stringify({ error: { code: 0 } })
+    );
+
+    expect(error.code).toBe("0");
+    expect(error.details).toBeUndefined();
+    expect(error.subcode).toBeUndefined();
+    expect(error.traceId).toBeUndefined();
+  });
+});

--- a/packages/adapter-whatsapp/src/errors.ts
+++ b/packages/adapter-whatsapp/src/errors.ts
@@ -1,0 +1,51 @@
+import { AdapterError } from "@chat-adapter/shared";
+
+function record(value: unknown): Record<string, unknown> | undefined {
+  return typeof value === "object" && value !== null && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : undefined;
+}
+
+export class WhatsAppApiError extends AdapterError {
+  readonly status: number;
+  readonly details?: string;
+  readonly subcode?: number;
+  readonly traceId?: string;
+  readonly raw: unknown;
+
+  constructor(message: string, status: number, body: string) {
+    let raw: unknown = body;
+    try {
+      raw = JSON.parse(body);
+    } catch {
+      raw = body;
+    }
+
+    const error = record(record(raw)?.error);
+    const code = error?.code;
+    super(
+      `${message}: ${status} ${body}`,
+      "whatsapp",
+      typeof code === "number" && Number.isInteger(code)
+        ? String(code)
+        : undefined
+    );
+    this.name = "WhatsAppApiError";
+    this.status = status;
+    this.raw = raw;
+
+    const details = record(error?.error_data)?.details;
+    if (typeof details === "string") {
+      this.details = details;
+    }
+    if (
+      typeof error?.error_subcode === "number" &&
+      Number.isInteger(error.error_subcode)
+    ) {
+      this.subcode = error.error_subcode;
+    }
+    if (typeof error?.fbtrace_id === "string") {
+      this.traceId = error.fbtrace_id;
+    }
+  }
+}

--- a/packages/adapter-whatsapp/src/errors.ts
+++ b/packages/adapter-whatsapp/src/errors.ts
@@ -1,4 +1,20 @@
 import { AdapterError } from "@chat-adapter/shared";
+import type { WhatsAppGraphError, WhatsAppGraphErrorBody } from "./types";
+
+/** Longest slice of a non-JSON response body kept in the error message. */
+const MESSAGE_BODY_LIMIT = 500;
+const INTEGER_STRING = /^-?\d+$/;
+
+/**
+ * Meta error codes that the Graph API uses for throttling.
+ *
+ * @see https://developers.facebook.com/documentation/business-messaging/whatsapp/support/error-codes/
+ */
+const RATE_LIMIT_CODES = new Set([
+  4, 17, 32, 613, 80_007, 130_429, 131_048, 131_056,
+]);
+const AUTH_CODES = new Set([0, 190]);
+const PERMISSION_CODES = new Set([3, 10]);
 
 function record(value: unknown): Record<string, unknown> | undefined {
   return typeof value === "object" && value !== null && !Array.isArray(value)
@@ -6,11 +22,91 @@ function record(value: unknown): Record<string, unknown> | undefined {
     : undefined;
 }
 
+/**
+ * Read an integer field, accepting the numeric strings that proxies and
+ * emulators in front of the Cloud API sometimes emit.
+ */
+function integer(value: unknown): number | undefined {
+  if (typeof value === "number") {
+    return Number.isInteger(value) ? value : undefined;
+  }
+  if (typeof value === "string" && INTEGER_STRING.test(value)) {
+    return Number(value);
+  }
+  return undefined;
+}
+
+function string(value: unknown): string | undefined {
+  return typeof value === "string" ? value : undefined;
+}
+
+function parseGraphError(raw: unknown): WhatsAppGraphError | undefined {
+  const error = record(record(raw)?.error);
+  if (!error) {
+    return undefined;
+  }
+  const details = string(record(error.error_data)?.details);
+  return {
+    code: integer(error.code),
+    error_data: details === undefined ? undefined : { details },
+    error_subcode: integer(error.error_subcode),
+    fbtrace_id: string(error.fbtrace_id),
+    message: string(error.message),
+    type: string(error.type),
+  };
+}
+
+/**
+ * Map an HTTP status and Meta error code onto the shared `AdapterError.code`
+ * taxonomy so cross-adapter handlers can branch without WhatsApp knowledge.
+ */
+function taxonomyCode(status: number, code?: number): string | undefined {
+  if (status === 429 || (code !== undefined && RATE_LIMIT_CODES.has(code))) {
+    return "RATE_LIMITED";
+  }
+  if (status === 401 || (code !== undefined && AUTH_CODES.has(code))) {
+    return "AUTH_FAILED";
+  }
+  if (
+    status === 403 ||
+    (code !== undefined &&
+      (PERMISSION_CODES.has(code) || (code >= 200 && code <= 299)))
+  ) {
+    return "PERMISSION_DENIED";
+  }
+  if (status === 404) {
+    return "NOT_FOUND";
+  }
+  return undefined;
+}
+
+/**
+ * A non-2xx response from the Meta Graph API.
+ *
+ * `code` follows the shared `AdapterError` taxonomy (`RATE_LIMITED`,
+ * `AUTH_FAILED`, `PERMISSION_DENIED`, `NOT_FOUND`) when the status or Meta
+ * error code maps onto it. Meta's own numeric code is exposed as `errorCode`.
+ */
 export class WhatsAppApiError extends AdapterError {
+  /** HTTP response status. */
   readonly status: number;
+  /** Meta's numeric error code, such as `130429`. */
+  readonly errorCode?: number;
+  /** Meta's human-readable `error.message`. */
+  readonly providerMessage?: string;
+  /** Meta's `error.type`, such as `"OAuthException"`. */
+  readonly type?: string;
+  /** Meta's `error.error_data.details`. */
   readonly details?: string;
+  /** Meta's `error.error_subcode`. Optional and deprecated in the Cloud API. */
   readonly subcode?: number;
+  /** Meta's `error.fbtrace_id`. */
   readonly traceId?: string;
+  /**
+   * The parsed response body, shaped like {@link WhatsAppGraphErrorBody} when
+   * Meta answered with its error envelope, or the original text when the body
+   * is not valid JSON.
+   */
   readonly raw: unknown;
 
   constructor(message: string, status: number, body: string) {
@@ -18,34 +114,28 @@ export class WhatsAppApiError extends AdapterError {
     try {
       raw = JSON.parse(body);
     } catch {
-      raw = body;
+      // Keep the text body for non-JSON responses such as proxy error pages.
     }
 
-    const error = record(record(raw)?.error);
-    const code = error?.code;
+    const error = parseGraphError(raw);
+    const summary =
+      error?.message ??
+      (body.length > MESSAGE_BODY_LIMIT
+        ? `${body.slice(0, MESSAGE_BODY_LIMIT)}…`
+        : body);
     super(
-      `${message}: ${status} ${body}`,
+      `${message}: ${status} ${summary}`,
       "whatsapp",
-      typeof code === "number" && Number.isInteger(code)
-        ? String(code)
-        : undefined
+      taxonomyCode(status, error?.code)
     );
     this.name = "WhatsAppApiError";
     this.status = status;
     this.raw = raw;
-
-    const details = record(error?.error_data)?.details;
-    if (typeof details === "string") {
-      this.details = details;
-    }
-    if (
-      typeof error?.error_subcode === "number" &&
-      Number.isInteger(error.error_subcode)
-    ) {
-      this.subcode = error.error_subcode;
-    }
-    if (typeof error?.fbtrace_id === "string") {
-      this.traceId = error.fbtrace_id;
-    }
+    this.errorCode = error?.code;
+    this.providerMessage = error?.message;
+    this.type = error?.type;
+    this.details = error?.error_data?.details;
+    this.subcode = error?.error_subcode;
+    this.traceId = error?.fbtrace_id;
   }
 }

--- a/packages/adapter-whatsapp/src/index.test.ts
+++ b/packages/adapter-whatsapp/src/index.test.ts
@@ -1645,13 +1645,41 @@ describe("API errors", () => {
     await expect(result).rejects.toMatchObject({
       name: "WhatsAppApiError",
       adapter: "whatsapp",
-      code: "130429",
+      code: "RATE_LIMITED",
+      errorCode: 130_429,
       status: 400,
+      providerMessage: raw.error.message,
+      type: "OAuthException",
       details: raw.error.error_data.details,
       traceId: "trace123",
       raw,
     });
     expect(fetchSpy).toHaveBeenCalledOnce();
+  });
+
+  it.each(operations)("wraps transport failures for $name", async ({ run }) => {
+    const cause = new TypeError("fetch failed");
+    fetchSpy.mockRejectedValue(cause);
+
+    const result = run(createTestAdapter());
+    await expect(result).rejects.toBeInstanceOf(NetworkError);
+    await expect(result).rejects.toMatchObject({
+      adapter: "whatsapp",
+      code: "NETWORK_ERROR",
+      originalError: cause,
+    });
+  });
+
+  it.each(operations)("wraps non-JSON success bodies for $name", async ({
+    run,
+  }) => {
+    fetchSpy.mockResolvedValue(
+      new Response("<html>Bad gateway</html>", { status: 200 })
+    );
+
+    const result = run(createTestAdapter());
+    await expect(result).rejects.toBeInstanceOf(NetworkError);
+    await expect(result).rejects.toThrow("response was not valid JSON");
   });
 });
 

--- a/packages/adapter-whatsapp/src/index.test.ts
+++ b/packages/adapter-whatsapp/src/index.test.ts
@@ -23,6 +23,7 @@ import {
   getWhatsAppMediaType,
   splitMessage,
   WhatsAppAdapter,
+  WhatsAppApiError,
   type WhatsAppThreadId,
 } from "./index";
 import type {
@@ -1581,6 +1582,76 @@ describe("postMessage", () => {
     expect(sent.type).toBe("interactive");
     expect(sent.recipient).toBe("US.13491208655302741918");
     expect(sent).not.toHaveProperty("to");
+  });
+});
+
+describe("API errors", () => {
+  let fetchSpy: MockInstance;
+
+  beforeEach(() => {
+    fetchSpy = vi.spyOn(global, "fetch");
+  });
+
+  afterEach(() => {
+    fetchSpy.mockRestore();
+  });
+
+  const operations = [
+    {
+      name: "message sends",
+      run: (adapter: WhatsAppAdapter) =>
+        adapter.postMessage("whatsapp:123456789:15551234567", "hello"),
+    },
+    {
+      name: "media uploads",
+      run: (adapter: WhatsAppAdapter) =>
+        adapter.postMessage("whatsapp:123456789:15551234567", {
+          files: [
+            {
+              data: Buffer.from("report"),
+              filename: "report.txt",
+              mimeType: "text/plain",
+            },
+          ],
+        }),
+    },
+    {
+      name: "media metadata requests",
+      run: (adapter: WhatsAppAdapter) => adapter.downloadMedia("media123"),
+    },
+  ];
+
+  it.each(operations)("preserves Meta error fields for $name", async ({
+    run,
+  }) => {
+    const raw = {
+      error: {
+        message: "(#130429) Rate limit hit",
+        type: "OAuthException",
+        code: 130429,
+        error_data: {
+          messaging_product: "whatsapp",
+          details: "Cloud API message throughput has been reached.",
+        },
+        fbtrace_id: "trace123",
+      },
+    };
+    fetchSpy.mockResolvedValue(
+      new Response(JSON.stringify(raw), { status: 400 })
+    );
+
+    const result = run(createTestAdapter());
+    await expect(result).rejects.toBeInstanceOf(WhatsAppApiError);
+    await expect(result).rejects.toMatchObject({
+      name: "WhatsAppApiError",
+      adapter: "whatsapp",
+      code: "130429",
+      status: 400,
+      details: raw.error.error_data.details,
+      traceId: "trace123",
+      raw,
+    });
+    expect(fetchSpy).toHaveBeenCalledOnce();
   });
 });
 

--- a/packages/adapter-whatsapp/src/index.ts
+++ b/packages/adapter-whatsapp/src/index.ts
@@ -292,6 +292,8 @@ export function splitMessage(text: string): string[] {
 // Re-export types
 export type {
   WhatsAppAdapterConfig,
+  WhatsAppGraphError,
+  WhatsAppGraphErrorBody,
   WhatsAppMediaResponse,
   WhatsAppRawMessage,
   WhatsAppTemplateButtonParameter,
@@ -1160,26 +1162,12 @@ export class WhatsAppAdapter
     transport?: AttachmentTransport
   ): Promise<Buffer> {
     // Step 1: Get the media URL
-    const metaResponse = await fetch(`${this.graphApiUrl}/${mediaId}`, {
-      headers: { Authorization: `Bearer ${this.accessToken}` },
-    });
-
-    if (!metaResponse.ok) {
-      const errorBody = await metaResponse.text();
-      this.logger.error("Failed to get media URL", {
-        status: metaResponse.status,
-        body: errorBody,
-        mediaId,
-      });
-      throw new WhatsAppApiError(
-        "Failed to get media URL",
-        metaResponse.status,
-        errorBody
-      );
-    }
-
-    const mediaInfo: WhatsAppMediaResponse =
-      (await metaResponse.json()) as WhatsAppMediaResponse;
+    const mediaInfo = await this.graphFetchJson<WhatsAppMediaResponse>(
+      `${this.graphApiUrl}/${mediaId}`,
+      { headers: { Authorization: `Bearer ${this.accessToken}` } },
+      "Failed to get media URL",
+      { mediaId }
+    );
 
     if (!isWhatsAppMediaUrl(mediaInfo.url, this.graphApiUrl)) {
       throw new NetworkError(
@@ -2172,29 +2160,18 @@ export class WhatsAppAdapter
     path: string,
     formData: FormData
   ): Promise<T> {
-    const response = await fetch(`${this.graphApiUrl}${path}`, {
-      method: "POST",
-      headers: {
-        Authorization: `Bearer ${this.accessToken}`,
+    return this.graphFetchJson<T>(
+      `${this.graphApiUrl}${path}`,
+      {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${this.accessToken}`,
+        },
+        body: formData,
       },
-      body: formData,
-    });
-
-    if (!response.ok) {
-      const errorBody = await response.text();
-      this.logger.error("WhatsApp API upload error", {
-        status: response.status,
-        body: errorBody,
-        path,
-      });
-      throw new WhatsAppApiError(
-        "WhatsApp API upload error",
-        response.status,
-        errorBody
-      );
-    }
-
-    return response.json() as Promise<T>;
+      "WhatsApp API upload error",
+      { path }
+    );
   }
 
   /**
@@ -2227,30 +2204,71 @@ export class WhatsAppAdapter
     path: string,
     body: unknown
   ): Promise<T> {
-    const response = await fetch(`${this.graphApiUrl}${path}`, {
-      method: "POST",
-      headers: {
-        Authorization: `Bearer ${this.accessToken}`,
-        "Content-Type": "application/json",
+    return this.graphFetchJson<T>(
+      `${this.graphApiUrl}${path}`,
+      {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${this.accessToken}`,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify(body),
       },
-      body: JSON.stringify(body),
-    });
+      "WhatsApp API error",
+      { path }
+    );
+  }
 
-    if (!response.ok) {
-      const errorBody = await response.text();
-      this.logger.error("WhatsApp API error", {
-        status: response.status,
-        body: errorBody,
-        path,
-      });
-      throw new WhatsAppApiError(
-        "WhatsApp API error",
-        response.status,
-        errorBody
+  /**
+   * Fetch a Graph API endpoint and parse its JSON body.
+   *
+   * Transport failures and unparseable bodies become `NetworkError`s; a
+   * non-2xx response becomes a `WhatsAppApiError` carrying Meta's error
+   * envelope. `label` prefixes the error message and log line, and
+   * `context` is attached to the log line.
+   */
+  private async graphFetchJson<T>(
+    url: string,
+    init: RequestInit,
+    label: string,
+    context: Record<string, unknown>
+  ): Promise<T> {
+    let response: Response;
+    try {
+      response = await fetch(url, init);
+    } catch (error) {
+      this.logger.error(label, { ...context, error });
+      throw new NetworkError(
+        "whatsapp",
+        `${label}: request failed`,
+        error instanceof Error ? error : undefined
       );
     }
 
-    return response.json() as Promise<T>;
+    if (!response.ok) {
+      const errorBody = await response.text();
+      this.logger.error(label, {
+        status: response.status,
+        body: errorBody,
+        ...context,
+      });
+      throw new WhatsAppApiError(label, response.status, errorBody);
+    }
+
+    try {
+      return (await response.json()) as T;
+    } catch (error) {
+      this.logger.error(label, {
+        status: response.status,
+        ...context,
+        error,
+      });
+      throw new NetworkError(
+        "whatsapp",
+        `${label}: response was not valid JSON`,
+        error instanceof Error ? error : undefined
+      );
+    }
   }
 
   /**

--- a/packages/adapter-whatsapp/src/index.ts
+++ b/packages/adapter-whatsapp/src/index.ts
@@ -45,6 +45,7 @@ import {
   cardToWhatsApp,
   decodeWhatsAppCallbackData,
 } from "./cards";
+import { WhatsAppApiError } from "./errors";
 import { WhatsAppFormatConverter } from "./markdown";
 import type {
   WhatsAppAdapterConfig,
@@ -62,6 +63,8 @@ import type {
   WhatsAppWebhookPayload,
   WhatsAppWebhookValue,
 } from "./types";
+
+export { WhatsAppApiError } from "./errors";
 
 /** Platform label for shared buffer utilities (not yet in PlatformName union). */
 const WHATSAPP_BUFFER_PLATFORM = "whatsapp" as PlatformName;
@@ -1168,8 +1171,10 @@ export class WhatsAppAdapter
         body: errorBody,
         mediaId,
       });
-      throw new Error(
-        `Failed to get media URL: ${metaResponse.status} ${errorBody}`
+      throw new WhatsAppApiError(
+        "Failed to get media URL",
+        metaResponse.status,
+        errorBody
       );
     }
 
@@ -2182,8 +2187,10 @@ export class WhatsAppAdapter
         body: errorBody,
         path,
       });
-      throw new Error(
-        `WhatsApp API upload error: ${response.status} ${errorBody}`
+      throw new WhatsAppApiError(
+        "WhatsApp API upload error",
+        response.status,
+        errorBody
       );
     }
 
@@ -2236,9 +2243,10 @@ export class WhatsAppAdapter
         body: errorBody,
         path,
       });
-      throw new AdapterError(
-        `WhatsApp API error: ${response.status} ${errorBody}`,
-        "whatsapp"
+      throw new WhatsAppApiError(
+        "WhatsApp API error",
+        response.status,
+        errorBody
       );
     }
 

--- a/packages/adapter-whatsapp/src/types.ts
+++ b/packages/adapter-whatsapp/src/types.ts
@@ -350,6 +350,31 @@ export interface WhatsAppTypingIndicatorResponse {
 }
 
 /**
+ * Error object returned by the Meta Graph API on a failed request.
+ *
+ * @see https://developers.facebook.com/documentation/business-messaging/whatsapp/support/error-codes/
+ */
+export interface WhatsAppGraphError {
+  code?: number;
+  error_data?: {
+    details?: string;
+    messaging_product?: string;
+  };
+  /** Optional and deprecated in the Cloud API. */
+  error_subcode?: number;
+  fbtrace_id?: string;
+  message?: string;
+  type?: string;
+}
+
+/**
+ * Body of a failed Meta Graph API response.
+ */
+export interface WhatsAppGraphErrorBody {
+  error?: WhatsAppGraphError;
+}
+
+/**
  * Fields shared by every interactive message shape.
  */
 interface WhatsAppInteractiveBase {


### PR DESCRIPTION
## summary

- export `WhatsAppApiError` so consumers can handle Meta error codes without parsing error messages
- expose HTTP status, provider details, optional subcode and trace ID, and the raw response
- cover message requests, media uploads, and media metadata failures while preserving existing error messages and `AdapterError` compatibility
- add regression coverage and document error handling

closes #712