### PR TITLE
fix(whatsapp): stop escaping literal tildes and rewriting markers in code content

### DIFF
--- a/packages/adapter-whatsapp/src/markdown.test.ts
+++ b/packages/adapter-whatsapp/src/markdown.test.ts
@@ -102,11 +102,43 @@ describe("WhatsAppFormatConverter", () => {
       expect(result).not.toContain("~~strikethrough~~");
     });
 
-    it("should preserve escaped asterisks and tildes as literals", () => {
+    it("should preserve escaped asterisks as literals while keeping tildes unescaped", () => {
       const ast = converter.toAst("a \\* b and c \\~ d");
       const result = converter.fromAst(ast);
       expect(result).toContain("\\*");
-      expect(result).toContain("\\~");
+      expect(result).not.toContain("\\~");
+      expect(result).toContain("~");
+    });
+
+    it("should not escape literal tildes in plain text", () => {
+      const ast = converter.toAst("(~80 % easy)");
+      const result = converter.fromAst(ast);
+      expect(result).toBe("(~80 % easy)");
+    });
+
+    it("should not escape multiple literal tildes", () => {
+      const ast = converter.toAst("run ~45 min\n\npace ~6:29/km");
+      const result = converter.fromAst(ast);
+      expect(result).toBe("run ~45 min\n\npace ~6:29/km");
+    });
+
+    it("should preserve a literal backslash before a tilde", () => {
+      const ast = converter.toAst("a \\\\~ b");
+      const result = converter.fromAst(ast);
+      expect(result).toBe("a \\\\~ b");
+    });
+
+    it("should not rewrite markers inside fenced code", () => {
+      const ast = converter.toAst("x\n\n```\n**keep** ~y~\n```\n\nz");
+      const result = converter.fromAst(ast);
+      expect(result).toContain("```\n**keep** ~y~\n```");
+      expect(result).toContain("\nz");
+    });
+
+    it("should not rewrite markers inside inline code", () => {
+      const ast = converter.toAst("before `**keep** ~y~` after");
+      const result = converter.fromAst(ast);
+      expect(result).toContain("`**keep** ~y~`");
     });
 
     it("should convert standard italic to WhatsApp underscore italic", () => {

--- a/packages/adapter-whatsapp/src/markdown.ts
+++ b/packages/adapter-whatsapp/src/markdown.ts
@@ -110,12 +110,44 @@ export class WhatsAppFormatConverter extends BaseFormatConverter {
    * This only converts **bold** -> *bold* and ~~strike~~ -> ~strike~.
    */
   private toWhatsAppFormat(text: string): string {
-    let result = text;
-    // Convert **bold** -> *bold*
+    const lines = text.split("\n");
+    let inFence = false;
+    let fenceLength = 0;
+    const converted = lines.map((line) => {
+      const fence = line.match(/^(`{3,})/);
+      if (fence) {
+        if (!inFence) {
+          inFence = true;
+          fenceLength = fence[1].length;
+          return line;
+        }
+        if (fence[1].length >= fenceLength && /^\s*$/.test(line.slice(fence[1].length))) {
+          inFence = false;
+          return line;
+        }
+      }
+      if (inFence) {
+        return line;
+      }
+      return this.convertTextOutsideCode(line);
+    });
+    return converted.join("\n");
+  }
+
+  private convertTextOutsideCode(line: string): string {
+    const codeSpans: string[] = [];
+    const masked = line.replace(/(`+)([\s\S]*?)\1/g, (span) => {
+      codeSpans.push(span);
+      return `\u0000${codeSpans.length - 1}\u0000`;
+    });
+    let result = masked.replace(/(\\*)~/g, (match, slashes: string) =>
+      slashes.length % 2 === 1 ? `${slashes.slice(0, -1)}~` : match
+    );
     result = result.replace(/\*\*(.+?)\*\*/g, "*$1*");
-    // Convert ~~strikethrough~~ -> ~strikethrough~
     result = result.replace(/~~(.+?)~~/g, "~$1~");
-    return result;
+    return result.replace(/\u0000(\d+)\u0000/g, (_, index: string) =>
+      codeSpans[Number(index)]
+    );
   }
 
   /**
@@ -126,13 +158,18 @@ export class WhatsAppFormatConverter extends BaseFormatConverter {
    * Careful not to convert _italic_ (which is the same in both formats).
    */
   private fromWhatsAppFormat(text: string): string {
-    // Convert *bold* to **bold** (single * not preceded/followed by *, no newlines)
-    let result = text.replace(
+    const codeSpans: string[] = [];
+    const masked = text.replace(/(`+)([\s\S]*?)\1/g, (span) => {
+      codeSpans.push(span);
+      return `\u0000${codeSpans.length - 1}\u0000`;
+    });
+    let result = masked.replace(
       /(?<!\*)\*(?!\*)([^\n*]+?)(?<!\*)\*(?!\*)/g,
       "**$1**"
     );
-    // Convert ~strike~ to ~~strike~~ (single ~ not preceded/followed by ~, no newlines)
     result = result.replace(/(?<!~)~(?!~)([^\n~]+?)(?<!~)~(?!~)/g, "~~$1~~");
-    return result;
+    return result.replace(/\u0000(\d+)\u0000/g, (_, index: string) =>
+      codeSpans[Number(index)]
+    );
   }
 }


### PR DESCRIPTION
## Summary

Fixes #908

The WhatsApp formatter was delivering serializer-escaped tildes to users: text like `(~80 % easy)` arrived as `(\\~80 % easy)` because `remark-stringify` escapes literal `~` characters and `toWhatsAppFormat` left those escapes intact.

The whole-string marker conversions also rewrote `**bold**` and `~~strikethrough~~` inside fenced and inline code (`**literal**` in a code block became `*literal*`).

## Changes

- `toWhatsAppFormat` now processes the stringified output line by line, skipping fenced code regions, and resolves serializer-added tilde escapes only when they are not part of a real escaped backslash sequence
- Inline code spans are masked out before any conversion and restored afterwards, in both `toWhatsAppFormat` and `fromWhatsAppFormat`
- `fromWhatsAppFormat` no longer rewrites `*bold*` / `~strike~` inside inline code, so a round trip through the adapter preserves code content exactly

## Testing

- Regression tests for the reported repro: `(~80 % easy)` round trips unchanged, and multiple literal tildes stay unescaped
- Tests for intentional escapes (`\\~` stays intact), fenced code, and inline code in both directions
- Full adapter-whatsapp suite passes (235 tests) and `tsc --noEmit` is clean

cc @vercel/chat