### PR TITLE
fix(teams): preserve outgoing mention text

### DIFF
--- a/.changeset/lemon-hotels-send.md
+++ b/.changeset/lemon-hotels-send.md
@@ -1,0 +1,5 @@
+---
+"@chat-adapter/teams": patch
+---
+
+preserve outgoing @names as plain text instead of generating mention markup without matching entities

--- a/apps/docs/content/adapters/official/teams.mdx
+++ b/apps/docs/content/adapters/official/teams.mdx
@@ -88,6 +88,10 @@ bot.onNewMention(async (thread, message) => {
 });
 ```
 
+## Mentions
+
+Incoming Teams mentions are supported. Outgoing `@name` text, including multi-word names, stays plain text and does not notify the user. The adapter does not resolve display names into user identities or generate mention entities. Teams requires [matching mention text and entities](https://learn.microsoft.com/en-us/microsoftteams/platform/bots/how-to/conversations/channel-and-group-conversations#add-mentions-to-your-messages) for a real mention; `<at>` markup alone is not sufficient.
+
 ## Configuration
 
 <TypeTable

--- a/packages/adapter-teams/README.md
+++ b/packages/adapter-teams/README.md
@@ -154,6 +154,10 @@ TEAMS_APP_TENANT_ID=...  # Required for SingleTenant apps
 TEAMS_API_URL=...        # Optional, for GCC-High or sovereign-cloud deployments
 ```
 
+## Mentions
+
+Incoming Teams mentions are supported. Outgoing `@name` text, including multi-word names, stays plain text and does not notify the user. The adapter does not resolve display names into user identities or generate mention entities. Teams requires [matching mention text and entities](https://learn.microsoft.com/en-us/microsoftteams/platform/bots/how-to/conversations/channel-and-group-conversations#add-mentions-to-your-messages) for a real mention; `<at>` markup alone is not sufficient.
+
 ## Features
 
 ### Messaging

--- a/packages/adapter-teams/src/markdown.test.ts
+++ b/packages/adapter-teams/src/markdown.test.ts
@@ -104,10 +104,10 @@ describe("TeamsFormatConverter", () => {
       expect(result).toContain("2. second");
     });
 
-    it("should convert @mentions to <at>mention</at>", () => {
+    it("should preserve @mentions as text", () => {
       const ast = converter.toAst("Hello @someone");
       const result = converter.fromAst(ast);
-      expect(result).toContain("<at>someone</at>");
+      expect(result).toBe("Hello @someone");
     });
 
     it("should not turn email addresses into mentions", () => {
@@ -205,14 +205,41 @@ describe("TeamsFormatConverter", () => {
   });
 
   describe("renderPostable", () => {
-    it("should convert @mentions in plain strings", () => {
+    it("should preserve @mentions in plain strings", () => {
       const result = converter.renderPostable("Hello @user");
-      expect(result).toBe("Hello <at>user</at>");
+      expect(result).toBe("Hello @user");
     });
 
-    it("should convert @mentions in raw messages", () => {
+    it("should preserve @mentions in raw messages", () => {
       const result = converter.renderPostable({ raw: "Hello @user" });
-      expect(result).toBe("Hello <at>user</at>");
+      expect(result).toBe("Hello @user");
+    });
+
+    it.each([
+      "Hi @Alex Smith, meet @someone",
+      "[user@example.com](mailto:user@example.com) and [@someone](https://example.com/@someone)",
+      "Use `@someone` or **@Alex Smith**",
+      "```text\n@Alex Smith\n```",
+    ])("preserves names and formatting in %j", (text) => {
+      for (const message of [
+        text,
+        { raw: text },
+        { markdown: text },
+        { ast: converter.toAst(text) },
+      ]) {
+        expect(converter.renderPostable(message)).toBe(text);
+      }
+    });
+
+    it("preserves explicit mention markup in raw text", () => {
+      const text = "Hi <at>Alex Smith</at>";
+      expect(converter.renderPostable(text)).toBe(text);
+      expect(converter.renderPostable({ raw: text })).toBe(text);
+    });
+
+    it("decodes incoming full-name mentions without recreating markup", () => {
+      const ast = converter.toAst("Hi <at>Alex Smith</at>");
+      expect(converter.fromAst(ast)).toBe("Hi @Alex Smith");
     });
 
     it("should render markdown messages", () => {

--- a/packages/adapter-teams/src/markdown.ts
+++ b/packages/adapter-teams/src/markdown.ts
@@ -11,7 +11,7 @@
  * Teams also accepts standard markdown in most cases.
  */
 
-import { escapeTableCell, replaceBareMentions } from "@chat-adapter/shared";
+import { escapeTableCell } from "@chat-adapter/shared";
 import {
   type AdapterPostableMessage,
   BaseFormatConverter,
@@ -35,23 +35,14 @@ import {
 
 export class TeamsFormatConverter extends BaseFormatConverter {
   /**
-   * Convert bare `@mentions` to Teams format (`@name` → `<at>name</at>`),
-   * leaving emails, URLs, code spans, and existing `<at>…</at>` tokens
-   * untouched.
-   */
-  private convertMentionsToTeams(text: string): string {
-    return replaceBareMentions(text, (_mention, name) => `<at>${name}</at>`);
-  }
-
-  /**
-   * Override renderPostable to convert @mentions in plain strings.
+   * Render text messages while preserving raw strings.
    */
   override renderPostable(message: AdapterPostableMessage): string {
     if (typeof message === "string") {
-      return this.convertMentionsToTeams(message);
+      return message;
     }
     if ("raw" in message) {
-      return this.convertMentionsToTeams(message.raw);
+      return message.raw;
     }
     if ("markdown" in message) {
       return this.fromAst(parseMarkdown(message.markdown));
@@ -141,8 +132,7 @@ export class TeamsFormatConverter extends BaseFormatConverter {
     }
 
     if (isTextNode(node)) {
-      // Convert bare @mentions to Teams format <at>mention</at>
-      return this.convertMentionsToTeams(node.value);
+      return node.value;
     }
 
     if (isStrongNode(node)) {

--- a/packages/integration-tests/src/teams.test.ts
+++ b/packages/integration-tests/src/teams.test.ts
@@ -361,9 +361,10 @@ describe("Teams Integration", () => {
       expect(text).toContain("`code`");
     });
 
-    it("should convert @mentions to Teams format in posted messages", async () => {
+    it("should preserve @names in posted and edited messages", async () => {
       chat.onNewMention(async (thread) => {
-        await thread.post("Hey @john, check this out!");
+        const message = await thread.post("Hey @Alex Smith, check this out!");
+        await message.edit({ markdown: "Thanks **@Alex Smith** and @someone" });
       });
 
       const activity = createTeamsActivity({
@@ -387,7 +388,10 @@ describe("Teams Integration", () => {
       await tracker.waitForAll();
 
       const sentActivity = mockTeamsApp.sentActivities[0] as { text: string };
-      expect(sentActivity.text).toBe("Hey <at>john</at>, check this out!");
+      expect(sentActivity.text).toBe("Hey @Alex Smith, check this out!");
+      expect(mockTeamsApp.updatedActivities).toContainEqual(
+        expect.objectContaining({ text: "Thanks **@Alex Smith** and @someone" })
+      );
     });
   });
 


### PR DESCRIPTION
## summary

- keep outgoing `@names` as plain text instead of generating `<at>` markup without the mention entities Teams requires
- preserve multi-word names across plain text, raw, markdown, and AST messages
- keep incoming mention decoding and explicit raw markup unchanged
- add formatter and send/edit regression tests and document that plain-text names do not notify users

closes #853