### PR TITLE
fix(whatsapp): preserve literal text during formatting

### DIFF
--- a/.changeset/quick-whatsapp-formatting.md
+++ b/.changeset/quick-whatsapp-formatting.md
@@ -1,0 +1,5 @@
+---
+"@chat-adapter/whatsapp": patch
+---
+
+Avoid exponential serialization time for nested bold and strikethrough formatting in WhatsApp messages.

--- a/.changeset/tidy-whatsapp-literals.md
+++ b/.changeset/tidy-whatsapp-literals.md
@@ -1,0 +1,6 @@
+---
+"@chat-adapter/whatsapp": patch
+"chat": patch
+---
+
+Preserve literal tildes and backslashes in outgoing WhatsApp Markdown instead of adding visible Markdown escapes. Render bold and strikethrough from their AST nodes so formatting markers inside inline and fenced code remain unchanged. Expose typed serialization handlers in `stringifyMarkdown` for platform-specific output.

--- a/apps/docs/content/adapters/official/whatsapp.mdx
+++ b/apps/docs/content/adapters/official/whatsapp.mdx
@@ -162,6 +162,13 @@ From your Meta app dashboard, copy:
 
 ## Advanced
 
+### Message formatting
+
+Pass `{ markdown: text }` to convert standard Markdown to WhatsApp formatting:
+`**bold**` becomes `*bold*`, `_italic_` stays `_italic_`, and `~~strike~~` becomes
+`~strike~`. Literal text such as `(~80 % easy)` is sent without additional
+Markdown escapes. Code content and intentional backslashes are preserved.
+
 ### Inbound attachments
 
 Incoming media attachments expose a lazy `fetchData()`. Media is downloaded only from Meta's `fbcdn.net` and `fbsbx.com` hosts or the configured Graph origin. Downloads refuse private and internal addresses, are limited to 25 MB, and time out after 30 seconds, and the access token never follows a redirect off those hosts. Pass a custom transport to `downloadMedia()` to route downloads through a proxy.

--- a/apps/docs/content/docs/api/markdown.mdx
+++ b/apps/docs/content/docs/api/markdown.mdx
@@ -179,6 +179,20 @@ Convert an mdast AST back to a markdown string.
 const md = stringifyMarkdown(ast); // "**Hello** world"
 ```
 
+Pass `handlers` in the options to customize how individual mdast node types are
+serialized, for example when rendering a platform-specific Markdown dialect:
+
+```typescript
+const md = stringifyMarkdown(ast, {
+  handlers: {
+    text: (node) => node.value,
+  },
+});
+```
+
+Custom handlers replace the default serializer for those node types, so they are
+responsible for any escaping required by the destination format.
+
 ### toPlainText
 
 Strip all formatting and return plain text.

--- a/packages/adapter-whatsapp/src/markdown.test.ts
+++ b/packages/adapter-whatsapp/src/markdown.test.ts
@@ -105,8 +105,7 @@ describe("WhatsAppFormatConverter", () => {
     it("should preserve escaped asterisks and tildes as literals", () => {
       const ast = converter.toAst("a \\* b and c \\~ d");
       const result = converter.fromAst(ast);
-      expect(result).toContain("\\*");
-      expect(result).toContain("\\~");
+      expect(result).toBe("a * b and c ~ d");
     });
 
     it("should convert standard italic to WhatsApp underscore italic", () => {
@@ -165,6 +164,32 @@ describe("WhatsAppFormatConverter", () => {
   });
 
   describe("renderPostable", () => {
+    it.each([
+      ["(~80 % easy)", "(~80 % easy)"],
+      ["~45 min, Pace ~6:29/km", "~45 min, Pace ~6:29/km"],
+      [
+        String.raw`C:\Users\Luis and foo_bar`,
+        String.raw`C:\Users\Luis and foo_bar`,
+      ],
+      [
+        String.raw`A backslash before a tilde: \\\~80`,
+        String.raw`A backslash before a tilde: \~80`,
+      ],
+      [String.raw`Literal \*\*stars\*\*`, "Literal **stars**"],
+      ["`~80 **literal** ~~literal~~`", "`~80 **literal** ~~literal~~`"],
+      [
+        "```\n~80 **literal** ~~literal~~ C:\\Users\\Luis\n```",
+        "```\n~80 **literal** ~~literal~~ C:\\Users\\Luis\n```",
+      ],
+      [
+        "- **Monday** — Rest\n- _Tuesday_ — ~~Tempo~~",
+        "- *Monday* — Rest\n- _Tuesday_ — ~Tempo~",
+      ],
+      ["**bold _italic_ ~~strike~~**", "*bold _italic_ ~strike~*"],
+    ])("preserves literal text and formatting in %s", (markdown, expected) => {
+      expect(converter.renderPostable({ markdown })).toBe(expected);
+    });
+
     it("should render a plain string", () => {
       const result = converter.renderPostable("Hello world");
       expect(result).toBe("Hello world");

--- a/packages/adapter-whatsapp/src/markdown.test.ts
+++ b/packages/adapter-whatsapp/src/markdown.test.ts
@@ -190,6 +190,23 @@ describe("WhatsAppFormatConverter", () => {
       expect(converter.renderPostable({ markdown })).toBe(expected);
     });
 
+    it("renders deeply nested formatting without exponential lookahead", () => {
+      let markdown = "end";
+      let expected = "end";
+      for (let depth = 0; depth < 23; depth++) {
+        const marker = depth % 2 === 0 ? "*" : "~";
+        markdown = `text ${marker}${marker}${markdown} end${marker}${marker}`;
+        expected = `text ${marker}${expected} end${marker}`;
+      }
+
+      const start = performance.now();
+      const result = converter.renderPostable({ markdown });
+      const elapsed = performance.now() - start;
+      expect(result).toBe(expected);
+      // Allow ample CI headroom while catching repeated subtree serialization.
+      expect(elapsed).toBeLessThan(1000);
+    });
+
     it("should render a plain string", () => {
       const result = converter.renderPostable("Hello world");
       expect(result).toBe("Hello world");

--- a/packages/adapter-whatsapp/src/markdown.ts
+++ b/packages/adapter-whatsapp/src/markdown.ts
@@ -62,7 +62,7 @@ export class WhatsAppFormatConverter extends BaseFormatConverter {
       }
       return node;
     });
-    return stringifyMarkdown(transformed, {
+    const options = {
       emphasis: "_",
       bullet: "-",
       handlers: {
@@ -72,7 +72,11 @@ export class WhatsAppFormatConverter extends BaseFormatConverter {
         delete: (node, _parent, state, info) =>
           `~${state.containerPhrasing(node, { ...info, before: "~", after: "~" })}~`,
       },
-    }).trim();
+    } satisfies Parameters<typeof stringifyMarkdown>[1];
+    // Lookahead must not serialize nested formatting a second time.
+    Object.assign(options.handlers.strong, { peek: () => "*" });
+    Object.assign(options.handlers.delete, { peek: () => "~" });
+    return stringifyMarkdown(transformed, options).trim();
   }
 
   /**

--- a/packages/adapter-whatsapp/src/markdown.ts
+++ b/packages/adapter-whatsapp/src/markdown.ts
@@ -27,8 +27,8 @@ export class WhatsAppFormatConverter extends BaseFormatConverter {
    * Convert an AST to WhatsApp markdown format.
    *
    * Transforms unsupported nodes (headings, thematic breaks, tables)
-   * into WhatsApp-compatible equivalents, then converts standard markdown
-   * bold/strikethrough to WhatsApp syntax.
+   * into WhatsApp-compatible equivalents and renders supported formatting
+   * directly in WhatsApp syntax.
    */
   fromAst(ast: Root): string {
     const transformed = walkAst(structuredClone(ast), (node: Content) => {
@@ -62,12 +62,17 @@ export class WhatsAppFormatConverter extends BaseFormatConverter {
       }
       return node;
     });
-    // Use _ for emphasis and - for bullets so the only * in output is **strong**
-    const markdown = stringifyMarkdown(transformed, {
+    return stringifyMarkdown(transformed, {
       emphasis: "_",
       bullet: "-",
+      handlers: {
+        text: (node) => node.value,
+        strong: (node, _parent, state, info) =>
+          `*${state.containerPhrasing(node, { ...info, before: "*", after: "*" })}*`,
+        delete: (node, _parent, state, info) =>
+          `~${state.containerPhrasing(node, { ...info, before: "~", after: "~" })}~`,
+      },
     }).trim();
-    return this.toWhatsAppFormat(markdown);
   }
 
   /**
@@ -102,20 +107,6 @@ export class WhatsAppFormatConverter extends BaseFormatConverter {
       return this.fromAst(message.ast);
     }
     return super.renderPostable(message);
-  }
-
-  /**
-   * Convert remaining standard markdown markers to WhatsApp format.
-   * The stringifier already outputs _italic_ and - bullets.
-   * This only converts **bold** -> *bold* and ~~strike~~ -> ~strike~.
-   */
-  private toWhatsAppFormat(text: string): string {
-    let result = text;
-    // Convert **bold** -> *bold*
-    result = result.replace(/\*\*(.+?)\*\*/g, "*$1*");
-    // Convert ~~strikethrough~~ -> ~strikethrough~
-    result = result.replace(/~~(.+?)~~/g, "~$1~");
-    return result;
   }
 
   /**

--- a/packages/chat/src/markdown.ts
+++ b/packages/chat/src/markdown.ts
@@ -24,7 +24,9 @@ import type {
 import { toString as mdastToString } from "mdast-util-to-string";
 import remarkGfm from "remark-gfm";
 import remarkParse from "remark-parse";
-import remarkStringify from "remark-stringify";
+import remarkStringify, {
+  type Options as MarkdownStringifyOptions,
+} from "remark-stringify";
 import { unified } from "unified";
 import type { CardChild, CardElement, ChartElement } from "./cards";
 import type { AdapterPostableMessage } from "./types";
@@ -300,6 +302,7 @@ export interface StringifyOptions {
   bullet?: "*" | "-" | "+";
   /** Emphasis marker character. Default: `'*'` */
   emphasis?: "*" | "_";
+  handlers?: MarkdownStringifyOptions["handlers"];
 }
 
 /**


### PR DESCRIPTION
## Summary

Fixes #908.

Outgoing WhatsApp Markdown such as `(~80 % easy)` currently becomes `(\~80 % easy)`, leaving a visible backslash in the delivered message. Render literal text, bold, and strikethrough directly from the Markdown AST so literal tildes and intentional backslashes are preserved, and formatting markers inside inline and fenced code remain unchanged.

Expose typed serialization handlers in `stringifyMarkdown` and provide lookahead markers to avoid repeated subtree serialization for deeply nested formatting. Includes regression tests, patch changesets, and documentation updates.

## Test plan

- `pnpm validate` passes (knip, lint/format, typecheck, tests, and build).
- `pnpm konsistent` passes.
- `pnpm changeset status` recognizes the patch changesets.
- Regression coverage includes literal tildes, intentional backslashes, escaped markers, inline/fenced code, lists, and nested formatting, including a deep-nesting performance check.

## Checklist

- [x] All commits are signed and verified
- [x] All commits are signed off for the DCO (`git commit -s`)
- [x] `pnpm validate` passes
- [x] Changeset added
- [x] Documentation updated
