### PR TITLE
perf(telegram): skip unused plain draft rendering

### DIFF
--- a/.changeset/lazy-telegram-draft-fallback.md
+++ b/.changeset/lazy-telegram-draft-fallback.md
@@ -1,0 +1,5 @@
+---
+"@chat-adapter/telegram": patch
+---
+
+Skip unused plain-text conversion for rich and Markdown native draft updates. Plain-text fallback and final delivery keep their existing behavior.

--- a/packages/adapter-telegram/src/index.test.ts
+++ b/packages/adapter-telegram/src/index.test.ts
@@ -2254,6 +2254,87 @@ describe("TelegramAdapter", () => {
     expect(finalSendBody.rich_message.markdown).toBe("hello world");
   });
 
+  it.each([
+    "rich",
+    "markdown",
+    "plain",
+  ] as const)("renders plain text only when selected for %s native drafts", async (format) => {
+    const plainText = vi.spyOn(await import("chat"), "markdownToPlainText");
+    mockFetch.mockImplementation((url, init) => {
+      const method = new URL(String(url)).pathname.split("/").at(-1);
+      const body = JSON.parse(String(init?.body)) as {
+        parse_mode?: string;
+      };
+      if (method === "getMe") {
+        return Promise.resolve(
+          telegramOk({ id: 999, is_bot: true, first_name: "Bot" })
+        );
+      }
+      if (method === "sendRichMessageDraft" && format !== "rich") {
+        return Promise.resolve(
+          telegramError(404, 404, "Not Found: method not found")
+        );
+      }
+      if (
+        method === "sendMessageDraft" &&
+        body.parse_mode &&
+        format === "plain"
+      ) {
+        return Promise.resolve(
+          telegramError(400, 400, "Bad Request: can't parse entities")
+        );
+      }
+      return Promise.resolve(
+        telegramOk(
+          method?.endsWith("Draft")
+            ? true
+            : sampleMessage({ text: "hello world" })
+        )
+      );
+    });
+
+    const adapter = createTelegramAdapter({
+      botToken: "token",
+      mode: "webhook",
+      logger: mockLogger,
+      nativeStreaming: true,
+      userName: "mybot",
+    });
+
+    try {
+      await adapter.initialize(createMockChat());
+      async function* textStream(): AsyncIterable<string> {
+        yield "**hello**";
+        expect(plainText).toHaveBeenCalledTimes(format === "plain" ? 1 : 0);
+        yield " world";
+        expect(plainText).toHaveBeenCalledTimes(format === "plain" ? 2 : 0);
+      }
+
+      const result = await adapter.stream("telegram:123", textStream(), {
+        updateIntervalMs: 0,
+      });
+      expect(result?.id).toBe("123:11");
+
+      const finalCall = mockFetch.mock.calls.at(-1);
+      const finalBody = JSON.parse(String(finalCall?.[1]?.body));
+      if (format === "rich") {
+        expect(String(finalCall?.[0])).toContain("/sendRichMessage");
+        expect(finalBody.rich_message.markdown).toBe("**hello** world");
+        expect(plainText).not.toHaveBeenCalled();
+      } else {
+        expect(String(finalCall?.[0])).toContain("/sendMessage");
+        expect(finalBody.text).toBe(
+          format === "markdown" ? "*hello* world" : "hello world"
+        );
+        expect(finalBody.parse_mode).toBe(
+          format === "markdown" ? "MarkdownV2" : undefined
+        );
+      }
+    } finally {
+      plainText.mockRestore();
+    }
+  });
+
   it("flushes trailing table-like lines before completing a rich stream", async () => {
     mockFetch
       .mockResolvedValueOnce(

--- a/packages/adapter-telegram/src/index.ts
+++ b/packages/adapter-telegram/src/index.ts
@@ -2228,11 +2228,13 @@ export class TelegramAdapter
         return;
       }
 
-      let draftText = renderPlainText(accumulated);
+      let draftText: string;
       if (streamUsesRich) {
         draftText = truncateRichMarkdown(renderer.render());
       } else if (streamUsesMarkdown) {
         draftText = renderMarkdownText(renderer.render());
+      } else {
+        draftText = renderPlainText(accumulated);
       }
       await sendDraft(draftText, streamUsesMarkdown);
     };


### PR DESCRIPTION
## Summary

<!-- What does this PR do? -->

Native Telegram drafts rendered the accumulated Markdown as plain text before replacing it with the rich or Markdown result. This computes only the selected draft format, while keeping the rich-to-Markdown-to-plain fallback and final delivery behavior unchanged.

```diff
 draft flush
-  convert Markdown to plain text
   select rich, Markdown, or plain format
+  convert to plain text only when selected
   send draft
```

For an 82-chunk rich response, the pinned reproduction reduces discarded plain conversion from 83 calls over 139,400 characters to 0. It sends the same 83 Bot API requests with identical bodies and outcomes.

Repro: [**Before**](https://github.com/onmax/repros/tree/repro/telegram-lazy-plain/telegram-lazy-plain) · [**After**](https://github.com/onmax/repros/tree/repro/telegram-lazy-plain/telegram-lazy-plain-fix). Run locally with the commands below.

## Test plan

<!-- How did you verify the changes? -->

Copy and run:

```sh
git clone --depth 1 --filter=blob:none --sparse --branch repro/telegram-lazy-plain https://github.com/onmax/repros.git telegram-lazy-plain-repro
cd telegram-lazy-plain-repro
git sparse-checkout set telegram-lazy-plain telegram-lazy-plain-fix
cd telegram-lazy-plain
corepack pnpm install --frozen-lockfile --ignore-scripts && corepack pnpm verify
cd ../telegram-lazy-plain-fix
corepack pnpm install --frozen-lockfile --ignore-scripts && corepack pnpm verify
```

Ran adapter tests, typecheck, build, `pnpm validate`, and the eight reproduction controls.

## Checklist

- [x] All commits are signed and verified
- [x] All commits are signed off for the DCO (`git commit -s`)
- [x] `pnpm validate` passes
- [x] Changeset added (or N/A — see [CONTRIBUTING.md](./CONTRIBUTING.md))
- [x] Documentation updated (or N/A)

Documentation: not applicable; public behavior and configuration are unchanged.
