### PR TITLE
feat(teams): dispatch bot join events

### DIFF
--- a/.changeset/chilly-parents-glow.md
+++ b/.changeset/chilly-parents-glow.md
@@ -1,0 +1,5 @@
+---
+"@chat-adapter/teams": minor
+---
+
+emit Teams bot-join events and expose the bot user ID

--- a/apps/docs/content/adapters/official/teams.mdx
+++ b/apps/docs/content/adapters/official/teams.mdx
@@ -296,6 +296,23 @@ By default, Teams bots only receive messages when directly @-mentioned. The RSC 
 
 Run `teams app doctor <appId>` to diagnose common issues — bot registration, AAD app health, manifest consistency, and endpoint reachability.
 
+## Bot joins
+
+`onMemberJoinedChannel` fires when a `conversationUpdate` activity adds this bot to a channel or group chat. `adapter.botUserId` is the Teams bot ID (`28:<appId>`), so the same bot-join guard works across adapters:
+
+```typescript
+bot.onMemberJoinedChannel(async (event) => {
+  if (event.userId !== event.adapter.botUserId) {
+    return;
+  }
+  await bot.channel(event.channelId).post("Hello! Thanks for adding me.");
+});
+```
+
+For team installations, `channelId` identifies the channel selected during installation, not the team ID. `inviterId` comes from the activity sender. Pass your platform's `waitUntil` to the webhook handler to track asynchronous welcome handlers.
+
+This dispatches bot joins only. Personal installs, ordinary member additions, removals, and `installationUpdate` activities do not emit this event. See Microsoft's [conversation event documentation](https://learn.microsoft.com/en-us/microsoftteams/platform/bots/how-to/conversations/subscribe-to-conversation-events#members-added) for the underlying payloads.
+
 ## Low-level APIs
 
 Use the low-level Teams subpaths when your app already owns routing, state, sessions, or workflow execution and only needs Teams-specific primitives.

--- a/apps/docs/content/docs/handling-events.mdx
+++ b/apps/docs/content/docs/handling-events.mdx
@@ -500,7 +500,7 @@ bot.onDirectMessage((thread, message) => {
 
 ### Handling member joined channel
 
-`onMemberJoinedChannel` fires when a user joins a Slack channel. Use it to post welcome messages or onboard users automatically.
+`onMemberJoinedChannel` fires when a member joins a channel. Slack emits it for every user who joins a channel the bot can see. Teams emits it only when the bot itself is added to a channel or group chat. Use it to post welcome messages or onboard users automatically.
 
 ```typescript title="lib/bot.ts" lineNumbers
 bot.onMemberJoinedChannel(async (event) => {
@@ -520,7 +520,7 @@ The `event` object includes:
 
 | Property | Type | Description |
 |----------|------|-------------|
-| `adapter` | `Adapter` | The Slack adapter |
+| `adapter` | `Adapter` | The adapter that emitted the event (Slack or Teams) |
 | `channelId` | `string` | The channel that was joined |
-| `userId` | `string` | The user who joined |
+| `userId` | `string` | The user who joined. On Teams this is always the bot (`28:<appId>`) |
 | `inviterId` | `string` (optional) | The user who invited them |

--- a/packages/adapter-teams/README.md
+++ b/packages/adapter-teams/README.md
@@ -209,6 +209,23 @@ TEAMS_API_URL=...        # Optional, for GCC-High or sovereign-cloud deployments
 
 Incoming thread IDs preserve the Teams conversation type when the legacy ID-prefix heuristic would route it incorrectly. When Teams omits `conversationType`, the adapter falls back to `conversation.isGroup` and the activity's team context. This keeps correctly classified IDs stable while selecting the buffered fallback for group chats whose IDs begin with `a:`. Thread IDs created by older adapter versions remain supported.
 
+## Bot joins
+
+`onMemberJoinedChannel` fires when a `conversationUpdate` activity adds this bot to a channel or group chat. `adapter.botUserId` is the Teams bot ID (`28:<appId>`), so the same bot-join guard works across adapters:
+
+```typescript
+bot.onMemberJoinedChannel(async (event) => {
+  if (event.userId !== event.adapter.botUserId) {
+    return;
+  }
+  await bot.channel(event.channelId).post("Hello! Thanks for adding me.");
+});
+```
+
+For team installations, `channelId` identifies the channel selected during installation, not the team ID. `inviterId` comes from the activity sender. Pass your platform's `waitUntil` to the webhook handler to track asynchronous welcome handlers.
+
+This dispatches bot joins only. Personal installs, ordinary member additions, removals, and `installationUpdate` activities do not emit this event. See Microsoft's [conversation event documentation](https://learn.microsoft.com/en-us/microsoftteams/platform/bots/how-to/conversations/subscribe-to-conversation-events#members-added) for the underlying payloads.
+
 ## Incoming attachments
 
 Incoming inline images and files are exposed through `message.attachments` with a lazy `fetchData()` method. The adapter authenticates connector-hosted inline attachments through the configured Teams bot client, while [Teams file download cards](https://learn.microsoft.com/en-us/microsoftteams/platform/bots/how-to/bots-filesv4) use their direct download URL without the bot token.

--- a/packages/adapter-teams/src/index.ts
+++ b/packages/adapter-teams/src/index.ts
@@ -10,6 +10,7 @@ import type {
   Account,
   Activity,
   IAdaptiveCardActionInvokeActivity,
+  IConversationUpdateActivity,
   IMessageActivity,
   IMessageReactionActivity,
   ITaskFetchInvokeActivity,
@@ -149,6 +150,8 @@ export class TeamsAdapter implements Adapter<TeamsThreadId, unknown> {
       httpServerAdapter: this.bridgeAdapter,
     });
 
+    this.botUserId = this.app.id ? `28:${this.app.id}` : undefined;
+
     this.graphReader = new TeamsGraphReader({
       botId: this.app.id ?? "",
       graph: this.app.graph,
@@ -202,11 +205,41 @@ export class TeamsAdapter implements Adapter<TeamsThreadId, unknown> {
 
     this.app.on("conversationUpdate", async (ctx) => {
       this.cacheUserContext(ctx.activity);
+      this.handleConversationUpdate(ctx.activity);
     });
 
     this.app.on("installationUpdate", async (ctx) => {
       this.cacheUserContext(ctx.activity);
     });
+  }
+
+  protected handleConversationUpdate(
+    activity: IConversationUpdateActivity
+  ): void {
+    const conversationType = conversationTypeFromActivity(activity);
+    const userId = this.botUserId;
+    if (
+      !(this.chat && userId) ||
+      (conversationType !== "channel" && conversationType !== "groupChat") ||
+      !activity.conversation?.id ||
+      !activity.serviceUrl ||
+      activity.recipient?.id !== userId ||
+      !activity.membersAdded?.some((member) => member.id === userId)
+    ) {
+      return;
+    }
+
+    this.chat.processMemberJoinedChannel(
+      {
+        adapter: this,
+        channelId: this.channelIdFromThreadId(
+          this.threadIdFromActivity(activity)
+        ),
+        userId,
+        inviterId: activity.from?.id,
+      },
+      this.bridgeAdapter.getWebhookOptions(activity.id)
+    );
   }
 
   /**

--- a/packages/adapter-teams/src/index.ts
+++ b/packages/adapter-teams/src/index.ts
@@ -216,30 +216,77 @@ export class TeamsAdapter implements Adapter<TeamsThreadId, unknown> {
   protected handleConversationUpdate(
     activity: IConversationUpdateActivity
   ): void {
-    const conversationType = conversationTypeFromActivity(activity);
+    if (!this.chat) {
+      this.logger.warn(
+        "Chat instance not initialized, ignoring conversationUpdate"
+      );
+      return;
+    }
+
     const userId = this.botUserId;
-    if (
-      !(this.chat && userId) ||
-      (conversationType !== "channel" && conversationType !== "groupChat") ||
-      !activity.conversation?.id ||
-      !activity.serviceUrl ||
-      activity.recipient?.id !== userId ||
-      !activity.membersAdded?.some((member) => member.id === userId)
-    ) {
+    if (!userId) {
+      this.logger.warn(
+        "Teams app ID is not configured, ignoring conversationUpdate. " +
+          "Set appId or TEAMS_APP_ID to receive bot join events."
+      );
+      return;
+    }
+
+    const resolved = this.resolveBotJoin(activity);
+    if ("skip" in resolved) {
+      this.logger.debug("Ignoring conversationUpdate", {
+        activityId: activity.id,
+        reason: resolved.skip,
+      });
       return;
     }
 
     this.chat.processMemberJoinedChannel(
       {
         adapter: this,
-        channelId: this.channelIdFromThreadId(
-          this.threadIdFromActivity(activity)
-        ),
+        channelId: this.encodeThreadId(resolved.join),
         userId,
         inviterId: activity.from?.id,
       },
       this.bridgeAdapter.getWebhookOptions(activity.id)
     );
+  }
+
+  /**
+   * Decide whether a conversationUpdate is this bot being added to a channel
+   * or group chat. Returns the thread to dispatch on, or the reason to skip.
+   *
+   * Teams sends the bot's own ID as `recipient.id`, so membersAdded is
+   * compared against that platform-supplied value rather than a locally
+   * built one; the recipient itself is matched case-insensitively against
+   * the configured app ID.
+   */
+  private resolveBotJoin(
+    activity: IConversationUpdateActivity
+  ): { join: TeamsThreadId } | { skip: string } {
+    const recipientId = activity.recipient?.id;
+    if (!(recipientId && this.isBotAccountId(recipientId))) {
+      return { skip: "recipient is not this bot" };
+    }
+    if (!activity.membersAdded?.some((member) => member.id === recipientId)) {
+      return { skip: "bot was not among the added members" };
+    }
+    const conversationId = activity.conversation?.id;
+    if (!conversationId) {
+      return { skip: "missing conversation id" };
+    }
+    const serviceUrl = activity.serviceUrl;
+    if (!serviceUrl) {
+      return { skip: "missing serviceUrl" };
+    }
+    const conversationType = conversationTypeFromActivity(activity);
+    const isPersonal = conversationType
+      ? conversationType === "personal"
+      : !conversationId.startsWith("19:");
+    if (isPersonal) {
+      return { skip: "personal conversation" };
+    }
+    return { join: { conversationId, conversationType, serviceUrl } };
   }
 
   /**
@@ -285,10 +332,17 @@ export class TeamsAdapter implements Adapter<TeamsThreadId, unknown> {
     const conversationId = activity.conversation?.id || "";
     const baseChannelId = conversationId.replace(MESSAGEID_STRIP_PATTERN, "");
 
-    if (teamAadGroupId && channelData?.channel?.id) {
+    // Team-scoped conversationUpdate payloads (bot added to a team) carry
+    // team.aadGroupId but no channelData.channel; the conversation itself is
+    // the channel the bot was installed into.
+    const teamChannelId =
+      channelData?.channel?.id ??
+      (baseChannelId.startsWith("19:") ? baseChannelId : undefined);
+
+    if (teamAadGroupId && teamChannelId) {
       const context: TeamsChannelContext = {
         teamId: teamAadGroupId,
-        channelId: channelData.channel.id,
+        channelId: teamChannelId,
       };
       this.chat
         .getState()
@@ -1792,19 +1846,21 @@ export class TeamsAdapter implements Adapter<TeamsThreadId, unknown> {
 
   protected isMessageFromSelf(activity: Activity): boolean {
     const fromId = activity.from?.id;
-    if (!(fromId && this.app.id)) {
+    return fromId ? this.isBotAccountId(fromId) : false;
+  }
+
+  /**
+   * Whether a Teams account ID (`28:<appId>`, or a bare app ID) refers to
+   * this bot. GUID casing differs between configuration and Teams payloads,
+   * so the comparison is case-insensitive.
+   */
+  private isBotAccountId(accountId: string): boolean {
+    const appId = this.app.id?.toLowerCase();
+    if (!appId) {
       return false;
     }
-
-    if (fromId === this.app.id) {
-      return true;
-    }
-
-    if (fromId.endsWith(`:${this.app.id}`)) {
-      return true;
-    }
-
-    return false;
+    const normalized = accountId.toLowerCase();
+    return normalized === appId || normalized.endsWith(`:${appId}`);
   }
 
   renderFormatted(content: FormattedContent): string {

--- a/packages/adapter-teams/src/joins.test.ts
+++ b/packages/adapter-teams/src/joins.test.ts
@@ -13,31 +13,42 @@ const serviceUrl = "https://smba.trafficmanager.net/amer/";
 const conversationId = "19:channel@thread.tacv2";
 const logger = createMockLogger();
 
+const token = {
+  appId,
+  serviceUrl,
+  from: "azure" as const,
+  fromId: appId,
+  isExpired: () => false,
+  toString: () => "test-token",
+};
+
 class JoinAdapter extends TeamsAdapter {
-  prepare(options?: WebhookOptions) {
+  /** Return fixed WebhookOptions from the bridge instead of the real map. */
+  stubWebhookOptions(options?: WebhookOptions) {
+    return vi
+      .spyOn(this.bridgeAdapter, "getWebhookOptions")
+      .mockReturnValue(options);
+  }
+
+  /** Stub outbound Bot Framework calls so welcome posts do not hit the network. */
+  stubOutbound() {
     vi.spyOn(this.app.api.users, "getToken").mockResolvedValue({});
-    const send = vi.spyOn(this.app, "send").mockResolvedValue({
+    return vi.spyOn(this.app, "send").mockResolvedValue({
       id: "welcome",
       type: "message",
     });
-    const lookup = vi
-      .spyOn(this.bridgeAdapter, "getWebhookOptions")
-      .mockReturnValue(options);
-    return { send, lookup };
+  }
+
+  /** Accept webhooks without a JWT so handleWebhook can be driven end to end. */
+  allowUnauthenticatedWebhooks() {
+    const server = this.app.server as unknown as {
+      authorize: () => Promise<unknown>;
+    };
+    vi.spyOn(server, "authorize").mockResolvedValue({ success: true, token });
   }
 
   receive(body: { type: string; [key: string]: unknown }) {
-    return this.app.process({
-      body,
-      token: {
-        appId,
-        serviceUrl,
-        from: "azure",
-        fromId: appId,
-        isExpired: () => false,
-        toString: () => "test-token",
-      },
-    });
+    return this.app.process({ body, token });
   }
 }
 
@@ -69,13 +80,13 @@ describe("Teams bot joins", () => {
   let adapter: JoinAdapter;
   let chat: ReturnType<typeof createMockChatInstance>;
   let options: WebhookOptions;
-  let mocks: ReturnType<JoinAdapter["prepare"]>;
+  let lookup: ReturnType<JoinAdapter["stubWebhookOptions"]>;
 
   beforeEach(async () => {
     adapter = new JoinAdapter({ appId, appPassword: "test", logger });
     chat = createMockChatInstance();
     options = { waitUntil: vi.fn() };
-    mocks = adapter.prepare(options);
+    lookup = adapter.stubWebhookOptions(options);
     await adapter.initialize(chat);
   });
 
@@ -112,10 +123,14 @@ describe("Teams bot joins", () => {
       },
       options
     );
-    expect(mocks.lookup).toHaveBeenCalledWith("join-activity");
+    expect(lookup).toHaveBeenCalledWith("join-activity");
+  });
+
+  it("caches Graph channel context from the team-install payload", async () => {
+    await adapter.receive(activity());
     expect(chat.getState().set).toHaveBeenCalledWith(
-      "teams:serviceUrl:29:inviter",
-      serviceUrl,
+      `teams:channelContext:${conversationId}`,
+      JSON.stringify({ teamId: "team-aad", channelId: conversationId }),
       expect.any(Number)
     );
   });
@@ -153,13 +168,49 @@ describe("Teams bot joins", () => {
     expect(chat.processMemberJoinedChannel).toHaveBeenCalledOnce();
   });
 
+  it("falls back to the 19: prefix when the conversation type is unresolved", async () => {
+    await adapter.receive({
+      ...activity(),
+      conversation: { id: "19:unknown@thread.tacv2" },
+      channelData: undefined,
+    });
+    expect(chat.processMemberJoinedChannel).toHaveBeenCalledExactlyOnceWith(
+      expect.objectContaining({
+        channelId: adapter.encodeThreadId({
+          conversationId: "19:unknown@thread.tacv2",
+          serviceUrl,
+        }),
+        userId: botId,
+      }),
+      options
+    );
+  });
+
+  it("matches the bot identity regardless of app ID casing", async () => {
+    const upperAppId = appId.toUpperCase();
+    const upper = new JoinAdapter({
+      appId: upperAppId,
+      appPassword: "test",
+      logger,
+    });
+    upper.stubWebhookOptions(options);
+    await upper.initialize(chat);
+
+    await upper.receive(activity());
+    expect(chat.processMemberJoinedChannel).toHaveBeenCalledExactlyOnceWith(
+      expect.objectContaining({ userId: `28:${upperAppId}` }),
+      options
+    );
+    expect(upper.botUserId).toBe(`28:${upperAppId}`);
+  });
+
   it.each([
     { membersAdded: [{ id: "29:user" }] },
     { membersAdded: [] },
     { membersAdded: undefined, membersRemoved: [{ id: botId }] },
     { recipient: { id: "28:other-app" } },
     { conversation: { id: "personal", conversationType: "personal" } },
-    { conversation: { id: "19:unknown" } },
+    { conversation: { id: "a:unknown" } },
     { conversation: { id: "", conversationType: "channel" } },
     { serviceUrl: "" },
     { type: "installationUpdate", action: "add" },
@@ -170,6 +221,34 @@ describe("Teams bot joins", () => {
     expect(chat.processMemberJoinedChannel).not.toHaveBeenCalled();
   });
 
+  it("logs the skip reason at debug level", async () => {
+    await adapter.receive({
+      ...activity(),
+      membersAdded: [{ id: "29:user" }],
+    });
+    expect(logger.debug).toHaveBeenCalledWith(
+      "Ignoring conversationUpdate",
+      expect.objectContaining({
+        activityId: "join-activity",
+        reason: "bot was not among the added members",
+      })
+    );
+  });
+
+  it("warns instead of silently dropping joins when no app ID is configured", async () => {
+    vi.stubEnv("TEAMS_APP_ID", "");
+    const unconfigured = new JoinAdapter({ appPassword: "test", logger });
+    unconfigured.stubWebhookOptions(options);
+    await unconfigured.initialize(chat);
+    expect(unconfigured.botUserId).toBeUndefined();
+
+    await unconfigured.receive(activity());
+    expect(chat.processMemberJoinedChannel).not.toHaveBeenCalled();
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.stringContaining("TEAMS_APP_ID")
+    );
+  });
+
   it("dispatches only the bot when several members are added", async () => {
     await adapter.receive({
       ...activity(),
@@ -178,19 +257,43 @@ describe("Teams bot joins", () => {
     expect(chat.processMemberJoinedChannel).toHaveBeenCalledOnce();
   });
 
+  it("passes handleWebhook options to the join through the bridge", async () => {
+    const runtime = new JoinAdapter({ appId, appPassword: "test", logger });
+    runtime.allowUnauthenticatedWebhooks();
+    await runtime.initialize(chat);
+    const webhookOptions: WebhookOptions = { waitUntil: vi.fn() };
+
+    const response = await runtime.handleWebhook(
+      new Request("https://example.com/api/webhooks/teams", {
+        method: "POST",
+        body: JSON.stringify(activity()),
+        headers: { "content-type": "application/json" },
+      }),
+      webhookOptions
+    );
+
+    expect(response.status).toBe(200);
+    expect(chat.processMemberJoinedChannel).toHaveBeenCalledExactlyOnceWith(
+      expect.objectContaining({ userId: botId }),
+      webhookOptions
+    );
+  });
+
   it("runs an asynchronous welcome handler using the existing channel API", async () => {
     const runtime = new JoinAdapter({ appId, appPassword: "test", logger });
     const tasks: Promise<unknown>[] = [];
     const waitUntil = (task: Promise<unknown>) => tasks.push(task);
-    const { send } = runtime.prepare({ waitUntil });
+    runtime.stubWebhookOptions({ waitUntil });
+    const send = runtime.stubOutbound();
     const bot = new Chat({
       userName: "test",
       adapters: { teams: runtime },
       state: createMockState(),
       logger,
     });
+    let received: MemberJoinedChannelEvent | undefined;
     const handler = vi.fn(async (event: MemberJoinedChannelEvent) => {
-      expect(event.userId).toBe(event.adapter.botUserId);
+      received = event;
       await Promise.resolve();
       await bot.channel(event.channelId).post("Welcome");
     });
@@ -201,6 +304,8 @@ describe("Teams bot joins", () => {
     expect(tasks).toHaveLength(1);
     await Promise.all(tasks);
     expect(handler).toHaveBeenCalledOnce();
+    expect(received?.userId).toBe(botId);
+    expect(received?.adapter.botUserId).toBe(botId);
     expect(send).toHaveBeenCalledWith(
       conversationId,
       expect.objectContaining({ text: "Welcome" })

--- a/packages/adapter-teams/src/joins.test.ts
+++ b/packages/adapter-teams/src/joins.test.ts
@@ -1,0 +1,209 @@
+import {
+  createMockChatInstance,
+  createMockLogger,
+  createMockState,
+} from "@chat-adapter/tests";
+import { Chat, type MemberJoinedChannelEvent, type WebhookOptions } from "chat";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { TeamsAdapter } from "./index";
+
+const appId = "11111111-2222-3333-4444-555555555555";
+const botId = `28:${appId}`;
+const serviceUrl = "https://smba.trafficmanager.net/amer/";
+const conversationId = "19:channel@thread.tacv2";
+const logger = createMockLogger();
+
+class JoinAdapter extends TeamsAdapter {
+  prepare(options?: WebhookOptions) {
+    vi.spyOn(this.app.api.users, "getToken").mockResolvedValue({});
+    const send = vi.spyOn(this.app, "send").mockResolvedValue({
+      id: "welcome",
+      type: "message",
+    });
+    const lookup = vi
+      .spyOn(this.bridgeAdapter, "getWebhookOptions")
+      .mockReturnValue(options);
+    return { send, lookup };
+  }
+
+  receive(body: { type: string; [key: string]: unknown }) {
+    return this.app.process({
+      body,
+      token: {
+        appId,
+        serviceUrl,
+        from: "azure",
+        fromId: appId,
+        isExpired: () => false,
+        toString: () => "test-token",
+      },
+    });
+  }
+}
+
+function activity() {
+  return {
+    type: "conversationUpdate",
+    id: "join-activity",
+    channelId: "msteams",
+    serviceUrl,
+    from: { id: "29:inviter", aadObjectId: "inviter-aad" },
+    recipient: { id: botId },
+    conversation: {
+      id: conversationId,
+      conversationType: "channel",
+      isGroup: true,
+      tenantId: "tenant",
+    },
+    membersAdded: [{ id: botId }],
+    channelData: {
+      eventType: "teamMemberAdded",
+      team: { id: "19:team", aadGroupId: "team-aad" },
+      settings: { selectedChannel: { id: conversationId } },
+      tenant: { id: "tenant" },
+    },
+  };
+}
+
+describe("Teams bot joins", () => {
+  let adapter: JoinAdapter;
+  let chat: ReturnType<typeof createMockChatInstance>;
+  let options: WebhookOptions;
+  let mocks: ReturnType<JoinAdapter["prepare"]>;
+
+  beforeEach(async () => {
+    adapter = new JoinAdapter({ appId, appPassword: "test", logger });
+    chat = createMockChatInstance();
+    options = { waitUntil: vi.fn() };
+    mocks = adapter.prepare(options);
+    await adapter.initialize(chat);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllEnvs();
+  });
+
+  it("exposes the configured bot identity", () => {
+    expect(adapter.botUserId).toBe(botId);
+  });
+
+  it("uses the resolved app identity with environment fallback", () => {
+    vi.stubEnv("TEAMS_APP_ID", "environment-app");
+    const fallback = new TeamsAdapter({ appPassword: "test", logger });
+    const explicit = new TeamsAdapter({
+      appId,
+      appPassword: "test",
+      logger,
+    });
+    expect(fallback.botUserId).toBe("28:environment-app");
+    expect(explicit.botUserId).toBe(botId);
+  });
+
+  it("dispatches the captured channel-join shape through the SDK router", async () => {
+    const response = await adapter.receive(activity());
+    expect(response.status).toBe(200);
+    expect(chat.processMemberJoinedChannel).toHaveBeenCalledExactlyOnceWith(
+      {
+        adapter,
+        channelId: adapter.encodeThreadId({ conversationId, serviceUrl }),
+        userId: botId,
+        inviterId: "29:inviter",
+      },
+      options
+    );
+    expect(mocks.lookup).toHaveBeenCalledWith("join-activity");
+    expect(chat.getState().set).toHaveBeenCalledWith(
+      "teams:serviceUrl:29:inviter",
+      serviceUrl,
+      expect.any(Number)
+    );
+  });
+
+  it("dispatches group-chat joins without channelData", async () => {
+    const body = activity();
+    await adapter.receive({
+      ...body,
+      conversation: {
+        id: "group-chat",
+        conversationType: "groupChat",
+        isGroup: true,
+      },
+      channelData: undefined,
+    });
+    expect(chat.processMemberJoinedChannel).toHaveBeenCalledWith(
+      expect.objectContaining({
+        channelId: adapter.encodeThreadId({
+          conversationId: "group-chat",
+          conversationType: "groupChat",
+          serviceUrl,
+        }),
+        userId: botId,
+      }),
+      options
+    );
+  });
+
+  it("uses group metadata when conversationType is absent", async () => {
+    const body = activity();
+    await adapter.receive({
+      ...body,
+      conversation: { ...body.conversation, conversationType: undefined },
+    });
+    expect(chat.processMemberJoinedChannel).toHaveBeenCalledOnce();
+  });
+
+  it.each([
+    { membersAdded: [{ id: "29:user" }] },
+    { membersAdded: [] },
+    { membersAdded: undefined, membersRemoved: [{ id: botId }] },
+    { recipient: { id: "28:other-app" } },
+    { conversation: { id: "personal", conversationType: "personal" } },
+    { conversation: { id: "19:unknown" } },
+    { conversation: { id: "", conversationType: "channel" } },
+    { serviceUrl: "" },
+    { type: "installationUpdate", action: "add" },
+    { type: "installationUpdate", action: "remove" },
+  ])("does not emit a bot join for %j", async (overrides) => {
+    const response = await adapter.receive({ ...activity(), ...overrides });
+    expect(response.status).toBe(200);
+    expect(chat.processMemberJoinedChannel).not.toHaveBeenCalled();
+  });
+
+  it("dispatches only the bot when several members are added", async () => {
+    await adapter.receive({
+      ...activity(),
+      membersAdded: [{ id: "29:user" }, { id: botId }, { id: botId }],
+    });
+    expect(chat.processMemberJoinedChannel).toHaveBeenCalledOnce();
+  });
+
+  it("runs an asynchronous welcome handler using the existing channel API", async () => {
+    const runtime = new JoinAdapter({ appId, appPassword: "test", logger });
+    const tasks: Promise<unknown>[] = [];
+    const waitUntil = (task: Promise<unknown>) => tasks.push(task);
+    const { send } = runtime.prepare({ waitUntil });
+    const bot = new Chat({
+      userName: "test",
+      adapters: { teams: runtime },
+      state: createMockState(),
+      logger,
+    });
+    const handler = vi.fn(async (event: MemberJoinedChannelEvent) => {
+      expect(event.userId).toBe(event.adapter.botUserId);
+      await Promise.resolve();
+      await bot.channel(event.channelId).post("Welcome");
+    });
+    bot.onMemberJoinedChannel(handler);
+    await bot.initialize();
+
+    await runtime.receive(activity());
+    expect(tasks).toHaveLength(1);
+    await Promise.all(tasks);
+    expect(handler).toHaveBeenCalledOnce();
+    expect(send).toHaveBeenCalledWith(
+      conversationId,
+      expect.objectContaining({ text: "Welcome" })
+    );
+  });
+});


### PR DESCRIPTION
## summary

- dispatch `onMemberJoinedChannel` when the bot joins a Teams channel or group chat
- expose `botUserId` from the configured app identity
- preserve channel routing, inviter identity, and webhook `waitUntil` tracking
- add regression tests and document the bot-only scope

addresses the bot-join portion of #847; personal install/uninstall hooks remain separate