### PR TITLE
fix(telegram): preserve links during truncation

### DIFF
--- a/.changeset/smart-onions-pay.md
+++ b/.changeset/smart-onions-pay.md
@@ -2,4 +2,4 @@
 "@chat-adapter/telegram": patch
 ---
 
-Preserve backticks in link destinations when truncating Telegram MarkdownV2 messages and captions. Keep incomplete links and code delimiters from leaking through length limits.
+Stop cutting Telegram MarkdownV2 messages and captions at a backtick inside a link destination. Messages that fit the length limit now ship exactly as rendered, and a length cut that lands inside a link, code span, or underline now removes the incomplete entity before the ellipsis.

--- a/.changeset/smart-onions-pay.md
+++ b/.changeset/smart-onions-pay.md
@@ -1,0 +1,5 @@
+---
+"@chat-adapter/telegram": patch
+---
+
+Preserve backticks in link destinations when truncating Telegram MarkdownV2 messages and captions. Keep incomplete links and code delimiters from leaking through length limits.

--- a/apps/docs/content/adapters/official/telegram.mdx
+++ b/apps/docs/content/adapters/official/telegram.mdx
@@ -298,7 +298,7 @@ On Telegram Bot API 10.1 and newer, explicit `{ markdown }` and `{ ast }` messag
 
 Plain strings, raw messages, cards, and media captions retain their existing lightweight message paths. Cards and captions use Telegram's `MarkdownV2` parse mode with context-aware escaping. Older or custom Bot API servers automatically fall back to this existing path when rich message methods are unavailable.
 
-MarkdownV2 fallback messages and captions preserve special characters, including backticks, inside link destinations. When a length limit cuts through a link or code span, the incomplete entity is removed before the ellipsis.
+MarkdownV2 fallback messages and captions that fit the length limit ship exactly as rendered, including backticks and other special characters inside link destinations. When a length limit cuts through a link, code span, or underline, the incomplete entity is removed before the ellipsis.
 
 Pass `{ raw: "..." }` only if you need to ship a fully pre-escaped MarkdownV2 string.
 

--- a/apps/docs/content/adapters/official/telegram.mdx
+++ b/apps/docs/content/adapters/official/telegram.mdx
@@ -298,6 +298,8 @@ On Telegram Bot API 10.1 and newer, explicit `{ markdown }` and `{ ast }` messag
 
 Plain strings, raw messages, cards, and media captions retain their existing lightweight message paths. Cards and captions use Telegram's `MarkdownV2` parse mode with context-aware escaping. Older or custom Bot API servers automatically fall back to this existing path when rich message methods are unavailable.
 
+MarkdownV2 fallback messages and captions preserve special characters, including backticks, inside link destinations. When a length limit cuts through a link or code span, the incomplete entity is removed before the ellipsis.
+
 Pass `{ raw: "..." }` only if you need to ship a fully pre-escaped MarkdownV2 string.
 
 ### Notes

--- a/packages/adapter-telegram/src/index.test.ts
+++ b/packages/adapter-telegram/src/index.test.ts
@@ -25,9 +25,11 @@ import {
   type TelegramUpdate,
 } from "./index";
 import {
+  endsWithOrphanBackslash,
   TELEGRAM_CAPTION_LIMIT,
   TELEGRAM_MESSAGE_LIMIT,
   TelegramFormatConverter,
+  trimToMarkdownV2SafeBoundary,
 } from "./markdown";
 
 const mockFetch = vi.fn<typeof fetch>();
@@ -5303,40 +5305,6 @@ describe("message length limits", () => {
       .mockResolvedValueOnce(telegramOk(sampleMessage()));
   }
 
-  /**
-   * Count unescaped occurrences of a single-char entity delimiter.
-   * Preceded by `\` means escaped; we ignore those. Double `\\` means a
-   * literal backslash, so the following delimiter is unescaped.
-   */
-  function countUnescaped(text: string, marker: string): number {
-    let count = 0;
-    for (let i = 0; i < text.length; i++) {
-      if (text[i] !== marker) {
-        continue;
-      }
-      let backslashes = 0;
-      let j = i - 1;
-      while (j >= 0 && text[j] === "\\") {
-        backslashes++;
-        j--;
-      }
-      // Even number of preceding backslashes → marker is unescaped
-      if (backslashes % 2 === 0) {
-        count++;
-      }
-    }
-    return count;
-  }
-
-  function endsWithOrphanBackslash(text: string): boolean {
-    let trailing = 0;
-    for (let i = text.length - 1; i >= 0 && text[i] === "\\"; i--) {
-      trailing++;
-    }
-    // Odd trailing backslashes = last `\` has nothing to escape
-    return trailing % 2 === 1;
-  }
-
   it("plain string over 4096 chars truncates to exactly the limit with '...' and no parse_mode", async () => {
     const adapter = await createInitializedAdapter();
     mockFetch.mockResolvedValueOnce(telegramOk(sampleMessage()));
@@ -5477,13 +5445,8 @@ describe("message length limits", () => {
     const ellipsis = text.endsWith("\\.\\.\\.") ? "\\.\\.\\." : "...";
     const beforeEllipsis = text.slice(0, -ellipsis.length);
 
-    // Every entity delimiter must appear an even number of unescaped times
-    for (const marker of ["*", "_", "~", "`"]) {
-      expect(
-        countUnescaped(beforeEllipsis, marker) % 2,
-        `${marker} count must be even`
-      ).toBe(0);
-    }
+    // The production trimmer must consider the shipped text balanced.
+    expect(trimToMarkdownV2SafeBoundary(beforeEllipsis)).toBe(beforeEllipsis);
   });
 
   it("MarkdownV2 truncation closes or drops an unmatched inline code span", async () => {
@@ -5499,7 +5462,7 @@ describe("message length limits", () => {
     const ellipsis = text.endsWith("\\.\\.\\.") ? "\\.\\.\\." : "...";
     const beforeEllipsis = text.slice(0, -ellipsis.length);
 
-    expect(countUnescaped(beforeEllipsis, "`") % 2).toBe(0);
+    expect(trimToMarkdownV2SafeBoundary(beforeEllipsis)).toBe(beforeEllipsis);
   });
 
   it("MarkdownV2 caption over 1024 escapes the ellipsis", async () => {

--- a/packages/adapter-telegram/src/index.test.ts
+++ b/packages/adapter-telegram/src/index.test.ts
@@ -5406,6 +5406,62 @@ describe("message length limits", () => {
     expect(endsWithOrphanBackslash(beforeEllipsis)).toBe(false);
   });
 
+  it("preserves URL backticks and trailing text in a legacy MarkdownV2 post", async () => {
+    const adapter = await createInitializedAdapter();
+    useLegacyMessage();
+    const markdown = "before [x](https://example.com/a`b) after";
+
+    await adapter.postMessage("telegram:123", { markdown });
+
+    expect(String(mockFetch.mock.calls[2]?.[0])).toContain("/sendMessage");
+    expect(readSentBody(2)).toMatchObject({
+      parse_mode: "MarkdownV2",
+      text: markdown,
+    });
+    expect(readSentBody(2).rich_message).toBeUndefined();
+  });
+
+  it("preserves URL backticks and trailing text in a legacy MarkdownV2 edit", async () => {
+    const adapter = await createInitializedAdapter();
+    mockFetch
+      .mockResolvedValueOnce(
+        telegramError(400, 400, "Bad Request: rich message is unsupported")
+      )
+      .mockResolvedValueOnce(telegramOk(sampleMessage()));
+    const markdown = "before [x](https://example.com/a`b) after";
+
+    await adapter.editMessage("telegram:123", "123:1", { markdown });
+
+    expect(String(mockFetch.mock.calls[2]?.[0])).toContain("/editMessageText");
+    expect(readSentBody(2)).toMatchObject({
+      parse_mode: "MarkdownV2",
+      text: markdown,
+    });
+    expect(readSentBody(2).rich_message).toBeUndefined();
+  });
+
+  it("preserves URL backticks and trailing text in a MarkdownV2 file caption", async () => {
+    const adapter = await createInitializedAdapter();
+    mockFetch.mockResolvedValueOnce(telegramOk(sampleMessage()));
+    const markdown = "before [x](https://example.com/a`b) after";
+
+    await adapter.postMessage("telegram:123", {
+      markdown,
+      files: [
+        {
+          filename: "report.txt",
+          data: Buffer.from("payload"),
+          mimeType: "text/plain",
+        },
+      ],
+    });
+
+    expect(String(mockFetch.mock.calls[1]?.[0])).toContain("/sendDocument");
+    const formData = mockFetch.mock.calls[1]?.[1]?.body as FormData;
+    expect(formData.get("parse_mode")).toBe("MarkdownV2");
+    expect(formData.get("caption")).toBe(markdown);
+  });
+
   it("MarkdownV2 truncation leaves all entity delimiters balanced (no unclosed **bold**)", async () => {
     const adapter = await createInitializedAdapter();
     useLegacyMessage();

--- a/packages/adapter-telegram/src/markdown.test.ts
+++ b/packages/adapter-telegram/src/markdown.test.ts
@@ -2,7 +2,6 @@ import { describe, expect, it } from "vitest";
 import {
   endsWithOrphanBackslash,
   escapeMarkdownV2,
-  findUnescapedPositions,
   TelegramFormatConverter,
   truncateForTelegram,
 } from "./markdown";
@@ -536,7 +535,132 @@ describe("truncateForTelegram", () => {
     expect(result).toBe(input);
   });
 
+  it.each([
+    ["before \\`literal", "before \\`literal"],
+    ["before \\\\`unfinished", "before \\\\"],
+    ["`a\\`b`", "`a\\`b`"],
+    ["```\na\\`b\n```", "```\na\\`b\n```"],
+    ["`a``b`", "`a``b`"],
+  ])("respects escape parity around code delimiters: %s", (input, expected) => {
+    expect(truncateForTelegram(input, 4096, "MarkdownV2")).toBe(expected);
+  });
+
   describe("link URLs with raw entity-marker characters", () => {
+    it.each([
+      1024, 4096,
+    ])("preserves one or three URL backticks under the %i character limit", (limit) => {
+      for (const ticks of ["`", "```"]) {
+        const input = `before [x](https://example.com/a${ticks}b_*~) after`;
+        expect(truncateForTelegram(input, limit, "MarkdownV2")).toBe(input);
+      }
+    });
+
+    it("preserves an explicit Markdown link with a backtick destination", () => {
+      const converter = new TelegramFormatConverter();
+      const rendered = converter.renderPostable({
+        markdown: "[x](https://example.com/a`b)",
+      });
+      expect(rendered).toBe("[x](https://example.com/a`b)");
+      expect(truncateForTelegram(rendered, 4096, "MarkdownV2")).toBe(rendered);
+    });
+
+    it("preserves the original bare-URL underscore reproduction", () => {
+      const converter = new TelegramFormatConverter();
+      const rendered = converter.renderPostable({
+        markdown:
+          "See billing: https://example.com/org/org_abc123def456ghi789jkl/billing",
+      });
+      expect(rendered).toContain(
+        "](https://example.com/org/org_abc123def456ghi789jkl/billing)"
+      );
+      expect(truncateForTelegram(rendered, 4096, "MarkdownV2")).toBe(rendered);
+    });
+
+    it("preserves an autolinked bare URL containing a backtick", () => {
+      const converter = new TelegramFormatConverter();
+      const rendered = converter.renderPostable({
+        markdown: "before https://example.com/a`b after",
+      });
+      expect(rendered).toBe(
+        "before [https://example\\.com/a\\`b](https://example.com/a`b) after"
+      );
+      expect(truncateForTelegram(rendered, 4096, "MarkdownV2")).toBe(rendered);
+    });
+
+    it("preserves a backtick destination supplied through an AST", () => {
+      const converter = new TelegramFormatConverter();
+      const rendered = converter.fromAst({
+        type: "root",
+        children: [
+          {
+            type: "paragraph",
+            children: [
+              {
+                type: "link",
+                url: "https://example.com/a`b",
+                children: [{ type: "text", value: "x" }],
+              },
+            ],
+          },
+        ],
+      });
+      expect(rendered).toBe("[x](https://example.com/a`b)");
+      expect(truncateForTelegram(rendered, 4096, "MarkdownV2")).toBe(rendered);
+    });
+
+    it.each([
+      "`before` [x](https://example.com/a`b) `after`",
+      "```js\nbefore\n```\n[x](https://example.com/a`b)\n```js\nafter\n```",
+      "before [x\\]](https://example.com/a\\)`b\\\\) after",
+      "before [x](https://example.com/a\\`b) after",
+      "before [x](https://example.com/a\\\\`b) after",
+      "`[x](https://example.com/a\\`b)`",
+      "```\n[x](https://example.com/a\\`b)\n```",
+    ])("preserves links alongside code and escaped delimiters: %s", (input) => {
+      expect(truncateForTelegram(input, 4096, "MarkdownV2")).toBe(input);
+    });
+
+    it.each([
+      "`unfinished",
+      "```js\nunfinished",
+    ])("does not let URL backticks balance unfinished code: %s", (code) => {
+      const prefix = "before [x](https://example.com/a`b) ";
+      expect(truncateForTelegram(prefix + code, 4096, "MarkdownV2")).toBe(
+        prefix
+      );
+    });
+
+    it("retreats before a partial link at every destination cut", () => {
+      const prefix = "before ";
+      const link = "[x\\]](https://example.com/a\\)`b\\\\)";
+      const input = `${prefix}${link} after ${"z".repeat(100)}`;
+      for (
+        let cut = prefix.length;
+        cut <= prefix.length + link.length + 1;
+        cut++
+      ) {
+        const expected =
+          cut < prefix.length + link.length ? prefix : input.slice(0, cut);
+        const result = truncateForTelegram(input, cut + 6, "MarkdownV2");
+        expect(result, `cut at ${cut}`).toBe(`${expected}\\.\\.\\.`);
+        expect(endsWithOrphanBackslash(result)).toBe(false);
+      }
+    });
+
+    it.each([
+      "`code`",
+      "```js\ncode\n```",
+    ])("retreats before code when cutting through its body or delimiters: %s", (code) => {
+      const prefix = "[x](https://example.com/a`b) ";
+      const input = `${prefix}${code} ${"z".repeat(100)}`;
+      for (let cut = 1; cut < code.length; cut++) {
+        expect(
+          truncateForTelegram(input, prefix.length + cut + 6, "MarkdownV2"),
+          `cut at ${cut}`
+        ).toBe(`${prefix}\\.\\.\\.`);
+      }
+    });
+
     it("preserves a link whose URL contains one underscore", () => {
       const input = "[x](https://e.co/?a_b=1)";
       expect(truncateForTelegram(input, 4096, "MarkdownV2")).toBe(input);
@@ -586,24 +710,6 @@ describe("truncateForTelegram", () => {
     const input = `${"a".repeat(80)}*${"b".repeat(100)}`;
     const result = truncateForTelegram(input, 100, "MarkdownV2");
     expect(result).toBe(`${"a".repeat(80)}\\.\\.\\.`);
-  });
-});
-
-describe("findUnescapedPositions", () => {
-  it("finds unescaped markers", () => {
-    expect(findUnescapedPositions("*a*", "*")).toEqual([0, 2]);
-  });
-
-  it("ignores escaped markers", () => {
-    expect(findUnescapedPositions("\\*a*", "*")).toEqual([3]);
-  });
-
-  it("handles double backslash (escaped backslash) before marker", () => {
-    expect(findUnescapedPositions("\\\\*", "*")).toEqual([2]);
-  });
-
-  it("returns empty for no markers", () => {
-    expect(findUnescapedPositions("hello", "*")).toEqual([]);
   });
 });
 

--- a/packages/adapter-telegram/src/markdown.test.ts
+++ b/packages/adapter-telegram/src/markdown.test.ts
@@ -3,6 +3,7 @@ import {
   endsWithOrphanBackslash,
   escapeMarkdownV2,
   TelegramFormatConverter,
+  trimToMarkdownV2SafeBoundary,
   truncateForTelegram,
 } from "./markdown";
 
@@ -474,6 +475,11 @@ describe("truncateForTelegram", () => {
     expect(truncateForTelegram("hello", 100, "plain")).toBe("hello");
   });
 
+  it("returns MarkdownV2 that fits the limit unchanged, even with unpaired markers", () => {
+    const input = "Hello *world* _italic and bold *bold*";
+    expect(truncateForTelegram(input, 4096, "MarkdownV2")).toBe(input);
+  });
+
   it("truncates plain text with literal ellipsis", () => {
     const result = truncateForTelegram("a".repeat(200), 100, "plain");
     expect(result.length).toBe(100);
@@ -494,14 +500,6 @@ describe("truncateForTelegram", () => {
     expect(result.endsWith("\\.\\.\\.")).toBe(true);
   });
 
-  it("strips unclosed bold before ellipsis", () => {
-    const input = `${"a".repeat(80)}*${"b".repeat(100)}`;
-    const result = truncateForTelegram(input, 100, "MarkdownV2");
-    const beforeEllipsis = result.replace(ESCAPED_ELLIPSIS_PATTERN, "");
-    const stars = [...beforeEllipsis].filter((c) => c === "*").length;
-    expect(stars % 2).toBe(0);
-  });
-
   it("handles input that is all special chars", () => {
     const input = ".".repeat(200);
     const rendered = escapeMarkdownV2(input);
@@ -510,193 +508,10 @@ describe("truncateForTelegram", () => {
     expect(result.endsWith("\\.\\.\\.")).toBe(true);
   });
 
-  it("strips unpaired entity markers when under the limit (streaming leak)", () => {
-    const input = "Hello *world* _italic and bold *bold*";
-    const result = truncateForTelegram(input, 4096, "MarkdownV2");
-    const underscores = [...result].filter((c) => c === "_").length;
-    expect(underscores % 2).toBe(0);
-  });
-
-  it("preserves code fences with literal asterisks (no false-positive trim)", () => {
-    const input = "```python\nprint(*args, **kwargs)\n```";
-    const result = truncateForTelegram(input, 4096, "MarkdownV2");
-    expect(result).toBe(input);
-  });
-
   it("does not modify plain parseMode messages", () => {
     const input = "Hello *world* _unclosed";
     const result = truncateForTelegram(input, 4096, "plain");
     expect(result).toBe(input);
-  });
-
-  it("preserves balanced MarkdownV2 under the limit (no-op)", () => {
-    const input = "*bold* _italic_ ~strike~ `code`";
-    const result = truncateForTelegram(input, 4096, "MarkdownV2");
-    expect(result).toBe(input);
-  });
-
-  it.each([
-    ["before \\`literal", "before \\`literal"],
-    ["before \\\\`unfinished", "before \\\\"],
-    ["`a\\`b`", "`a\\`b`"],
-    ["```\na\\`b\n```", "```\na\\`b\n```"],
-    ["`a``b`", "`a``b`"],
-  ])("respects escape parity around code delimiters: %s", (input, expected) => {
-    expect(truncateForTelegram(input, 4096, "MarkdownV2")).toBe(expected);
-  });
-
-  describe("link URLs with raw entity-marker characters", () => {
-    it.each([
-      1024, 4096,
-    ])("preserves one or three URL backticks under the %i character limit", (limit) => {
-      for (const ticks of ["`", "```"]) {
-        const input = `before [x](https://example.com/a${ticks}b_*~) after`;
-        expect(truncateForTelegram(input, limit, "MarkdownV2")).toBe(input);
-      }
-    });
-
-    it("preserves an explicit Markdown link with a backtick destination", () => {
-      const converter = new TelegramFormatConverter();
-      const rendered = converter.renderPostable({
-        markdown: "[x](https://example.com/a`b)",
-      });
-      expect(rendered).toBe("[x](https://example.com/a`b)");
-      expect(truncateForTelegram(rendered, 4096, "MarkdownV2")).toBe(rendered);
-    });
-
-    it("preserves the original bare-URL underscore reproduction", () => {
-      const converter = new TelegramFormatConverter();
-      const rendered = converter.renderPostable({
-        markdown:
-          "See billing: https://example.com/org/org_abc123def456ghi789jkl/billing",
-      });
-      expect(rendered).toContain(
-        "](https://example.com/org/org_abc123def456ghi789jkl/billing)"
-      );
-      expect(truncateForTelegram(rendered, 4096, "MarkdownV2")).toBe(rendered);
-    });
-
-    it("preserves an autolinked bare URL containing a backtick", () => {
-      const converter = new TelegramFormatConverter();
-      const rendered = converter.renderPostable({
-        markdown: "before https://example.com/a`b after",
-      });
-      expect(rendered).toBe(
-        "before [https://example\\.com/a\\`b](https://example.com/a`b) after"
-      );
-      expect(truncateForTelegram(rendered, 4096, "MarkdownV2")).toBe(rendered);
-    });
-
-    it("preserves a backtick destination supplied through an AST", () => {
-      const converter = new TelegramFormatConverter();
-      const rendered = converter.fromAst({
-        type: "root",
-        children: [
-          {
-            type: "paragraph",
-            children: [
-              {
-                type: "link",
-                url: "https://example.com/a`b",
-                children: [{ type: "text", value: "x" }],
-              },
-            ],
-          },
-        ],
-      });
-      expect(rendered).toBe("[x](https://example.com/a`b)");
-      expect(truncateForTelegram(rendered, 4096, "MarkdownV2")).toBe(rendered);
-    });
-
-    it.each([
-      "`before` [x](https://example.com/a`b) `after`",
-      "```js\nbefore\n```\n[x](https://example.com/a`b)\n```js\nafter\n```",
-      "before [x\\]](https://example.com/a\\)`b\\\\) after",
-      "before [x](https://example.com/a\\`b) after",
-      "before [x](https://example.com/a\\\\`b) after",
-      "`[x](https://example.com/a\\`b)`",
-      "```\n[x](https://example.com/a\\`b)\n```",
-    ])("preserves links alongside code and escaped delimiters: %s", (input) => {
-      expect(truncateForTelegram(input, 4096, "MarkdownV2")).toBe(input);
-    });
-
-    it.each([
-      "`unfinished",
-      "```js\nunfinished",
-    ])("does not let URL backticks balance unfinished code: %s", (code) => {
-      const prefix = "before [x](https://example.com/a`b) ";
-      expect(truncateForTelegram(prefix + code, 4096, "MarkdownV2")).toBe(
-        prefix
-      );
-    });
-
-    it("retreats before a partial link at every destination cut", () => {
-      const prefix = "before ";
-      const link = "[x\\]](https://example.com/a\\)`b\\\\)";
-      const input = `${prefix}${link} after ${"z".repeat(100)}`;
-      for (
-        let cut = prefix.length;
-        cut <= prefix.length + link.length + 1;
-        cut++
-      ) {
-        const expected =
-          cut < prefix.length + link.length ? prefix : input.slice(0, cut);
-        const result = truncateForTelegram(input, cut + 6, "MarkdownV2");
-        expect(result, `cut at ${cut}`).toBe(`${expected}\\.\\.\\.`);
-        expect(endsWithOrphanBackslash(result)).toBe(false);
-      }
-    });
-
-    it.each([
-      "`code`",
-      "```js\ncode\n```",
-    ])("retreats before code when cutting through its body or delimiters: %s", (code) => {
-      const prefix = "[x](https://example.com/a`b) ";
-      const input = `${prefix}${code} ${"z".repeat(100)}`;
-      for (let cut = 1; cut < code.length; cut++) {
-        expect(
-          truncateForTelegram(input, prefix.length + cut + 6, "MarkdownV2"),
-          `cut at ${cut}`
-        ).toBe(`${prefix}\\.\\.\\.`);
-      }
-    });
-
-    it("preserves a link whose URL contains one underscore", () => {
-      const input = "[x](https://e.co/?a_b=1)";
-      expect(truncateForTelegram(input, 4096, "MarkdownV2")).toBe(input);
-    });
-
-    it("preserves a link whose URL contains an odd number of underscores", () => {
-      const input = "[x](https://e.co/?a_b=1&c_d=2&e_f=3)";
-      expect(truncateForTelegram(input, 4096, "MarkdownV2")).toBe(input);
-    });
-
-    it("preserves surrounding entities alongside an underscore-bearing URL", () => {
-      const input = "text *bold* [x](https://e.co/?a_b=1)";
-      expect(truncateForTelegram(input, 4096, "MarkdownV2")).toBe(input);
-    });
-
-    it("preserves a link whose URL contains * and ~", () => {
-      const input = "[x](https://e.co/?glob=*.ts&home=~user)";
-      expect(truncateForTelegram(input, 4096, "MarkdownV2")).toBe(input);
-    });
-
-    it("preserves a message ending with a link whose URL has odd underscores (regression)", () => {
-      const converter = new TelegramFormatConverter();
-      const rendered = converter.renderPostable({
-        markdown:
-          "body text\n\n[Read more](https://example.com/page?first_param=a&second_param=b&third_param=c)",
-      });
-      const result = truncateForTelegram(rendered, 4096, "MarkdownV2");
-      expect(result).toBe(rendered);
-      expect(result).toContain("&third_param=c)");
-    });
-
-    it("still strips an unpaired underscore outside any link URL", () => {
-      const input = "_oops [x](https://e.co/?a_b=1)";
-      const result = truncateForTelegram(input, 4096, "MarkdownV2");
-      expect(result).toBe("");
-    });
   });
 
   it("trims back to before the [ when hard-truncated inside a link URL", () => {
@@ -710,6 +525,161 @@ describe("truncateForTelegram", () => {
     const input = `${"a".repeat(80)}*${"b".repeat(100)}`;
     const result = truncateForTelegram(input, 100, "MarkdownV2");
     expect(result).toBe(`${"a".repeat(80)}\\.\\.\\.`);
+  });
+
+  it("trims at the __ opener when hard-truncated inside underline", () => {
+    const input = `__b__ rest ${"z".repeat(100)}`;
+    expect(truncateForTelegram(input, 9, "MarkdownV2")).toBe("\\.\\.\\.");
+    expect(truncateForTelegram(input, 11, "MarkdownV2")).toBe("__b__\\.\\.\\.");
+  });
+
+  it("keeps a rendered link whose URL has odd underscores when the cut lands after it", () => {
+    const converter = new TelegramFormatConverter();
+    const rendered = converter.renderPostable({
+      markdown:
+        "body text\n\n[Read more](https://example.com/page?first_param=a&second_param=b&third_param=c)",
+    });
+    const input = `${rendered} ${"z".repeat(100)}`;
+    const result = truncateForTelegram(
+      input,
+      rendered.length + 6,
+      "MarkdownV2"
+    );
+    expect(result).toBe(`${rendered}\\.\\.\\.`);
+    expect(result).toContain("&third_param=c)");
+  });
+
+  it("retreats before a partial link at every destination cut", () => {
+    const prefix = "before ";
+    const link = "[x\\]](https://example.com/a\\)`b\\\\)";
+    const input = `${prefix}${link} after ${"z".repeat(100)}`;
+    for (
+      let cut = prefix.length;
+      cut <= prefix.length + link.length + 1;
+      cut++
+    ) {
+      const expected =
+        cut < prefix.length + link.length ? prefix : input.slice(0, cut);
+      const result = truncateForTelegram(input, cut + 6, "MarkdownV2");
+      expect(result, `cut at ${cut}`).toBe(`${expected}\\.\\.\\.`);
+      expect(endsWithOrphanBackslash(result)).toBe(false);
+    }
+  });
+
+  it.each([
+    "`code`",
+    "```js\ncode\n```",
+  ])("retreats before code when cutting through its body or delimiters: %s", (code) => {
+    const prefix = "[x](https://example.com/a`b) ";
+    const input = `${prefix}${code} ${"z".repeat(100)}`;
+    for (let cut = 1; cut < code.length; cut++) {
+      expect(
+        truncateForTelegram(input, prefix.length + cut + 6, "MarkdownV2"),
+        `cut at ${cut}`
+      ).toBe(`${prefix}\\.\\.\\.`);
+    }
+  });
+});
+
+describe("trimToMarkdownV2SafeBoundary", () => {
+  it.each([
+    "*bold* _italic_ ~strike~ `code`",
+    "__underline__ and _italic_",
+    "```python\nprint(*args, **kwargs)\n```",
+    "Result: `` done",
+    "``x`` done",
+    "`` x\n\n```\ncode\n```",
+    "[a] b",
+    "see [ref] and *bold*",
+    "*b* [x](u) [y] z",
+  ])("leaves balanced MarkdownV2 unchanged: %s", (input) => {
+    expect(trimToMarkdownV2SafeBoundary(input)).toBe(input);
+  });
+
+  it.each([
+    ["Hello *world* _italic and bold *bold*", "Hello *world* "],
+    ["_oops [x](https://e.co/?a_b=1)", ""],
+    ["__b", ""],
+    ["_a_ __b__ _c", "_a_ __b__ "],
+    ["before [x]", "before "],
+    ["before [x](https://e", "before "],
+    ["a `", "a "],
+    ["a ``", "a "],
+    ["a ```js\ncode", "a "],
+  ])("drops the unpaired tail of %j", (input, expected) => {
+    expect(trimToMarkdownV2SafeBoundary(input)).toBe(expected);
+  });
+
+  it.each([
+    ["before \\`literal", "before \\`literal"],
+    ["before \\\\`unfinished", "before \\\\"],
+    ["`a\\`b`", "`a\\`b`"],
+    ["```\na\\`b\n```", "```\na\\`b\n```"],
+    ["`a``b`", "`a``b`"],
+    ["\\*a*", "\\*a"],
+    ["\\\\*a", "\\\\"],
+    ["\\_a_", "\\_a"],
+    ["\\\\_a", "\\\\"],
+    ["\\~a~", "\\~a"],
+    ["\\\\~a", "\\\\"],
+  ])("respects escape parity around delimiters: %j", (input, expected) => {
+    expect(trimToMarkdownV2SafeBoundary(input)).toBe(expected);
+  });
+
+  describe("link URLs with raw entity-marker characters", () => {
+    it.each(["`", "```"])("preserves %s inside a link destination", (ticks) => {
+      const input = `before [x](https://example.com/a${ticks}b_*~) after`;
+      expect(trimToMarkdownV2SafeBoundary(input)).toBe(input);
+    });
+
+    it("preserves an explicit Markdown link with a backtick destination", () => {
+      const converter = new TelegramFormatConverter();
+      const rendered = converter.renderPostable({
+        markdown: "[x](https://example.com/a`b)",
+      });
+      expect(rendered).toBe("[x](https://example.com/a`b)");
+      expect(trimToMarkdownV2SafeBoundary(rendered)).toBe(rendered);
+    });
+
+    it("preserves an autolinked bare URL containing a backtick", () => {
+      const converter = new TelegramFormatConverter();
+      const rendered = converter.renderPostable({
+        markdown: "before https://example.com/a`b after",
+      });
+      expect(rendered).toBe(
+        "before [https://example\\.com/a\\`b](https://example.com/a`b) after"
+      );
+      expect(trimToMarkdownV2SafeBoundary(rendered)).toBe(rendered);
+    });
+
+    it.each([
+      "`before` [x](https://example.com/a`b) `after`",
+      "```js\nbefore\n```\n[x](https://example.com/a`b)\n```js\nafter\n```",
+      "before [x\\]](https://example.com/a\\)`b\\\\) after",
+      "before [x](https://example.com/a\\`b) after",
+      "before [x](https://example.com/a\\\\`b) after",
+      "`[x](https://example.com/a\\`b)`",
+      "```\n[x](https://example.com/a\\`b)\n```",
+    ])("preserves links alongside code and escaped delimiters: %s", (input) => {
+      expect(trimToMarkdownV2SafeBoundary(input)).toBe(input);
+    });
+
+    it.each([
+      "`unfinished",
+      "```js\nunfinished",
+    ])("does not let URL backticks balance unfinished code: %s", (code) => {
+      const prefix = "before [x](https://example.com/a`b) ";
+      expect(trimToMarkdownV2SafeBoundary(prefix + code)).toBe(prefix);
+    });
+
+    it.each([
+      "[x](https://e.co/?a_b=1)",
+      "[x](https://e.co/?a_b=1&c_d=2&e_f=3)",
+      "text *bold* [x](https://e.co/?a_b=1)",
+      "[x](https://e.co/?glob=*.ts&home=~user)",
+    ])("preserves a link whose URL contains entity markers: %s", (input) => {
+      expect(trimToMarkdownV2SafeBoundary(input)).toBe(input);
+    });
   });
 });
 

--- a/packages/adapter-telegram/src/markdown.ts
+++ b/packages/adapter-telegram/src/markdown.ts
@@ -61,8 +61,11 @@ export const TELEGRAM_MESSAGE_LIMIT = 4096;
 export const TELEGRAM_CAPTION_LIMIT = 1024;
 
 // Entity delimiters whose opener/closer pairing must be preserved when
-// truncating a rendered MarkdownV2 string.
-const MARKDOWN_V2_ENTITY_MARKERS = ["*", "_", "~", "`"] as const;
+// truncating a rendered MarkdownV2 string. Telegram reads `__` as underline,
+// which pairs separately from single `_` italics.
+const MARKDOWN_V2_ENTITY_MARKERS = ["*", "_", "__", "~", "`"] as const;
+
+type EntityMarker = (typeof MARKDOWN_V2_ENTITY_MARKERS)[number];
 
 const MARKDOWN_V2_ELLIPSIS = "\\.\\.\\.";
 const PLAIN_ELLIPSIS = "...";
@@ -74,18 +77,39 @@ export function escapeMarkdownV2(text: string): string {
   return text.replace(MARKDOWNV2_SPECIAL_CHARS, "\\$1");
 }
 
+interface DelimiterScan {
+  /** Number of `]` that close a link label. */
+  closeBrackets: number;
+  /**
+   * Unescaped entity delimiter positions outside code and link URLs. Fences
+   * and `__` record one position per delimiter so a cut through an opener
+   * retreats to its first character.
+   */
+  markers: Record<EntityMarker, number[]>;
+  /** Unescaped `[` positions outside code and link URLs. */
+  openBrackets: number[];
+}
+
 /**
- * Return unescaped entity delimiter positions, ignoring literal markers in
- * code and link destinations. For backticks, record one position per inline
- * code or fence delimiter so an unfinished fence retreats to its opener.
+ * Single pass over a MarkdownV2 string collecting every delimiter the trimmer
+ * pairs up. Markers inside fenced code, inline code, or the `(...)` part of a
+ * link are literal text and are skipped.
  */
-function findEntityDelimiterPositions(text: string, marker: string): number[] {
-  const positions: number[] = [];
+function scanDelimiters(text: string): DelimiterScan {
+  const markers: Record<EntityMarker, number[]> = {
+    "*": [],
+    _: [],
+    __: [],
+    "~": [],
+    "`": [],
+  };
+  const openBrackets: number[] = [];
+  let closeBrackets = 0;
   let inFence = false;
   let inInline = false;
+  let inLinkUrl = false;
   let backslashes = 0;
-  // Index of the `]` that opened the current `](...)` link URL, or -1.
-  let linkCloseBracket = -1;
+  const lastIndex = text.length - 1;
 
   for (let i = 0; i < text.length; i++) {
     const ch = text[i];
@@ -97,58 +121,77 @@ function findEntityDelimiterPositions(text: string, marker: string): number[] {
 
     const escaped = backslashes % 2 === 1;
     backslashes = 0;
+    if (escaped) {
+      continue;
+    }
 
-    if (linkCloseBracket >= 0) {
-      if (ch === ")" && !escaped) {
-        // A link's `]` only counts toward bracket pairing once its URL
-        // closes, so a slice mid-URL leaves the `[` unmatched.
-        if (marker === "]") {
-          positions.push(linkCloseBracket);
-        }
-        linkCloseBracket = -1;
+    if (inLinkUrl) {
+      // A link's `]` only counts toward bracket pairing once its URL
+      // closes, so a slice mid-URL leaves the `[` unmatched.
+      if (ch === ")") {
+        inLinkUrl = false;
+        closeBrackets++;
       }
       continue;
     }
 
-    if (ch === "`" && !escaped) {
-      const isTriple = text[i + 1] === "`" && text[i + 2] === "`";
-      if (isTriple && !inInline) {
-        if (marker === "`") {
-          positions.push(i);
-        }
+    if (ch === "`") {
+      if (!inInline && text.startsWith("```", i)) {
+        markers["`"].push(i);
         inFence = !inFence;
         i += 2;
         continue;
       }
-      if (!inFence) {
-        if (marker === "`") {
-          positions.push(i);
-        }
-        // A cut after two opening fence backticks is still an unfinished
-        // delimiter, not a balanced empty inline-code span.
-        if (!inInline && text[i + 1] === "`") {
-          i += 1;
-        }
-        inInline = !inInline;
+      if (inFence) {
+        continue;
       }
-      continue;
-    }
-
-    if (ch === "]" && !escaped && !inFence && !inInline) {
-      if (text[i + 1] === "(") {
-        linkCloseBracket = i;
+      markers["`"].push(i);
+      // A slice that ends in two opening backticks is a cut fence, not a
+      // balanced empty inline-code span.
+      if (!inInline && i + 2 === text.length && text[i + 1] === "`") {
         i += 1;
       }
-      // A cut immediately after the label's `]` also leaves the link open.
+      inInline = !inInline;
       continue;
     }
 
-    if (ch === marker && !escaped && !inFence && !inInline) {
-      positions.push(i);
+    if (inFence || inInline) {
+      continue;
+    }
+
+    if (ch === "[") {
+      openBrackets.push(i);
+      continue;
+    }
+
+    if (ch === "]") {
+      if (text[i + 1] === "(") {
+        inLinkUrl = true;
+        i += 1;
+      } else if (i < lastIndex) {
+        // Telegram accepts a bare `[label]`; only a `]` that ends the slice
+        // may have lost its `(url)` to the cut.
+        closeBrackets++;
+      }
+      continue;
+    }
+
+    if (ch === "_") {
+      if (text[i + 1] === "_") {
+        markers.__.push(i);
+        i += 1;
+      } else {
+        markers._.push(i);
+      }
+      continue;
+    }
+
+    if (ch === "*" || ch === "~") {
+      markers[ch].push(i);
     }
   }
 
-  return positions;
+  return { markers, openBrackets, closeBrackets };
 }
 
 export function endsWithOrphanBackslash(text: string): boolean {
@@ -164,15 +207,17 @@ export function endsWithOrphanBackslash(text: string): boolean {
  * a length-based truncation:
  *
  *  - orphan trailing `\` (would escape the appended ellipsis or nothing)
- *  - unclosed entity delimiter (`*`, `_`, `~`, `` ` ``) left open because
- *    the slice cut between the opener and its closer
+ *  - unclosed entity delimiter (`*`, `_`, `__`, `~`, `` ` ``) left open
+ *    because the slice cut between the opener and its closer
  *  - unmatched `[` from a link whose closer was cut off, or whose `(...)`
  *    URL part was left unterminated by the slice
  *
  * Best-effort: may drop more than strictly necessary in edge cases, but
  * guarantees the output is parseable MarkdownV2 (when the input was).
+ *
+ * Exported for tests; production callers go through `truncateForTelegram`.
  */
-function trimToMarkdownV2SafeBoundary(text: string): string {
+export function trimToMarkdownV2SafeBoundary(text: string): string {
   let current = text;
   const maxIterations = current.length + 1;
 
@@ -182,32 +227,25 @@ function trimToMarkdownV2SafeBoundary(text: string): string {
       continue;
     }
 
-    let minUnsafePosition = current.length;
+    const scan = scanDelimiters(current);
+    let cut = current.length;
 
     for (const marker of MARKDOWN_V2_ENTITY_MARKERS) {
-      const positions = findEntityDelimiterPositions(current, marker);
+      const positions = scan.markers[marker];
       if (positions.length % 2 === 1) {
-        const lastUnpaired = positions.at(-1) ?? current.length;
-        if (lastUnpaired < minUnsafePosition) {
-          minUnsafePosition = lastUnpaired;
-        }
+        cut = Math.min(cut, positions.at(-1) ?? cut);
       }
     }
 
-    const openBrackets = findEntityDelimiterPositions(current, "[");
-    const closeBrackets = findEntityDelimiterPositions(current, "]");
-    if (openBrackets.length > closeBrackets.length) {
-      const lastOpen = openBrackets.at(-1) ?? current.length;
-      if (lastOpen < minUnsafePosition) {
-        minUnsafePosition = lastOpen;
-      }
+    if (scan.openBrackets.length > scan.closeBrackets) {
+      cut = Math.min(cut, scan.openBrackets.at(-1) ?? cut);
     }
 
-    if (minUnsafePosition >= current.length) {
+    if (cut >= current.length) {
       return current;
     }
 
-    current = current.slice(0, minUnsafePosition);
+    current = current.slice(0, cut);
   }
 
   return current;
@@ -216,6 +254,10 @@ function trimToMarkdownV2SafeBoundary(text: string): string {
 /**
  * Truncate a rendered string to `limit` characters, appending a
  * parse-mode-appropriate ellipsis.
+ *
+ * Text that fits the limit is returned unchanged: the MarkdownV2 renderer
+ * emits balanced entities, so there is nothing to repair, and a trim there
+ * could only delete valid content.
  *
  * For MarkdownV2, the naive slice + "..." is unsafe: `.` is reserved and
  * must be escaped, and the slice can leave orphan escape characters (`\`)
@@ -229,12 +271,11 @@ export function truncateForTelegram(
   limit: number,
   parseMode: TelegramParseMode
 ): string {
-  const isMarkdownV2 = parseMode === "MarkdownV2";
-
   if (text.length <= limit) {
-    return isMarkdownV2 ? trimToMarkdownV2SafeBoundary(text) : text;
+    return text;
   }
 
+  const isMarkdownV2 = parseMode === "MarkdownV2";
   const ellipsis = isMarkdownV2 ? MARKDOWN_V2_ELLIPSIS : PLAIN_ELLIPSIS;
   let slice = text.slice(0, limit - ellipsis.length);
 

--- a/packages/adapter-telegram/src/markdown.ts
+++ b/packages/adapter-telegram/src/markdown.ts
@@ -75,37 +75,11 @@ export function escapeMarkdownV2(text: string): string {
 }
 
 /**
- * Return indices of every occurrence of `marker` in `text` that is NOT
- * preceded by an odd number of backslashes (i.e. not escaped).
+ * Return unescaped entity delimiter positions, ignoring literal markers in
+ * code and link destinations. For backticks, record one position per inline
+ * code or fence delimiter so an unfinished fence retreats to its opener.
  */
-export function findUnescapedPositions(text: string, marker: string): number[] {
-  const positions: number[] = [];
-  for (let i = 0; i < text.length; i++) {
-    if (text[i] !== marker) {
-      continue;
-    }
-    let backslashes = 0;
-    let j = i - 1;
-    while (j >= 0 && text[j] === "\\") {
-      backslashes++;
-      j--;
-    }
-    if (backslashes % 2 === 0) {
-      positions.push(i);
-    }
-  }
-  return positions;
-}
-
-/**
- * Like `findUnescapedPositions` but skips occurrences inside fenced code
- * blocks (``` ```), inline code spans (`` ` ``), or the `(...)` URL part
- * of an inline link, where Telegram treats entity markers as literal text.
- */
-function findUnescapedPositionsOutsideCode(
-  text: string,
-  marker: string
-): number[] {
+function findEntityDelimiterPositions(text: string, marker: string): number[] {
   const positions: number[] = [];
   let inFence = false;
   let inInline = false;
@@ -139,25 +113,33 @@ function findUnescapedPositionsOutsideCode(
     if (ch === "`" && !escaped) {
       const isTriple = text[i + 1] === "`" && text[i + 2] === "`";
       if (isTriple && !inInline) {
+        if (marker === "`") {
+          positions.push(i);
+        }
         inFence = !inFence;
         i += 2;
         continue;
       }
       if (!inFence) {
+        if (marker === "`") {
+          positions.push(i);
+        }
+        // A cut after two opening fence backticks is still an unfinished
+        // delimiter, not a balanced empty inline-code span.
+        if (!inInline && text[i + 1] === "`") {
+          i += 1;
+        }
         inInline = !inInline;
       }
       continue;
     }
 
-    if (
-      ch === "]" &&
-      !escaped &&
-      !inFence &&
-      !inInline &&
-      text[i + 1] === "("
-    ) {
-      linkCloseBracket = i;
-      i += 1;
+    if (ch === "]" && !escaped && !inFence && !inInline) {
+      if (text[i + 1] === "(") {
+        linkCloseBracket = i;
+        i += 1;
+      }
+      // A cut immediately after the label's `]` also leaves the link open.
       continue;
     }
 
@@ -203,10 +185,7 @@ function trimToMarkdownV2SafeBoundary(text: string): string {
     let minUnsafePosition = current.length;
 
     for (const marker of MARKDOWN_V2_ENTITY_MARKERS) {
-      const positions =
-        marker === "`"
-          ? findUnescapedPositions(current, marker)
-          : findUnescapedPositionsOutsideCode(current, marker);
+      const positions = findEntityDelimiterPositions(current, marker);
       if (positions.length % 2 === 1) {
         const lastUnpaired = positions.at(-1) ?? current.length;
         if (lastUnpaired < minUnsafePosition) {
@@ -215,8 +194,8 @@ function trimToMarkdownV2SafeBoundary(text: string): string {
       }
     }
 
-    const openBrackets = findUnescapedPositionsOutsideCode(current, "[");
-    const closeBrackets = findUnescapedPositionsOutsideCode(current, "]");
+    const openBrackets = findEntityDelimiterPositions(current, "[");
+    const closeBrackets = findEntityDelimiterPositions(current, "]");
     if (openBrackets.length > closeBrackets.length) {
       const lastOpen = openBrackets.at(-1) ?? current.length;
       if (lastOpen < minUnsafePosition) {


### PR DESCRIPTION
Stops Telegram MarkdownV2 messages from being cut at a backtick inside a link destination. Rendered text that fits the length limit now ships exactly as it was rendered. The safe-boundary trimmer only runs on the over-limit slice, where it removes an incomplete link, code span, or underline before the ellipsis.

This covers message posts, edits, and attachment captions. The original underscore URL case was already fixed; this closes the remaining backtick and truncation cases.

Changes:

- Return text that fits the length limit unchanged instead of trimming it
- Replace the per-marker scans with a single pass that groups delimiter positions by marker and counts closed links
- Treat two backticks as a cut fence only at the end of the slice, so empty inline code spans keep their trailing content
- Count a bare `]` as a link closer unless it ends the slice
- Pair `__` underline separately from `_` italic
- Test the trimmer directly, covering escaped `*`, `_`, `~`, empty code spans, bare brackets, and underline
- Import the production helpers in the adapter tests instead of local copies
- Update the changeset and docs paragraph

Closes #866
