### PR TITLE
feat(teams): render tables as the Adaptive Card 1.5 Table element

### DIFF
--- a/.changeset/teams-native-table.md
+++ b/.changeset/teams-native-table.md
@@ -1,0 +1,12 @@
+---
+"chat": minor
+"@chat-adapter/teams": minor
+---
+
+feat(teams): render tables as the Adaptive Card 1.5 Table element
+
+The Teams adapter now renders `Table` as the native Adaptive Cards `Table` element instead of a `Container` of `ColumnSet`s. Teams draws grid lines between cells, sizes columns by relative weight and marks the header row for accessibility. The `@chat-adapter/teams/cards` subpath emits the same element.
+
+`Table` gains optional rendering options that only Teams reads: `widths` (positive integer column weights), `verticalAlign` (vertical alignment of cell content), `gridLines` (default `true`) and `gridStyle`. Other adapters ignore them. Pass `gridLines: false` to keep a borderless table.
+
+The chat JSX runtime now forwards `align` on `<Table>`, matching `fromReactElement`.

--- a/apps/docs/content/adapters/official/teams.mdx
+++ b/apps/docs/content/adapters/official/teams.mdx
@@ -24,7 +24,7 @@ features:
   selectMenus: no
   tables:
     status: yes
-    label: GFM
+    label: Adaptive Card Table
   fields: yes
   imagesInCards: yes
   modals: yes
@@ -522,6 +522,8 @@ await postTeamsMessage({
 ```
 
 Use the full Chat SDK card JSX when you want cross-platform rendering. Use `@chat-adapter/teams/cards` when you are building a Teams-only runtime and want Adaptive Card output directly.
+
+Table children render as the Adaptive Card `Table` element with grid lines on by default. The optional `align`, `widths`, `verticalAlign`, `gridLines` and `gridStyle` fields tune the grid, a table with empty `headers` renders without a header row, and a table with no columns emits no element.
 
 ### Modals
 

--- a/apps/docs/content/docs/api/cards.mdx
+++ b/apps/docs/content/docs/api/cards.mdx
@@ -283,10 +283,27 @@ Table({
       description: 'Rows per page on platforms that paginate tables (Slack: 1-100, default 5).',
       type: 'number',
     },
+    widths: {
+      description: 'Relative column widths, one positive integer weight per column (default 1 each). Rendered by Teams only; other adapters ignore it.',
+      type: 'number[]',
+    },
+    verticalAlign: {
+      description: 'Vertical alignment of cell content. Rendered by Teams only; other adapters ignore it.',
+      type: '"top" | "center" | "bottom"',
+    },
+    gridLines: {
+      description: 'Draw grid lines between cells. Rendered by Teams only; other adapters ignore it.',
+      type: 'boolean',
+      default: 'true',
+    },
+    gridStyle: {
+      description: 'Style of the grid lines between cells. Rendered by Teams only; other adapters ignore it.',
+      type: '"default" | "emphasis" | "accent" | "good" | "attention" | "warning"',
+    },
   }}
 />
 
-On platforms with native table support (Slack, Teams, GitHub, Linear), tables render as formatted tables. On Slack, tables render as paginated, sortable data table blocks. Discord card payloads preserve GFM markdown tables. On other platforms (Google Chat, Telegram), tables render as padded ASCII text.
+On platforms with native table support (Slack, Teams, GitHub, Linear), tables render as formatted tables. On Slack, tables render as paginated, sortable data table blocks. On Teams, tables render as the Adaptive Card `Table` element with grid lines and weighted column widths. Discord card payloads preserve GFM markdown tables. On other platforms (Google Chat, Telegram), tables render as padded ASCII text.
 
 ## Chart
 

--- a/apps/docs/content/docs/cards.mdx
+++ b/apps/docs/content/docs/cards.mdx
@@ -245,6 +245,23 @@ Optional column alignment:
 />
 ```
 
+On Teams, tables render as the native Adaptive Card `Table` element: grid lines between cells, columns sized by relative weight and a header row marked for accessibility. The optional `widths`, `verticalAlign`, `gridLines` and `gridStyle` props tune that rendering and are ignored on other platforms:
+
+```tsx title="lib/bot.tsx"
+<Table
+  headers={["Service", "Status", "Latency"]}
+  rows={[
+    ["api", "ok", "120 ms"],
+    ["worker", "degraded", "840 ms"],
+  ]}
+  widths={[2, 1, 1]}
+  align={["left", "center", "right"]}
+  gridStyle="emphasis"
+/>
+```
+
+Pass `gridLines={false}` for a borderless table. A table with empty `headers` renders without a header row.
+
 On Slack, tables render as paginated, sortable [data tables](https://docs.slack.dev/reference/block-kit/blocks/data-table-block). The optional `caption` (accessible table description) and `pageSize` (rows per page, 1–100) props tune that rendering and are ignored on other platforms:
 
 ```tsx title="lib/bot.tsx"

--- a/packages/adapter-teams/README.md
+++ b/packages/adapter-teams/README.md
@@ -178,7 +178,7 @@ Incoming Teams mentions are supported. Outgoing `@name` text, including multi-wo
 | Buttons | Yes |
 | Link buttons | Yes |
 | Select menus | No |
-| Tables | GFM |
+| Tables | Adaptive Card Table |
 | Fields | Yes |
 | Images in cards | Yes |
 | Modals | Yes |

--- a/packages/adapter-teams/src/cards-primitives/index.test.ts
+++ b/packages/adapter-teams/src/cards-primitives/index.test.ts
@@ -323,3 +323,94 @@ describe("Teams card primitives", () => {
     expect(parseTeamsInputResponse({})).toBeNull();
   });
 });
+
+describe("Teams card primitives tables", () => {
+  const cell = (text: string, options: Record<string, unknown> = {}) => ({
+    items: [{ text, type: "TextBlock", wrap: true, ...options }],
+    type: "TableCell",
+  });
+
+  it("renders tables as the Adaptive Card Table element", () => {
+    const card = cardToAdaptiveCard({
+      children: [
+        {
+          align: ["left", "right"],
+          gridStyle: "emphasis",
+          headers: ["Name", "Score"],
+          rows: [["Ada :white_check_mark:", "10"], ["Bob"]],
+          type: "table",
+          verticalAlign: "top",
+          widths: [3, 1],
+        },
+      ],
+      type: "card",
+    });
+
+    expect(card.body[0]).toEqual({
+      columns: [
+        { horizontalCellContentAlignment: "Left", width: 3 },
+        { horizontalCellContentAlignment: "Right", width: 1 },
+      ],
+      firstRowAsHeaders: true,
+      gridStyle: "emphasis",
+      rows: [
+        {
+          cells: [
+            cell("Name", { weight: "Bolder" }),
+            cell("Score", { weight: "Bolder" }),
+          ],
+          type: "TableRow",
+        },
+        { cells: [cell("Ada ✅"), cell("10")], type: "TableRow" },
+        { cells: [cell("Bob"), cell("")], type: "TableRow" },
+      ],
+      showGridLines: true,
+      type: "Table",
+      verticalCellContentAlignment: "Top",
+    });
+  });
+
+  it("omits the header row of a headerless table and honours gridLines", () => {
+    const card = cardToAdaptiveCard({
+      children: [
+        { gridLines: false, headers: [], rows: [["a", "b"]], type: "table" },
+      ],
+      type: "card",
+    });
+
+    expect(card.body[0]).toMatchObject({
+      columns: [{ width: 1 }, { width: 1 }],
+      firstRowAsHeaders: false,
+      rows: [{ cells: [cell("a"), cell("b")], type: "TableRow" }],
+      showGridLines: false,
+      type: "Table",
+    });
+  });
+
+  it("emits no element for a table with no columns", () => {
+    const card = cardToAdaptiveCard({
+      children: [{ headers: [], rows: [[]], type: "table" }],
+      type: "card",
+    });
+
+    expect(card.body).toEqual([]);
+  });
+
+  it("falls back to weight 1 for a width that is not a positive integer", () => {
+    const card = cardToAdaptiveCard({
+      children: [
+        {
+          headers: ["A", "B", "C", "D"],
+          rows: [],
+          type: "table",
+          widths: [0, -1, 1.5, 2],
+        },
+      ],
+      type: "card",
+    });
+
+    expect(card.body[0]).toMatchObject({
+      columns: [{ width: 1 }, { width: 1 }, { width: 1 }, { width: 2 }],
+    });
+  });
+});

--- a/packages/adapter-teams/src/cards-primitives/index.ts
+++ b/packages/adapter-teams/src/cards-primitives/index.ts
@@ -12,7 +12,9 @@ import type {
   TeamsRadioSelectElement,
   TeamsSectionElement,
   TeamsSelectElement,
+  TeamsTableAlignment,
   TeamsTableElement,
+  TeamsTableVerticalAlignment,
   TeamsTextElement,
 } from "./types";
 
@@ -83,8 +85,10 @@ function convertChild(child: TeamsCardChild): ConvertedChild {
       return { actions: [], body: [convertFields(child)] };
     case "link":
       return { actions: [], body: [convertLink(child)] };
-    case "table":
-      return { actions: [], body: [convertTable(child)] };
+    case "table": {
+      const table = convertTable(child);
+      return { actions: [], body: table === null ? [] : [table] };
+    }
     default:
       return { actions: [], body: [] };
   }
@@ -210,27 +214,83 @@ function convertLink(link: TeamsLinkElement): unknown {
   return textBlock(`[${link.label}](${link.url})`);
 }
 
+const TABLE_HORIZONTAL_ALIGNMENT: Record<
+  TeamsTableAlignment,
+  "Center" | "Left" | "Right"
+> = {
+  center: "Center",
+  left: "Left",
+  right: "Right",
+};
+
+const TABLE_VERTICAL_ALIGNMENT: Record<
+  TeamsTableVerticalAlignment,
+  "Bottom" | "Center" | "Top"
+> = {
+  bottom: "Bottom",
+  center: "Center",
+  top: "Top",
+};
+
+// Adaptive Cards treats a column width as a relative weight only when it is a
+// positive integer; Teams desktop and mobile disagree on anything else, so an
+// invalid weight falls back to the default instead of reaching the wire.
+function columnWeight(width: number | undefined): number {
+  return width !== undefined && Number.isInteger(width) && width > 0
+    ? width
+    : 1;
+}
+
 function convertTable(table: TeamsTableElement): unknown {
+  // The column count follows the widest row so a short row is padded with
+  // empty cells instead of shifting the grid.
+  const columnCount = Math.max(
+    table.headers.length,
+    ...table.rows.map((row) => row.length)
+  );
+  // No columns means nothing to draw, as the empty ASCII fallback says.
+  if (columnCount === 0) {
+    return null;
+  }
+  const toRow = (cells: string[], options: Record<string, unknown> = {}) => ({
+    cells: Array.from({ length: columnCount }, (_, index) => ({
+      items: [textBlock(cells[index] ?? "", options)],
+      type: "TableCell",
+    })),
+    type: "TableRow",
+  });
+  const hasHeader = table.headers.length > 0;
+  const rows = table.rows.map((row) => toRow(row));
+  if (hasHeader) {
+    rows.unshift(toRow(table.headers, { weight: "Bolder" }));
+  }
+
   return {
-    items: [
-      {
-        columns: table.headers.map((header) => ({
-          items: [textBlock(header, { weight: "Bolder" })],
-          type: "Column",
-          width: "stretch",
-        })),
-        type: "ColumnSet",
-      },
-      ...table.rows.map((row) => ({
-        columns: row.map((cell) => ({
-          items: [textBlock(cell)],
-          type: "Column",
-          width: "stretch",
-        })),
-        type: "ColumnSet",
-      })),
-    ],
-    type: "Container",
+    columns: Array.from({ length: columnCount }, (_, index) => {
+      const align = table.align?.[index];
+      return {
+        ...(align
+          ? {
+              horizontalCellContentAlignment: TABLE_HORIZONTAL_ALIGNMENT[align],
+            }
+          : {}),
+        width: columnWeight(table.widths?.[index]),
+      };
+    }),
+    // The Adaptive Cards schema spells this `firstRowAsHeader`, but the Teams
+    // renderers and @microsoft/teams.cards read the plural and ignore the
+    // singular.
+    firstRowAsHeaders: hasHeader,
+    ...(table.gridStyle ? { gridStyle: table.gridStyle } : {}),
+    rows,
+    showGridLines: table.gridLines ?? true,
+    type: "Table",
+    ...(table.verticalAlign
+      ? {
+          verticalCellContentAlignment:
+            TABLE_VERTICAL_ALIGNMENT[table.verticalAlign],
+        }
+      : {}),
   };
 }
 

--- a/packages/adapter-teams/src/cards-primitives/index.ts
+++ b/packages/adapter-teams/src/cards-primitives/index.ts
@@ -85,10 +85,8 @@ function convertChild(child: TeamsCardChild): ConvertedChild {
       return { actions: [], body: [convertFields(child)] };
     case "link":
       return { actions: [], body: [convertLink(child)] };
-    case "table": {
-      const table = convertTable(child);
-      return { actions: [], body: table === null ? [] : [table] };
-    }
+    case "table":
+      return { actions: [], body: convertTable(child) };
     default:
       return { actions: [], body: [] };
   }
@@ -241,16 +239,26 @@ function columnWeight(width: number | undefined): number {
     : 1;
 }
 
-function convertTable(table: TeamsTableElement): unknown {
-  // The column count follows the widest row so a short row is padded with
-  // empty cells instead of shifting the grid.
-  const columnCount = Math.max(
-    table.headers.length,
-    ...table.rows.map((row) => row.length)
-  );
-  // No columns means nothing to draw, as the empty ASCII fallback says.
+// The widest row sets the column count, so a short row is padded with empty
+// cells instead of shifting the grid. Accumulated in a loop rather than
+// `Math.max(...rows.map(...))`, which spreads one argument per row and blows
+// the call-argument limit on a large table.
+function tableColumnCount(headers: string[], rows: string[][]): number {
+  let count = headers.length;
+  for (const row of rows) {
+    if (row.length > count) {
+      count = row.length;
+    }
+  }
+  return count;
+}
+
+// Returns an array so "no columns means nothing to draw" needs no null check at
+// the call site, matching what the empty ASCII fallback says.
+function convertTable(table: TeamsTableElement): unknown[] {
+  const columnCount = tableColumnCount(table.headers, table.rows);
   if (columnCount === 0) {
-    return null;
+    return [];
   }
   const toRow = (cells: string[], options: Record<string, unknown> = {}) => ({
     cells: Array.from({ length: columnCount }, (_, index) => ({
@@ -265,33 +273,38 @@ function convertTable(table: TeamsTableElement): unknown {
     rows.unshift(toRow(table.headers, { weight: "Bolder" }));
   }
 
-  return {
-    columns: Array.from({ length: columnCount }, (_, index) => {
-      const align = table.align?.[index];
-      return {
-        ...(align
-          ? {
-              horizontalCellContentAlignment: TABLE_HORIZONTAL_ALIGNMENT[align],
-            }
-          : {}),
-        width: columnWeight(table.widths?.[index]),
-      };
-    }),
-    // The Adaptive Cards schema spells this `firstRowAsHeader`, but the Teams
-    // renderers and @microsoft/teams.cards read the plural and ignore the
-    // singular.
-    firstRowAsHeaders: hasHeader,
-    ...(table.gridStyle ? { gridStyle: table.gridStyle } : {}),
-    rows,
-    showGridLines: table.gridLines ?? true,
-    type: "Table",
-    ...(table.verticalAlign
-      ? {
-          verticalCellContentAlignment:
-            TABLE_VERTICAL_ALIGNMENT[table.verticalAlign],
-        }
-      : {}),
-  };
+  return [
+    {
+      columns: Array.from({ length: columnCount }, (_, index) => {
+        const align = table.align?.[index];
+        return {
+          ...(align
+            ? {
+                horizontalCellContentAlignment:
+                  TABLE_HORIZONTAL_ALIGNMENT[align],
+              }
+            : {}),
+          width: columnWeight(table.widths?.[index]),
+        };
+      }),
+      // Plural on purpose — see the matching note in `cards.ts`. The prose
+      // property table on Microsoft's Table reference page says
+      // `firstRowAsHeader`, but the plural is what renderers read, and the
+      // property defaults to `true` when absent, so emitting the singular
+      // would give a headerless table a header row.
+      firstRowAsHeaders: hasHeader,
+      ...(table.gridStyle ? { gridStyle: table.gridStyle } : {}),
+      rows,
+      showGridLines: table.gridLines ?? true,
+      type: "Table",
+      ...(table.verticalAlign
+        ? {
+            verticalCellContentAlignment:
+              TABLE_VERTICAL_ALIGNMENT[table.verticalAlign],
+          }
+        : {}),
+    },
+  ];
 }
 
 function textBlock(

--- a/packages/adapter-teams/src/cards-primitives/types.ts
+++ b/packages/adapter-teams/src/cards-primitives/types.ts
@@ -1,5 +1,14 @@
 export type TeamsButtonStyle = "danger" | "default" | "primary";
 export type TeamsCardWidth = "default" | "full";
+export type TeamsTableAlignment = "center" | "left" | "right";
+export type TeamsTableGridStyle =
+  | "accent"
+  | "attention"
+  | "default"
+  | "emphasis"
+  | "good"
+  | "warning";
+export type TeamsTableVerticalAlignment = "bottom" | "center" | "top";
 export type TeamsTextStyle = "bold" | "muted" | "plain";
 
 export interface TeamsCardElement {
@@ -108,9 +117,19 @@ export interface TeamsLinkElement {
 }
 
 export interface TeamsTableElement {
+  /** Horizontal alignment of cell content, one entry per column */
+  align?: TeamsTableAlignment[];
+  /** Draw grid lines between cells (default true) */
+  gridLines?: boolean;
+  /** Style of the grid lines between cells */
+  gridStyle?: TeamsTableGridStyle;
   headers: string[];
   rows: string[][];
   type: "table";
+  /** Vertical alignment of cell content */
+  verticalAlign?: TeamsTableVerticalAlignment;
+  /** Relative column widths, one positive integer weight per column (default 1 each) */
+  widths?: number[];
 }
 
 export interface TeamsAdaptiveCard {

--- a/packages/adapter-teams/src/cards.test.ts
+++ b/packages/adapter-teams/src/cards.test.ts
@@ -1,3 +1,4 @@
+import type { ITable, ITextBlock } from "@microsoft/teams.cards";
 import {
   Actions,
   Button,
@@ -13,9 +14,12 @@ import {
   Section,
   Select,
   SelectOption,
+  Table,
+  type TableOptions,
 } from "chat";
 import { describe, expect, it } from "vitest";
 import { cardToAdaptiveCard, cardToFallbackText } from "./cards";
+import { cardToAdaptiveCard as primitivesCardToAdaptiveCard } from "./cards-primitives";
 
 describe("cardToAdaptiveCard", () => {
   it("creates a valid adaptive card structure", () => {
@@ -501,5 +505,204 @@ describe("cardToAdaptiveCard with Teams-specific hints", () => {
     const adaptive = cardToAdaptiveCard(card);
 
     expect(adaptive.actions?.[0]?.tooltip).toBeUndefined();
+  });
+});
+
+describe("cardToAdaptiveCard with Table", () => {
+  const renderTable = (options: TableOptions): ITable =>
+    cardToAdaptiveCard(Card({ children: [Table(options)] })).body[0] as ITable;
+
+  const cellTexts = (table: ITable, rowIndex: number): string[] =>
+    (table.rows?.[rowIndex].cells ?? []).map(
+      (cell) => (cell.items[0] as ITextBlock).text
+    );
+
+  it("renders a native Table with grid lines and a bold header row by default", () => {
+    const table = renderTable({
+      headers: ["Name", "Score"],
+      rows: [
+        ["Alice", "98"],
+        ["Bob", "87"],
+      ],
+    });
+
+    expect(table).toMatchObject({
+      type: "Table",
+      showGridLines: true,
+      firstRowAsHeaders: true,
+    });
+    expect(table.gridStyle).toBeUndefined();
+    expect(table.horizontalCellContentAlignment).toBeUndefined();
+    expect(table.verticalCellContentAlignment).toBeUndefined();
+    expect(table.columns).toHaveLength(2);
+    expect(table.rows).toHaveLength(3);
+    expect(table.rows?.[0]).toMatchObject({
+      type: "TableRow",
+      cells: [
+        {
+          type: "TableCell",
+          items: [
+            { type: "TextBlock", text: "Name", weight: "Bolder", wrap: true },
+          ],
+        },
+        {
+          type: "TableCell",
+          items: [
+            { type: "TextBlock", text: "Score", weight: "Bolder", wrap: true },
+          ],
+        },
+      ],
+    });
+    expect(table.rows?.[1]).toMatchObject({
+      type: "TableRow",
+      cells: [
+        { items: [{ type: "TextBlock", text: "Alice", wrap: true }] },
+        { items: [{ type: "TextBlock", text: "98", wrap: true }] },
+      ],
+    });
+    expect(
+      (table.rows?.[1].cells?.[0].items[0] as ITextBlock).weight
+    ).toBeUndefined();
+  });
+
+  it("weights every column 1 unless widths says otherwise", () => {
+    expect(renderTable({ headers: ["A", "B"], rows: [] }).columns).toEqual([
+      { width: 1 },
+      { width: 1 },
+    ]);
+    expect(
+      renderTable({ headers: ["A", "B", "C"], rows: [], widths: [3, 1] })
+        .columns
+    ).toEqual([{ width: 3 }, { width: 1 }, { width: 1 }]);
+  });
+
+  it("falls back to weight 1 for a width that is not a positive integer", () => {
+    expect(
+      renderTable({
+        headers: ["A", "B", "C", "D", "E"],
+        rows: [],
+        widths: [0, -1, 1.5, Number.NaN, 2],
+      }).columns
+    ).toEqual([
+      { width: 1 },
+      { width: 1 },
+      { width: 1 },
+      { width: 1 },
+      { width: 2 },
+    ]);
+  });
+
+  it("maps per-column align onto the column definitions", () => {
+    const table = renderTable({
+      headers: ["A", "B", "C"],
+      rows: [["1", "2", "3"]],
+      align: ["left", "center", "right"],
+    });
+
+    expect(
+      table.columns?.map((column) => column.horizontalCellContentAlignment)
+    ).toEqual(["Left", "Center", "Right"]);
+    expect(table.horizontalCellContentAlignment).toBeUndefined();
+  });
+
+  it.each([
+    ["top", "Top"],
+    ["center", "Center"],
+    ["bottom", "Bottom"],
+  ] as const)("maps verticalAlign %s to %s", (verticalAlign, expected) => {
+    expect(
+      renderTable({ headers: ["A"], rows: [], verticalAlign })
+        .verticalCellContentAlignment
+    ).toBe(expected);
+  });
+
+  it("omits the header row and the header flag for a headerless table", () => {
+    const table = renderTable({ headers: [], rows: [["Alice", "98"]] });
+
+    expect(table.firstRowAsHeaders).toBe(false);
+    expect(table.columns).toHaveLength(2);
+    expect(table.rows).toHaveLength(1);
+    expect(cellTexts(table, 0)).toEqual(["Alice", "98"]);
+    expect(
+      (table.rows?.[0].cells?.[0].items[0] as ITextBlock).weight
+    ).toBeUndefined();
+  });
+
+  it("emits no element for a table with no columns", () => {
+    const render = (rows: string[][]) =>
+      cardToAdaptiveCard(Card({ children: [Table({ headers: [], rows })] }))
+        .body;
+
+    expect(render([])).toEqual([]);
+    expect(render([[]])).toEqual([]);
+  });
+
+  it("turns grid lines off on request", () => {
+    expect(
+      renderTable({ headers: ["A"], rows: [], gridLines: false }).showGridLines
+    ).toBe(false);
+  });
+
+  it("passes gridStyle through", () => {
+    expect(
+      renderTable({ headers: ["A"], rows: [], gridStyle: "emphasis" }).gridStyle
+    ).toBe("emphasis");
+  });
+
+  it("pads a ragged row with empty cells", () => {
+    const table = renderTable({
+      headers: ["A", "B", "C"],
+      rows: [["1"], ["1", "2", "3", "4"]],
+    });
+
+    expect(table.columns).toHaveLength(4);
+    expect(cellTexts(table, 0)).toEqual(["A", "B", "C", ""]);
+    expect(cellTexts(table, 1)).toEqual(["1", "", "", ""]);
+    expect(cellTexts(table, 2)).toEqual(["1", "2", "3", "4"]);
+  });
+
+  it("converts emoji placeholders in headers and cells", () => {
+    const table = renderTable({
+      headers: ["Status {{emoji:check}}"],
+      rows: [["Done {{emoji:check}}"]],
+    });
+
+    expect(cellTexts(table, 0)).toEqual(["Status ✅"]);
+    expect(cellTexts(table, 1)).toEqual(["Done ✅"]);
+  });
+
+  it("keeps the ASCII fallback text", () => {
+    const text = cardToFallbackText(
+      Card({
+        children: [
+          Table({
+            headers: ["Name", "Score"],
+            rows: [["Alice", "98"]],
+            widths: [3, 1],
+            gridStyle: "emphasis",
+          }),
+        ],
+      })
+    );
+
+    expect(text).toContain("Name  | Score\n------|------\nAlice | 98");
+  });
+
+  it("emits the same Table as the dependency-free cards subpath", () => {
+    const options: TableOptions = {
+      headers: ["Name", "Score"],
+      rows: [["Alice", "98"], ["Bob"]],
+      align: ["left", "right"],
+      widths: [3, 1],
+      gridStyle: "emphasis",
+    };
+    const primitives = primitivesCardToAdaptiveCard({
+      children: [{ ...options, type: "table" }],
+      type: "card",
+    }).body[0] as Record<string, unknown>;
+
+    expect(JSON.parse(JSON.stringify(renderTable(options)))).toMatchObject(
+      primitives
+    );
   });
 });

--- a/packages/adapter-teams/src/cards.test.ts
+++ b/packages/adapter-teams/src/cards.test.ts
@@ -688,14 +688,38 @@ describe("cardToAdaptiveCard with Table", () => {
     expect(text).toContain("Name  | Score\n------|------\nAlice | 98");
   });
 
-  it("emits the same Table as the dependency-free cards subpath", () => {
-    const options: TableOptions = {
-      headers: ["Name", "Score"],
-      rows: [["Alice", "98"], ["Bob"]],
-      align: ["left", "right"],
-      widths: [3, 1],
-      gridStyle: "emphasis",
-    };
+  // The two converters are independent implementations by design — the
+  // primitives subpath may not import `@microsoft/teams.cards`. These cases
+  // are what stops them drifting, so they exercise every option that differs
+  // between them, not just the common path.
+  it.each<{ name: string; options: TableOptions }>([
+    {
+      name: "a ragged table with alignment, widths and a grid style",
+      options: {
+        headers: ["Name", "Score"],
+        rows: [["Alice", "98"], ["Bob"]],
+        align: ["left", "right"],
+        widths: [3, 1],
+        gridStyle: "emphasis",
+        verticalAlign: "center",
+      },
+    },
+    {
+      name: "a borderless table",
+      options: {
+        headers: ["Name"],
+        rows: [["Alice"]],
+        gridLines: false,
+      },
+    },
+    {
+      name: "a headerless table",
+      options: {
+        headers: [],
+        rows: [["Alice", "98"]],
+      },
+    },
+  ])("emits the same Table as the cards subpath for $name", ({ options }) => {
     const primitives = primitivesCardToAdaptiveCard({
       children: [{ ...options, type: "table" }],
       type: "card",

--- a/packages/adapter-teams/src/cards.ts
+++ b/packages/adapter-teams/src/cards.ts
@@ -13,23 +13,30 @@ import {
 import type {
   ActionArray,
   ActionStyle,
+  TableOptions as AdaptiveTableOptions,
   CardElementArray,
   ChoiceSetInputOptions,
+  ColumnDefinitionOptions,
+  HorizontalAlignment,
   OpenUrlActionOptions,
   SubmitActionOptions,
+  TextBlockOptions,
+  VerticalAlignment,
 } from "@microsoft/teams.cards";
 import {
   AdaptiveCard,
   Image as AdaptiveImage,
   Choice,
   ChoiceSetInput,
-  Column,
-  ColumnSet,
+  ColumnDefinition,
   Container,
   Fact,
   FactSet,
   OpenUrlAction,
   SubmitAction,
+  Table,
+  TableCell,
+  TableRow,
   TextBlock,
 } from "@microsoft/teams.cards";
 import type {
@@ -44,7 +51,9 @@ import type {
   RadioSelectElement,
   SectionElement,
   SelectElement,
+  TableAlignment,
   TableElement,
+  TableVerticalAlignment,
   TextElement,
 } from "chat";
 import { cardChildToFallbackText } from "chat";
@@ -148,8 +157,10 @@ function convertChildToAdaptive(child: CardChild): ConvertResult {
         ],
         actions: [],
       };
-    case "table":
-      return { elements: [convertTableToElement(child)], actions: [] };
+    case "table": {
+      const table = convertTableToElement(child);
+      return { elements: table ? [table] : [], actions: [] };
+    }
     default: {
       const text = cardChildToFallbackText(child);
       if (text) {
@@ -329,26 +340,92 @@ function convertSectionToElements(element: SectionElement): ConvertResult {
   return { elements, actions };
 }
 
-function convertTableToElement(element: TableElement): Container {
-  // Adaptive Cards Table element
-  const headerColumns = element.headers.map((header) =>
-    new Column(
-      new TextBlock(convertEmoji(header), { weight: "Bolder", wrap: true })
-    ).withOptions({ width: "stretch" })
+const TABLE_HORIZONTAL_ALIGNMENT: Record<TableAlignment, HorizontalAlignment> =
+  {
+    left: "Left",
+    center: "Center",
+    right: "Right",
+  };
+
+const TABLE_VERTICAL_ALIGNMENT: Record<
+  TableVerticalAlignment,
+  VerticalAlignment
+> = {
+  top: "Top",
+  center: "Center",
+  bottom: "Bottom",
+};
+
+// Adaptive Cards treats a column width as a relative weight only when it is a
+// positive integer; Teams desktop and mobile disagree on anything else, so an
+// invalid weight falls back to the default instead of reaching the wire.
+function columnWeight(width: number | undefined): number {
+  return width !== undefined && Number.isInteger(width) && width > 0
+    ? width
+    : 1;
+}
+
+function convertTableToElement(element: TableElement): Table | null {
+  // The column count follows the widest row so a short row is padded with
+  // empty cells instead of shifting the grid, as the ASCII fallback does.
+  const columnCount = Math.max(
+    element.headers.length,
+    ...element.rows.map((row) => row.length)
   );
+  // No columns means nothing to draw, as the empty ASCII fallback says.
+  if (columnCount === 0) {
+    return null;
+  }
 
-  const headerRow = new ColumnSet().withColumns(...headerColumns);
-
-  const dataRows = element.rows.map((row) => {
-    const cols = row.map((cell) =>
-      new Column(new TextBlock(convertEmoji(cell), { wrap: true })).withOptions(
-        { width: "stretch" }
-      )
-    );
-    return new ColumnSet().withColumns(...cols);
+  const columns = Array.from({ length: columnCount }, (_, index) => {
+    const options: ColumnDefinitionOptions = {
+      width: columnWeight(element.widths?.[index]),
+    };
+    const align = element.align?.[index];
+    if (align) {
+      options.horizontalCellContentAlignment =
+        TABLE_HORIZONTAL_ALIGNMENT[align];
+    }
+    return new ColumnDefinition(options);
   });
 
-  return new Container(headerRow, ...dataRows);
+  const toRow = (cells: string[], textOptions: TextBlockOptions = {}) =>
+    new TableRow({
+      cells: Array.from(
+        { length: columnCount },
+        (_, index) =>
+          new TableCell(
+            new TextBlock(convertEmoji(cells[index] ?? ""), {
+              wrap: true,
+              ...textOptions,
+            })
+          )
+      ),
+    });
+
+  const hasHeader = element.headers.length > 0;
+  const rows = element.rows.map((row) => toRow(row));
+  if (hasHeader) {
+    rows.unshift(toRow(element.headers, { weight: "Bolder" }));
+  }
+
+  const options: AdaptiveTableOptions = {
+    columns,
+    // The Adaptive Cards schema spells this `firstRowAsHeader`, but the Teams
+    // renderers and @microsoft/teams.cards read the plural and ignore the
+    // singular.
+    firstRowAsHeaders: hasHeader,
+    rows,
+    showGridLines: element.gridLines ?? true,
+  };
+  if (element.gridStyle) {
+    options.gridStyle = element.gridStyle;
+  }
+  if (element.verticalAlign) {
+    options.verticalCellContentAlignment =
+      TABLE_VERTICAL_ALIGNMENT[element.verticalAlign];
+  }
+  return new Table(options);
 }
 
 function convertFieldsToElement(element: FieldsElement): FactSet {

--- a/packages/adapter-teams/src/cards.ts
+++ b/packages/adapter-teams/src/cards.ts
@@ -13,10 +13,8 @@ import {
 import type {
   ActionArray,
   ActionStyle,
-  TableOptions as AdaptiveTableOptions,
   CardElementArray,
   ChoiceSetInputOptions,
-  ColumnDefinitionOptions,
   HorizontalAlignment,
   OpenUrlActionOptions,
   SubmitActionOptions,
@@ -157,10 +155,8 @@ function convertChildToAdaptive(child: CardChild): ConvertResult {
         ],
         actions: [],
       };
-    case "table": {
-      const table = convertTableToElement(child);
-      return { elements: table ? [table] : [], actions: [] };
-    }
+    case "table":
+      return { elements: convertTableToElements(child), actions: [] };
     default: {
       const text = cardChildToFallbackText(child);
       if (text) {
@@ -365,28 +361,36 @@ function columnWeight(width: number | undefined): number {
     : 1;
 }
 
-function convertTableToElement(element: TableElement): Table | null {
-  // The column count follows the widest row so a short row is padded with
-  // empty cells instead of shifting the grid, as the ASCII fallback does.
-  const columnCount = Math.max(
-    element.headers.length,
-    ...element.rows.map((row) => row.length)
-  );
-  // No columns means nothing to draw, as the empty ASCII fallback says.
+// The widest row sets the column count, so a short row is padded with empty
+// cells instead of shifting the grid. Accumulated in a loop rather than
+// `Math.max(...rows.map(...))`, which spreads one argument per row and blows
+// the call-argument limit on a large table.
+function tableColumnCount(headers: string[], rows: string[][]): number {
+  let count = headers.length;
+  for (const row of rows) {
+    if (row.length > count) {
+      count = row.length;
+    }
+  }
+  return count;
+}
+
+// Returns an array so "no columns means nothing to draw" needs no null check at
+// the call site, matching what the empty ASCII fallback says.
+function convertTableToElements(element: TableElement): Table[] {
+  const columnCount = tableColumnCount(element.headers, element.rows);
   if (columnCount === 0) {
-    return null;
+    return [];
   }
 
   const columns = Array.from({ length: columnCount }, (_, index) => {
-    const options: ColumnDefinitionOptions = {
-      width: columnWeight(element.widths?.[index]),
-    };
     const align = element.align?.[index];
-    if (align) {
-      options.horizontalCellContentAlignment =
-        TABLE_HORIZONTAL_ALIGNMENT[align];
-    }
-    return new ColumnDefinition(options);
+    return new ColumnDefinition({
+      width: columnWeight(element.widths?.[index]),
+      horizontalCellContentAlignment: align
+        ? TABLE_HORIZONTAL_ALIGNMENT[align]
+        : undefined,
+    });
   });
 
   const toRow = (cells: string[], textOptions: TextBlockOptions = {}) =>
@@ -409,23 +413,25 @@ function convertTableToElement(element: TableElement): Table | null {
     rows.unshift(toRow(element.headers, { weight: "Bolder" }));
   }
 
-  const options: AdaptiveTableOptions = {
-    columns,
-    // The Adaptive Cards schema spells this `firstRowAsHeader`, but the Teams
-    // renderers and @microsoft/teams.cards read the plural and ignore the
-    // singular.
-    firstRowAsHeaders: hasHeader,
-    rows,
-    showGridLines: element.gridLines ?? true,
-  };
-  if (element.gridStyle) {
-    options.gridStyle = element.gridStyle;
-  }
-  if (element.verticalAlign) {
-    options.verticalCellContentAlignment =
-      TABLE_VERTICAL_ALIGNMENT[element.verticalAlign];
-  }
-  return new Table(options);
+  return [
+    new Table({
+      columns,
+      // Adaptive Cards spells this `firstRowAsHeaders`: that is the name
+      // `@microsoft/teams.cards` declares (default `true`) and the name every
+      // sample on Microsoft's own Table reference page uses. The prose property
+      // table on that page says `firstRowAsHeader`, singular; the plural is what
+      // renderers read. Do not "correct" it — because the property defaults to
+      // `true` when absent, a headerless table would silently regain a header
+      // row. The plain-object converter in `cards-primitives/` says the same.
+      firstRowAsHeaders: hasHeader,
+      rows,
+      showGridLines: element.gridLines ?? true,
+      gridStyle: element.gridStyle,
+      verticalCellContentAlignment: element.verticalAlign
+        ? TABLE_VERTICAL_ALIGNMENT[element.verticalAlign]
+        : undefined,
+    }),
+  ];
 }
 
 function convertFieldsToElement(element: FieldsElement): FactSet {

--- a/packages/chat/src/cards.test.ts
+++ b/packages/chat/src/cards.test.ts
@@ -251,6 +251,34 @@ describe("Card Builder Functions", () => {
       expect(table.caption).toBeUndefined();
       expect(table.pageSize).toBeUndefined();
     });
+
+    it("carries the Teams-only rendering options", () => {
+      const table = Table({
+        headers: ["Name", "Score"],
+        rows: [["Ada", "10"]],
+        align: ["left", "right"],
+        widths: [3, 1],
+        verticalAlign: "bottom",
+        gridLines: false,
+        gridStyle: "emphasis",
+      });
+      expect(table).toMatchObject({
+        type: "table",
+        align: ["left", "right"],
+        widths: [3, 1],
+        verticalAlign: "bottom",
+        gridLines: false,
+        gridStyle: "emphasis",
+      });
+    });
+
+    it("leaves the rendering options undefined when omitted", () => {
+      expect(Table({ headers: ["A"], rows: [["1"]] })).toEqual({
+        type: "table",
+        headers: ["A"],
+        rows: [["1"]],
+      });
+    });
   });
 
   describe("Chart", () => {

--- a/packages/chat/src/cards.ts
+++ b/packages/chat/src/cards.ts
@@ -166,12 +166,28 @@ export interface FieldsElement {
 /** Column alignment for table elements */
 export type TableAlignment = "left" | "center" | "right";
 
+/** Vertical alignment of table cell content */
+export type TableVerticalAlignment = "top" | "center" | "bottom";
+
+/** Style of the grid lines drawn between table cells */
+export type TableGridStyle =
+  | "default"
+  | "emphasis"
+  | "accent"
+  | "good"
+  | "attention"
+  | "warning";
+
 /** Table element for structured data display */
 export interface TableElement {
   /** Column alignment */
   align?: TableAlignment[];
   /** Accessible table caption (used by platforms with native table support) */
   caption?: string;
+  /** Draw grid lines between cells (default true). Rendered by Teams only; other adapters ignore it */
+  gridLines?: boolean;
+  /** Style of the grid lines between cells. Rendered by Teams only; other adapters ignore it */
+  gridStyle?: TableGridStyle;
   /** Column header labels */
   headers: string[];
   /** Rows per page on platforms that paginate tables (Slack: 1-100, default 5) */
@@ -179,6 +195,10 @@ export interface TableElement {
   /** Data rows (each row is an array of cell strings) */
   rows: string[][];
   type: "table";
+  /** Vertical alignment of cell content. Rendered by Teams only; other adapters ignore it */
+  verticalAlign?: TableVerticalAlignment;
+  /** Relative column widths, one positive integer weight per column (default 1 each). Rendered by Teams only; other adapters ignore it */
+  widths?: number[];
 }
 
 /** Chart segment for pie charts */
@@ -543,12 +563,20 @@ export interface TableOptions {
   align?: TableAlignment[];
   /** Accessible table caption (used by platforms with native table support) */
   caption?: string;
+  /** Draw grid lines between cells (default true). Rendered by Teams only; other adapters ignore it */
+  gridLines?: boolean;
+  /** Style of the grid lines between cells. Rendered by Teams only; other adapters ignore it */
+  gridStyle?: TableGridStyle;
   /** Column header labels */
   headers: string[];
   /** Rows per page on platforms that paginate tables (Slack: 1-100, default 5) */
   pageSize?: number;
   /** Data rows */
   rows: string[][];
+  /** Vertical alignment of cell content. Rendered by Teams only; other adapters ignore it */
+  verticalAlign?: TableVerticalAlignment;
+  /** Relative column widths, one positive integer weight per column (default 1 each). Rendered by Teams only; other adapters ignore it */
+  widths?: number[];
 }
 
 /**
@@ -564,6 +592,19 @@ export interface TableOptions {
  *   ],
  * })
  * ```
+ *
+ * On Teams the table renders as a native Adaptive Card table; `widths`,
+ * `verticalAlign`, `gridLines` and `gridStyle` tune that rendering and are
+ * ignored elsewhere:
+ *
+ * ```ts
+ * Table({
+ *   headers: ["Service", "Status"],
+ *   rows: [["api", "ok"]],
+ *   widths: [3, 1],
+ *   gridStyle: "emphasis",
+ * })
+ * ```
  */
 export function Table(options: TableOptions): TableElement {
   return {
@@ -573,6 +614,10 @@ export function Table(options: TableOptions): TableElement {
     align: options.align,
     caption: options.caption,
     pageSize: options.pageSize,
+    widths: options.widths,
+    verticalAlign: options.verticalAlign,
+    gridLines: options.gridLines,
+    gridStyle: options.gridStyle,
   };
 }
 
@@ -850,13 +895,8 @@ export function fromReactElement(element: unknown): AnyCardElement | null {
       );
 
     case "Table":
-      return Table({
-        headers: props.headers as string[],
-        rows: props.rows as string[][],
-        align: props.align as TableAlignment[] | undefined,
-        caption: props.caption as string | undefined,
-        pageSize: props.pageSize as number | undefined,
-      });
+      // Table() copies each option by name, so extra React props never leak.
+      return Table(props as unknown as TableOptions);
 
     case "Chart":
       return Chart({

--- a/packages/chat/src/cards.ts
+++ b/packages/chat/src/cards.ts
@@ -178,27 +178,15 @@ export type TableGridStyle =
   | "attention"
   | "warning";
 
-/** Table element for structured data display */
-export interface TableElement {
-  /** Column alignment */
-  align?: TableAlignment[];
-  /** Accessible table caption (used by platforms with native table support) */
-  caption?: string;
-  /** Draw grid lines between cells (default true). Rendered by Teams only; other adapters ignore it */
-  gridLines?: boolean;
-  /** Style of the grid lines between cells. Rendered by Teams only; other adapters ignore it */
-  gridStyle?: TableGridStyle;
-  /** Column header labels */
-  headers: string[];
-  /** Rows per page on platforms that paginate tables (Slack: 1-100, default 5) */
-  pageSize?: number;
-  /** Data rows (each row is an array of cell strings) */
-  rows: string[][];
+/**
+ * Table element for structured data display.
+ *
+ * Carries exactly the `TableOptions` fields — a table has no children, so the
+ * builder's options and the element differ only by the discriminant. Declared
+ * by extension so a new option is documented once.
+ */
+export interface TableElement extends TableOptions {
   type: "table";
-  /** Vertical alignment of cell content. Rendered by Teams only; other adapters ignore it */
-  verticalAlign?: TableVerticalAlignment;
-  /** Relative column widths, one positive integer weight per column (default 1 each). Rendered by Teams only; other adapters ignore it */
-  widths?: number[];
 }
 
 /** Chart segment for pie charts */

--- a/packages/chat/src/index.ts
+++ b/packages/chat/src/index.ts
@@ -200,7 +200,9 @@ export type {
   SeriesChartDefinition,
   TableAlignment,
   TableElement,
+  TableGridStyle,
   TableOptions,
+  TableVerticalAlignment,
   TextElement,
   TextStyle,
 } from "./cards";

--- a/packages/chat/src/jsx-react.test.tsx
+++ b/packages/chat/src/jsx-react.test.tsx
@@ -22,6 +22,7 @@ import {
   Image,
   LinkButton,
   Section,
+  Table,
   Text,
 } from "./cards";
 
@@ -317,6 +318,36 @@ describe("fromReactElement - React JSX mode", () => {
       const reactDivider = createReactElement(Divider, {});
       const result = fromReactElement(reactDivider);
       expect(result?.type).toBe("divider");
+    });
+  });
+
+  describe("Table conversion", () => {
+    it("converts Table with alignment and Teams rendering options", () => {
+      const reactTable = createReactElement(Table, {
+        headers: ["Name", "Score"],
+        rows: [["Alice", "98"]],
+        align: ["left", "right"],
+        caption: "Scores",
+        pageSize: 10,
+        widths: [3, 1],
+        verticalAlign: "bottom",
+        gridLines: false,
+        gridStyle: "good",
+      });
+
+      const result = fromReactElement(reactTable);
+      expect(result).toEqual({
+        type: "table",
+        headers: ["Name", "Score"],
+        rows: [["Alice", "98"]],
+        align: ["left", "right"],
+        caption: "Scores",
+        pageSize: 10,
+        widths: [3, 1],
+        verticalAlign: "bottom",
+        gridLines: false,
+        gridStyle: "good",
+      });
     });
   });
 

--- a/packages/chat/src/jsx-runtime.test.tsx
+++ b/packages/chat/src/jsx-runtime.test.tsx
@@ -337,6 +337,32 @@ describe("chat-sdk JSX runtime with actual JSX syntax", () => {
       expect(result?.children[0].type).toBe("text");
       expect(result?.children[1].type).toBe("table");
     });
+
+    it("passes alignment and Teams rendering options through", () => {
+      const element = (
+        <Card title="Scores">
+          <Table
+            align={["left", "right"]}
+            gridLines={false}
+            gridStyle="accent"
+            headers={["Name", "Score"]}
+            rows={[["Alice", "98"]]}
+            verticalAlign="top"
+            widths={[3, 1]}
+          />
+        </Card>
+      );
+      const result = toCardElement(element);
+
+      expect(result?.children[0]).toMatchObject({
+        type: "table",
+        align: ["left", "right"],
+        widths: [3, 1],
+        verticalAlign: "top",
+        gridLines: false,
+        gridStyle: "accent",
+      });
+    });
   });
 
   describe("isJSX detection", () => {

--- a/packages/chat/src/jsx-runtime.ts
+++ b/packages/chat/src/jsx-runtime.ts
@@ -61,6 +61,7 @@ import {
   type SectionElement,
   Table,
   type TableElement,
+  type TableOptions,
   Text,
   type TextElement,
   type TextStyle,
@@ -240,13 +241,8 @@ export interface SelectOptionProps {
   value: string;
 }
 
-/** Props for Table component in JSX */
-export interface TableProps {
-  caption?: string;
-  headers: string[];
-  pageSize?: number;
-  rows: string[][];
-}
+/** Props for Table component in JSX (a Table has no children, so its props are its options) */
+export type TableProps = TableOptions;
 
 /** Props for Chart component in JSX */
 export interface ChartProps {
@@ -446,12 +442,7 @@ export interface RadioSelectComponent {
 }
 
 export interface TableComponent {
-  (options: {
-    caption?: string;
-    headers: string[];
-    pageSize?: number;
-    rows: string[][];
-  }): TableElement;
+  (options: TableOptions): TableElement;
   (props: TableProps): ChatElement;
 }
 
@@ -897,13 +888,9 @@ function resolveJSXElement(element: JSXElement): AnyCardElement {
   }
 
   if (type === Table) {
-    const tableProps = props as TableProps;
-    return Table({
-      headers: tableProps.headers,
-      rows: tableProps.rows,
-      caption: tableProps.caption,
-      pageSize: tableProps.pageSize,
-    });
+    // Table() copies each option by name, so a new option is added there once
+    // and reaches JSX without a second list here.
+    return Table(props as TableProps);
   }
 
   if (type === Chart) {


### PR DESCRIPTION
## Summary

The Teams adapter rendered `Table` as a `Container` of `ColumnSet`s, one per row with every column `stretch`, which Adaptive Cards draws as stacked columns: no grid lines, no column sizing, no header semantics. Adaptive Cards 1.5, the version the adapter already declares, has a native [`Table`](https://adaptivecards.microsoft.com/?topic=Table) element that Teams renders as an actual table with grid lines, weighted column widths, per-column alignment and an accessible header row.

- **`@chat-adapter/teams`** — `convertTableToElement` now builds the 1.5 `Table` element from `@microsoft/teams.cards` (`Table`, `TableRow`, `TableCell`, `ColumnDefinition`) through the library's typed option objects. One column definition per column; a bold header row with `firstRowAsHeaders: true` only when `headers` is non-empty (`headers: []` yields a headerless table); one wrapped `TextBlock` per cell with the adapter's emoji conversion applied as before. Ragged rows are padded with empty cells, mirroring `tableElementToAscii`, and a table with no columns at all emits no element, matching its empty ASCII fallback. The dependency-free `@chat-adapter/teams/cards` subpath emits the same element, and a parity test renders one table through both paths. The declared card version stays `1.5`.
- **`chat`** — `Table` / `TableOptions` / `TableProps` gain optional, platform-neutral rendering options, each documented "Rendered by Teams only; other adapters ignore it": `widths` (positive integer column weights, parallel to `align`; anything else falls back to 1, because Teams desktop and mobile disagree on zero, negative and fractional weights), `verticalAlign` (`"top" | "center" | "bottom"`), `gridLines` (default `true`) and `gridStyle` (`"default" | "emphasis" | "accent" | "good" | "attention" | "warning"`). They survive the factory, the chat JSX runtime and `fromReactElement`. Every field is optional, so no existing call site changes. `TableVerticalAlignment` and `TableGridStyle` are exported next to `TableAlignment`.
- The chat JSX runtime dropped `align` on `<Table>` because `TableProps` and the resolver kept their own copy of the option list. `TableProps` is now an alias of `TableOptions`, and both the JSX resolver and `fromReactElement` hand the props to `Table()`, which copies each option by name, so a new option is added in one place.
- Docs: the Table section and `TableOptions` reference, the Teams adapter page and its README feature row. Changeset bumps `chat` and `@chat-adapter/teams` as `minor`.

No other adapter reads the new fields; they consume `headers`, `rows`, `align`, `caption` and `pageSize` only, and none of their tests changed.

### Rendering change for every Teams table

Every existing `Table` on Teams now renders with grid lines (`showGridLines: true`): a table with lines is what the element means and what Teams draws for a markdown table. If you would rather existing cards keep a borderless look, I am happy to flip the default to `gridLines: false`; say so and I will update the default, tests and docs.

### `firstRowAsHeaders`

The published Adaptive Cards schema spells the header flag `firstRowAsHeader`, but the Teams renderers and `@microsoft/teams.cards` read the plural `firstRowAsHeaders` (default `true`) and ignore the singular. Microsoft confirmed in [msteams-docs#9241](https://github.com/MicrosoftDocs/msteams-docs/issues/9241) that `firstRowAsHeaders: false` renders a headerless table on Teams desktop, web and mobile; the schema discrepancy is tracked in [AdaptiveCards#8599](https://github.com/microsoft/AdaptiveCards/issues/8599). The adapter sets the flag through the library's typed options, and a comment at each emit site records the trap. Because the library defaults it on, a headerless table sets it to `false` explicitly.

## Test plan

- `pnpm check`, `pnpm typecheck`, `pnpm knip`, `pnpm konsistent`: clean.
- `pnpm --filter @chat-adapter/teams test`: new `cardToAdaptiveCard with Table` suite covering the native `Table` with grid lines on by default; default weight 1, `widths` on the column definitions, and the fallback to 1 for zero, negative, fractional and NaN weights; per-column `align` and table-level `verticalAlign` for every value; header row and `firstRowAsHeaders` only when headers exist; no element for a table with no columns; `gridLines: false`; `gridStyle`; ragged-row padding; emoji placeholders in cells; the ASCII fallback unchanged; and a parity test asserting the full adapter and the `@chat-adapter/teams/cards` subpath emit the same JSON. The `cards-primitives` suite covers the subpath the same way.
- `pnpm --filter chat test`: each new option survives `Table()`, the chat JSX runtime (`<Table>`) and `fromReactElement`.
- Full `pnpm test` across every package.
- `pnpm validate`.

## Checklist

- [x] All commits are signed and verified
- [x] All commits are signed off for the DCO (`git commit -s`)
- [x] `pnpm validate` passes
- [x] Changeset added (or N/A — see [CONTRIBUTING.md](./CONTRIBUTING.md))
- [x] Documentation updated (or N/A)
