### PR TITLE
fix(slack): close open tasks on stream rotation

### DIFF
--- a/.changeset/clean-tasks-rotate.md
+++ b/.changeset/clean-tasks-rotate.md
@@ -1,0 +1,5 @@
+---
+"@chat-adapter/slack": patch
+---
+
+Complete open task cards when a native Slack stream segment rotates, then replay the in-progress cards in the next segment. Retired segments now finish without Slack's error indicator.

--- a/packages/adapter-slack/AGENTS.md
+++ b/packages/adapter-slack/AGENTS.md
@@ -282,8 +282,9 @@ works in segments: once a segment is `streamSegmentMaxAgeMs` old (the
 clock starts at the first call Slack accepts, not at construction), the
 next paragraph break (or, after a 30 s grace, the next line break)
 finalizes it and a new `chatStream` continues the reply. Rotation closes
-and reopens an open code fence, repeats a table header, replays the plan
-and open task cards, and keeps `session_status: "processing"` with
+open task cards in the retired segment, replays them into the new segment,
+closes and reopens an open code fence, repeats a table header, replays the
+plan, and keeps `session_status: "processing"` with
 `agentView`. Tests drive this with a mocked `Date.now()`; see the
 "native stream rotation" describe block.
 

--- a/packages/adapter-slack/src/index.test.ts
+++ b/packages/adapter-slack/src/index.test.ts
@@ -11122,7 +11122,7 @@ describe("native stream rotation", () => {
     });
   });
 
-  it("replays the plan and open task cards into the new segment", async () => {
+  it("completes open task cards before replaying them into the new segment", async () => {
     await withClock(async (tick) => {
       const { adapter, segments } = setup();
       const plan = { type: "plan_update" as const, title: "Plan" };
@@ -11150,7 +11150,10 @@ describe("native stream rotation", () => {
 
       await adapter.stream(THREAD, stream());
 
-      expect(segments[0].stop).toHaveBeenCalledWith({ token: TOKEN });
+      expect(segments[0].stop).toHaveBeenCalledWith({
+        chunks: [{ ...oneInProgress, status: "complete" }],
+        token: TOKEN,
+      });
       expect(segments[1].append).toHaveBeenNthCalledWith(1, {
         chunks: [plan, oneInProgress],
         token: TOKEN,

--- a/packages/adapter-slack/src/index.ts
+++ b/packages/adapter-slack/src/index.ts
@@ -6044,10 +6044,22 @@ export class SlackAdapter implements Adapter<SlackThreadId, unknown> {
       const finalText =
         (head.length > 0 ? withSegmentPrefix(head) : "") + closer;
       const ageMs = segmentAgeMs();
+      const closingTaskChunks =
+        structuredChunksSupported && openTasks.size > 0
+          ? Array.from(openTasks.values(), (task) => ({
+              ...task,
+              status: "complete" as const,
+            }))
+          : undefined;
       try {
         const result = await segment.streamer.stop({
           token,
           ...(finalText.length > 0 ? { markdown_text: finalText } : {}),
+          ...(closingTaskChunks
+            ? {
+                chunks: closingTaskChunks as ChatStopStreamArguments["chunks"],
+              }
+            : {}),
           // Keep the agent session marked busy: the reply continues in the
           // next segment, and chat.stopStream defaults to "active".
           ...(this.agentView ? { session_status: "processing" } : {}),


### PR DESCRIPTION
 Long-running native Slack streams rotate to a new message before Slack expires them. If a task was still in_progress during rotation, the previous message was stopped with the task left open. Slack then displayed that message with a red error indicator.

This change sends a complete update for each open task when the previous stream segment stops. The original in_progress tasks are replayed in the new segment so the work can continue without the previous message appearing as an error.

 Fixes #911