### PR TITLE
fix(teams): ack Adaptive Card invokes with non-empty response

### DIFF
--- a/.changeset/teams-invoke-ack.md
+++ b/.changeset/teams-invoke-ack.md
@@ -1,0 +1,5 @@
+---
+"@chat-adapter/teams": patch
+---
+
+Fix Teams Adaptive Card button clicks returning an empty invoke response, which caused Teams to retry and duplicate onAction delivery

--- a/packages/adapter-teams/src/index.test.ts
+++ b/packages/adapter-teams/src/index.test.ts
@@ -1914,6 +1914,64 @@ describe("TeamsAdapter", () => {
   });
 });
 
+describe("card.action invoke ack", () => {
+  it("returns a non-empty Adaptive Card invoke response so Teams does not retry", async () => {
+    const adapter = createTeamsAdapter({
+      appId: "test-app",
+      appPassword: "test",
+      logger,
+    });
+    const chat = createMockChatInstance();
+    await adapter.initialize(chat);
+
+    type CardActionHandler = (ctx: {
+      activity: Record<string, unknown>;
+    }) => Promise<unknown>;
+
+    const app = (
+      adapter as unknown as {
+        app: {
+          router: {
+            select: (activity: Record<string, unknown>) => CardActionHandler[];
+          };
+        };
+      }
+    ).app;
+
+    const activity = {
+      conversation: { id: "19:abc@thread.tacv2" },
+      from: { id: "29:user-1", name: "Ada" },
+      id: "invoke-1",
+      name: "adaptiveCard/action",
+      serviceUrl: TEST_SERVICE_URL,
+      type: "invoke",
+      value: {
+        action: {
+          data: { actionId: "thumbs_up", value: JSON.stringify({ id: "x" }) },
+          type: "Action.Submit",
+        },
+        trigger: "manual",
+      },
+    };
+
+    const handlers = app.router.select(activity);
+    expect(handlers.length).toBeGreaterThan(0);
+
+    const response = await handlers[0]({ activity });
+
+    expect(response).toEqual({
+      statusCode: 200,
+      type: "application/vnd.microsoft.activity.message",
+      value: "OK",
+    });
+    expect(
+      typeof (response as { value: unknown }).value === "string" &&
+        (response as { value: string }).value.length > 0
+    ).toBe(true);
+    expect(chat.processAction).toHaveBeenCalledOnce();
+  });
+});
+
 describe("subclass extensibility", () => {
   it("exposes protected members and methods to subclasses", () => {
     class TestSubclass extends TeamsAdapter {

--- a/packages/adapter-teams/src/index.ts
+++ b/packages/adapter-teams/src/index.ts
@@ -9,6 +9,7 @@ import {
 import type {
   Account,
   Activity,
+  AdaptiveCardActionMessageResponse,
   IAdaptiveCardActionInvokeActivity,
   IConversationUpdateActivity,
   IMessageActivity,
@@ -90,6 +91,16 @@ interface ActionSubmitData {
   actionId?: string;
   value?: string;
 }
+
+/**
+ * Valid adaptiveCard/action invoke acknowledgement.
+ * An empty `value` makes Teams show "Unable to reach app" and retry the invoke.
+ */
+const CARD_ACTION_INVOKE_ACK: AdaptiveCardActionMessageResponse = {
+  statusCode: 200,
+  type: "application/vnd.microsoft.activity.message",
+  value: "OK",
+};
 
 const MESSAGEID_CAPTURE_PATTERN = /messageid=(\d+)/;
 const MESSAGEID_STRIP_PATTERN = /;messageid=\d+/;
@@ -180,11 +191,11 @@ export class TeamsAdapter implements Adapter<TeamsThreadId, unknown> {
     this.app.on("card.action", async (ctx) => {
       this.cacheUserContext(ctx.activity);
       await this.handleAdaptiveCardAction(ctx);
-      return {
-        statusCode: 200,
-        type: "application/vnd.microsoft.activity.message",
-        value: "",
-      };
+      // Teams rejects an empty activity.message value and retries the invoke,
+      // which re-delivers the action (duplicate onAction). Ack with a non-empty
+      // Adaptive Card invoke response so the client stops retrying.
+      // https://learn.microsoft.com/en-us/adaptive-cards/authoring-cards/universal-action-model#response-format
+      return CARD_ACTION_INVOKE_ACK;
     });
 
     this.app.on(


### PR DESCRIPTION
## Summary

- Teams Adaptive Card card.action invokes previously returned an empty activity.message value, which Teams treats as a failed ack.
- That caused the app-unreachable banner and an invoke retry, so onAction ran twice for a single click.
- The handler now returns a valid Adaptive Card invoke response with a non-empty message value so Teams stops retrying.
- Added a regression test that exercises the registered card.action route and asserts a non-empty invoke ack.

Closes #731

## Test plan

- [x] Unit tests in packages/adapter-teams index.test.ts (86 passed)
- [x] Typecheck for packages/adapter-teams
- [ ] Manually click an Adaptive Card Action.Submit button in Teams and confirm no error banner and a single onAction delivery
