### PR TITLE
feat(twilio): add WhatsApp and RCS typing indicators

### DIFF
--- a/.changeset/twilio-typing-indicators.md
+++ b/.changeset/twilio-typing-indicators.md
@@ -1,0 +1,5 @@
+---
+"@chat-adapter/twilio": minor
+---
+
+Add WhatsApp and RCS typing indicators through Twilio's Messaging v3 Indicators API.

--- a/apps/docs/content/adapters/official/twilio.mdx
+++ b/apps/docs/content/adapters/official/twilio.mdx
@@ -240,7 +240,7 @@ await thread.post({
 });
 ```
 
-Custom status text is ignored. WhatsApp shows the indicator for up to 25 seconds or until the reply is delivered; RCS up to 20 seconds. SMS has no typing API, so `startTyping()` is a no-op.
+Custom status text is ignored. WhatsApp shows the indicator for up to 25 seconds or until the reply is delivered; RCS up to 20 seconds. SMS has no typing API, so `startTyping()` is a no-op — including SMS threads keyed by a Messaging Service SID. For RCS threads keyed by `MG…`, set `rcsSenderId`.
 
 ## Media
 

--- a/apps/docs/content/adapters/official/twilio.mdx
+++ b/apps/docs/content/adapters/official/twilio.mdx
@@ -40,7 +40,9 @@ features:
   mentions: no
   addReactions: no
   removeReactions: no
-  typingIndicator: no
+  typingIndicator:
+    status: partial
+    label: WhatsApp + RCS
   messageUpdatedEvents: no
   messageDeletedEvents: no
   directMessages: yes
@@ -226,6 +228,20 @@ await thread.post({
 
 Over RCS, this renders as a rich card with tappable buttons. Over SMS, it falls back to plain text.
 
+## Typing indicators
+
+WhatsApp and RCS support typing indicators through `thread.startTyping()` or `adapter.startTyping(threadId)`. Twilio uses one endpoint with different JSON per channel: WhatsApp needs `{ channel: "WHATSAPP", messageId }` (the latest inbound Message SID), and RCS needs `{ channel: "RCS", from, to, event: "START" }` with `rcs:` addresses.
+
+```typescript title="typing.ts" lineNumbers
+await thread.startTyping();
+
+await thread.post({
+  markdown: "Thanks, I am checking that now.",
+});
+```
+
+Custom status text is ignored. WhatsApp shows the indicator for up to 25 seconds or until the reply is delivered; RCS up to 20 seconds. SMS has no typing API, so `startTyping()` is a no-op.
+
 ## Media
 
 Inbound MMS media is exposed as message attachments. Twilio media URLs are not treated as public files, so each attachment includes `fetchData()` and `fetchMetadata` for authenticated downloads and queue rehydration.
@@ -304,7 +320,7 @@ For live calls, `updateTwilioCall()` in `@chat-adapter/twilio/api` can post repl
 
 ### Notes
 
-- Twilio does not support message edits, reactions, modals, or typing indicators for SMS.
+- Twilio does not support message edits, reactions, or modals. Typing indicators work on WhatsApp and RCS; SMS/MMS has no typing API.
 - Cards render as rich RCS content when the sender is a Messaging Service (`MG…`) or RCS address; otherwise they fall back to plain text.
 - RCS read receipts (`EventType=READ`) are parsed and logged but not surfaced to Chat SDK handlers (no delivery API exists today).
 - `fetchMessages` uses the Messages API and is best for phone-number based threads. Messaging Service history can be less precise because inbound webhooks identify the receiving phone number, not only the Messaging Service SID.

--- a/packages/adapter-twilio/README.md
+++ b/packages/adapter-twilio/README.md
@@ -78,6 +78,8 @@ WhatsApp and RCS conversations can show a typing indicator via `thread.startTypi
 - WhatsApp: `{ channel: "WHATSAPP", messageId }` (inbound Message SID)
 - RCS: `{ channel: "RCS", from: "rcs:<agent_id>", to: "rcs:+E164", event: "START" }`
 
+Messaging Service (`MG…`) threads are treated as SMS unless `rcsSenderId` is set or the thread sender is already `rcs:`.
+
 ## Media
 
 Inbound MMS media is exposed as attachments. Twilio media URLs are private, so attachments include `fetchData()` for authenticated downloads.

--- a/packages/adapter-twilio/README.md
+++ b/packages/adapter-twilio/README.md
@@ -71,6 +71,13 @@ createTwilioAdapter({
 
 Use `phoneNumber` for a single Twilio number, or `messagingServiceSid` when sending through a Twilio Messaging Service.
 
+## Typing indicators
+
+WhatsApp and RCS conversations can show a typing indicator via `thread.startTyping()`. Twilio's v3 Indicators API uses one URL with channel-specific JSON:
+
+- WhatsApp: `{ channel: "WHATSAPP", messageId }` (inbound Message SID)
+- RCS: `{ channel: "RCS", from: "rcs:<agent_id>", to: "rcs:+E164", event: "START" }`
+
 ## Media
 
 Inbound MMS media is exposed as attachments. Twilio media URLs are private, so attachments include `fetchData()` for authenticated downloads.

--- a/packages/adapter-twilio/src/api/index.test.ts
+++ b/packages/adapter-twilio/src/api/index.test.ts
@@ -7,6 +7,7 @@ import {
   fetchTwilioMessage,
   listTwilioMessages,
   sendTwilioMessage,
+  sendTwilioTypingIndicator,
   TwilioApiError,
   updateTwilioCall,
 } from "./index";
@@ -211,6 +212,91 @@ describe("Twilio api helpers", () => {
     expect(accountSid).not.toHaveBeenCalled();
     expect(authToken).not.toHaveBeenCalled();
     expect(request).not.toHaveBeenCalled();
+  });
+
+  it("sends typing indicators as JSON to the messaging API", async () => {
+    const request = mockFetch({ success: true });
+
+    const result = await sendTwilioTypingIndicator({
+      channel: "WHATSAPP",
+      credentials: credentials(),
+      fetch: request,
+      messageId: "SM123",
+    });
+
+    expect(result).toEqual({ success: true });
+    expect(String(request.mock.calls[0]?.[0])).toBe(
+      "https://messaging.twilio.com/v3/Indicators/Typing.json"
+    );
+    expect(request.mock.calls[0]?.[1]).toEqual(
+      expect.objectContaining({
+        body: JSON.stringify({
+          channel: "WHATSAPP",
+          messageId: "SM123",
+        }),
+        headers: {
+          authorization: "Basic QUMxMjM6dG9rZW4=",
+          "content-type": "application/json",
+        },
+        method: "POST",
+      })
+    );
+  });
+
+  it("sends an RCS typing body without messageId", async () => {
+    const request = mockFetch({ success: true });
+
+    await sendTwilioTypingIndicator({
+      channel: "RCS",
+      credentials: credentials(),
+      event: "START",
+      fetch: request,
+      from: "rcs:brand_agent",
+      to: "rcs:+15550000002",
+    });
+
+    expect(String(request.mock.calls[0]?.[0])).toBe(
+      "https://messaging.twilio.com/v3/Indicators/Typing.json"
+    );
+    expect(JSON.parse(String(request.mock.calls[0]?.[1]?.body))).toEqual({
+      channel: "RCS",
+      event: "START",
+      from: "rcs:brand_agent",
+      to: "rcs:+15550000002",
+    });
+  });
+
+  it("includes Twilio error details on typing indicator HTTP failures", async () => {
+    const request = mockFetch(
+      {
+        code: 20422,
+        message:
+          "the specified message cannot be used to send a typing indicator",
+      },
+      400
+    );
+
+    await expect(
+      sendTwilioTypingIndicator({
+        credentials: credentials(),
+        fetch: request,
+        messageId: "SMoutbound",
+      })
+    ).rejects.toThrow(
+      "Twilio API returned HTTP 400: 20422 the specified message cannot be used to send a typing indicator"
+    );
+  });
+
+  it("throws TwilioApiError when typing indicator success is false", async () => {
+    const request = mockFetch({ success: false });
+
+    await expect(
+      sendTwilioTypingIndicator({
+        credentials: credentials(),
+        fetch: request,
+        messageId: "SM123",
+      })
+    ).rejects.toBeInstanceOf(TwilioApiError);
   });
 
   it("throws TwilioApiError for non-ok responses", async () => {

--- a/packages/adapter-twilio/src/api/index.ts
+++ b/packages/adapter-twilio/src/api/index.ts
@@ -104,6 +104,14 @@ export interface ListTwilioMessagesOptions extends TwilioApiOptions {
   to?: string;
 }
 
+export interface SendTwilioTypingIndicatorOptions extends TwilioApiOptions {
+  channel?: "RCS" | "WHATSAPP";
+  event?: "START";
+  from?: string;
+  messageId?: string;
+  to?: string;
+}
+
 export interface CallTwilioApiOptions extends TwilioApiOptions {
   body?: TwilioFormFields | URLSearchParams;
   method?: "DELETE" | "GET" | "POST";
@@ -116,14 +124,30 @@ export class TwilioApiError extends Error {
   status: number;
 
   constructor(message: string, options: { body: unknown; status: number }) {
-    super(message);
+    super(appendTwilioErrorDetail(message, options.body));
     this.name = "TwilioApiError";
     this.body = options.body;
     this.status = options.status;
   }
 }
 
+function appendTwilioErrorDetail(message: string, body: unknown): string {
+  if (typeof body === "string" && body.trim()) {
+    return `${message}: ${body.trim()}`;
+  }
+  if (!body || typeof body !== "object") {
+    return message;
+  }
+  const record = body as { code?: unknown; message?: unknown };
+  const details = [
+    record.code == null ? undefined : String(record.code),
+    typeof record.message === "string" ? record.message : undefined,
+  ].filter(Boolean);
+  return details.length > 0 ? `${message}: ${details.join(" ")}` : message;
+}
+
 const DEFAULT_API_URL = "https://api.twilio.com";
+const DEFAULT_MESSAGING_API_URL = "https://messaging.twilio.com";
 
 export async function resolveTwilioCredential(
   value: TwilioCredential | undefined,
@@ -318,6 +342,60 @@ export async function fetchTwilioMedia(
     });
   }
   return response.arrayBuffer();
+}
+
+export async function sendTwilioTypingIndicator(
+  options: SendTwilioTypingIndicatorOptions
+): Promise<{ success?: boolean }> {
+  const body: Record<string, string> = {};
+  if (options.channel) {
+    body.channel = options.channel;
+  }
+  if (options.event) {
+    body.event = options.event;
+  }
+  if (options.from) {
+    body.from = options.from;
+  }
+  if (options.to) {
+    body.to = options.to;
+  }
+  if (options.messageId) {
+    body.messageId = options.messageId;
+  }
+  const accountSid = await resolveTwilioCredential(
+    options.credentials?.accountSid,
+    "TWILIO_ACCOUNT_SID"
+  );
+  const authToken = await resolveTwilioCredential(
+    options.credentials?.authToken,
+    "TWILIO_AUTH_TOKEN"
+  );
+  const url = new URL("/v3/Indicators/Typing.json", DEFAULT_MESSAGING_API_URL);
+  const request = options.fetch ?? fetch;
+  const response = await request(url, {
+    body: JSON.stringify(body),
+    headers: {
+      authorization: twilioAuthorization(accountSid, authToken),
+      "content-type": "application/json",
+    },
+    method: "POST",
+  });
+  const responseBody = await parseTwilioResponse(response);
+  if (!response.ok) {
+    throw new TwilioApiError(`Twilio API returned HTTP ${response.status}`, {
+      body: responseBody,
+      status: response.status,
+    });
+  }
+  const result = (responseBody ?? {}) as { success?: boolean };
+  if (result.success === false) {
+    throw new TwilioApiError("Twilio typing indicator failed", {
+      body: responseBody,
+      status: response.status,
+    });
+  }
+  return result;
 }
 
 export async function listTwilioMessages(

--- a/packages/adapter-twilio/src/channel.ts
+++ b/packages/adapter-twilio/src/channel.ts
@@ -69,6 +69,10 @@ export function isRcsCapableSender(sender: string): boolean {
   return sender.startsWith("MG") || isRcsAddress(sender);
 }
 
+export function isWhatsAppAddress(address: string): boolean {
+  return address.startsWith(WHATSAPP_PREFIX);
+}
+
 export function normalizeRcsSenderId(senderId: string): string {
   return senderId.startsWith(RCS_PREFIX)
     ? senderId

--- a/packages/adapter-twilio/src/index.test.ts
+++ b/packages/adapter-twilio/src/index.test.ts
@@ -861,6 +861,98 @@ describe("TwilioAdapter", () => {
   });
 });
 
+describe("startTyping", () => {
+  const whatsappThreadId =
+    "twilio:whatsapp%3A%2B15550000001:whatsapp%3A%2B15550000002";
+  const rcsThreadId = "twilio:MG123:%2B15550000002";
+  const smsThreadId = "twilio:%2B15550000001:%2B15550000002";
+
+  it("sends a WhatsApp typing indicator for the latest inbound message", async () => {
+    const fetch = mockFetch({ success: true });
+    const adapter = createTwilioAdapter({
+      accountSid: "AC123",
+      authToken: "token",
+      fetch,
+    });
+    const chat = new Chat({
+      adapters: { twilio: adapter },
+      logger: createMockLogger(),
+      state: createMockState(),
+      userName: "bot",
+    });
+    await chat.initialize();
+    await chat.handleIncomingMessage(
+      adapter,
+      whatsappThreadId,
+      createTestMessage("SMinbound", "hello", {
+        author: {
+          fullName: "whatsapp:+15550000002",
+          isBot: false,
+          isMe: false,
+          userId: "whatsapp:+15550000002",
+          userName: "whatsapp:+15550000002",
+        },
+        threadId: whatsappThreadId,
+      })
+    );
+
+    await adapter.startTyping(whatsappThreadId, "thinking");
+
+    expect(String(fetch.mock.calls[0]?.[0])).toBe(
+      "https://messaging.twilio.com/v3/Indicators/Typing.json"
+    );
+    expect(JSON.parse(String(fetch.mock.calls[0]?.[1]?.body))).toEqual({
+      channel: "WHATSAPP",
+      messageId: "SMinbound",
+    });
+  });
+
+  it("skips WhatsApp typing when there is no inbound Message SID", async () => {
+    const fetch = mockFetch({ success: true });
+    const adapter = createTwilioAdapter({
+      accountSid: "AC123",
+      authToken: "token",
+      fetch,
+    });
+
+    await adapter.startTyping(whatsappThreadId);
+
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  it("sends an RCS typing indicator with rcs: addresses", async () => {
+    const fetch = mockFetch({ success: true });
+    const adapter = createTwilioAdapter({
+      accountSid: "AC123",
+      authToken: "token",
+      fetch,
+      rcsSenderId: "brand_agent",
+    });
+
+    await adapter.startTyping(rcsThreadId);
+
+    expect(JSON.parse(String(fetch.mock.calls[0]?.[1]?.body))).toEqual({
+      channel: "RCS",
+      event: "START",
+      from: "rcs:brand_agent",
+      to: "rcs:+15550000002",
+    });
+  });
+
+  it("does not post typing for SMS threads", async () => {
+    const fetch = mockFetch({ success: true });
+    const adapter = createTwilioAdapter({
+      accountSid: "AC123",
+      authToken: "token",
+      fetch,
+    });
+
+    await adapter.startTyping(smsThreadId);
+
+    expect(fetch).not.toHaveBeenCalled();
+  });
+});
+
 const threadIdAdapter = createTwilioAdapter();
 
 threadIdContract<TwilioThreadId>({

--- a/packages/adapter-twilio/src/index.test.ts
+++ b/packages/adapter-twilio/src/index.test.ts
@@ -939,6 +939,38 @@ describe("startTyping", () => {
     });
   });
 
+  it("does not post typing for Messaging Service SMS threads", async () => {
+    const fetch = mockFetch({ success: true });
+    const adapter = createTwilioAdapter({
+      accountSid: "AC123",
+      authToken: "token",
+      fetch,
+    });
+
+    await adapter.startTyping(rcsThreadId);
+
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  it("sends RCS typing from an rcs: thread sender without rcsSenderId", async () => {
+    const fetch = mockFetch({ success: true });
+    const adapter = createTwilioAdapter({
+      accountSid: "AC123",
+      authToken: "token",
+      fetch,
+    });
+    const threadId = "twilio:rcs%3Abrand_agent:%2B15550000002";
+
+    await adapter.startTyping(threadId);
+
+    expect(JSON.parse(String(fetch.mock.calls[0]?.[1]?.body))).toEqual({
+      channel: "RCS",
+      event: "START",
+      from: "rcs:brand_agent",
+      to: "rcs:+15550000002",
+    });
+  });
+
   it("does not post typing for SMS threads", async () => {
     const fetch = mockFetch({ success: true });
     const adapter = createTwilioAdapter({

--- a/packages/adapter-twilio/src/index.ts
+++ b/packages/adapter-twilio/src/index.ts
@@ -325,27 +325,29 @@ export class TwilioAdapter
       });
       return;
     }
-    if (
-      isRcsAddress(thread.sender) ||
-      isRcsAddress(thread.recipient) ||
-      isRcsCapableSender(thread.sender)
-    ) {
-      let from = thread.sender;
-      if (!isRcsAddress(from) && this.rcsSenderId) {
-        from = normalizeRcsSenderId(this.rcsSenderId);
-      }
-      let to = thread.recipient;
-      if (!isRcsAddress(to) && to.startsWith("+")) {
-        to = `rcs:${to}`;
-      }
-      await sendTwilioTypingIndicator({
-        ...this.apiOptions(),
-        channel: "RCS",
-        event: "START",
-        from,
-        to,
-      });
+    let from = thread.sender;
+    if (!isRcsAddress(from) && this.rcsSenderId) {
+      from = normalizeRcsSenderId(this.rcsSenderId);
     }
+    // MG senders can be SMS or RCS. Only POST when `from` is a real RCS
+    // agent id so SMS threads keyed by a Messaging Service stay a no-op.
+    if (!isRcsAddress(from)) {
+      return;
+    }
+    let to = thread.recipient;
+    if (!isRcsAddress(to) && to.startsWith("+")) {
+      to = `rcs:${to}`;
+    }
+    if (!isRcsAddress(to)) {
+      return;
+    }
+    await sendTwilioTypingIndicator({
+      ...this.apiOptions(),
+      channel: "RCS",
+      event: "START",
+      from,
+      to,
+    });
   }
 
   parseMessage(raw: TwilioRawMessage): Message<TwilioRawMessage> {

--- a/packages/adapter-twilio/src/index.ts
+++ b/packages/adapter-twilio/src/index.ts
@@ -18,13 +18,19 @@ import type {
   UserInfo,
   WebhookOptions,
 } from "chat";
-import { ConsoleLogger, Message, NotImplementedError } from "chat";
+import {
+  ConsoleLogger,
+  Message,
+  NotImplementedError,
+  ThreadHistoryCache,
+} from "chat";
 import {
   deleteTwilioMessage,
   fetchTwilioMedia,
   fetchTwilioMessage,
   listTwilioMessages,
   sendTwilioMessage,
+  sendTwilioTypingIndicator,
   type TwilioApiOptions,
   type TwilioMessageResource,
 } from "./api";
@@ -36,7 +42,9 @@ import {
   TWILIO_EMPTY_CARD_FALLBACK,
 } from "./cards";
 import {
+  isRcsAddress,
   isRcsCapableSender,
+  isWhatsAppAddress,
   normalizeRcsSenderId,
   resolveInboundThreadSender,
 } from "./channel";
@@ -300,7 +308,45 @@ export class TwilioAdapter
     );
   }
 
-  async startTyping(): Promise<void> {}
+  async startTyping(threadId: string, _status?: string): Promise<void> {
+    const thread = this.decodeThreadId(threadId);
+    if (
+      isWhatsAppAddress(thread.sender) ||
+      isWhatsAppAddress(thread.recipient)
+    ) {
+      const messageId = await this.latestInboundMessageId(threadId);
+      if (!messageId) {
+        return;
+      }
+      await sendTwilioTypingIndicator({
+        ...this.apiOptions(),
+        channel: "WHATSAPP",
+        messageId,
+      });
+      return;
+    }
+    if (
+      isRcsAddress(thread.sender) ||
+      isRcsAddress(thread.recipient) ||
+      isRcsCapableSender(thread.sender)
+    ) {
+      let from = thread.sender;
+      if (!isRcsAddress(from) && this.rcsSenderId) {
+        from = normalizeRcsSenderId(this.rcsSenderId);
+      }
+      let to = thread.recipient;
+      if (!isRcsAddress(to) && to.startsWith("+")) {
+        to = `rcs:${to}`;
+      }
+      await sendTwilioTypingIndicator({
+        ...this.apiOptions(),
+        channel: "RCS",
+        event: "START",
+        from,
+        to,
+      });
+    }
+  }
 
   parseMessage(raw: TwilioRawMessage): Message<TwilioRawMessage> {
     if (isTwilioWebhookPayload(raw)) {
@@ -566,6 +612,24 @@ export class TwilioAdapter
     };
   }
 
+  protected async latestInboundMessageId(
+    threadId: string
+  ): Promise<string | null> {
+    if (!this.chat) {
+      return null;
+    }
+    const history = await new ThreadHistoryCache(
+      this.chat.getState()
+    ).getMessages(threadId);
+    for (let index = history.length - 1; index >= 0; index--) {
+      const message = history[index];
+      if (message && !message.author.isMe) {
+        return message.id;
+      }
+    }
+    return null;
+  }
+
   protected defaultSender(): string {
     // phoneNumber-first matches the adapter's pre-RCS behavior so openDM()
     // keeps producing the same thread ids for existing deployments that
@@ -646,6 +710,7 @@ export {
   inferTwilioChannel,
   isRcsAddress,
   isRcsCapableSender,
+  isWhatsAppAddress,
   normalizeRcsSenderId,
   resolveInboundThreadSender,
 } from "./channel";


### PR DESCRIPTION
## Summary

Adds typing indicators on the Twilio adapter for WhatsApp and RCS, using Twilio’s [v3 Indicators API](https://www.twilio.com/en-us/changelog/v3-typing-indicator-api) (`POST https://messaging.twilio.com/v3/Indicators/Typing.json`).

- **WhatsApp:** `{ channel: "WHATSAPP", messageId }` — `messageId` must be an inbound SM/MM SID
- **RCS:** `{ channel: "RCS", from: "rcs:<agent_id>", to: "rcs:+E164", event: "START" }`

SMS/MMS has no typing API, so `startTyping()` is a no-op there. Docs mark the feature as `typingIndicator: partial` (WhatsApp + RCS).

### Behavior notes

- **WhatsApp** only sends typing when Chat has inbound thread history (so we have a Message SID). `startTyping()` before any inbound message is a no-op; an outbound SID is rejected by Twilio (20422).
- **RCS** needs `from` in `rcs:<agent_id>` form. If the thread is keyed by a Messaging Service SID (`MG…`), set `rcsSenderId` / `TWILIO_RCS_SENDER_ID`. Otherwise we still POST `from=MG…` and Twilio returns 400 (`from must match rcs:<agent_id>`).

## Test plan

- Unit tests for the WhatsApp body, RCS body, WhatsApp-without-SID no-op, and SMS no-op
- `pnpm validate` passes locally
- Manually tested against a real Twilio account on both channels
- Cross-checked [RCS typing docs](https://www.twilio.com/docs/rcs/send-an-rcs-message#send-an-rcs-typing-indicator) and [WhatsApp typing docs](https://www.twilio.com/docs/whatsapp/api/typing-indicators-resource#send-a-typing-indicator)

Live failures we hit were **sender-profile** issues (tester agent / region), not payload shape, once the two bodies above were used.

## Checklist

- [x] All commits are signed and verified
- [x] All commits are signed off for the DCO (`git commit -s`)
- [x] `pnpm validate` passes
- [x] Changeset added (or N/A — see [CONTRIBUTING.md](./CONTRIBUTING.md))
- [x] Documentation updated (or N/A)