### PR TITLE
fix(chat): retry initialization after a failed attempt

### DIFF
--- a/.changeset/brave-owls-retry.md
+++ b/.changeset/brave-owls-retry.md
@@ -1,0 +1,5 @@
+---
+"chat": patch
+---
+
+Retry initialization after a failed attempt. `Chat` no longer keeps a rejected initialization promise, so once the state adapter (for example Redis) recovers, the next `initialize()` call or webhook tries again instead of rejecting with the original connection error until the process restarts. Concurrent callers still share one attempt.

--- a/packages/chat/src/chat.test.ts
+++ b/packages/chat/src/chat.test.ts
@@ -5826,3 +5826,72 @@ describe("Chat", () => {
     });
   });
 });
+
+describe("Chat initialization retry (#922)", () => {
+  it("retries initialization after a failed attempt once the state recovers", async () => {
+    const mockAdapter = createMockAdapter("slack");
+    const mockState = createMockState();
+    const refused = Object.assign(new Error("connect ECONNREFUSED"), {
+      code: "ECONNREFUSED",
+    });
+    mockState.connect = vi
+      .fn()
+      .mockRejectedValueOnce(refused)
+      .mockResolvedValue(undefined);
+
+    const chat = new Chat({
+      userName: "testbot",
+      adapters: { slack: mockAdapter },
+      state: mockState,
+      logger: mockLogger,
+    });
+
+    await expect(chat.initialize()).rejects.toBe(refused);
+    // The adapters were never reached by the failed attempt.
+    expect(mockAdapter.initialize).not.toHaveBeenCalled();
+
+    // Redis is back: the next call must try again instead of replaying the
+    // rejected promise.
+    await expect(chat.initialize()).resolves.toBeUndefined();
+    expect(mockState.connect).toHaveBeenCalledTimes(2);
+    expect(mockAdapter.initialize).toHaveBeenCalledTimes(1);
+
+    // Once initialized, further calls are no-ops.
+    await chat.initialize();
+    expect(mockState.connect).toHaveBeenCalledTimes(2);
+  });
+
+  it("still shares one attempt between concurrent callers, including a failing one", async () => {
+    const mockAdapter = createMockAdapter("slack");
+    const mockState = createMockState();
+    let rejectConnect: (error: Error) => void = () => {};
+    mockState.connect = vi
+      .fn()
+      .mockImplementationOnce(
+        () =>
+          new Promise<void>((_, reject) => {
+            rejectConnect = reject;
+          })
+      )
+      .mockResolvedValue(undefined);
+
+    const chat = new Chat({
+      userName: "testbot",
+      adapters: { slack: mockAdapter },
+      state: mockState,
+      logger: mockLogger,
+    });
+
+    const first = chat.initialize();
+    const second = chat.initialize();
+    expect(mockState.connect).toHaveBeenCalledTimes(1);
+
+    const refused = new Error("connect ECONNREFUSED");
+    rejectConnect(refused);
+    await expect(first).rejects.toBe(refused);
+    await expect(second).rejects.toBe(refused);
+
+    await expect(chat.initialize()).resolves.toBeUndefined();
+    expect(mockState.connect).toHaveBeenCalledTimes(2);
+  });
+});

--- a/packages/chat/src/chat.ts
+++ b/packages/chat/src/chat.ts
@@ -497,9 +497,17 @@ export class Chat<
       return;
     }
 
-    // Avoid concurrent initialization
+    // Avoid concurrent initialization. A failed attempt is forgotten so the
+    // next caller retries once the dependency (e.g. Redis) has recovered,
+    // instead of every later webhook rejecting with the first error (#922).
     if (!this.initPromise) {
-      this.initPromise = this.doInitialize();
+      const attempt = this.doInitialize().catch((error: unknown) => {
+        if (this.initPromise === attempt) {
+          this.initPromise = null;
+        }
+        throw error;
+      });
+      this.initPromise = attempt;
     }
 
     await this.initPromise;


### PR DESCRIPTION
## Summary

Fixes #922.

`Chat.ensureInitialized()` cached the first `doInitialize()` promise for the lifetime of the instance. When the state adapter's `connect()` rejected (Redis refusing the connection at startup, as in the issue's reproduction), that rejected promise was replayed to every later `initialize()` call and webhook, even after the ioredis adapter and the Redis client had recovered. Only `shutdown()` or a process restart cleared it.

The failed attempt is now forgotten: the rejection still propagates to everyone awaiting that attempt, but the next caller starts a new one. Concurrent callers keep sharing the in-flight attempt, and a successful initialization stays a no-op for later calls. The guard `this.initPromise === attempt` keeps a `shutdown()` that ran in between from being clobbered.

Note on partial failures: if `connect()` succeeds but an adapter's `initialize()` throws, the retry runs `doInitialize()` again from the top, including `connect()` and every adapter's `initialize()`. That matches what already happens after `shutdown()` today; the issue's case never reaches the adapters.

## Test plan

Two tests in `packages/chat/src/chat.test.ts`:

- `connect()` rejects once (`ECONNREFUSED`) and then resolves: the first `initialize()` rejects with that error and never reaches the adapters, the second succeeds (`connect` called twice, adapter initialized once), and a third call is a no-op.
- Two concurrent callers during a failing attempt share it (one `connect` call, both reject with the same error), and the next call succeeds.

```
packages/chat: npx vitest run src/chat.test.ts   # 179 passed
packages/chat: npx tsc --noEmit                   # clean
pnpm check                                        # 720 files, no fixes, 1 pre-existing warning outside this diff
```

`pnpm knip` did not run to completion here because only the `chat...` workspace subset is installed locally (missing `tsup` binaries in other packages), not because of this change.

## Checklist

- [x] All commits are signed and verified
- [x] All commits are signed off for the DCO (`git commit -s`)
- [ ] `pnpm validate` passes (partial, see above; CI will run the full set)
- [x] Changeset added (or N/A — see [CONTRIBUTING.md](./CONTRIBUTING.md))
- [x] Documentation updated (or N/A)