### PR TITLE
fix(slack): render markdown in post-and-edit stream fallback

### DIFF
--- a/.changeset/tidy-pugs-repeat.md
+++ b/.changeset/tidy-pugs-repeat.md
@@ -1,0 +1,5 @@
+---
+"@chat-adapter/slack": patch
+---
+
+Stream post-and-edit fallback updates through Slack's `markdown_text` field instead of `text`, so live-updating messages render markdown while the stream is in progress (and get the 12,000-character ceiling rather than 4,000)

--- a/packages/adapter-slack/src/index.test.ts
+++ b/packages/adapter-slack/src/index.test.ts
@@ -11359,6 +11359,11 @@ describe("native streaming fallback", () => {
     }
   }
 
+  /** Fallback posts and edits go through `markdown`, never a bare string. */
+  function markdownOf(message: unknown): string {
+    return (message as { markdown?: string }).markdown ?? "";
+  }
+
   it("finishes agent streams with an active session status", async () => {
     const { adapter } = createAdapter({ agentView: true });
     const append = vi.fn().mockResolvedValue({ ok: true });
@@ -11414,7 +11419,35 @@ describe("native streaming fallback", () => {
     const lastPosted = editSpy.mock.calls.length
       ? editSpy.mock.calls.at(-1)?.[2]
       : postSpy.mock.calls.at(-1)?.[1];
-    expect(lastPosted).toContain("world");
+    expect(markdownOf(lastPosted)).toContain("world");
+  });
+
+  it("streams fallback updates through markdown, not plain text", async () => {
+    const { adapter, postSpy, editSpy } = createAdapter();
+    const append = vi.fn().mockRejectedValue(new Error("no streaming here"));
+    mockClientMethod(
+      adapter,
+      "chatStream",
+      vi.fn().mockReturnValue({ append, stop: vi.fn(), ts: undefined })
+    );
+
+    await adapter.stream(
+      "slack:D123:1234567890.000000",
+      textStream("**bold** ", "and `code`")
+    );
+
+    // A bare string resolves to Slack's `text` field, which renders legacy
+    // mrkdwn only — every live edit would show the raw `**`/backticks.
+    for (const [, message] of postSpy.mock.calls) {
+      expect(message).toEqual({ markdown: expect.any(String) });
+    }
+    for (const [, , message] of editSpy.mock.calls) {
+      expect(message).toEqual({ markdown: expect.any(String) });
+    }
+    const lastPosted = editSpy.mock.calls.length
+      ? editSpy.mock.calls.at(-1)?.[2]
+      : postSpy.mock.calls.at(-1)?.[1];
+    expect(markdownOf(lastPosted)).toContain("**bold**");
   });
 
   it("latches native streaming off after an unsupported-method platform error", async () => {
@@ -11514,7 +11547,7 @@ describe("native streaming fallback", () => {
 
     expect(result).toMatchObject({ id: "fallback-ts" });
     expect(postSpy).toHaveBeenCalledTimes(1);
-    expect(postSpy.mock.calls.at(-1)?.[1]).toContain("short reply");
+    expect(markdownOf(postSpy.mock.calls.at(-1)?.[1])).toContain("short reply");
   });
 
   it("propagates stop() failures once native content has rendered", async () => {
@@ -11564,7 +11597,7 @@ describe("native streaming fallback", () => {
     // The structured chunk didn't fail the stream, and the text still
     // arrived via the post-and-edit fallback.
     expect(postSpy).toHaveBeenCalledTimes(1);
-    expect(postSpy.mock.calls.at(-1)?.[1]).toContain("hello");
+    expect(markdownOf(postSpy.mock.calls.at(-1)?.[1])).toContain("hello");
   });
 });
 

--- a/packages/adapter-slack/src/index.ts
+++ b/packages/adapter-slack/src/index.ts
@@ -5860,10 +5860,18 @@ export class SlackAdapter implements Adapter<SlackThreadId, unknown> {
       if (!(force || now - lastFallbackEditAt >= updateIntervalMs)) {
         return;
       }
+      // Post through the markdown field, not the plain-text one. `getCommittableText()`
+      // already yields append-safe markdown, and a bare string resolves to Slack's `text`,
+      // which only renders legacy mrkdwn (and caps at 4,000 chars instead of 12,000) — so
+      // every intermediate edit showed raw `**`/`#` syntax to the user.
       if (fallback.message) {
-        await this.editMessage(threadId, fallback.message.id, committable);
+        await this.editMessage(threadId, fallback.message.id, {
+          markdown: committable,
+        });
       } else {
-        fallback.message = await this.postMessage(threadId, committable);
+        fallback.message = await this.postMessage(threadId, {
+          markdown: committable,
+        });
       }
       fallbackSent = committable;
       lastFallbackEditAt = now;


### PR DESCRIPTION
## Summary

`SlackAdapter.stream()`'s post-and-edit fallback passes its accumulated text to `postMessage`/`editMessage` as a **bare string**, which `SlackFormatConverter.toSlackPayload` resolves to Slack's `text` field:

```ts
if (fallback.message) {
  await this.editMessage(threadId, fallback.message.id, committable);
} else {
  fallback.message = await this.postMessage(threadId, committable);
}
```

`text` renders classic mrkdwn (`*bold*`) only, not the GFM the renderer emits — so **every intermediate edit during a fallback stream shows the user raw `**`/`#`/backtick syntax**. Only a caller-side final replacement recovers the formatting, and only for the last frame; every frame before it was wrong while it was on screen.

It's also a materially smaller ceiling: `text` on `chat.update` caps at 4,000 characters vs. `markdown_text`'s 12,000, so fallback mode fails on long answers sooner than it needs to — `msg_too_long` mid-stream, independent of the formatting bug.

`StreamingMarkdownRenderer.getCommittableText()` is already documented as text "safe for append-only streaming" — it holds back unclosed inline markers (`**`, `*`, `~~`, `` ` ``, `[`) and unconfirmed table headers. And the renderer's own class doc is explicit about which side owns conversion: "Outputs markdown (not platform text). Format conversion still happens in the adapter's editMessage → renderPostable → fromAst pipeline." Native mode honors that; fallback mode ships the same output through the wrong field. Wrapping it as `{ markdown: committable }` routes it into the same `markdown_text` field native mode streams into, via `toSlackPayload`'s existing `markdown` branch — nothing new to build.

Per Slack's reference for [`chat.postMessage`](https://docs.slack.dev/reference/methods/chat.postMessage/) and [`chat.update`](https://docs.slack.dev/reference/methods/chat.update/), `markdown_text` needs no scope beyond the `chat:write` the adapter already holds and carries no app-feature gate. Its one constraint is mutual exclusivity with `text`/`blocks` (`markdown_text_conflict`), and `toSlackPayload` emits exactly one field per branch, so that conflict can't arise here.

One behavior change worth naming: Slack documents that mobile notifications use `message.text` for block-based messages, and doesn't document how push previews are derived for `markdown_text`. In practice we see no notification regression — our app already posts `markdown_text` in native mode and for final message replacements — but flagging it rather than leaving it to be discovered.

### How we hit this

A Slack Workflow Builder–authored message (posted as a bot, no real `event.user`) leaves `recipient_user_id` invalid for native streaming, so the adapter drops into fallback from the first send and stays there for the whole answer. That root cause is separate and app-side — not part of this PR — but it's what made this reproducible for us. Note it isn't the only route in: once `switchToFallback()` latches `nativeStreamingBroken` on a `feature_not_enabled` / `method_deprecated` / `unknown_method` error, *every* subsequent stream on that adapter instance takes this path.

## Test plan

- `pnpm validate` — 43/43 tasks pass (knip, lint, typecheck, test, build).
- `pnpm test:workspace` — 3,714 passed / 6 skipped, 102 files.
- New test in `packages/adapter-slack/src/index.test.ts`: `streams fallback updates through markdown, not plain text` — asserts every `postMessage`/`editMessage` call in fallback mode receives `{ markdown: <string> }` rather than a bare string, and that markdown syntax survives to the last frame.
- Three existing `native streaming fallback` tests read the posted payload to assert content; updated to read `.markdown` via a small `markdownOf` helper. These are the only places in the suite that assumed the bare-string shape — worth knowing for anyone auditing the blast radius.

## Checklist

- [x] All commits are signed and verified
- [x] All commits are signed off for the DCO (`git commit -s`)
- [x] `pnpm validate` passes
- [x] Changeset added (patch, `@chat-adapter/slack`)
- [x] Documentation updated (N/A — no public API change)
