### PR TITLE
feat(slack): support egress proxies

### DIFF
--- a/.changeset/quiet-rivers-hold.md
+++ b/.changeset/quiet-rivers-hold.md
@@ -1,0 +1,5 @@
+---
+"@chat-adapter/shared": patch
+---
+
+Enforce the guarded download deadline inside `downloadAttachment` itself, for both the wait for response headers and the body read. A late response is destroyed, so the timeout holds even when a custom transport ignores the supplied signal.

--- a/.changeset/twenty-beans-rhyme.md
+++ b/.changeset/twenty-beans-rhyme.md
@@ -1,0 +1,6 @@
+---
+"@chat-adapter/slack": minor
+"chat": minor
+---
+
+Support Slack egress proxies across Socket Mode, response URLs, webhook forwarding, and guarded file downloads with adapter-scoped transport options.

--- a/.changeset/twenty-beans-rhyme.md
+++ b/.changeset/twenty-beans-rhyme.md
@@ -1,6 +1,5 @@
 ---
 "@chat-adapter/slack": minor
-"chat": minor
 ---
 
 Support Slack egress proxies across Socket Mode, response URLs, webhook forwarding, and guarded file downloads with adapter-scoped transport options.

--- a/apps/docs/content/adapters/official/slack.mdx
+++ b/apps/docs/content/adapters/official/slack.mdx
@@ -180,10 +180,18 @@ bot.onNewMention(async (thread, message) => {
       description:
         "Override the Slack Web API base URL (e.g. for GovSlack or a self-hosted gateway).",
     },
+    fetch: {
+      type: "typeof globalThis.fetch",
+      description: "Fetch for response URLs and Socket Mode webhook forwarding. Defaults to global fetch.",
+    },
+    fileTransport: {
+      type: "AttachmentTransport",
+      description: "Guarded file download transport. Custom transports own connection and DNS policy.",
+    },
     webClientOptions: {
       type: 'Omit<WebClientOptions, "slackApiUrl">',
       description:
-        "Options forwarded to Slack WebClient instances. Supports settings such as retryConfig, per-request timeout, and rejectRateLimitedCalls.",
+        "Options forwarded to Slack WebClient instances. Supports retryConfig, per-request timeout, and rejectRateLimitedCalls. The agent also configures Socket Mode.",
     },
   }}
 />
@@ -626,7 +634,7 @@ The package still installs the full Slack adapter dependencies. The subpaths kee
 
 ### Inbound attachments
 
-Incoming file attachments expose a lazy `fetchData()`. Downloads go through a guarded fetcher that refuses private and internal addresses (including after redirects), limits responses to 25 MB, and times out after 30 seconds. The bot token is sent only to trusted Slack origins and never follows a redirect to another host. Override `createFileTransport()` in a subclass to route downloads through a proxy.
+Incoming file attachments expose a lazy `fetchData()`. Downloads go through a guarded fetcher that refuses private and internal addresses (including after redirects), limits responses to 25 MB, and times out after 30 seconds. The bot token is sent only to trusted Slack origins and never follows a redirect to another host. Set `fileTransport` to route downloads through a proxy, or override `createFileTransport()` in a subclass. See [Egress proxies](#egress-proxies) for transport requirements.
 
 ### Agents
 
@@ -1101,3 +1109,51 @@ Charts that violate Slack's constraints (50-character title, 12 segments/series,
 - [How to build a Slack bot with Next.js and Redis](https://vercel.com/kb/guide/how-to-build-a-slack-bot-with-next-js-and-redis?utm_source=chat-sdk_site&utm_medium=docs&utm_campaign=adapter-slack&utm_content=how-to-build-a-slack-bot-with-next-js-and-redis) — Walks through building a Slack bot with Next.js, covering project setup, Slack app configuration, event handling, interactive features, and deployment.
 
 See all guides and templates on the [resources](/resources?utm_source=chat-sdk_site&utm_medium=docs&utm_campaign=adapter-slack&utm_content=resources) page.
+
+## Egress proxies
+
+Configure each transport your deployment uses. `webClientOptions.agent` covers Slack Web API calls (including OAuth and all upload phases) and the HTTP/WebSocket connections for both persistent and transient Socket Mode. `fetch` covers `response_url` updates and Socket Mode forwarding to your application's webhook. `fileTransport` covers lazy `fetchData()` and rehydrated attachments.
+
+For Node.js, install `https-proxy-agent` and `undici` in your application. This example assumes a **controlled proxy that rejects internal destination addresses and DNS rebinding**, including when it resolves CONNECT destinations. A custom file transport replaces the default DNS-pinned transport; local DNS checks alone cannot enforce the address a remote proxy actually uses.
+
+```ts
+import { request } from "node:https";
+import { createSlackAdapter, type SlackAdapterConfig } from "@chat-adapter/slack";
+import { HttpsProxyAgent } from "https-proxy-agent";
+import { ProxyAgent } from "undici";
+
+const proxyUrl = process.env.HTTPS_PROXY!;
+const agent = new HttpsProxyAgent(proxyUrl);
+const dispatcher = new ProxyAgent(proxyUrl);
+
+// Node's native fetch accepts an Undici dispatcher. Keep the standard fetch
+// input/output types so Request, Response, and streaming bodies retain parity.
+const proxyFetch: typeof globalThis.fetch = (input, init) => {
+  const options: RequestInit = { ...init };
+  // Add Node's dispatcher extension separately from the standard fetch options.
+  Object.assign(options, { dispatcher });
+  return globalThis.fetch(input, options);
+};
+
+const fileTransport: NonNullable<SlackAdapterConfig["fileTransport"]> = (
+  url, signal, headers
+) => new Promise((resolve, reject) => {
+  // Return each raw response; the downloader handles redirects and strips
+  // Slack credentials on untrusted hops. The signal also aborts the body read.
+  const req = request(url, { agent, signal, headers }, resolve);
+  req.on("error", reject);
+  req.end();
+});
+
+const slack = createSlackAdapter({
+  webClientOptions: { agent },
+  fetch: proxyFetch,
+  fileTransport,
+});
+```
+
+The downloader still validates each URL, limits redirects, sends credentials only to trusted Slack origins, rejects HTML login pages, enforces a 30-second deadline, and limits decoded bodies to 25 MB. The transport must honor the supplied signal and must not follow redirects itself. Existing `createFileTransport()` subclass overrides take precedence over `fileTransport`.
+
+Only `agent` is forwarded from `webClientOptions` to Socket Mode; its app-token authentication, retry options, and API URL remain SDK defaults. Web API headers are not Socket Mode headers. Configure routing/bypass in your fetch implementation if the forwarded webhook uses an internal application URL. The adapter does not close caller-owned agents or dispatchers; close them when your application shuts down.
+
+Standalone `@chat-adapter/slack/api` functions have their own `options.fetch` parameter and do not inherit adapter configuration. Application callbacks, token resolvers, installation providers, and state adapters also own their network configuration. Proxy authentication, CA trust, WebSocket support, and destination policy must be configured for your deployment.

--- a/apps/docs/content/adapters/official/slack.mdx
+++ b/apps/docs/content/adapters/official/slack.mdx
@@ -191,7 +191,7 @@ bot.onNewMention(async (thread, message) => {
     webClientOptions: {
       type: 'Omit<WebClientOptions, "slackApiUrl">',
       description:
-        "Options forwarded to Slack WebClient instances. Supports retryConfig, per-request timeout, and rejectRateLimitedCalls. The agent also configures Socket Mode.",
+        "Options forwarded to Slack WebClient instances. Supports retryConfig, per-request timeout, and rejectRateLimitedCalls. The agent also configures Socket Mode; tls reaches only its HTTP calls.",
     },
   }}
 />
@@ -634,7 +634,57 @@ The package still installs the full Slack adapter dependencies. The subpaths kee
 
 ### Inbound attachments
 
-Incoming file attachments expose a lazy `fetchData()`. Downloads go through a guarded fetcher that refuses private and internal addresses (including after redirects), limits responses to 25 MB, and times out after 30 seconds. The bot token is sent only to trusted Slack origins and never follows a redirect to another host. Set `fileTransport` to route downloads through a proxy, or override `createFileTransport()` in a subclass. See [Egress proxies](#egress-proxies) for transport requirements.
+Incoming file attachments expose a lazy `fetchData()`. Downloads go through a guarded fetcher that limits responses to 25 MB, times out after 30 seconds, and, with the default transport, refuses private and internal addresses (including after redirects). The bot token is sent only to trusted Slack origins and never follows a redirect to another host. Set `fileTransport` to route downloads through a proxy, or override `createFileTransport()` in a subclass. A custom transport takes over the destination-address policy, so see [Egress proxies](#egress-proxies) for what it must enforce.
+
+### Egress proxies
+
+Configure each transport your deployment uses. `webClientOptions.agent` covers Slack Web API calls (including OAuth and all upload phases) and the HTTP/WebSocket connections for both persistent and transient Socket Mode. `fetch` covers `response_url` updates and Socket Mode forwarding to your application's webhook. `fileTransport` covers lazy `fetchData()` and rehydrated attachments.
+
+For Node.js, install `https-proxy-agent` and `undici` in your application. This example assumes a controlled proxy that rejects internal destination addresses and DNS rebinding, including when it resolves CONNECT destinations. A custom file transport replaces the default DNS-pinned transport, which is the only place resolved addresses are checked against the private-range blocklist. Local DNS checks alone cannot enforce the address a remote proxy actually uses, so that policy has to live in the proxy.
+
+```ts
+import { request } from "node:https";
+import {
+  type AttachmentTransport,
+  createSlackAdapter,
+} from "@chat-adapter/slack";
+import { HttpsProxyAgent } from "https-proxy-agent";
+import { ProxyAgent } from "undici";
+
+const proxyUrl = process.env.HTTPS_PROXY!;
+const agent = new HttpsProxyAgent(proxyUrl);
+const dispatcher = new ProxyAgent(proxyUrl);
+
+// Node's native fetch accepts an Undici dispatcher. Keep the standard fetch
+// input/output types so Request, Response, and streaming bodies retain parity.
+const proxyFetch: typeof globalThis.fetch = (input, init) => {
+  const options: RequestInit = { ...init };
+  // Add Node's dispatcher extension separately from the standard fetch options.
+  Object.assign(options, { dispatcher });
+  return globalThis.fetch(input, options);
+};
+
+const fileTransport: AttachmentTransport = (url, signal, headers) =>
+  new Promise((resolve, reject) => {
+    // Return each raw response; the downloader handles redirects and strips
+    // Slack credentials on untrusted hops.
+    const req = request(url, { agent, signal, headers }, resolve);
+    req.on("error", reject);
+    req.end();
+  });
+
+const slack = createSlackAdapter({
+  webClientOptions: { agent },
+  fetch: proxyFetch,
+  fileTransport,
+});
+```
+
+The downloader still validates each URL, limits redirects, sends credentials only to trusted Slack origins, rejects HTML login pages, and limits decoded bodies to 25 MB. The 30-second deadline is enforced by the downloader for both the wait for response headers and the body read, so it holds even if the transport ignores the signal. The transport should still honor the signal so the underlying connection is released promptly. The transport must not follow redirects itself. Existing `createFileTransport()` subclass overrides take precedence over `fileTransport`.
+
+Socket Mode receives `agent`, `tls`, and `apiUrl`, but only `agent` reaches the WebSocket itself; `tls` and `apiUrl` apply to its HTTP calls. The Slack SDK opens the WebSocket with the agent alone, so a custom CA or other TLS settings for that connection must be configured on the agent. App-token authentication, headers, and retry options remain SDK defaults, since Web API headers are not Socket Mode headers. Configure routing/bypass in your fetch implementation if the forwarded webhook uses an internal application URL. The adapter does not close caller-owned agents or dispatchers; close them when your application shuts down.
+
+Standalone `@chat-adapter/slack/api` functions have their own `options.fetch` parameter and do not inherit adapter configuration. Application callbacks, token resolvers, installation providers, and state adapters also own their network configuration. Proxy authentication, CA trust, WebSocket support, and destination policy must be configured for your deployment.
 
 ### Agents
 
@@ -1109,51 +1159,3 @@ Charts that violate Slack's constraints (50-character title, 12 segments/series,
 - [How to build a Slack bot with Next.js and Redis](https://vercel.com/kb/guide/how-to-build-a-slack-bot-with-next-js-and-redis?utm_source=chat-sdk_site&utm_medium=docs&utm_campaign=adapter-slack&utm_content=how-to-build-a-slack-bot-with-next-js-and-redis) — Walks through building a Slack bot with Next.js, covering project setup, Slack app configuration, event handling, interactive features, and deployment.
 
 See all guides and templates on the [resources](/resources?utm_source=chat-sdk_site&utm_medium=docs&utm_campaign=adapter-slack&utm_content=resources) page.
-
-## Egress proxies
-
-Configure each transport your deployment uses. `webClientOptions.agent` covers Slack Web API calls (including OAuth and all upload phases) and the HTTP/WebSocket connections for both persistent and transient Socket Mode. `fetch` covers `response_url` updates and Socket Mode forwarding to your application's webhook. `fileTransport` covers lazy `fetchData()` and rehydrated attachments.
-
-For Node.js, install `https-proxy-agent` and `undici` in your application. This example assumes a **controlled proxy that rejects internal destination addresses and DNS rebinding**, including when it resolves CONNECT destinations. A custom file transport replaces the default DNS-pinned transport; local DNS checks alone cannot enforce the address a remote proxy actually uses.
-
-```ts
-import { request } from "node:https";
-import { createSlackAdapter, type SlackAdapterConfig } from "@chat-adapter/slack";
-import { HttpsProxyAgent } from "https-proxy-agent";
-import { ProxyAgent } from "undici";
-
-const proxyUrl = process.env.HTTPS_PROXY!;
-const agent = new HttpsProxyAgent(proxyUrl);
-const dispatcher = new ProxyAgent(proxyUrl);
-
-// Node's native fetch accepts an Undici dispatcher. Keep the standard fetch
-// input/output types so Request, Response, and streaming bodies retain parity.
-const proxyFetch: typeof globalThis.fetch = (input, init) => {
-  const options: RequestInit = { ...init };
-  // Add Node's dispatcher extension separately from the standard fetch options.
-  Object.assign(options, { dispatcher });
-  return globalThis.fetch(input, options);
-};
-
-const fileTransport: NonNullable<SlackAdapterConfig["fileTransport"]> = (
-  url, signal, headers
-) => new Promise((resolve, reject) => {
-  // Return each raw response; the downloader handles redirects and strips
-  // Slack credentials on untrusted hops. The signal also aborts the body read.
-  const req = request(url, { agent, signal, headers }, resolve);
-  req.on("error", reject);
-  req.end();
-});
-
-const slack = createSlackAdapter({
-  webClientOptions: { agent },
-  fetch: proxyFetch,
-  fileTransport,
-});
-```
-
-The downloader still validates each URL, limits redirects, sends credentials only to trusted Slack origins, rejects HTML login pages, enforces a 30-second deadline, and limits decoded bodies to 25 MB. The transport must honor the supplied signal and must not follow redirects itself. Existing `createFileTransport()` subclass overrides take precedence over `fileTransport`.
-
-Only `agent` is forwarded from `webClientOptions` to Socket Mode; its app-token authentication, retry options, and API URL remain SDK defaults. Web API headers are not Socket Mode headers. Configure routing/bypass in your fetch implementation if the forwarded webhook uses an internal application URL. The adapter does not close caller-owned agents or dispatchers; close them when your application shuts down.
-
-Standalone `@chat-adapter/slack/api` functions have their own `options.fetch` parameter and do not inherit adapter configuration. Application callbacks, token resolvers, installation providers, and state adapters also own their network configuration. Proxy authentication, CA trust, WebSocket support, and destination policy must be configured for your deployment.

--- a/packages/adapter-shared/src/download.test.ts
+++ b/packages/adapter-shared/src/download.test.ts
@@ -328,6 +328,48 @@ describe("guarded attachment downloads", () => {
     ).rejects.toThrow("Timed out fetching the attachment");
   });
 
+  it("times out a transport that never responds and ignores the signal", async () => {
+    let settle: ((response: IncomingMessage) => void) | undefined;
+    const transport = vi.fn(
+      () =>
+        new Promise<IncomingMessage>((fulfill) => {
+          settle = fulfill;
+        })
+    );
+
+    await expect(
+      downloadAttachment("https://files.example.com/file", {
+        adapter: "test",
+        timeoutMs: 20,
+        transport,
+      })
+    ).rejects.toThrow("Timed out fetching the attachment");
+    // A response that arrives after the deadline is destroyed, not leaked.
+    const late = response("late");
+    settle?.(late);
+    await new Promise((resolve) => setImmediate(resolve));
+    expect(late.destroyed).toBe(true);
+  });
+
+  it("times out a body read that the transport does not tie to the signal", async () => {
+    // A Readable that never ends, from a transport that ignores the signal.
+    const hanging = Object.assign(new Readable({ read() {} }), {
+      headers: {},
+      statusCode: 200,
+      statusMessage: "OK",
+    }) as IncomingMessage;
+    const transport = vi.fn(async () => hanging);
+
+    await expect(
+      downloadAttachment("https://files.example.com/file", {
+        adapter: "test",
+        timeoutMs: 20,
+        transport,
+      })
+    ).rejects.toThrow("Timed out fetching the attachment");
+    expect(hanging.destroyed).toBe(true);
+  });
+
   it("decodes gzip response bodies", async () => {
     const transport = vi.fn(async () =>
       response(gzipSync(Buffer.from("file contents")), 200, {

--- a/packages/adapter-shared/src/download.ts
+++ b/packages/adapter-shared/src/download.ts
@@ -215,7 +215,68 @@ function createTransport(adapter: string): AttachmentTransport {
 export async function readAttachmentBody(
   response: IncomingMessage,
   adapter: string,
-  limit = LIMIT
+  limit = LIMIT,
+  signal?: AbortSignal
+): Promise<Buffer> {
+  // Enforce the deadline here as well as in the transport, so a transport
+  // that resolves a response without tying its stream to the signal cannot
+  // leave the body read hanging past the deadline.
+  if (signal?.aborted) {
+    response.destroy();
+    throw new NetworkError(adapter, "Timed out fetching the attachment");
+  }
+  const abort = () => response.destroy(signalError(signal));
+  signal?.addEventListener("abort", abort, { once: true });
+  try {
+    return await readBody(response, adapter, limit);
+  } finally {
+    signal?.removeEventListener("abort", abort);
+  }
+}
+
+function signalError(signal: AbortSignal | undefined): Error {
+  const reason: unknown = signal?.reason;
+  return reason instanceof Error ? reason : new Error(String(reason));
+}
+
+/**
+ * Waits for the transport's response, but gives up when the signal aborts so
+ * a transport that never settles cannot stall the download past its deadline.
+ * A response that arrives after the abort is destroyed rather than leaked.
+ */
+function awaitResponse(
+  pending: Promise<IncomingMessage>,
+  signal: AbortSignal,
+  adapter: string
+): Promise<IncomingMessage> {
+  return new Promise((fulfill, reject) => {
+    const abort = () =>
+      reject(new NetworkError(adapter, "Timed out fetching the attachment"));
+    if (signal.aborted) {
+      abort();
+    } else {
+      signal.addEventListener("abort", abort, { once: true });
+    }
+    pending.then(
+      (response) => {
+        signal.removeEventListener("abort", abort);
+        if (signal.aborted) {
+          response.destroy();
+        }
+        fulfill(response);
+      },
+      (error: unknown) => {
+        signal.removeEventListener("abort", abort);
+        reject(error);
+      }
+    );
+  });
+}
+
+async function readBody(
+  response: IncomingMessage,
+  adapter: string,
+  limit: number
 ): Promise<Buffer> {
   const header =
     response.headers["content-encoding"]?.trim().toLowerCase() || "identity";
@@ -272,7 +333,10 @@ export async function readAttachmentBody(
  * Downloads an untrusted attachment URL with SSRF protection: HTTPS only,
  * private and internal addresses refused (both as literals and after DNS
  * resolution), redirects revalidated, the decoded body capped at
- * options.limit, and the whole operation bounded by options.timeoutMs.
+ * options.limit, and the whole operation bounded by options.timeoutMs. The
+ * deadline is enforced by the downloader itself for both the wait for
+ * response headers and the body read (a late response is destroyed), so it
+ * holds even for a transport that ignores the signal.
  */
 export async function downloadAttachment(
   value: string,
@@ -293,11 +357,15 @@ export async function downloadAttachment(
   let url = validateAttachmentUrl(value, adapter, hosts);
   try {
     for (let hop = 0; hop <= redirects; hop += 1) {
-      const response = await send(url, signal, {
-        "accept-encoding": "gzip, deflate, br",
-        "user-agent": "Vercel.ChatSDK",
-        ...(typeof headers === "function" ? headers(url) : headers),
-      });
+      const response = await awaitResponse(
+        send(url, signal, {
+          "accept-encoding": "gzip, deflate, br",
+          "user-agent": "Vercel.ChatSDK",
+          ...(typeof headers === "function" ? headers(url) : headers),
+        }),
+        signal,
+        adapter
+      );
       const status = response.statusCode ?? 0;
       if (STATUSES.has(status)) {
         const location = response.headers.location;
@@ -329,7 +397,7 @@ export async function downloadAttachment(
           throw error;
         }
       }
-      return await readAttachmentBody(response, adapter, limit);
+      return await readAttachmentBody(response, adapter, limit, signal);
     }
     throw new NetworkError(adapter, "Too many attachment redirects");
   } catch (error) {

--- a/packages/adapter-slack/README.md
+++ b/packages/adapter-slack/README.md
@@ -358,7 +358,7 @@ After creating the app, go to **Basic Information** → **App Credentials** and 
 
 ## Inbound attachments
 
-Incoming file attachments expose a lazy `fetchData()`. Downloads go through a guarded fetcher that refuses private and internal addresses (including after redirects), limits responses to 25 MB, and times out after 30 seconds. The bot token is sent only to trusted Slack origins and never follows a redirect to another host. Override `createFileTransport()` in a subclass to route downloads through a proxy.
+Incoming file attachments expose a lazy `fetchData()`. Downloads go through a guarded fetcher that refuses private and internal addresses (including after redirects), limits responses to 25 MB, and times out after 30 seconds. The bot token is sent only to trusted Slack origins and never follows a redirect to another host. Set `fileTransport` to route downloads through a proxy, or override `createFileTransport()` in a subclass. See [Egress proxies](#egress-proxies) for transport requirements.
 
 ## Configuration
 
@@ -378,7 +378,9 @@ All options are auto-detected from environment variables when not provided. You 
 | `installationKeyPrefix` | No | Prefix for the state key used to store workspace installations. Defaults to `slack:installation`. The full key is `{prefix}:{teamId}` (or `{prefix}:{enterpriseId}` for Enterprise Grid org-wide installs) |
 | `installationProvider` | No | External installation lookup `{ getInstallation(installationId, isEnterpriseInstall) => Promise<SlackInstallation \| null> }`. When set, bypasses the internal state adapter for token resolution on incoming webhooks. Read-only — manage your own writes externally |
 | `apiUrl` | No | Override the Slack Web API base URL (e.g. for GovSlack or a self-hosted gateway). Auto-detected from `SLACK_API_URL` |
-| `webClientOptions` | No | Options forwarded to Slack `WebClient` instances, excluding `slackApiUrl`. Supports settings such as `retryConfig`, per-request `timeout`, and `rejectRateLimitedCalls` |
+| `fetch` | No | Fetch for response URLs and Socket Mode webhook forwarding; defaults to global fetch |
+| `fileTransport` | No | Guarded file download transport; custom transports own connection/DNS policy |
+| `webClientOptions` | No | Options forwarded to Slack `WebClient` instances, excluding `slackApiUrl`. Supports `retryConfig`, per-request `timeout`, and `rejectRateLimitedCalls`; `agent` also configures Socket Mode |
 | `logger` | No | Logger instance (defaults to `ConsoleLogger("info")`) |
 
 *`signingSecret` is required for webhook mode — either via config, `SLACK_SIGNING_SECRET` env var, or a `webhookVerifier`.
@@ -659,3 +661,51 @@ For agent-readable documentation, see [chat-sdk.dev/llms.txt](https://chat-sdk.d
 ## License
 
 MIT
+
+## Egress proxies
+
+Configure each transport your deployment uses. `webClientOptions.agent` covers Slack Web API calls (including OAuth and all upload phases) and the HTTP/WebSocket connections for both persistent and transient Socket Mode. `fetch` covers `response_url` updates and Socket Mode forwarding to your application's webhook. `fileTransport` covers lazy `fetchData()` and rehydrated attachments.
+
+For Node.js, install `https-proxy-agent` and `undici` in your application. This example assumes a **controlled proxy that rejects internal destination addresses and DNS rebinding**, including when it resolves CONNECT destinations. A custom file transport replaces the default DNS-pinned transport; local DNS checks alone cannot enforce the address a remote proxy actually uses.
+
+```ts
+import { request } from "node:https";
+import { createSlackAdapter, type SlackAdapterConfig } from "@chat-adapter/slack";
+import { HttpsProxyAgent } from "https-proxy-agent";
+import { ProxyAgent } from "undici";
+
+const proxyUrl = process.env.HTTPS_PROXY!;
+const agent = new HttpsProxyAgent(proxyUrl);
+const dispatcher = new ProxyAgent(proxyUrl);
+
+// Node's native fetch accepts an Undici dispatcher. Keep the standard fetch
+// input/output types so Request, Response, and streaming bodies retain parity.
+const proxyFetch: typeof globalThis.fetch = (input, init) => {
+  const options: RequestInit = { ...init };
+  // Add Node's dispatcher extension separately from the standard fetch options.
+  Object.assign(options, { dispatcher });
+  return globalThis.fetch(input, options);
+};
+
+const fileTransport: NonNullable<SlackAdapterConfig["fileTransport"]> = (
+  url, signal, headers
+) => new Promise((resolve, reject) => {
+  // Return each raw response; the downloader handles redirects and strips
+  // Slack credentials on untrusted hops. The signal also aborts the body read.
+  const req = request(url, { agent, signal, headers }, resolve);
+  req.on("error", reject);
+  req.end();
+});
+
+const slack = createSlackAdapter({
+  webClientOptions: { agent },
+  fetch: proxyFetch,
+  fileTransport,
+});
+```
+
+The downloader still validates each URL, limits redirects, sends credentials only to trusted Slack origins, rejects HTML login pages, enforces a 30-second deadline, and limits decoded bodies to 25 MB. The transport must honor the supplied signal and must not follow redirects itself. Existing `createFileTransport()` subclass overrides take precedence over `fileTransport`.
+
+Only `agent` is forwarded from `webClientOptions` to Socket Mode; its app-token authentication, retry options, and API URL remain SDK defaults. Web API headers are not Socket Mode headers. Configure routing/bypass in your fetch implementation if the forwarded webhook uses an internal application URL. The adapter does not close caller-owned agents or dispatchers; close them when your application shuts down.
+
+Standalone `@chat-adapter/slack/api` functions have their own `options.fetch` parameter and do not inherit adapter configuration. Application callbacks, token resolvers, installation providers, and state adapters also own their network configuration. Proxy authentication, CA trust, WebSocket support, and destination policy must be configured for your deployment.

--- a/packages/adapter-slack/README.md
+++ b/packages/adapter-slack/README.md
@@ -358,7 +358,57 @@ After creating the app, go to **Basic Information** → **App Credentials** and 
 
 ## Inbound attachments
 
-Incoming file attachments expose a lazy `fetchData()`. Downloads go through a guarded fetcher that refuses private and internal addresses (including after redirects), limits responses to 25 MB, and times out after 30 seconds. The bot token is sent only to trusted Slack origins and never follows a redirect to another host. Set `fileTransport` to route downloads through a proxy, or override `createFileTransport()` in a subclass. See [Egress proxies](#egress-proxies) for transport requirements.
+Incoming file attachments expose a lazy `fetchData()`. Downloads go through a guarded fetcher that limits responses to 25 MB, times out after 30 seconds, and, with the default transport, refuses private and internal addresses (including after redirects). The bot token is sent only to trusted Slack origins and never follows a redirect to another host. Set `fileTransport` to route downloads through a proxy, or override `createFileTransport()` in a subclass. A custom transport takes over the destination-address policy, so see [Egress proxies](#egress-proxies) for what it must enforce.
+
+## Egress proxies
+
+Configure each transport your deployment uses. `webClientOptions.agent` covers Slack Web API calls (including OAuth and all upload phases) and the HTTP/WebSocket connections for both persistent and transient Socket Mode. `fetch` covers `response_url` updates and Socket Mode forwarding to your application's webhook. `fileTransport` covers lazy `fetchData()` and rehydrated attachments.
+
+For Node.js, install `https-proxy-agent` and `undici` in your application. This example assumes a controlled proxy that rejects internal destination addresses and DNS rebinding, including when it resolves CONNECT destinations. A custom file transport replaces the default DNS-pinned transport, which is the only place resolved addresses are checked against the private-range blocklist. Local DNS checks alone cannot enforce the address a remote proxy actually uses, so that policy has to live in the proxy.
+
+```ts
+import { request } from "node:https";
+import {
+  type AttachmentTransport,
+  createSlackAdapter,
+} from "@chat-adapter/slack";
+import { HttpsProxyAgent } from "https-proxy-agent";
+import { ProxyAgent } from "undici";
+
+const proxyUrl = process.env.HTTPS_PROXY!;
+const agent = new HttpsProxyAgent(proxyUrl);
+const dispatcher = new ProxyAgent(proxyUrl);
+
+// Node's native fetch accepts an Undici dispatcher. Keep the standard fetch
+// input/output types so Request, Response, and streaming bodies retain parity.
+const proxyFetch: typeof globalThis.fetch = (input, init) => {
+  const options: RequestInit = { ...init };
+  // Add Node's dispatcher extension separately from the standard fetch options.
+  Object.assign(options, { dispatcher });
+  return globalThis.fetch(input, options);
+};
+
+const fileTransport: AttachmentTransport = (url, signal, headers) =>
+  new Promise((resolve, reject) => {
+    // Return each raw response; the downloader handles redirects and strips
+    // Slack credentials on untrusted hops.
+    const req = request(url, { agent, signal, headers }, resolve);
+    req.on("error", reject);
+    req.end();
+  });
+
+const slack = createSlackAdapter({
+  webClientOptions: { agent },
+  fetch: proxyFetch,
+  fileTransport,
+});
+```
+
+The downloader still validates each URL, limits redirects, sends credentials only to trusted Slack origins, rejects HTML login pages, and limits decoded bodies to 25 MB. The 30-second deadline is enforced by the downloader for both the wait for response headers and the body read, so it holds even if the transport ignores the signal. The transport should still honor the signal so the underlying connection is released promptly. The transport must not follow redirects itself. Existing `createFileTransport()` subclass overrides take precedence over `fileTransport`.
+
+Socket Mode receives `agent`, `tls`, and `apiUrl`, but only `agent` reaches the WebSocket itself; `tls` and `apiUrl` apply to its HTTP calls. The Slack SDK opens the WebSocket with the agent alone, so a custom CA or other TLS settings for that connection must be configured on the agent. App-token authentication, headers, and retry options remain SDK defaults, since Web API headers are not Socket Mode headers. Configure routing/bypass in your fetch implementation if the forwarded webhook uses an internal application URL. The adapter does not close caller-owned agents or dispatchers; close them when your application shuts down.
+
+Standalone `@chat-adapter/slack/api` functions have their own `options.fetch` parameter and do not inherit adapter configuration. Application callbacks, token resolvers, installation providers, and state adapters also own their network configuration. Proxy authentication, CA trust, WebSocket support, and destination policy must be configured for your deployment.
 
 ## Configuration
 
@@ -380,7 +430,7 @@ All options are auto-detected from environment variables when not provided. You 
 | `apiUrl` | No | Override the Slack Web API base URL (e.g. for GovSlack or a self-hosted gateway). Auto-detected from `SLACK_API_URL` |
 | `fetch` | No | Fetch for response URLs and Socket Mode webhook forwarding; defaults to global fetch |
 | `fileTransport` | No | Guarded file download transport; custom transports own connection/DNS policy |
-| `webClientOptions` | No | Options forwarded to Slack `WebClient` instances, excluding `slackApiUrl`. Supports `retryConfig`, per-request `timeout`, and `rejectRateLimitedCalls`; `agent` also configures Socket Mode |
+| `webClientOptions` | No | Options forwarded to Slack `WebClient` instances, excluding `slackApiUrl`. Supports `retryConfig`, per-request `timeout`, and `rejectRateLimitedCalls`; `agent` also configures Socket Mode, `tls` only its HTTP calls |
 | `logger` | No | Logger instance (defaults to `ConsoleLogger("info")`) |
 
 *`signingSecret` is required for webhook mode — either via config, `SLACK_SIGNING_SECRET` env var, or a `webhookVerifier`.
@@ -661,51 +711,3 @@ For agent-readable documentation, see [chat-sdk.dev/llms.txt](https://chat-sdk.d
 ## License
 
 MIT
-
-## Egress proxies
-
-Configure each transport your deployment uses. `webClientOptions.agent` covers Slack Web API calls (including OAuth and all upload phases) and the HTTP/WebSocket connections for both persistent and transient Socket Mode. `fetch` covers `response_url` updates and Socket Mode forwarding to your application's webhook. `fileTransport` covers lazy `fetchData()` and rehydrated attachments.
-
-For Node.js, install `https-proxy-agent` and `undici` in your application. This example assumes a **controlled proxy that rejects internal destination addresses and DNS rebinding**, including when it resolves CONNECT destinations. A custom file transport replaces the default DNS-pinned transport; local DNS checks alone cannot enforce the address a remote proxy actually uses.
-
-```ts
-import { request } from "node:https";
-import { createSlackAdapter, type SlackAdapterConfig } from "@chat-adapter/slack";
-import { HttpsProxyAgent } from "https-proxy-agent";
-import { ProxyAgent } from "undici";
-
-const proxyUrl = process.env.HTTPS_PROXY!;
-const agent = new HttpsProxyAgent(proxyUrl);
-const dispatcher = new ProxyAgent(proxyUrl);
-
-// Node's native fetch accepts an Undici dispatcher. Keep the standard fetch
-// input/output types so Request, Response, and streaming bodies retain parity.
-const proxyFetch: typeof globalThis.fetch = (input, init) => {
-  const options: RequestInit = { ...init };
-  // Add Node's dispatcher extension separately from the standard fetch options.
-  Object.assign(options, { dispatcher });
-  return globalThis.fetch(input, options);
-};
-
-const fileTransport: NonNullable<SlackAdapterConfig["fileTransport"]> = (
-  url, signal, headers
-) => new Promise((resolve, reject) => {
-  // Return each raw response; the downloader handles redirects and strips
-  // Slack credentials on untrusted hops. The signal also aborts the body read.
-  const req = request(url, { agent, signal, headers }, resolve);
-  req.on("error", reject);
-  req.end();
-});
-
-const slack = createSlackAdapter({
-  webClientOptions: { agent },
-  fetch: proxyFetch,
-  fileTransport,
-});
-```
-
-The downloader still validates each URL, limits redirects, sends credentials only to trusted Slack origins, rejects HTML login pages, enforces a 30-second deadline, and limits decoded bodies to 25 MB. The transport must honor the supplied signal and must not follow redirects itself. Existing `createFileTransport()` subclass overrides take precedence over `fileTransport`.
-
-Only `agent` is forwarded from `webClientOptions` to Socket Mode; its app-token authentication, retry options, and API URL remain SDK defaults. Web API headers are not Socket Mode headers. Configure routing/bypass in your fetch implementation if the forwarded webhook uses an internal application URL. The adapter does not close caller-owned agents or dispatchers; close them when your application shuts down.
-
-Standalone `@chat-adapter/slack/api` functions have their own `options.fetch` parameter and do not inherit adapter configuration. Application callbacks, token resolvers, installation providers, and state adapters also own their network configuration. Proxy authentication, CA trust, WebSocket support, and destination policy must be configured for your deployment.

--- a/packages/adapter-slack/src/api/client.ts
+++ b/packages/adapter-slack/src/api/client.ts
@@ -1,8 +1,9 @@
+import type { SlackFetch } from "../fetch";
 import { isSlackAuthUrl } from "../file";
 
-export type SlackBotToken = string | (() => Promise<string> | string);
+export type { SlackFetch } from "../fetch";
 
-export type SlackFetch = typeof fetch;
+export type SlackBotToken = string | (() => Promise<string> | string);
 
 export interface SlackApiResponse {
   error?: string;

--- a/packages/adapter-slack/src/fetch.ts
+++ b/packages/adapter-slack/src/fetch.ts
@@ -1,0 +1,2 @@
+/** Fetch implementation shape shared by the adapter and the standalone API helpers. */
+export type SlackFetch = typeof fetch;

--- a/packages/adapter-slack/src/index.test.ts
+++ b/packages/adapter-slack/src/index.test.ts
@@ -3,8 +3,6 @@
  */
 
 import { createHmac, randomBytes } from "node:crypto";
-import type { IncomingMessage } from "node:http";
-import { Readable } from "node:stream";
 import {
   type AttachmentTransport,
   AuthenticationError,
@@ -36,19 +34,17 @@ import {
   createSlackAdapter,
   SlackAdapter,
 } from "./index";
+import { incomingMessage } from "./test-fixtures";
 
 const FILE_ID_PATTERN = /^file-/;
 
 // Captures guarded file downloads at the transport seam; the resolved
 // per-hop headers show which token (if any) each hop would send.
 class TransportSlackAdapter extends SlackAdapter {
-  readonly fileTransport = vi.fn(
-    async (): Promise<IncomingMessage> =>
-      Object.assign(Readable.from([Buffer.from("file-bytes")]), {
-        headers: { "content-type": "application/octet-stream" },
-        statusCode: 200,
-        statusMessage: "OK",
-      }) as IncomingMessage
+  readonly fileTransport = vi.fn(async () =>
+    incomingMessage(Buffer.from("file-bytes"), {
+      headers: { "content-type": "application/octet-stream" },
+    })
   );
 
   protected override createFileTransport(): AttachmentTransport {

--- a/packages/adapter-slack/src/index.ts
+++ b/packages/adapter-slack/src/index.ts
@@ -12,7 +12,7 @@ import {
   toBuffer,
   ValidationError,
 } from "@chat-adapter/shared";
-import { SocketModeClient } from "@slack/socket-mode";
+import { SocketModeClient, type SocketModeOptions } from "@slack/socket-mode";
 import {
   type ChatAppendStreamArguments,
   type ChatStopStreamArguments,
@@ -81,6 +81,7 @@ import {
   encryptToken,
   isEncryptedTokenData,
 } from "./crypto";
+import type { SlackFetch } from "./fetch";
 import { isSlackAuthUrl } from "./file";
 import { escapeSlackText, unescapeSlackText } from "./format";
 import { SlackFormatConverter } from "./markdown";
@@ -428,6 +429,7 @@ function tableContinuation(text: string): string {
   return `${rows[separatorAt - 1]}\n${rows[separatorAt]}\n`;
 }
 
+export type { AttachmentTransport } from "@chat-adapter/shared";
 export type {
   SlackAdapterConfig,
   SlackAdapterMode,
@@ -1240,7 +1242,7 @@ export class SlackAdapter implements Adapter<SlackThreadId, unknown> {
   protected readonly tokenClientCache = new Map<string, WebClient>();
   protected readonly slackApiUrl: string | undefined;
   protected readonly webClientOptions: SlackAdapterConfig["webClientOptions"];
-  protected readonly configuredFetch: SlackAdapterConfig["fetch"];
+  protected readonly fetch: SlackFetch;
   protected readonly configuredFileTransport: AttachmentTransport | undefined;
   protected readonly signingSecret: string | undefined;
   protected readonly webhookVerifier:
@@ -1431,7 +1433,9 @@ export class SlackAdapter implements Adapter<SlackThreadId, unknown> {
 
     this.slackApiUrl = config.apiUrl ?? process.env.SLACK_API_URL;
     this.webClientOptions = config.webClientOptions;
-    this.configuredFetch = config.fetch;
+    // Resolve the global lazily so a fetch installed after construction (or
+    // a test stub) is still honored at request time.
+    this.fetch = config.fetch ?? ((...args) => globalThis.fetch(...args));
     this.configuredFileTransport = config.fileTransport;
     // WebClient token argument is only a fallback; every API call below routes
     // through withToken() which resolves the current provider per-call.
@@ -2842,11 +2846,37 @@ export class SlackAdapter implements Adapter<SlackThreadId, unknown> {
   // Socket Mode
   // ===========================================================================
 
-  private socketTransportOptions() {
-    const agent = this.webClientOptions?.agent;
-    // SocketModeClient mutates clientOptions and supplies app-token headers.
-    // Forward only the agent in a fresh object to preserve its auth and retries.
-    return agent ? { clientOptions: { agent } } : {};
+  /**
+   * Transport-shaped WebClient options for Socket Mode. SocketModeClient
+   * Object.assigns clientOptions over its own app-token headers and mutates
+   * the object to install retry defaults, so headers and retryConfig are not
+   * forwarded and every call returns a fresh object.
+   */
+  private socketTransportOptions(): Pick<SocketModeOptions, "clientOptions"> {
+    const clientOptions: NonNullable<SocketModeOptions["clientOptions"]> = {};
+    if (this.webClientOptions?.agent) {
+      clientOptions.agent = this.webClientOptions.agent;
+    }
+    if (this.webClientOptions?.tls) {
+      clientOptions.tls = this.webClientOptions.tls;
+    }
+    if (this.slackApiUrl) {
+      clientOptions.slackApiUrl = this.slackApiUrl;
+    }
+    return Object.keys(clientOptions).length > 0 ? { clientOptions } : {};
+  }
+
+  /** POSTs a JSON body through the configured fetch. */
+  private postJson(
+    url: string,
+    body: unknown,
+    headers: Record<string, string> = {}
+  ): Promise<Response> {
+    return this.fetch(url, {
+      method: "POST",
+      headers: { "Content-Type": "application/json", ...headers },
+      body: JSON.stringify(body),
+    });
   }
 
   /**
@@ -3197,17 +3227,9 @@ export class SlackAdapter implements Adapter<SlackThreadId, unknown> {
         webhookUrl,
       });
 
-      const response = await (this.configuredFetch ?? globalThis.fetch)(
-        webhookUrl,
-        {
-          method: "POST",
-          headers: {
-            "Content-Type": "application/json",
-            "x-slack-socket-token": this.socketForwardingSecret as string,
-          },
-          body: JSON.stringify(event),
-        }
-      );
+      const response = await this.postJson(webhookUrl, event, {
+        "x-slack-socket-token": this.socketForwardingSecret as string,
+      });
 
       if (response.ok) {
         this.logger.debug("Socket event forwarded successfully", {
@@ -7377,14 +7399,7 @@ export class SlackAdapter implements Adapter<SlackThreadId, unknown> {
       action,
       threadTs: options?.threadTs,
     });
-    const response = await (this.configuredFetch ?? globalThis.fetch)(
-      responseUrl,
-      {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify(payload),
-      }
-    );
+    const response = await this.postJson(responseUrl, payload);
 
     if (!response.ok) {
       const errorText = await response.text();

--- a/packages/adapter-slack/src/index.ts
+++ b/packages/adapter-slack/src/index.ts
@@ -1240,6 +1240,8 @@ export class SlackAdapter implements Adapter<SlackThreadId, unknown> {
   protected readonly tokenClientCache = new Map<string, WebClient>();
   protected readonly slackApiUrl: string | undefined;
   protected readonly webClientOptions: SlackAdapterConfig["webClientOptions"];
+  protected readonly configuredFetch: SlackAdapterConfig["fetch"];
+  protected readonly configuredFileTransport: AttachmentTransport | undefined;
   protected readonly signingSecret: string | undefined;
   protected readonly webhookVerifier:
     | ((request: Request, body: string) => unknown | Promise<unknown>)
@@ -1429,6 +1431,8 @@ export class SlackAdapter implements Adapter<SlackThreadId, unknown> {
 
     this.slackApiUrl = config.apiUrl ?? process.env.SLACK_API_URL;
     this.webClientOptions = config.webClientOptions;
+    this.configuredFetch = config.fetch;
+    this.configuredFileTransport = config.fileTransport;
     // WebClient token argument is only a fallback; every API call below routes
     // through withToken() which resolves the current provider per-call.
     this._client = new WebClient(undefined, {
@@ -2838,6 +2842,13 @@ export class SlackAdapter implements Adapter<SlackThreadId, unknown> {
   // Socket Mode
   // ===========================================================================
 
+  private socketTransportOptions() {
+    const agent = this.webClientOptions?.agent;
+    // SocketModeClient mutates clientOptions and supplies app-token headers.
+    // Forward only the agent in a fresh object to preserve its auth and retries.
+    return agent ? { clientOptions: { agent } } : {};
+  }
+
   /**
    * Start Socket Mode connection.
    * Creates a SocketModeClient, registers event handlers, and connects.
@@ -2850,7 +2861,10 @@ export class SlackAdapter implements Adapter<SlackThreadId, unknown> {
       );
     }
 
-    this.socketClient = new SocketModeClient({ appToken: this.appToken });
+    this.socketClient = new SocketModeClient({
+      appToken: this.appToken,
+      ...this.socketTransportOptions(),
+    });
 
     this.socketClient.on(
       "slack_event",
@@ -3084,7 +3098,10 @@ export class SlackAdapter implements Adapter<SlackThreadId, unknown> {
   ): Promise<void> {
     // appToken is guaranteed to exist — callers check before invoking
     const appToken = this.appToken as string;
-    const client = new SocketModeClient({ appToken });
+    const client = new SocketModeClient({
+      appToken,
+      ...this.socketTransportOptions(),
+    });
     let isShuttingDown = false;
 
     client.on(
@@ -3180,14 +3197,17 @@ export class SlackAdapter implements Adapter<SlackThreadId, unknown> {
         webhookUrl,
       });
 
-      const response = await fetch(webhookUrl, {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-          "x-slack-socket-token": this.socketForwardingSecret as string,
-        },
-        body: JSON.stringify(event),
-      });
+      const response = await (this.configuredFetch ?? globalThis.fetch)(
+        webhookUrl,
+        {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            "x-slack-socket-token": this.socketForwardingSecret as string,
+          },
+          body: JSON.stringify(event),
+        }
+      );
 
       if (response.ok) {
         this.logger.debug("Socket event forwarded successfully", {
@@ -4619,10 +4639,10 @@ export class SlackAdapter implements Adapter<SlackThreadId, unknown> {
 
   /**
    * Transport used for guarded file downloads. Subclasses can return a
-   * custom AttachmentTransport, e.g. to route downloads through a proxy.
+   * custom AttachmentTransport, overriding the configured fileTransport.
    */
   protected createFileTransport(): AttachmentTransport | undefined {
-    return undefined;
+    return this.configuredFileTransport;
   }
 
   rehydrateAttachment(attachment: Attachment): Attachment {
@@ -7357,11 +7377,14 @@ export class SlackAdapter implements Adapter<SlackThreadId, unknown> {
       action,
       threadTs: options?.threadTs,
     });
-    const response = await fetch(responseUrl, {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify(payload),
-    });
+    const response = await (this.configuredFetch ?? globalThis.fetch)(
+      responseUrl,
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(payload),
+      }
+    );
 
     if (!response.ok) {
       const errorText = await response.text();
@@ -7455,6 +7478,8 @@ export function createSlackAdapter(config?: SlackAdapterConfig): SlackAdapter {
     encryptionKey: config?.encryptionKey ?? process.env.SLACK_ENCRYPTION_KEY,
     installationKeyPrefix: config?.installationKeyPrefix,
     feedbackButtons: config?.feedbackButtons,
+    fetch: config?.fetch,
+    fileTransport: config?.fileTransport,
     installationProvider: config?.installationProvider,
     loadingMessages: config?.loadingMessages,
     logger: config?.logger ?? new ConsoleLogger("info").child("slack"),

--- a/packages/adapter-slack/src/proxy.test.ts
+++ b/packages/adapter-slack/src/proxy.test.ts
@@ -5,8 +5,15 @@ import { Agent } from "node:https";
 import { connect, type Socket } from "node:net";
 import type { Duplex } from "node:stream";
 import { createMockChatInstance, mockLogger } from "@chat-adapter/tests";
+import { SocketModeClient } from "@slack/socket-mode";
 import { expect, it, vi } from "vitest";
 import { createSlackAdapter } from "./index";
+
+// Reconnects wait clientPingTimeout (5s) per attempt in the real client;
+// the delay is not what this test proves, so run the callback immediately.
+interface Reconnectable {
+  delayReconnectAttempt(this: unknown, cb: () => Promise<unknown>): unknown;
+}
 
 // Real installed Slack HTTP and WebSocket clients, with an agent that routes
 // only known test destinations to a loopback HTTP fixture. No external DNS or
@@ -104,6 +111,12 @@ it("routes Web API, OAuth, upload phases and both Socket Mode connections throug
     }
     return connect({ host: "127.0.0.1", port: address.port });
   });
+  vi.spyOn(
+    SocketModeClient.prototype as unknown as Reconnectable,
+    "delayReconnectAttempt"
+  ).mockImplementation(function (this: unknown, cb) {
+    return cb.apply(this);
+  });
   const webClientOptions = {
     agent,
     retryConfig: { retries: 0 },
@@ -150,9 +163,7 @@ it("routes Web API, OAuth, upload phases and both Socket Mode connections throug
     firstSocket?.write(
       Buffer.concat([Buffer.from([0x81, refresh.length]), refresh])
     );
-    await vi.waitFor(() => expect(websocketConnections).toBe(2), {
-      timeout: 8000,
-    });
+    await vi.waitFor(() => expect(websocketConnections).toBe(2));
     let listener: Promise<unknown> | undefined;
     await adapter.startSocketModeListener(
       {
@@ -200,4 +211,4 @@ it("routes Web API, OAuth, upload phases and both Socket Mode connections throug
     });
     vi.restoreAllMocks();
   }
-}, 15_000);
+});

--- a/packages/adapter-slack/src/proxy.test.ts
+++ b/packages/adapter-slack/src/proxy.test.ts
@@ -1,0 +1,203 @@
+import { createHash } from "node:crypto";
+import { once } from "node:events";
+import { createServer } from "node:http";
+import { Agent } from "node:https";
+import { connect, type Socket } from "node:net";
+import type { Duplex } from "node:stream";
+import { createMockChatInstance, mockLogger } from "@chat-adapter/tests";
+import { expect, it, vi } from "vitest";
+import { createSlackAdapter } from "./index";
+
+// Real installed Slack HTTP and WebSocket clients, with an agent that routes
+// only known test destinations to a loopback HTTP fixture. No external DNS or
+// TLS traffic is required. This proves SDK transport selection, not CONNECT
+// authentication, TLS trust, or a production proxy's remote DNS policy.
+it("routes Web API, OAuth, upload phases and both Socket Mode connections through the agent", async () => {
+  const requests: Array<{
+    path: string;
+    authorization?: string;
+    body: string;
+  }> = [];
+  const destinations: string[] = [];
+  const sockets = new Set<Socket>();
+  let websocketConnections = 0;
+  let firstSocket: Duplex | undefined;
+  const server = createServer(async (request, response) => {
+    const chunks: Buffer[] = [];
+    for await (const chunk of request) {
+      chunks.push(Buffer.from(chunk));
+    }
+    const path = request.url ?? "";
+    requests.push({
+      path,
+      authorization: request.headers.authorization,
+      body: Buffer.concat(chunks).toString(),
+    });
+    let body: Record<string, unknown> = { ok: true };
+    switch (path) {
+      case "/api/auth.test":
+        body = { ok: true, user_id: "U_BOT", bot_id: "B_BOT" };
+        break;
+      case "/api/oauth.v2.access":
+        body = { ok: true, access_token: "xoxb-oauth", team: { id: "T123" } };
+        break;
+      case "/api/files.getUploadURLExternal":
+        body = {
+          ok: true,
+          upload_url: "https://upload.slack.test/upload",
+          file_id: "F123",
+        };
+        break;
+      case "/api/files.completeUploadExternal":
+        body = { ok: true, files: [{ id: "F123" }] };
+        break;
+      case "/api/apps.connections.open":
+        body = { ok: true, url: "wss://socket.slack.test/socket" };
+        break;
+      default:
+        break;
+    }
+    response.writeHead(200, { "Content-Type": "application/json" });
+    response.end(JSON.stringify(body));
+  });
+  server.on("connection", (socket) => {
+    sockets.add(socket);
+    socket.on("close", () => sockets.delete(socket));
+  });
+  server.on("upgrade", (request, socket) => {
+    websocketConnections += 1;
+    firstSocket ??= socket;
+    const accept = createHash("sha1")
+      .update(
+        `${request.headers["sec-websocket-key"]}258EAFA5-E914-47DA-95CA-C5AB0DC85B11`
+      )
+      .digest("base64");
+    socket.write(
+      `HTTP/1.1 101 Switching Protocols\r\nUpgrade: websocket\r\nConnection: Upgrade\r\nSec-WebSocket-Accept: ${accept}\r\n\r\n`
+    );
+    const hello = Buffer.from(
+      JSON.stringify({ type: "hello", num_connections: 1 })
+    );
+    socket.write(Buffer.concat([Buffer.from([0x81, hello.length]), hello]));
+    socket.on("data", (data: Buffer) => {
+      // Complete the client's close handshake; these short tests never need
+      // to wait for heartbeat timers or emulate application event frames.
+      if (data[0] === 0x88) {
+        socket.end(Buffer.from([0x88, 0]));
+      }
+    });
+  });
+  server.listen(0, "127.0.0.1");
+  await once(server, "listening");
+  const address = server.address();
+  if (!address || typeof address === "string") {
+    throw new Error("Missing fixture port");
+  }
+  const agent = new Agent({ keepAlive: false });
+  vi.spyOn(agent, "createConnection").mockImplementation((options) => {
+    const host = String(options.host);
+    destinations.push(host);
+    if (
+      !["slack.com", "upload.slack.test", "socket.slack.test"].includes(host)
+    ) {
+      throw new Error(`Unexpected outbound destination: ${host}`);
+    }
+    return connect({ host: "127.0.0.1", port: address.port });
+  });
+  const webClientOptions = {
+    agent,
+    retryConfig: { retries: 0 },
+    timeout: 2000,
+  };
+  const adapter = createSlackAdapter({
+    botToken: "xoxb-test",
+    appToken: "xapp-test",
+    mode: "socket",
+    logger: mockLogger,
+    webClientOptions,
+  });
+  const oauth = createSlackAdapter({
+    signingSecret: "secret",
+    clientId: "client",
+    clientSecret: "secret",
+    logger: mockLogger,
+    webClientOptions,
+  });
+  try {
+    await adapter.initialize(createMockChatInstance());
+    await adapter.webClient.chat.postMessage({
+      channel: "C123",
+      text: "proxy test",
+    });
+    await oauth.initialize(createMockChatInstance());
+    expect(
+      (
+        await oauth.handleOAuthCallback(
+          new Request("https://app.example/oauth?code=test")
+        )
+      ).teamId
+    ).toBe("T123");
+    await adapter.webClient.files.uploadV2({
+      channel_id: "C123",
+      filename: "test.txt",
+      file: Buffer.from("uploaded through agent"),
+    });
+    // Slack requests reconnection periodically; the real SDK must retain the
+    // same agent for the new HTTP handshake and WebSocket after its backoff.
+    const refresh = Buffer.from(
+      JSON.stringify({ type: "disconnect", reason: "refresh_requested" })
+    );
+    firstSocket?.write(
+      Buffer.concat([Buffer.from([0x81, refresh.length]), refresh])
+    );
+    await vi.waitFor(() => expect(websocketConnections).toBe(2), {
+      timeout: 8000,
+    });
+    let listener: Promise<unknown> | undefined;
+    await adapter.startSocketModeListener(
+      {
+        waitUntil: (promise) => {
+          listener = promise;
+        },
+      },
+      1
+    );
+    await listener;
+    expect(requests.map(({ path }) => path)).toEqual(
+      expect.arrayContaining([
+        "/api/auth.test",
+        "/api/chat.postMessage",
+        "/api/oauth.v2.access",
+        "/api/files.getUploadURLExternal",
+        "/upload",
+        "/api/files.completeUploadExternal",
+      ])
+    );
+    expect(
+      requests.filter(({ path }) => path === "/api/apps.connections.open")
+    ).toHaveLength(3);
+    expect(
+      requests
+        .filter(({ path }) => path === "/api/apps.connections.open")
+        .every(({ authorization }) => authorization === "Bearer xapp-test")
+    ).toBe(true);
+    expect(requests.find(({ path }) => path === "/upload")?.body).toContain(
+      "uploaded through agent"
+    );
+    expect(destinations).toContain("upload.slack.test");
+    expect(
+      destinations.filter((host) => host === "socket.slack.test")
+    ).toHaveLength(3);
+    expect(websocketConnections).toBe(3);
+  } finally {
+    await adapter.disconnect();
+    agent.destroy();
+    for (const socket of sockets) {
+      socket.destroy();
+    }
+    await new Promise<void>((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+    vi.restoreAllMocks();
+  }
+}, 15_000);

--- a/packages/adapter-slack/src/test-fixtures.ts
+++ b/packages/adapter-slack/src/test-fixtures.ts
@@ -1,0 +1,47 @@
+/**
+ * Shared fixtures for Slack adapter tests.
+ */
+
+import type { IncomingMessage } from "node:http";
+import { Readable } from "node:stream";
+
+/**
+ * Builds a minimal IncomingMessage for stubbing an AttachmentTransport.
+ * Pass a never-ending Readable as `body` to model a stalled download.
+ */
+export function incomingMessage(
+  body: Buffer | Readable = Buffer.from("file"),
+  {
+    headers = {},
+    statusCode = 200,
+    statusMessage = "OK",
+  }: {
+    headers?: IncomingMessage["headers"];
+    statusCode?: number;
+    statusMessage?: string;
+  } = {}
+): IncomingMessage {
+  const stream = Buffer.isBuffer(body) ? Readable.from([body]) : body;
+  return Object.assign(stream, {
+    headers,
+    statusCode,
+    statusMessage,
+  }) as IncomingMessage;
+}
+
+/** A message event carrying one private Slack file. */
+export const fileMessageEvent = {
+  type: "message",
+  user: "U123",
+  channel: "C123",
+  text: "file",
+  ts: "1.1",
+  files: [
+    {
+      id: "F123",
+      name: "file.pdf",
+      mimetype: "application/pdf",
+      url_private: "https://files.slack.com/file.pdf",
+    },
+  ],
+};

--- a/packages/adapter-slack/src/transport.test.ts
+++ b/packages/adapter-slack/src/transport.test.ts
@@ -1,4 +1,3 @@
-import type { IncomingMessage } from "node:http";
 import { Agent } from "node:https";
 import { Readable } from "node:stream";
 import { gzipSync } from "node:zlib";
@@ -11,6 +10,7 @@ import {
   SlackAdapter,
   type SlackAdapterConfig,
 } from "./index";
+import { fileMessageEvent, incomingMessage } from "./test-fixtures";
 
 vi.mock("@slack/socket-mode", () => ({
   SocketModeClient: vi.fn(
@@ -36,36 +36,10 @@ class InspectableSlackAdapter extends SlackAdapter {
   }
 }
 
-function response(
-  body = Buffer.from("file"),
-  headers = {},
-  statusCode = 200
-): IncomingMessage {
-  return Object.assign(Readable.from([body]), {
-    headers,
-    statusCode,
-    statusMessage: "fixture",
-  }) as IncomingMessage;
-}
 const auth = {
   botToken: "xoxb-test",
   signingSecret: "secret",
   logger: mockLogger,
-};
-const fileEvent = {
-  type: "message",
-  user: "U123",
-  channel: "C123",
-  text: "file",
-  ts: "1.1",
-  files: [
-    {
-      id: "F123",
-      name: "file.pdf",
-      mimetype: "application/pdf",
-      url_private: "https://files.slack.com/file.pdf",
-    },
-  ],
 };
 function ephemeralId(url = "https://hooks.slack.com/respond") {
   return `ephemeral:1.1:${btoa(JSON.stringify({ responseUrl: url, userId: "U123" }))}`;
@@ -107,27 +81,27 @@ describe("outbound transports", () => {
     agent.destroy();
   });
 
-  it("passes only a fresh agent option to persistent and transient Socket Mode clients", async () => {
+  it("passes fresh transport options to persistent and transient Socket Mode clients", async () => {
     const agent = new Agent();
+    const tls = { ca: "test-ca" };
     const webClientOptions = Object.freeze({
       agent,
+      tls,
       headers: { Authorization: "do-not-forward" },
+      retryConfig: { retries: 0 },
       timeout: 42,
     });
-    const adapter = createSlackAdapter({
+    const adapter = new InspectableSlackAdapter({
       ...auth,
+      apiUrl: "https://slack-gov.com/api/",
       appToken: "xapp-test",
       mode: "socket",
       webClientOptions,
     });
-    vi.spyOn(
-      (
-        adapter as unknown as {
-          _client: InspectableSlackAdapter["defaultClient"];
-        }
-      )._client.auth,
-      "test"
-    ).mockResolvedValue({ ok: true, user_id: "U_BOT" });
+    vi.spyOn(adapter.defaultClient.auth, "test").mockResolvedValue({
+      ok: true,
+      user_id: "U_BOT",
+    });
     await adapter.initialize(createMockChatInstance());
     let pending: Promise<unknown> | undefined;
     await adapter.startSocketModeListener(
@@ -143,12 +117,14 @@ describe("outbound transports", () => {
     for (const [options] of calls) {
       expect(options).toEqual({
         appToken: "xapp-test",
-        clientOptions: { agent },
+        clientOptions: {
+          agent,
+          tls,
+          slackApiUrl: "https://slack-gov.com/api/",
+        },
       });
-      expect(options?.clientOptions).not.toBe(webClientOptions);
     }
     expect(calls[0][0]?.clientOptions).not.toBe(calls[1][0]?.clientOptions);
-    expect(webClientOptions).not.toHaveProperty("retryConfig");
     await adapter.disconnect();
     agent.destroy();
   });
@@ -226,9 +202,9 @@ describe("outbound transports", () => {
     vi.stubEnv("SLACK_SIGNING_SECRET", "env-secret");
     const fileTransport = vi
       .fn<AttachmentTransport>()
-      .mockImplementation(async () => response());
+      .mockImplementation(async () => incomingMessage());
     const adapter = createSlackAdapter({ fileTransport, logger: mockLogger });
-    await adapter.parseMessage(fileEvent).attachments?.[0].fetchData?.();
+    await adapter.parseMessage(fileMessageEvent).attachments?.[0].fetchData?.();
     expect(fileTransport.mock.calls[0][2]).toMatchObject({
       authorization: "Bearer xoxb-env",
     });
@@ -245,9 +221,9 @@ describe("outbound transports", () => {
   ])("uses the configured guarded transport for lazy and rehydrated files", async (create) => {
     const fileTransport = vi
       .fn<AttachmentTransport>()
-      .mockImplementation(async () => response());
+      .mockImplementation(async () => incomingMessage());
     const adapter = create({ ...auth, fileTransport });
-    const attachment = adapter.parseMessage(fileEvent).attachments?.[0];
+    const attachment = adapter.parseMessage(fileMessageEvent).attachments?.[0];
     expect(attachment).toBeDefined();
     expect(fileTransport).not.toHaveBeenCalled();
     expect(await attachment?.fetchData?.()).toEqual(Buffer.from("file"));
@@ -271,39 +247,46 @@ describe("outbound transports", () => {
     const fileTransport = vi.fn<AttachmentTransport>();
     const subclassTransport = vi
       .fn<AttachmentTransport>()
-      .mockImplementation(async () => response());
+      .mockImplementation(async () => incomingMessage());
     class CustomAdapter extends SlackAdapter {
       protected override createFileTransport() {
         return subclassTransport;
       }
     }
     const adapter = new CustomAdapter({ ...auth, fileTransport });
-    await adapter.parseMessage(fileEvent).attachments?.[0].fetchData?.();
+    await adapter.parseMessage(fileMessageEvent).attachments?.[0].fetchData?.();
     expect(subclassTransport).toHaveBeenCalledOnce();
     expect(fileTransport).not.toHaveBeenCalled();
   });
 
-  it("strips Slack credentials on redirects and rejects internal redirect URLs", async () => {
+  it("delegates public-host redirects to the transport without credentials and rejects internal literals", async () => {
     const fileTransport = vi
       .fn<AttachmentTransport>()
       .mockResolvedValueOnce(
-        response(Buffer.alloc(0), { location: "https://cdn.example/file" }, 302)
+        incomingMessage(Buffer.alloc(0), {
+          headers: { location: "https://cdn.example/file" },
+          statusCode: 302,
+        })
       )
-      .mockResolvedValueOnce(response());
+      .mockResolvedValueOnce(incomingMessage());
     const adapter = createSlackAdapter({ ...auth, fileTransport });
-    await adapter.parseMessage(fileEvent).attachments?.[0].fetchData?.();
+    await adapter.parseMessage(fileMessageEvent).attachments?.[0].fetchData?.();
     expect(fileTransport.mock.calls[0][2]).toHaveProperty(
       "authorization",
       "Bearer xoxb-test"
     );
+    expect(fileTransport.mock.calls[1][0]).toEqual(
+      new URL("https://cdn.example/file")
+    );
     expect(fileTransport.mock.calls[1][2]).not.toHaveProperty("authorization");
-    fileTransport
-      .mockReset()
-      .mockResolvedValueOnce(
-        response(Buffer.alloc(0), { location: "https://127.0.0.1/file" }, 302)
-      );
+    fileTransport.mockReset().mockResolvedValueOnce(
+      incomingMessage(Buffer.alloc(0), {
+        headers: { location: "https://127.0.0.1/file" },
+        statusCode: 302,
+      })
+    );
     await expect(
-      adapter.parseMessage(fileEvent).attachments?.[0].fetchData?.()
+      adapter.parseMessage(fileMessageEvent).attachments?.[0].fetchData?.()
     ).rejects.toThrow();
     expect(fileTransport).toHaveBeenCalledOnce();
   });
@@ -311,14 +294,20 @@ describe("outbound transports", () => {
   it.each([
     [
       "HTML login",
-      () => response(Buffer.from("login"), { "content-type": "text/html" }),
+      () =>
+        incomingMessage(Buffer.from("login"), {
+          headers: { "content-type": "text/html" },
+        }),
     ],
-    ["non-success", () => response(Buffer.from("denied"), {}, 403)],
+    [
+      "non-success",
+      () => incomingMessage(Buffer.from("denied"), { statusCode: 403 }),
+    ],
     [
       "decoded size",
       () =>
-        response(gzipSync(Buffer.alloc(26 * 1024 * 1024)), {
-          "content-encoding": "gzip",
+        incomingMessage(gzipSync(Buffer.alloc(26 * 1024 * 1024)), {
+          headers: { "content-encoding": "gzip" },
         }),
     ],
   ] as const)("keeps %s rejection with a configured transport", async (_name, result) => {
@@ -327,32 +316,25 @@ describe("outbound transports", () => {
       fileTransport: async () => result(),
     });
     await expect(
-      adapter.parseMessage(fileEvent).attachments?.[0].fetchData?.()
+      adapter.parseMessage(fileMessageEvent).attachments?.[0].fetchData?.()
     ).rejects.toThrow();
   });
 
-  it("aborts the configured transport at the overall download deadline", async () => {
+  it.each([
+    ["never responds", () => new Promise<never>(() => undefined)],
+    [
+      "stalls the body",
+      async () => incomingMessage(new Readable({ read() {} })),
+    ],
+  ])("enforces the download deadline when a signal-ignoring transport %s", async (_name, fileTransport) => {
     const timeout = AbortSignal.timeout;
     const timeoutSpy = vi
       .spyOn(AbortSignal, "timeout")
       .mockImplementation(() => timeout(20));
-    let signal: AbortSignal | undefined;
-    const fileTransport: AttachmentTransport = (_url, abortSignal) => {
-      signal = abortSignal;
-      return new Promise((_resolve, reject) => {
-        abortSignal.addEventListener(
-          "abort",
-          () => reject(abortSignal.reason),
-          { once: true }
-        );
-      });
-    };
     const adapter = createSlackAdapter({ ...auth, fileTransport });
-    const pending = expect(
-      adapter.parseMessage(fileEvent).attachments?.[0].fetchData?.()
-    ).rejects.toThrow();
-    await pending;
+    await expect(
+      adapter.parseMessage(fileMessageEvent).attachments?.[0].fetchData?.()
+    ).rejects.toThrow("Timed out fetching the attachment");
     expect(timeoutSpy).toHaveBeenCalledWith(30_000);
-    expect(signal?.aborted).toBe(true);
   });
 });

--- a/packages/adapter-slack/src/transport.test.ts
+++ b/packages/adapter-slack/src/transport.test.ts
@@ -1,0 +1,358 @@
+import type { IncomingMessage } from "node:http";
+import { Agent } from "node:https";
+import { Readable } from "node:stream";
+import { gzipSync } from "node:zlib";
+import type { AttachmentTransport } from "@chat-adapter/shared";
+import { createMockChatInstance, mockLogger } from "@chat-adapter/tests";
+import { SocketModeClient } from "@slack/socket-mode";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  createSlackAdapter,
+  SlackAdapter,
+  type SlackAdapterConfig,
+} from "./index";
+
+vi.mock("@slack/socket-mode", () => ({
+  SocketModeClient: vi.fn(
+    class {
+      start = vi.fn(async () => ({}));
+      disconnect = vi.fn(async () => undefined);
+      on = vi.fn();
+    }
+  ),
+}));
+
+class InspectableSlackAdapter extends SlackAdapter {
+  get defaultClient() {
+    return this._client;
+  }
+  async forward() {
+    await this.forwardSocketEvent("https://app.example/webhook", {
+      type: "socket_event",
+      eventType: "events_api",
+      body: { event: { type: "message" } },
+      timestamp: 123,
+    });
+  }
+}
+
+function response(
+  body = Buffer.from("file"),
+  headers = {},
+  statusCode = 200
+): IncomingMessage {
+  return Object.assign(Readable.from([body]), {
+    headers,
+    statusCode,
+    statusMessage: "fixture",
+  }) as IncomingMessage;
+}
+const auth = {
+  botToken: "xoxb-test",
+  signingSecret: "secret",
+  logger: mockLogger,
+};
+const fileEvent = {
+  type: "message",
+  user: "U123",
+  channel: "C123",
+  text: "file",
+  ts: "1.1",
+  files: [
+    {
+      id: "F123",
+      name: "file.pdf",
+      mimetype: "application/pdf",
+      url_private: "https://files.slack.com/file.pdf",
+    },
+  ],
+};
+function ephemeralId(url = "https://hooks.slack.com/respond") {
+  return `ephemeral:1.1:${btoa(JSON.stringify({ responseUrl: url, userId: "U123" }))}`;
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.unstubAllEnvs();
+  vi.useRealTimers();
+});
+
+describe("outbound transports", () => {
+  it("keeps the agent on default, rotated, and scoped WebClients without mutating headers", async () => {
+    const agent = new Agent();
+    const headers = Object.freeze({ "X-Test": "value" });
+    let token = "xoxb-first";
+    const adapter = new InspectableSlackAdapter({
+      ...auth,
+      botToken: () => token,
+      webClientOptions: { agent, headers },
+    });
+    const clients = [adapter.defaultClient, adapter.webClient];
+    token = "xoxb-second";
+    clients.push(adapter.webClient);
+    await adapter.withBotToken("xoxb-scoped", () => {
+      clients.push(adapter.webClient);
+    });
+    for (const client of clients) {
+      const defaults = (
+        client as unknown as {
+          axios: { defaults: { httpAgent: unknown; httpsAgent: unknown } };
+        }
+      ).axios.defaults;
+      expect(defaults.httpAgent).toBe(agent);
+      expect(defaults.httpsAgent).toBe(agent);
+    }
+    expect(new Set(clients).size).toBe(4);
+    expect(headers).toEqual({ "X-Test": "value" });
+    agent.destroy();
+  });
+
+  it("passes only a fresh agent option to persistent and transient Socket Mode clients", async () => {
+    const agent = new Agent();
+    const webClientOptions = Object.freeze({
+      agent,
+      headers: { Authorization: "do-not-forward" },
+      timeout: 42,
+    });
+    const adapter = createSlackAdapter({
+      ...auth,
+      appToken: "xapp-test",
+      mode: "socket",
+      webClientOptions,
+    });
+    vi.spyOn(
+      (
+        adapter as unknown as {
+          _client: InspectableSlackAdapter["defaultClient"];
+        }
+      )._client.auth,
+      "test"
+    ).mockResolvedValue({ ok: true, user_id: "U_BOT" });
+    await adapter.initialize(createMockChatInstance());
+    let pending: Promise<unknown> | undefined;
+    await adapter.startSocketModeListener(
+      {
+        waitUntil: (promise) => {
+          pending = promise;
+        },
+      },
+      1
+    );
+    await pending;
+    const calls = vi.mocked(SocketModeClient).mock.calls.slice(-2);
+    for (const [options] of calls) {
+      expect(options).toEqual({
+        appToken: "xapp-test",
+        clientOptions: { agent },
+      });
+      expect(options?.clientOptions).not.toBe(webClientOptions);
+    }
+    expect(calls[0][0]?.clientOptions).not.toBe(calls[1][0]?.clientOptions);
+    expect(webClientOptions).not.toHaveProperty("retryConfig");
+    await adapter.disconnect();
+    agent.destroy();
+  });
+
+  it.each([
+    createSlackAdapter,
+    (config: SlackAdapterConfig) => new SlackAdapter(config),
+  ])("uses configured fetch for response replacements and deletions", async (create) => {
+    const fetch = vi
+      .fn<typeof globalThis.fetch>()
+      .mockImplementation(async () => new Response("ok"));
+    const globalFetch = vi
+      .spyOn(globalThis, "fetch")
+      .mockRejectedValue(new Error("unexpected global fetch"));
+    const adapter = create({ ...auth, fetch });
+    await adapter.editMessage("slack:C123:1.1", ephemeralId(), "updated");
+    await adapter.deleteMessage("slack:C123:1.1", ephemeralId());
+    expect(fetch).toHaveBeenCalledTimes(2);
+    expect(JSON.parse(fetch.mock.calls[0][1]?.body as string)).toMatchObject({
+      replace_original: true,
+      text: "updated",
+    });
+    expect(JSON.parse(fetch.mock.calls[1][1]?.body as string)).toMatchObject({
+      delete_original: true,
+    });
+    expect(fetch.mock.calls[0][1]?.method).toBe("POST");
+    await expect(
+      adapter.deleteMessage(
+        "slack:C123:1.1",
+        ephemeralId("https://evil.example")
+      )
+    ).rejects.toThrow();
+    expect(fetch).toHaveBeenCalledTimes(2);
+    expect(globalFetch).not.toHaveBeenCalled();
+  });
+
+  it("forwards socket events with the configured fetch and forwarding credential", async () => {
+    const fetch = vi
+      .fn<typeof globalThis.fetch>()
+      .mockResolvedValue(new Response("ok"));
+    const globalFetch = vi
+      .spyOn(globalThis, "fetch")
+      .mockRejectedValue(new Error("unexpected global fetch"));
+    const adapter = new InspectableSlackAdapter({
+      ...auth,
+      appToken: "xapp-test",
+      socketForwardingSecret: "forward-secret",
+      fetch,
+    });
+    await adapter.forward();
+    expect(fetch).toHaveBeenCalledWith("https://app.example/webhook", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "x-slack-socket-token": "forward-secret",
+      },
+      body: JSON.stringify({
+        type: "socket_event",
+        eventType: "events_api",
+        body: { event: { type: "message" } },
+        timestamp: 123,
+      }),
+    });
+    expect(globalFetch).not.toHaveBeenCalled();
+    fetch.mockResolvedValueOnce(new Response("proxy failure", { status: 502 }));
+    await adapter.forward();
+    expect(mockLogger.error).toHaveBeenCalledWith(
+      "Failed to forward socket event",
+      expect.objectContaining({ status: 502 })
+    );
+  });
+
+  it("preserves env authentication with transport-only config and resolves global fetch at request time", async () => {
+    vi.stubEnv("SLACK_BOT_TOKEN", "xoxb-env");
+    vi.stubEnv("SLACK_SIGNING_SECRET", "env-secret");
+    const fileTransport = vi
+      .fn<AttachmentTransport>()
+      .mockImplementation(async () => response());
+    const adapter = createSlackAdapter({ fileTransport, logger: mockLogger });
+    await adapter.parseMessage(fileEvent).attachments?.[0].fetchData?.();
+    expect(fileTransport.mock.calls[0][2]).toMatchObject({
+      authorization: "Bearer xoxb-env",
+    });
+    const fetch = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValue(new Response("ok"));
+    await adapter.deleteMessage("slack:C123:1.1", ephemeralId());
+    expect(fetch).toHaveBeenCalledOnce();
+  });
+
+  it.each([
+    createSlackAdapter,
+    (config: SlackAdapterConfig) => new SlackAdapter(config),
+  ])("uses the configured guarded transport for lazy and rehydrated files", async (create) => {
+    const fileTransport = vi
+      .fn<AttachmentTransport>()
+      .mockImplementation(async () => response());
+    const adapter = create({ ...auth, fileTransport });
+    const attachment = adapter.parseMessage(fileEvent).attachments?.[0];
+    expect(attachment).toBeDefined();
+    expect(fileTransport).not.toHaveBeenCalled();
+    expect(await attachment?.fetchData?.()).toEqual(Buffer.from("file"));
+    expect(
+      await adapter
+        .rehydrateAttachment({
+          type: "file",
+          url: "https://files.slack.com/file.pdf",
+        })
+        .fetchData?.()
+    ).toEqual(Buffer.from("file"));
+    expect(fileTransport).toHaveBeenCalledTimes(2);
+    expect(fileTransport).toHaveBeenCalledWith(
+      new URL("https://files.slack.com/file.pdf"),
+      expect.any(AbortSignal),
+      expect.objectContaining({ authorization: "Bearer xoxb-test" })
+    );
+  });
+
+  it("preserves subclass overrides over the configured transport", async () => {
+    const fileTransport = vi.fn<AttachmentTransport>();
+    const subclassTransport = vi
+      .fn<AttachmentTransport>()
+      .mockImplementation(async () => response());
+    class CustomAdapter extends SlackAdapter {
+      protected override createFileTransport() {
+        return subclassTransport;
+      }
+    }
+    const adapter = new CustomAdapter({ ...auth, fileTransport });
+    await adapter.parseMessage(fileEvent).attachments?.[0].fetchData?.();
+    expect(subclassTransport).toHaveBeenCalledOnce();
+    expect(fileTransport).not.toHaveBeenCalled();
+  });
+
+  it("strips Slack credentials on redirects and rejects internal redirect URLs", async () => {
+    const fileTransport = vi
+      .fn<AttachmentTransport>()
+      .mockResolvedValueOnce(
+        response(Buffer.alloc(0), { location: "https://cdn.example/file" }, 302)
+      )
+      .mockResolvedValueOnce(response());
+    const adapter = createSlackAdapter({ ...auth, fileTransport });
+    await adapter.parseMessage(fileEvent).attachments?.[0].fetchData?.();
+    expect(fileTransport.mock.calls[0][2]).toHaveProperty(
+      "authorization",
+      "Bearer xoxb-test"
+    );
+    expect(fileTransport.mock.calls[1][2]).not.toHaveProperty("authorization");
+    fileTransport
+      .mockReset()
+      .mockResolvedValueOnce(
+        response(Buffer.alloc(0), { location: "https://127.0.0.1/file" }, 302)
+      );
+    await expect(
+      adapter.parseMessage(fileEvent).attachments?.[0].fetchData?.()
+    ).rejects.toThrow();
+    expect(fileTransport).toHaveBeenCalledOnce();
+  });
+
+  it.each([
+    [
+      "HTML login",
+      () => response(Buffer.from("login"), { "content-type": "text/html" }),
+    ],
+    ["non-success", () => response(Buffer.from("denied"), {}, 403)],
+    [
+      "decoded size",
+      () =>
+        response(gzipSync(Buffer.alloc(26 * 1024 * 1024)), {
+          "content-encoding": "gzip",
+        }),
+    ],
+  ] as const)("keeps %s rejection with a configured transport", async (_name, result) => {
+    const adapter = createSlackAdapter({
+      ...auth,
+      fileTransport: async () => result(),
+    });
+    await expect(
+      adapter.parseMessage(fileEvent).attachments?.[0].fetchData?.()
+    ).rejects.toThrow();
+  });
+
+  it("aborts the configured transport at the overall download deadline", async () => {
+    const timeout = AbortSignal.timeout;
+    const timeoutSpy = vi
+      .spyOn(AbortSignal, "timeout")
+      .mockImplementation(() => timeout(20));
+    let signal: AbortSignal | undefined;
+    const fileTransport: AttachmentTransport = (_url, abortSignal) => {
+      signal = abortSignal;
+      return new Promise((_resolve, reject) => {
+        abortSignal.addEventListener(
+          "abort",
+          () => reject(abortSignal.reason),
+          { once: true }
+        );
+      });
+    };
+    const adapter = createSlackAdapter({ ...auth, fileTransport });
+    const pending = expect(
+      adapter.parseMessage(fileEvent).attachments?.[0].fetchData?.()
+    ).rejects.toThrow();
+    await pending;
+    expect(timeoutSpy).toHaveBeenCalledWith(30_000);
+    expect(signal?.aborted).toBe(true);
+  });
+});

--- a/packages/adapter-slack/src/types.ts
+++ b/packages/adapter-slack/src/types.ts
@@ -5,6 +5,7 @@
 import type { AttachmentTransport } from "@chat-adapter/shared";
 import type { WebClientOptions } from "@slack/web-api";
 import type { AppContextEntity, Logger } from "chat";
+import type { SlackFetch } from "./fetch";
 import type { SlackWebhookVerifier } from "./webhook/index";
 
 export type SlackAdapterMode = "webhook" | "socket";
@@ -153,14 +154,17 @@ export interface SlackAdapterConfig {
    * forwarding. Defaults to globalThis.fetch at request time. Does not affect
    * Web API clients, Socket Mode connections, files, or standalone /api helpers.
    */
-  fetch?: typeof globalThis.fetch;
+  fetch?: SlackFetch;
   /**
    * Transport for lazy and rehydrated file downloads. Replaces the default
-   * DNS-pinned HTTPS transport; the transport or egress proxy must reject
-   * internal destination addresses and DNS rebinding. Return the raw response
-   * without following redirects, and honor the supplied AbortSignal. The
-   * downloader retains URL, redirect, credential, deadline, and body-size checks.
-   * Subclass createFileTransport() overrides take precedence.
+   * DNS-pinned HTTPS transport, which is the only place resolved addresses
+   * are checked against the private-range blocklist, so the transport or
+   * egress proxy must reject internal destination addresses and DNS
+   * rebinding. Return the raw response without following redirects, and
+   * honor the supplied AbortSignal. The downloader still validates URLs,
+   * limits redirects, scopes credentials, destroys the response at the
+   * deadline, and caps the body size. Subclass createFileTransport()
+   * overrides take precedence.
    */
   fileTransport?: AttachmentTransport;
   /**
@@ -248,9 +252,12 @@ export interface SlackAdapterConfig {
    * });
    * ```
    *
-   * `agent` also configures both Socket Mode connections (HTTP and WebSocket).
-   * It does not configure `fetch` or `fileTransport`. Other options apply only
-   * to Web API clients. Use `apiUrl` to override the Slack Web API base URL.
+   * `agent` also configures Socket Mode, both its HTTP calls and its
+   * WebSocket. `tls` and `apiUrl` reach only Socket Mode's HTTP calls; the
+   * SDK opens the WebSocket with the agent alone, so a custom CA or other
+   * TLS settings for that connection belong on the agent. None of these
+   * configure `fetch` or `fileTransport`. Other options apply only to Web
+   * API clients. Use `apiUrl` to override the Slack Web API base URL.
    */
   webClientOptions?: Omit<WebClientOptions, "slackApiUrl">;
   /**

--- a/packages/adapter-slack/src/types.ts
+++ b/packages/adapter-slack/src/types.ts
@@ -2,6 +2,7 @@
  * Slack adapter types.
  */
 
+import type { AttachmentTransport } from "@chat-adapter/shared";
 import type { WebClientOptions } from "@slack/web-api";
 import type { AppContextEntity, Logger } from "chat";
 import type { SlackWebhookVerifier } from "./webhook/index";
@@ -148,6 +149,21 @@ export interface SlackAdapterConfig {
    */
   feedbackButtons?: boolean | SlackFeedbackButtonsOptions;
   /**
+   * Fetch implementation for response_url requests and Socket Mode webhook
+   * forwarding. Defaults to globalThis.fetch at request time. Does not affect
+   * Web API clients, Socket Mode connections, files, or standalone /api helpers.
+   */
+  fetch?: typeof globalThis.fetch;
+  /**
+   * Transport for lazy and rehydrated file downloads. Replaces the default
+   * DNS-pinned HTTPS transport; the transport or egress proxy must reject
+   * internal destination addresses and DNS rebinding. Return the raw response
+   * without following redirects, and honor the supplied AbortSignal. The
+   * downloader retains URL, redirect, credential, deadline, and body-size checks.
+   * Subclass createFileTransport() overrides take precedence.
+   */
+  fileTransport?: AttachmentTransport;
+  /**
    * Prefix for the state key used to store workspace installations.
    * Defaults to `slack:installation`. The full key will be `{prefix}:{teamId}`.
    */
@@ -232,7 +248,9 @@ export interface SlackAdapterConfig {
    * });
    * ```
    *
-   * Use `apiUrl` to override the Slack Web API base URL.
+   * `agent` also configures both Socket Mode connections (HTTP and WebSocket).
+   * It does not configure `fetch` or `fileTransport`. Other options apply only
+   * to Web API clients. Use `apiUrl` to override the Slack Web API base URL.
    */
   webClientOptions?: Omit<WebClientOptions, "slackApiUrl">;
   /**

--- a/packages/integration-tests/src/documentation-test-utils.ts
+++ b/packages/integration-tests/src/documentation-test-utils.ts
@@ -141,6 +141,9 @@ export const VALID_PACKAGE_README_IMPORTS = [
   "ioredis",
   "pg",
   "postgres",
+  // Application-installed dependencies used by the Slack proxy recipe.
+  "https-proxy-agent",
+  "undici",
 ];
 
 export const VALID_DOC_PACKAGES = [
@@ -208,6 +211,9 @@ export const VALID_DOC_PACKAGES = [
   "ioredis",
   "pg",
   "postgres",
+  // Application-installed dependencies used by the Slack proxy recipe.
+  "https-proxy-agent",
+  "undici",
   "tsup",
   "vitest",
   "vitest/config",


### PR DESCRIPTION
Adds proxy configuration for Slack connections that previously bypassed `webClientOptions.agent`. Socket Mode now uses that agent for HTTP and WebSocket connections, and new `fetch` and `fileTransport` options cover response URLs, webhook forwarding, and attachment downloads.

```ts
createSlackAdapter({
  webClientOptions: { agent },
  fetch: proxyFetch,
  fileTransport,
});
```

Includes a setup example and guidance on the destination restrictions custom download transports need to enforce.

Closes #596
