### PR TITLE
fix(slack): surface custom status text in the Agent messaging experience

### DIFF
--- a/.changeset/surface-agent-view-custom-status.md
+++ b/.changeset/surface-agent-view-custom-status.md
@@ -1,0 +1,5 @@
+---
+"@chat-adapter/slack": minor
+---
+
+Surface custom status text in the Agent messaging experience. `startTyping` and `setAssistantStatus` with a custom status now call the legacy `assistant.threads.setStatus` endpoint, whose compatibility bridge renders the text in the agent-session loading UX — instead of silently dropping the text and showing the generic "Working…" indicator. Clearing (empty status) still transitions the session to `active` via the Agent Sessions lifecycle.

--- a/apps/docs/content/adapters/official/slack.mdx
+++ b/apps/docs/content/adapters/official/slack.mdx
@@ -718,11 +718,18 @@ The `SlackAdapter` exposes:
 | `startTyping(threadId, status?)` | Set the agent session to `processing`, or render a custom status label in the loading UX |
 
 `setAssistantStatus` and `setAssistantTitle` remain compatibility methods:
-under `agentView`, lifecycle changes map to `agents.sessions.*` and custom
-status text is surfaced through the legacy `assistant.threads.setStatus`
-compatibility bridge, which renders the text in the agent-session loading UX.
-Under legacy `assistant_view`, they call `assistant.threads.*` directly.
-`loadingMessages` only apply to the legacy experience.
+under `agentView`, clearing status and changing titles use `agents.sessions.*`.
+Custom status text uses the legacy `assistant.threads.setStatus` compatibility
+bridge. `setAssistantStatus` sends its `loadingMessages` argument, falls back to
+the adapter's `loadingMessages` config, and otherwise uses the custom status as
+the loading message. Under legacy `assistant_view`, these methods call
+`assistant.threads.*` directly.
+
+Custom labels and native session state are different paths. Use `startTyping()`
+without a custom status when you need native processing state and initiator
+attribution. The legacy endpoint cannot receive `initiator_user_id`, and an
+existing native processing indicator can take precedence over custom labels.
+Do not rely on custom labels alone to provide native stop-button behavior.
 
 Customize automatic titles with `sessionTitle`:
 

--- a/apps/docs/content/adapters/official/slack.mdx
+++ b/apps/docs/content/adapters/official/slack.mdx
@@ -715,11 +715,13 @@ The `SlackAdapter` exposes:
 | `setAssistantTitle(channelId, threadTs, title)` | Rename the agent session |
 | `setSuggestedPrompts(channelId, threadTs, prompts, title?)` | Show prompt suggestions |
 | `publishHomeView(userId, view)` | Publish a Home tab view |
-| `startTyping(threadId)` | Set the agent session to `processing` |
+| `startTyping(threadId, status?)` | Set the agent session to `processing`, or render a custom status label in the loading UX |
 
 `setAssistantStatus` and `setAssistantTitle` remain compatibility methods:
-under `agentView`, they map to `agents.sessions.*`; under legacy
-`assistant_view`, they call `assistant.threads.*`. Custom status text and
+under `agentView`, lifecycle changes map to `agents.sessions.*` and custom
+status text is surfaced through the legacy `assistant.threads.setStatus`
+compatibility bridge, which renders the text in the agent-session loading UX.
+Under legacy `assistant_view`, they call `assistant.threads.*` directly.
 `loadingMessages` only apply to the legacy experience.
 
 Customize automatic titles with `sessionTitle`:

--- a/apps/docs/content/docs/api/thread.mdx
+++ b/apps/docs/content/docs/api/thread.mdx
@@ -196,8 +196,9 @@ await thread.setState({ aiMode: false }, { replace: true });
 
 Show a typing indicator in the thread. No-op on platforms that don't support
 it. With Slack Agent messaging, this sets the session to `processing` and
-shows Slack's standard Working state plus a native stop button. Custom status
-text only applies to legacy `assistant_view`.
+shows Slack's standard Working state plus a native stop button. A custom
+status is rendered in the loading UX through the legacy
+`assistant.threads.setStatus` compatibility bridge.
 
 ```typescript
 await thread.startTyping();

--- a/apps/docs/content/docs/api/thread.mdx
+++ b/apps/docs/content/docs/api/thread.mdx
@@ -195,10 +195,14 @@ await thread.setState({ aiMode: false }, { replace: true });
 ## startTyping
 
 Show a typing indicator in the thread. No-op on platforms that don't support
-it. With Slack Agent messaging, this sets the session to `processing` and
-shows Slack's standard Working state plus a native stop button. A custom
-status is rendered in the loading UX through the legacy
-`assistant.threads.setStatus` compatibility bridge.
+it. With Slack Agent messaging, calling this without a custom status sets the
+session to `processing` and identifies the initiating user. Slack's native stop
+button also requires the `agent_session_stopped` event subscription.
+
+A custom status uses the legacy `assistant.threads.setStatus` compatibility
+bridge for loading labels instead. That endpoint cannot receive the initiating
+user, and an existing native processing indicator can take precedence over the
+label. Use the default indicator when you need native session behavior.
 
 ```typescript
 await thread.startTyping();

--- a/packages/adapter-slack/src/index.test.ts
+++ b/packages/adapter-slack/src/index.test.ts
@@ -6249,7 +6249,7 @@ describe("agent_view DM threading", () => {
     expect(threadId).toBe("slack:D1:");
   });
 
-  it("updates the Agent Session lifecycle on an agent_view DM thread", async () => {
+  it("routes custom labels and clearing separately on an agent_view DM thread", async () => {
     const adapter = createSlackAdapter({
       agentView: true,
       botToken: "xoxb-test-token",
@@ -6283,6 +6283,7 @@ describe("agent_view DM threading", () => {
         channel_id: "D1",
         thread_ts: "1771.99",
         status: "Thinking...",
+        loading_messages: ["Thinking..."],
       })
     );
     // An explicit empty status ends typing via the Agent Sessions lifecycle.
@@ -6302,6 +6303,7 @@ describe("agent_view DM threading", () => {
         channel_id: "D1",
         thread_ts: "1771.99",
         status: "Reading xyz.md",
+        loading_messages: ["Reading xyz.md"],
       })
     );
   });
@@ -6313,6 +6315,65 @@ describe("agent_view DM threading", () => {
 
 describe("startTyping", () => {
   const secret = "test-signing-secret";
+
+  it.each([
+    { status: undefined, expected: "processing" },
+    { status: "", expected: "active" },
+  ])("uses native $expected without custom text in agent view", async ({
+    status,
+    expected,
+  }) => {
+    const adapter = createSlackAdapter({
+      agentView: true,
+      botToken: "xoxb-test-token",
+      signingSecret: secret,
+      logger: mockLogger,
+      loadingMessages: ["Configured..."],
+    });
+    const sessions = vi.fn().mockResolvedValue({ ok: true });
+    const legacy = vi.fn().mockResolvedValue({ ok: true });
+    mockClientMethod(adapter, "apiCall", sessions);
+    mockClientMethod(adapter, "assistant.threads.setStatus", legacy);
+
+    await adapter.startTyping("slack:D123:1.2", status, {
+      initiatorUserId: "U123",
+    });
+
+    expect(sessions).toHaveBeenCalledExactlyOnceWith(
+      "agents.sessions.setStatus",
+      {
+        channel_id: "D123",
+        thread_ts: "1.2",
+        status: expected,
+        initiator_user_id: "U123",
+        token: "xoxb-test-token",
+      }
+    );
+    expect(legacy).not.toHaveBeenCalled();
+  });
+
+  it("does not fall back to a legacy label when native status fails", async () => {
+    const adapter = createSlackAdapter({
+      agentView: true,
+      botToken: "xoxb-test-token",
+      signingSecret: secret,
+      logger: mockLogger,
+    });
+    const failure = new Error("API error");
+    const legacy = vi.fn().mockResolvedValue({ ok: true });
+    mockClientMethod(adapter, "apiCall", vi.fn().mockRejectedValue(failure));
+    mockClientMethod(adapter, "assistant.threads.setStatus", legacy);
+
+    await expect(
+      adapter.startTyping("slack:D123:1.2")
+    ).resolves.toBeUndefined();
+
+    expect(legacy).not.toHaveBeenCalled();
+    expect(mockLogger.warn).toHaveBeenCalledWith(
+      "Slack API: agents.sessions.setStatus failed",
+      expect.objectContaining({ error: failure })
+    );
+  });
 
   it("calls assistant.threads.setStatus with default status", async () => {
     const adapter = createSlackAdapter({
@@ -8269,6 +8330,47 @@ describe("setAssistantStatus", () => {
         loading_messages: ["Step 1", "Step 2"],
       })
     );
+  });
+
+  it.each([
+    { configured: undefined, supplied: undefined, expected: ["Working..."] },
+    {
+      configured: ["Configured..."],
+      supplied: undefined,
+      expected: ["Configured..."],
+    },
+    {
+      configured: ["Configured..."],
+      supplied: ["Searching...", "Reading..."],
+      expected: ["Searching...", "Reading..."],
+    },
+  ])("passes agent loading messages $expected", async ({
+    configured,
+    supplied,
+    expected,
+  }) => {
+    const adapter = createSlackAdapter({
+      agentView: true,
+      botToken: "xoxb-test-token",
+      signingSecret: secret,
+      logger: mockLogger,
+      loadingMessages: configured,
+    });
+    const status = vi.fn().mockResolvedValue({ ok: true });
+    const sessions = vi.fn().mockResolvedValue({ ok: true });
+    mockClientMethod(adapter, "assistant.threads.setStatus", status);
+    mockClientMethod(adapter, "apiCall", sessions);
+
+    await adapter.setAssistantStatus("D123", "1.2", "Working...", supplied);
+
+    expect(status).toHaveBeenCalledWith({
+      channel_id: "D123",
+      thread_ts: "1.2",
+      status: "Working...",
+      loading_messages: expected,
+      token: "xoxb-test-token",
+    });
+    expect(sessions).not.toHaveBeenCalled();
   });
 
   it("surfaces custom status text via the legacy API and clears via the sessions lifecycle", async () => {

--- a/packages/adapter-slack/src/index.test.ts
+++ b/packages/adapter-slack/src/index.test.ts
@@ -6258,6 +6258,11 @@ describe("agent_view DM threading", () => {
     });
     const apiCall = vi.fn().mockResolvedValue({ ok: true });
     mockClientMethod(adapter, "apiCall", apiCall);
+    mockClientMethod(
+      adapter,
+      "assistant.threads.setStatus",
+      vi.fn().mockResolvedValue({ ok: true })
+    );
 
     await adapter.startTyping("slack:D1:1771.99", "Thinking...", {
       initiatorUserId: "U1",
@@ -6265,8 +6270,22 @@ describe("agent_view DM threading", () => {
     await adapter.startTyping("slack:D1:1771.99", "", {
       initiatorUserId: "U1",
     });
+    await adapter.startTyping("slack:D1:1771.99", "Reading xyz.md", {
+      initiatorUserId: "U1",
+    });
 
     const client = getClient(adapter);
+    // Custom statuses are surfaced through the legacy Assistants API, whose
+    // compatibility bridge renders the text in the agent-session loading UX.
+    expect(client.assistant.threads.setStatus).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({
+        channel_id: "D1",
+        thread_ts: "1771.99",
+        status: "Thinking...",
+      })
+    );
+    // An explicit empty status ends typing via the Agent Sessions lifecycle.
     expect(client.apiCall).toHaveBeenNthCalledWith(
       1,
       "agents.sessions.setStatus",
@@ -6274,17 +6293,15 @@ describe("agent_view DM threading", () => {
         channel_id: "D1",
         initiator_user_id: "U1",
         thread_ts: "1771.99",
-        status: "processing",
+        status: "active",
       })
     );
-    expect(client.apiCall).toHaveBeenNthCalledWith(
+    expect(client.assistant.threads.setStatus).toHaveBeenNthCalledWith(
       2,
-      "agents.sessions.setStatus",
       expect.objectContaining({
         channel_id: "D1",
-        initiator_user_id: "U1",
         thread_ts: "1771.99",
-        status: "active",
+        status: "Reading xyz.md",
       })
     );
   });
@@ -8254,7 +8271,7 @@ describe("setAssistantStatus", () => {
     );
   });
 
-  it("maps agent status text to session lifecycle states", async () => {
+  it("surfaces custom status text via the legacy API and clears via the sessions lifecycle", async () => {
     const adapter = createSlackAdapter({
       agentView: true,
       botToken: "xoxb-test-token",
@@ -8263,19 +8280,34 @@ describe("setAssistantStatus", () => {
     });
     const apiCall = vi.fn().mockResolvedValue({ ok: true });
     mockClientMethod(adapter, "apiCall", apiCall);
+    mockClientMethod(
+      adapter,
+      "assistant.threads.setStatus",
+      vi.fn().mockResolvedValue({ ok: true })
+    );
 
     await adapter.setAssistantStatus("D123", "1.2", "Working...");
     await adapter.setAssistantStatus("D123", "1.2", "");
 
-    expect(apiCall).toHaveBeenNthCalledWith(
-      1,
-      "agents.sessions.setStatus",
-      expect.objectContaining({ status: "processing" })
+    const client = getClient(adapter);
+    // A custom status is surfaced through the legacy Assistants API, whose
+    // compatibility bridge renders the text in the agent-session loading UX.
+    expect(client.assistant.threads.setStatus).toHaveBeenCalledWith(
+      expect.objectContaining({
+        channel_id: "D123",
+        thread_ts: "1.2",
+        status: "Working...",
+      })
     );
-    expect(apiCall).toHaveBeenNthCalledWith(
-      2,
+    // An empty status clears the loading state via the Agent Sessions
+    // lifecycle.
+    expect(apiCall).toHaveBeenCalledWith(
       "agents.sessions.setStatus",
-      expect.objectContaining({ status: "active" })
+      expect.objectContaining({
+        channel_id: "D123",
+        thread_ts: "1.2",
+        status: "active",
+      })
     );
   });
 });

--- a/packages/adapter-slack/src/index.ts
+++ b/packages/adapter-slack/src/index.ts
@@ -3325,7 +3325,10 @@ export class SlackAdapter implements Adapter<SlackThreadId, unknown> {
         } catch (error) {
           this.logger.warn(
             "agent_view DM subscription check failed; using per-message thread",
-            { error: String(error), threadId }
+            {
+              error: String(error),
+              threadId,
+            }
           );
         }
         try {
@@ -3366,7 +3369,10 @@ export class SlackAdapter implements Adapter<SlackThreadId, unknown> {
         .catch((error) => {
           this.logger.warn(
             "Skipping Slack agent session title after message processing failed",
-            { error, threadId }
+            {
+              error,
+              threadId,
+            }
           );
         });
       options?.waitUntil?.(titleTask);
@@ -3495,7 +3501,10 @@ export class SlackAdapter implements Adapter<SlackThreadId, unknown> {
             // Never let a lookup failure on the old snapshot drop the edit
             this.logger.warn(
               "Falling back to sync parse for pre-edit message",
-              { error, threadId }
+              {
+                error,
+                threadId,
+              }
             );
             return this.parseSlackMessageSync(snapshot, threadId);
           }
@@ -4088,29 +4097,26 @@ export class SlackAdapter implements Adapter<SlackThreadId, unknown> {
     status: string,
     loadingMessages?: string[]
   ): Promise<void> {
-    if (this.agentView) {
-      if (loadingMessages?.length || status.trim()) {
-        this.logger.debug(
-          "Slack Agent Sessions use the standard Working status; custom loading text is ignored"
-        );
-      }
-      await this.setSessionStatus(
-        channelId,
-        threadTs,
-        status.trim() ? "processing" : "active"
-      );
+    // An empty status clears the loading state; the Agent Sessions lifecycle
+    // has no "clear", so it maps to `active`.
+    if (this.agentView && !status.trim()) {
+      await this.setSessionStatus(channelId, threadTs, "active");
       return;
     }
 
-    const effectiveLoadingMessages = loadingMessages ?? this.loadingMessages;
+    // A custom status is surfaced through the legacy Assistants API: its
+    // compatibility bridge renders the text in the agent-session loading UX,
+    // while `agents.sessions.setStatus` only supports lifecycle states.
     await this._client.assistant.threads.setStatus(
       await this.withToken({
         channel_id: channelId,
         thread_ts: threadTs,
         status,
-        ...(effectiveLoadingMessages && {
-          loading_messages: effectiveLoadingMessages,
-        }),
+        ...(this.agentView
+          ? {}
+          : {
+              loading_messages: loadingMessages ?? this.loadingMessages,
+            }),
       })
     );
   }
@@ -5589,7 +5595,7 @@ export class SlackAdapter implements Adapter<SlackThreadId, unknown> {
       this.logger.debug("Slack: startTyping skipped - no thread context");
       return;
     }
-    if (this.agentView) {
+    if (this.agentView && !status) {
       const sessionStatus = status === "" ? "active" : "processing";
       this.logger.debug("Slack API: agents.sessions.setStatus", {
         channel,
@@ -5610,6 +5616,9 @@ export class SlackAdapter implements Adapter<SlackThreadId, unknown> {
       return;
     }
 
+    // A custom status is surfaced through the legacy Assistants API: its
+    // compatibility bridge renders the text in the agent-session loading UX,
+    // while `agents.sessions.setStatus` only supports lifecycle states.
     this.logger.debug("Slack API: assistant.threads.setStatus", {
       channel,
       threadTs,
@@ -5699,7 +5708,10 @@ export class SlackAdapter implements Adapter<SlackThreadId, unknown> {
     if (!this.nativeStreaming || this.nativeStreamingBroken) {
       this.logger.debug(
         "Slack: using fallback stream - native streaming disabled",
-        { configured: this.nativeStreaming, broken: this.nativeStreamingBroken }
+        {
+          configured: this.nativeStreaming,
+          broken: this.nativeStreamingBroken,
+        }
       );
       return null;
     }
@@ -5866,7 +5878,10 @@ export class SlackAdapter implements Adapter<SlackThreadId, unknown> {
       }
       this.logger.warn(
         "Slack native streaming unavailable, falling back to post-and-edit",
-        { channel, error }
+        {
+          channel,
+          error,
+        }
       );
     };
 
@@ -6233,14 +6248,20 @@ export class SlackAdapter implements Adapter<SlackThreadId, unknown> {
         }
         this.logger.warn(
           "Slack: stream expired before stop, stream-end blocks skipped",
-          { channel, messageId: expiredTs, skippedBlocks: stopBlocks.length }
+          {
+            channel,
+            messageId: expiredTs,
+            skippedBlocks: stopBlocks.length,
+          }
         );
         await this.endTyping(threadId, options?.sessionStatus ?? "active");
         return { id: expiredTs, threadId, raw: { ts: expiredTs } };
       }
       this.logger.warn(
         "Slack: stream expired before stop, delivering the rest in a new message",
-        { channel }
+        {
+          channel,
+        }
       );
       await startNextSegment(lastFlushed);
       result = await segment.streamer.stop({

--- a/packages/adapter-slack/src/index.ts
+++ b/packages/adapter-slack/src/index.ts
@@ -4088,6 +4088,11 @@ export class SlackAdapter implements Adapter<SlackThreadId, unknown> {
    * Uses Agent Sessions when `agentView` is enabled and the legacy Assistants
    * API otherwise.
    *
+   * A custom status is surfaced through the legacy Assistants API: its
+   * compatibility bridge renders the text in the agent-session loading UX.
+   * An empty status clears the loading state via the Agent Sessions
+   * lifecycle.
+   *
    * When `loadingMessages` is omitted, falls back to the adapter-level
    * `loadingMessages` config.
    */

--- a/packages/adapter-slack/src/index.ts
+++ b/packages/adapter-slack/src/index.ts
@@ -4117,11 +4117,10 @@ export class SlackAdapter implements Adapter<SlackThreadId, unknown> {
         channel_id: channelId,
         thread_ts: threadTs,
         status,
-        ...(this.agentView
-          ? {}
-          : {
-              loading_messages: loadingMessages ?? this.loadingMessages,
-            }),
+        loading_messages:
+          loadingMessages ??
+          this.loadingMessages ??
+          (this.agentView ? [status] : undefined),
       })
     );
   }


### PR DESCRIPTION
## summary

- restore custom loading labels for `startTyping` and `setAssistantStatus` under `agentView`, which stopped displaying after #862 moved status updates to the native sessions API
- send custom labels through `assistant.threads.setStatus` with `loading_messages`; `setAssistantStatus` preserves explicit arrays, then configured defaults, then falls back to the custom status
- keep native `processing` and initiator attribution when `startTyping()` has no custom status, and use native `active` when clearing
- add regression coverage for message precedence, native routing, clearing, and native API failures
- verify custom labels in DMs and channels, streamed completion, and real native stop-button cancellation against locally built packages

## limitations

custom labels and native session state are not equivalent: in the test workspace, the custom-label path displayed the requested text but did not create a native processing session or stop button, even with `agent_session_stopped` enabled

use `startTyping()` without custom text when native processing and stop behavior are required; an existing native processing indicator can also take precedence over a custom label

Slack's [native sessions API](https://docs.slack.dev/ai/agent-sessions/) does not accept custom loading text, so this restores labels through the [legacy status endpoint](https://docs.slack.dev/reference/methods/assistant.threads.setStatus/) without promising identical lifecycle behavior
