### PR TITLE
feat(history): support uncapped per-user retention

### DIFF
--- a/.changeset/tidy-users-remember.md
+++ b/.changeset/tidy-users-remember.md
@@ -1,0 +1,5 @@
+---
+"chat": minor
+---
+
+Allow `history.user.maxPerUser` and legacy `transcripts.maxPerUser` to be `false` to disable count-based history eviction. The default remains 200 entries per user.

--- a/apps/docs/content/docs/api/history.mdx
+++ b/apps/docs/content/docs/api/history.mdx
@@ -44,8 +44,8 @@ Same fields as the deprecated `TranscriptsConfig`, plus an optional `identity` r
       type: 'number | DurationString | undefined',
     },
     maxPerUser: {
-      description: 'Hard cap per user key. Older entries are evicted on append.',
-      type: 'number',
+      description: 'Hard cap per user key. Older entries are evicted on append. Set `false` for no cap.',
+      type: 'number | false',
       default: '200',
     },
     storeFormatted: {

--- a/apps/docs/content/docs/api/transcripts.mdx
+++ b/apps/docs/content/docs/api/transcripts.mdx
@@ -29,8 +29,8 @@ import { Chat } from "chat";
       type: 'number | DurationString | undefined',
     },
     maxPerUser: {
-      description: 'Hard cap per user. Older entries are evicted on append.',
-      type: 'number',
+      description: 'Hard cap per user. Older entries are evicted on append. Set `false` for no cap.',
+      type: 'number | false',
       default: '200',
     },
     storeFormatted: {
@@ -137,7 +137,7 @@ list(query: ListQuery): Promise<TranscriptEntry[]>;
       type: 'string',
     },
     limit: {
-      description: 'Maximum entries returned. Cannot exceed `maxPerUser` because that is the storage cap.',
+      description: 'Maximum entries returned. Cannot exceed the stored entry count. `maxPerUser` limits storage unless set to `false`.',
       type: 'number',
       default: '50',
     },

--- a/apps/docs/content/docs/history.mdx
+++ b/apps/docs/content/docs/history.mdx
@@ -55,6 +55,8 @@ const bot = new Chat({
 
 `history.user` requires an identity resolver — set `history.user.identity`, or keep the deprecated top-level `identity` field during migration. Omitting both when `history.user` (or legacy `transcripts`) is set throws at construction.
 
+Set `history.user.maxPerUser: false` to disable count-based eviction. Omit `retention` as well to keep entries without a TTL. The state adapter must use durable storage to retain history across restarts. The legacy `transcripts.maxPerUser` field also accepts `false`.
+
 Thread and channel scopes are always available on `bot.history`. The **thread cache** (for adapters with `persistThreadHistory: true`, e.g. Telegram and WhatsApp) is tuned via `history.thread`:
 
 ```typescript

--- a/packages/chat/src/history/user.test.ts
+++ b/packages/chat/src/history/user.test.ts
@@ -363,6 +363,29 @@ describe("UserHistoryApiImpl", () => {
   });
 
   describe("maxPerUser eviction", () => {
+    it.each([
+      { maxPerUser: false as const, expected: 205, first: "msg 0" },
+      { maxPerUser: undefined, expected: 200, first: "msg 5" },
+    ])("retains $expected entries with maxPerUser=$maxPerUser", async ({
+      maxPerUser,
+      expected,
+      first,
+    }) => {
+      api = new UserHistoryApiImpl(state, { maxPerUser });
+      const thread = createTestThread();
+      for (let i = 0; i < 205; i++) {
+        await api.append(
+          thread,
+          { role: "assistant", text: `msg ${i}` },
+          { userKey: "u1" }
+        );
+      }
+      const list = await api.list({ userKey: "u1", limit: 300 });
+      expect(list).toHaveLength(expected);
+      expect(list[0]?.text).toBe(first);
+      expect(list.at(-1)?.text).toBe("msg 204");
+    });
+
     it("trims to maxPerUser via appendToList semantics", async () => {
       api = new UserHistoryApiImpl(state, { maxPerUser: 3 });
       const thread = createTestThread();

--- a/packages/chat/src/history/user.ts
+++ b/packages/chat/src/history/user.ts
@@ -88,13 +88,16 @@ function keyFor(userKey: string): string {
  */
 export class UserHistoryApiImpl implements TranscriptsApi {
   private readonly state: StateAdapter;
-  private readonly maxPerUser: number;
+  private readonly maxPerUser: number | undefined;
   private readonly retentionMs: number | undefined;
   private readonly storeFormatted: boolean;
 
   constructor(state: StateAdapter, config: TranscriptsConfig) {
     this.state = state;
-    this.maxPerUser = config.maxPerUser ?? DEFAULT_MAX_PER_USER;
+    this.maxPerUser =
+      config.maxPerUser === false
+        ? undefined
+        : (config.maxPerUser ?? DEFAULT_MAX_PER_USER);
     this.retentionMs = parseDuration(config.retention);
     this.storeFormatted = config.storeFormatted ?? false;
   }

--- a/packages/chat/src/transcripts-wiring.test.ts
+++ b/packages/chat/src/transcripts-wiring.test.ts
@@ -114,7 +114,10 @@ describe("Chat — History API wiring", () => {
     expect(chat.transcripts).toBe(api);
   });
 
-  it("merges legacy transcripts settings under history.user during migration", async () => {
+  it.each([
+    50,
+    false,
+  ] as const)("merges legacy maxPerUser=%s under history.user", async (maxPerUser) => {
     // A config migrating one field at a time: identity moved to history.user,
     // retention/maxPerUser still on the legacy transcripts block. Both must
     // apply — the legacy settings must not be silently dropped.
@@ -124,7 +127,7 @@ describe("Chat — History API wiring", () => {
       state: mockState,
       logger: mockLogger,
       history: { user: { identity: () => "u1" } },
-      transcripts: { maxPerUser: 50, retention: "30d" },
+      transcripts: { maxPerUser, retention: "30d" },
     });
 
     const msg = createTestMessage("m1", "hello");
@@ -138,7 +141,10 @@ describe("Chat — History API wiring", () => {
     expect(mockState.appendToList).toHaveBeenCalledWith(
       expect.stringContaining("u1"),
       expect.objectContaining({ userKey: "u1" }),
-      { maxLength: 50, ttlMs: thirtyDaysMs }
+      {
+        maxLength: maxPerUser === false ? undefined : maxPerUser,
+        ttlMs: thirtyDaysMs,
+      }
     );
   });
 

--- a/packages/chat/src/types.ts
+++ b/packages/chat/src/types.ts
@@ -2782,8 +2782,8 @@ export interface UserHistoryConfig {
    * One of the two must be set when user history is enabled.
    */
   identity?: IdentityResolver;
-  /** Hard cap; older entries evicted on append. Default 200. */
-  maxPerUser?: number;
+  /** Hard cap; older entries evicted on append. Default 200. Set false for no cap. */
+  maxPerUser?: number | false;
   /**
    * Default retention applied as the list TTL. Refreshed on every append.
    * Omit for no expiry.
@@ -2993,8 +2993,8 @@ export type UserHistoryEntry = HistoryEntry;
 export type DurationString = `${number}${"s" | "m" | "h" | "d"}`;
 
 export interface TranscriptsConfig {
-  /** Hard cap; older messages evicted on append. Default 200. */
-  maxPerUser?: number;
+  /** Hard cap; older messages evicted on append. Default 200. Set false for no cap. */
+  maxPerUser?: number | false;
   /**
    * Default retention applied as the list TTL. Refreshed on every append
    * (matches `appendToList` semantics). Omit for no expiry.


### PR DESCRIPTION
## Summary

Allow `history.user.maxPerUser: false` and legacy `transcripts.maxPerUser: false` to disable count-based eviction. Apps that retain complete user history can keep entries beyond the default 200. Numeric limits still trim older entries, and retention TTL remains independent.

## Test plan

Added coverage for retaining 205 entries with no cap, the default 200-entry cap, and legacy configuration merging. The existing numeric-limit test remains. `pnpm validate` passed.

## Checklist

- [x] All commits are signed and verified
- [x] All commits are signed off for the DCO (`git commit -s`)
- [x] `pnpm validate` passes
- [x] Changeset added (or N/A — see [CONTRIBUTING.md](./CONTRIBUTING.md))
- [x] Documentation updated (or N/A)
