### PR TITLE
chore(discord): update discord-api-types to 0.38 and dedupe types

### DIFF
--- a/.changeset/bump-discord-api-types.md
+++ b/.changeset/bump-discord-api-types.md
@@ -1,0 +1,5 @@
+---
+"@chat-adapter/discord": patch
+---
+
+Update `discord-api-types` from 0.37 to 0.38 and import `MessageType` from `discord-api-types/v10` instead of the deprecated `v9` entrypoint. This also dedupes the copy pulled in by `discord.js`, so only one version of the package is installed.

--- a/.changeset/bump-discord-api-types.md
+++ b/.changeset/bump-discord-api-types.md
@@ -2,4 +2,4 @@
 "@chat-adapter/discord": patch
 ---
 
-Update `discord-api-types` from 0.37 to 0.38 and import `MessageType` from `discord-api-types/v10` instead of the deprecated `v9` entrypoint. This also dedupes the copy pulled in by `discord.js`, so only one version of the package is installed.
+Update `discord-api-types` from 0.37 to 0.38 and use its types for every Discord payload instead of hand-written copies. `DiscordComponentType` and `DiscordMessageFlag` are now re-exports of `ComponentType` and `MessageFlags`, with the same values. Gateway forwarding now includes the channel type and, for DM reactions, the reacting user on reaction events, so forwarded reactions in threads and DMs resolve correctly.

--- a/.changeset/bump-discord-api-types.md
+++ b/.changeset/bump-discord-api-types.md
@@ -1,5 +1,9 @@
 ---
-"@chat-adapter/discord": patch
+"@chat-adapter/discord": minor
 ---
 
-Update `discord-api-types` from 0.37 to 0.38 and use its types for every Discord payload instead of hand-written copies. `DiscordComponentType` and `DiscordMessageFlag` are now re-exports of `ComponentType` and `MessageFlags`, with the same values. Gateway forwarding now includes the channel type and, for DM reactions, the reacting user on reaction events, so forwarded reactions in threads and DMs resolve correctly.
+Update `discord-api-types` from 0.37 to 0.38 and use its types for every Discord payload instead of hand-written copies. `DiscordComponentType` and `DiscordMessageFlag` are now re-exports of `ComponentType` and `MessageFlags`, with the same values.
+
+Type changes for TypeScript consumers of `DiscordInteractionFlagsContext`: `interaction` is now `APIChatInputApplicationCommandInteraction` and `user` is `APIUser`, so `user.avatar` and `user.global_name` are `string | null` instead of optional strings. Application command interactions other than chat input (context menu commands) now receive a 400 response instead of being treated as slash commands.
+
+Gateway forwarding now includes the channel type and, for DM reactions, the reacting user on reaction events, so forwarded reactions in threads and DMs resolve correctly.

--- a/packages/adapter-discord/AGENTS.md
+++ b/packages/adapter-discord/AGENTS.md
@@ -237,8 +237,9 @@ When you add a new interaction type, capture a fresh fixture in
 ## Coding conventions
 
 - Use named exports throughout. No default exports.
-- The Discord API typings live in `types.ts` — extend them rather
-  than reaching for `discord-api-types` for new fields.
+- Discord payload types come from `discord-api-types/v10`. `types.ts`
+  only declares adapter configuration and the Gateway forwarding
+  envelope; do not hand-write Discord API shapes.
 - Errors map to `@chat-adapter/shared` (`AuthenticationError`,
   `AdapterRateLimitError`, `NetworkError`, `ValidationError`).
 - Top-level regex literals only.

--- a/packages/adapter-discord/package.json
+++ b/packages/adapter-discord/package.json
@@ -29,7 +29,7 @@
   "dependencies": {
     "@chat-adapter/shared": "workspace:*",
     "chat": "workspace:*",
-    "discord-api-types": "^0.37.119",
+    "discord-api-types": "^0.38.55",
     "discord-interactions": "^4.4.0",
     "discord.js": "^14.25.1"
   },

--- a/packages/adapter-discord/src/cards.ts
+++ b/packages/adapter-discord/src/cards.ts
@@ -27,24 +27,31 @@ import {
   convertEmojiPlaceholders,
   tableElementToAscii,
 } from "chat";
-import type { APIEmbed, APIEmbedField } from "discord-api-types/v10";
-import { ButtonStyle } from "discord-api-types/v10";
-import type {
-  DiscordActionRow,
-  DiscordButton,
-  DiscordContainerChild,
-  DiscordMediaGallery,
-  DiscordMessageComponent,
-  DiscordSection,
-  DiscordStringSelect,
-  DiscordTextDisplay,
-  DiscordThumbnail,
-} from "./types";
 import {
-  DiscordComponentType,
-  DiscordContentFormat,
-  DiscordMessageFlag,
-} from "./types";
+  type APIActionRowComponent,
+  type APIButtonComponent,
+  type APIButtonComponentWithCustomId,
+  type APIButtonComponentWithURL,
+  type APIComponentInContainer,
+  type APIEmbed,
+  type APIEmbedField,
+  type APIMediaGalleryComponent,
+  type APIMessageTopLevelComponent,
+  type APISectionComponent,
+  type APIStringSelectComponent,
+  type APITextDisplayComponent,
+  type APIThumbnailComponent,
+  ButtonStyle,
+  ComponentType,
+  MessageFlags,
+  type RESTPostAPIChannelMessageJSONBody,
+  SeparatorSpacingSize,
+} from "discord-api-types/v10";
+import { DiscordContentFormat } from "./types";
+
+type DiscordActionRow = APIActionRowComponent<
+  APIButtonComponent | APIStringSelectComponent
+>;
 
 const DISCORD_CUSTOM_ID_DELIMITER = "\n";
 const DISCORD_CUSTOM_ID_MAX_LENGTH = 100;
@@ -59,22 +66,18 @@ interface DiscordCardPayloadOptions {
   contentFormat?: DiscordContentFormat;
 }
 
-interface DiscordEmbedCardPayload {
+type DiscordCardPayload = Required<
+  Pick<RESTPostAPIChannelMessageJSONBody, "components" | "embeds">
+> &
+  Pick<RESTPostAPIChannelMessageJSONBody, "flags">;
+
+interface DiscordEmbedCardPayload extends DiscordCardPayload {
   components: DiscordActionRow[];
-  embeds: APIEmbed[];
-  flags?: number;
 }
 
-interface DiscordComponentsV2CardPayload {
-  components: DiscordMessageComponent[];
+interface DiscordComponentsV2CardPayload extends DiscordCardPayload {
   embeds: [];
-  flags: number;
-}
-
-interface DiscordCardPayload {
-  components: DiscordMessageComponent[];
-  embeds: APIEmbed[];
-  flags?: number;
+  flags: MessageFlags;
 }
 
 function validateDiscordCustomId(customId: string): void {
@@ -197,19 +200,19 @@ export function cardToDiscordPayload(
  * section accessories. Discord caps a single message at 40 total components.
  */
 function countComponentsV2(
-  components: readonly DiscordMessageComponent[]
+  components: readonly APIMessageTopLevelComponent[]
 ): number {
   let total = 0;
   for (const component of components) {
     total += 1;
     switch (component.type) {
-      case DiscordComponentType.Container:
+      case ComponentType.Container:
         total += countComponentsV2(component.components);
         break;
-      case DiscordComponentType.ActionRow:
+      case ComponentType.ActionRow:
         total += component.components.length;
         break;
-      case DiscordComponentType.Section:
+      case ComponentType.Section:
         total += component.components.length + 1;
         break;
       default:
@@ -223,17 +226,19 @@ function countComponentsV2(
  * Sum the character length of every Text Display in a Components v2 tree.
  * Discord caps the combined text across all text displays at 4000 characters.
  */
-function countTextV2(components: readonly DiscordMessageComponent[]): number {
+function countTextV2(
+  components: readonly APIMessageTopLevelComponent[]
+): number {
   let total = 0;
   for (const component of components) {
     switch (component.type) {
-      case DiscordComponentType.TextDisplay:
+      case ComponentType.TextDisplay:
         total += component.content.length;
         break;
-      case DiscordComponentType.Container:
+      case ComponentType.Container:
         total += countTextV2(component.components);
         break;
-      case DiscordComponentType.Section:
+      case ComponentType.Section:
         total += countTextV2(component.components);
         break;
       default:
@@ -250,7 +255,7 @@ function countTextV2(components: readonly DiscordMessageComponent[]): number {
  * overflow from either source with a clear error instead of an opaque 400.
  */
 export function validateComponentsV2(
-  components: readonly DiscordMessageComponent[]
+  components: readonly APIMessageTopLevelComponent[]
 ): void {
   const componentCount = countComponentsV2(components);
   if (componentCount > DISCORD_MAX_COMPONENTS_V2) {
@@ -272,7 +277,7 @@ export function validateComponentsV2(
 function cardToDiscordComponentsV2Payload(
   card: CardElement
 ): DiscordComponentsV2CardPayload {
-  const children: DiscordContainerChild[] = [];
+  const children: APIComponentInContainer[] = [];
 
   if (card.title) {
     children.push(toTextDisplay(`# ${convertEmoji(card.title)}`));
@@ -290,9 +295,9 @@ function cardToDiscordComponentsV2Payload(
     children.push(...cardChildToComponentsV2(child));
   }
 
-  const components: DiscordMessageComponent[] = [
+  const components: APIMessageTopLevelComponent[] = [
     {
-      type: DiscordComponentType.Container,
+      type: ComponentType.Container,
       accent_color: DISCORD_BLURPLE,
       components: children.length > 0 ? children : [toTextDisplay(" ")],
     },
@@ -302,7 +307,7 @@ function cardToDiscordComponentsV2Payload(
 
   return {
     embeds: [],
-    flags: DiscordMessageFlag.IsComponentsV2,
+    flags: MessageFlags.IsComponentsV2,
     components,
   };
 }
@@ -354,7 +359,7 @@ function processChild(
   }
 }
 
-function cardChildToComponentsV2(child: CardChild): DiscordContainerChild[] {
+function cardChildToComponentsV2(child: CardChild): APIComponentInContainer[] {
   switch (child.type) {
     case "text":
       return [toTextDisplay(convertTextElement(child))];
@@ -362,7 +367,11 @@ function cardChildToComponentsV2(child: CardChild): DiscordContainerChild[] {
       return [toMediaGallery(child)];
     case "divider":
       return [
-        { type: DiscordComponentType.Separator, divider: true, spacing: 1 },
+        {
+          type: ComponentType.Separator,
+          divider: true,
+          spacing: SeparatorSpacingSize.Small,
+        },
       ];
     case "actions":
       return convertActionsToV2Rows(child);
@@ -398,18 +407,18 @@ function convertTextElement(element: TextElement): string {
   return text;
 }
 
-function toTextDisplay(content: string): DiscordTextDisplay {
+function toTextDisplay(content: string): APITextDisplayComponent {
   return {
-    type: DiscordComponentType.TextDisplay,
+    type: ComponentType.TextDisplay,
     content,
   };
 }
 
 function toMediaGallery(
   image: ImageElement | { url: string }
-): DiscordMediaGallery {
+): APIMediaGalleryComponent {
   return {
-    type: DiscordComponentType.MediaGallery,
+    type: ComponentType.MediaGallery,
     items: [
       {
         media: {
@@ -423,9 +432,9 @@ function toMediaGallery(
   };
 }
 
-function toThumbnail(image: ImageElement): DiscordThumbnail {
+function toThumbnail(image: ImageElement): APIThumbnailComponent {
   return {
-    type: DiscordComponentType.Thumbnail,
+    type: ComponentType.Thumbnail,
     media: {
       url: image.url,
     },
@@ -446,7 +455,7 @@ function convertTableElement(element: TableElement): string {
  * Discord limits each action row to 5 components, so we chunk buttons.
  */
 function convertActionsToRows(element: ActionsElement): DiscordActionRow[] {
-  const buttons: DiscordButton[] = element.children
+  const buttons: APIButtonComponent[] = element.children
     .filter((child) => child.type === "button" || child.type === "link-button")
     .map((button) => {
       if (button.type === "link-button") {
@@ -458,7 +467,7 @@ function convertActionsToRows(element: ActionsElement): DiscordActionRow[] {
   const rows: DiscordActionRow[] = [];
   for (let i = 0; i < buttons.length; i += DISCORD_MAX_BUTTONS_PER_ROW) {
     rows.push({
-      type: DiscordComponentType.ActionRow,
+      type: ComponentType.ActionRow,
       components: buttons.slice(i, i + DISCORD_MAX_BUTTONS_PER_ROW),
     });
   }
@@ -467,12 +476,12 @@ function convertActionsToRows(element: ActionsElement): DiscordActionRow[] {
 
 function convertActionsToV2Rows(element: ActionsElement): DiscordActionRow[] {
   const rows: DiscordActionRow[] = [];
-  let buttons: DiscordButton[] = [];
+  let buttons: APIButtonComponent[] = [];
 
   const flushButtons = () => {
     for (let i = 0; i < buttons.length; i += DISCORD_MAX_BUTTONS_PER_ROW) {
       rows.push({
-        type: DiscordComponentType.ActionRow,
+        type: ComponentType.ActionRow,
         components: buttons.slice(i, i + DISCORD_MAX_BUTTONS_PER_ROW),
       });
     }
@@ -492,7 +501,7 @@ function convertActionsToV2Rows(element: ActionsElement): DiscordActionRow[] {
 
     flushButtons();
     rows.push({
-      type: DiscordComponentType.ActionRow,
+      type: ComponentType.ActionRow,
       components: [convertSelectElement(child)],
     });
   }
@@ -504,9 +513,11 @@ function convertActionsToV2Rows(element: ActionsElement): DiscordActionRow[] {
 /**
  * Convert a button element to a Discord button.
  */
-function convertButtonElement(button: ButtonElement): DiscordButton {
-  const discordButton: DiscordButton = {
-    type: DiscordComponentType.Button,
+function convertButtonElement(
+  button: ButtonElement
+): APIButtonComponentWithCustomId {
+  const discordButton: APIButtonComponentWithCustomId = {
+    type: ComponentType.Button,
     style: getButtonStyle(button.style),
     label: button.label,
     custom_id: encodeDiscordCustomId(button.id, button.value),
@@ -522,9 +533,11 @@ function convertButtonElement(button: ButtonElement): DiscordButton {
 /**
  * Convert a link button element to a Discord link button.
  */
-function convertLinkButtonElement(button: LinkButtonElement): DiscordButton {
+function convertLinkButtonElement(
+  button: LinkButtonElement
+): APIButtonComponentWithURL {
   return {
-    type: DiscordComponentType.Button,
+    type: ComponentType.Button,
     style: ButtonStyle.Link,
     label: button.label,
     url: button.url,
@@ -533,7 +546,7 @@ function convertLinkButtonElement(button: LinkButtonElement): DiscordButton {
 
 function convertSelectElement(
   select: SelectElement | RadioSelectElement
-): DiscordStringSelect {
+): APIStringSelectComponent {
   const options = select.options
     .slice(0, DISCORD_MAX_SELECT_OPTIONS)
     .map((option) => ({
@@ -546,7 +559,7 @@ function convertSelectElement(
     }));
 
   return {
-    type: DiscordComponentType.StringSelect,
+    type: ComponentType.StringSelect,
     custom_id: encodeDiscordCustomId(select.id),
     options,
     max_values: 1,
@@ -560,7 +573,9 @@ function convertSelectElement(
 /**
  * Map button style to Discord button style.
  */
-function getButtonStyle(style?: ButtonElement["style"]): ButtonStyle {
+function getButtonStyle(
+  style?: ButtonElement["style"]
+): APIButtonComponentWithCustomId["style"] {
   switch (style) {
     case "primary":
       return ButtonStyle.Primary;
@@ -587,10 +602,10 @@ function processSectionElement(
 
 function convertSectionElementToV2(
   element: SectionElement
-): DiscordContainerChild[] {
-  const textDisplays: DiscordTextDisplay[] = [];
-  const extraComponents: DiscordContainerChild[] = [];
-  let accessory: DiscordSection["accessory"] | undefined;
+): APIComponentInContainer[] {
+  const textDisplays: APITextDisplayComponent[] = [];
+  const extraComponents: APIComponentInContainer[] = [];
+  let accessory: APISectionComponent["accessory"] | undefined;
 
   for (const child of element.children) {
     switch (child.type) {
@@ -624,9 +639,9 @@ function convertSectionElementToV2(
       }
       case "divider":
         extraComponents.push({
-          type: DiscordComponentType.Separator,
+          type: ComponentType.Separator,
           divider: true,
-          spacing: 1,
+          spacing: SeparatorSpacingSize.Small,
         });
         break;
       case "section":
@@ -646,11 +661,11 @@ function convertSectionElementToV2(
     // A Discord Section requires text components to hold an accessory. When
     // there are no text displays, fall back to rendering the accessory as a
     // standalone component so its content isn't silently dropped.
-    const accessoryComponents: DiscordContainerChild[] = [];
+    const accessoryComponents: APIComponentInContainer[] = [];
     if (accessory) {
-      if (accessory.type === DiscordComponentType.Thumbnail) {
+      if (accessory.type === ComponentType.Thumbnail) {
         accessoryComponents.push({
-          type: DiscordComponentType.MediaGallery,
+          type: ComponentType.MediaGallery,
           items: [
             {
               media: { url: accessory.media.url },
@@ -662,7 +677,7 @@ function convertSectionElementToV2(
         });
       } else {
         accessoryComponents.push({
-          type: DiscordComponentType.ActionRow,
+          type: ComponentType.ActionRow,
           components: [accessory],
         });
       }
@@ -670,8 +685,8 @@ function convertSectionElementToV2(
     return [...textDisplays, ...accessoryComponents, ...extraComponents];
   }
 
-  const section: DiscordSection = {
-    type: DiscordComponentType.Section,
+  const section: APISectionComponent = {
+    type: ComponentType.Section,
     components: textDisplays.slice(0, DISCORD_MAX_SECTION_TEXT_DISPLAYS),
     accessory,
   };
@@ -685,7 +700,7 @@ function convertSectionElementToV2(
 
 function getSectionAccessoryButton(
   element: ActionsElement
-): DiscordButton | undefined {
+): APIButtonComponent | undefined {
   if (element.children.length !== 1) {
     return undefined;
   }
@@ -724,7 +739,7 @@ function convertFieldsElement(
 
 function convertFieldsElementToV2(
   element: FieldsElement
-): DiscordTextDisplay[] {
+): APITextDisplayComponent[] {
   if (element.children.length === 0) {
     return [];
   }

--- a/packages/adapter-discord/src/index.test.ts
+++ b/packages/adapter-discord/src/index.test.ts
@@ -12,7 +12,7 @@ import {
 } from "@chat-adapter/tests";
 import type { ChatInstance } from "chat";
 import { Actions, Button, Card, Select, SelectOption } from "chat";
-import { type Client, Events } from "discord.js";
+import { type Client, Collection, Events } from "discord.js";
 import { InteractionType } from "discord-api-types/v10";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
@@ -4097,6 +4097,17 @@ describe("legacy gateway interactions", () => {
     return new EventEmitter() as Client;
   }
 
+  // Fields discord.js sets on every BaseInteraction.
+  const gatewayInteractionBase = {
+    appPermissions: { bitfield: 0n },
+    attachmentSizeLimit: 8_388_608,
+    authorizingIntegrationOwners: {},
+    context: 0,
+    entitlements: new Collection(),
+    guildLocale: "en-US",
+    locale: "en-US",
+  };
+
   it("handles slash command interactions from the gateway", async () => {
     const adapter = new TestGatewayDiscordAdapter({
       botToken: "test-token",
@@ -4113,6 +4124,7 @@ describe("legacy gateway interactions", () => {
 
     adapter.listen(client);
     client.emit(Events.InteractionCreate, {
+      ...gatewayInteractionBase,
       id: "interaction123",
       applicationId: "test-app-id",
       token: "interaction-token",
@@ -4131,6 +4143,8 @@ describe("legacy gateway interactions", () => {
         globalName: "Test User",
         bot: false,
       },
+      commandGuildId: null,
+      commandId: "command123",
       commandName: "test",
       commandType: 1,
       options: {
@@ -4181,6 +4195,7 @@ describe("legacy gateway interactions", () => {
 
     adapter.listen(client);
     client.emit(Events.InteractionCreate, {
+      ...gatewayInteractionBase,
       id: "interaction123",
       applicationId: "test-app-id",
       token: "interaction-token",
@@ -4199,6 +4214,8 @@ describe("legacy gateway interactions", () => {
         globalName: "Test User",
         bot: false,
       },
+      commandGuildId: null,
+      commandId: "command123",
       commandName: "test",
       commandType: 1,
       options: {
@@ -4455,6 +4472,7 @@ describe("legacy gateway interactions", () => {
 
     adapter.listen(client);
     client.emit(Events.InteractionCreate, {
+      ...gatewayInteractionBase,
       id: "interaction123",
       applicationId: "test-app-id",
       token: "interaction-token",
@@ -4478,6 +4496,7 @@ describe("legacy gateway interactions", () => {
       message: {
         id: "message123",
       },
+      isAnySelectMenu: () => false,
       isChatInputCommand: () => false,
       isMessageComponent: () => true,
       deferUpdate,
@@ -4888,7 +4907,6 @@ describe("handleForwardedMessage - thread handling", () => {
           username: "testuser",
           bot: false,
         },
-        is_mention: true,
         mentions: [{ id: "test-app-id", username: "bot" }],
         attachments: [],
       },

--- a/packages/adapter-discord/src/index.test.ts
+++ b/packages/adapter-discord/src/index.test.ts
@@ -589,6 +589,38 @@ describe("handleWebhook - APPLICATION_COMMAND", () => {
     expect(responseBody).toEqual({ type: 5 }); // DeferredChannelMessageWithSource
   });
 
+  it("rejects application commands that are not chat input", async () => {
+    const body = JSON.stringify({
+      type: InteractionType.ApplicationCommand,
+      id: "interaction123",
+      application_id: "test-app-id",
+      token: "interaction-token",
+      version: 1,
+      guild_id: "guild123",
+      channel_id: "channel456",
+      member: {
+        user: {
+          id: "user789",
+          username: "testuser",
+          discriminator: "0001",
+        },
+        roles: [],
+        joined_at: "2021-01-01T00:00:00.000Z",
+      },
+      data: {
+        id: "cmd123",
+        name: "Report message",
+        type: 3, // Message context menu command
+        target_id: "msg123",
+      },
+    });
+    const request = createWebhookRequest(body);
+
+    const response = await adapter.handleWebhook(request);
+    expect(response.status).toBe(400);
+    expect(await response.text()).toBe("Unsupported application command type");
+  });
+
   it("sets initial deferred slash command interaction flags from config", async () => {
     const interactionFlags = vi
       .fn()

--- a/packages/adapter-discord/src/index.ts
+++ b/packages/adapter-discord/src/index.ts
@@ -45,24 +45,45 @@ import {
 import {
   type ChatInputCommandInteraction,
   Client,
+  type CommandInteractionOption,
   type Interaction as DiscordJsInteraction,
   type Message as DiscordJsMessage,
   type User as DiscordJsUser,
+  type Entitlement,
   Events,
   GatewayIntentBits,
   type MessageComponentInteraction,
   Partials,
 } from "discord.js";
 import {
+  type APIApplicationCommandInteraction,
+  type APIApplicationCommandInteractionDataOption,
+  type APIChatInputApplicationCommandInteraction,
+  type APIComponentInContainer,
+  type APIContainerComponent,
+  type APIEntitlement,
+  type APIFileComponent,
+  type APIInteraction,
+  type APIInteractionResponse,
+  type APIMediaGalleryComponent,
   type APIMessage,
+  type APIMessageComponentInteraction,
+  type APIMessageComponentInteractionData,
+  type APIMessageSelectMenuInteractionData,
+  type APIThreadChannel,
+  type APIUser,
   ChannelType,
+  ComponentType,
+  InteractionResponseType,
   InteractionType,
   MessageType,
+  type RESTGetAPIChannelResult,
+  type RESTGetAPIChannelThreadsArchivedPublicResult,
+  type RESTGetAPIGuildThreadsResult,
+  type RESTGetAPIUserResult,
+  type RESTPostAPICurrentUserCreateDMChannelResult,
 } from "discord-api-types/v10";
-import {
-  InteractionResponseType as DiscordInteractionResponseType,
-  verifyKey,
-} from "discord-interactions";
+import { verifyKey } from "discord-interactions";
 import {
   cardToDiscordPayload,
   decodeDiscordCustomId,
@@ -71,29 +92,19 @@ import {
 import { DiscordFormatConverter } from "./markdown";
 import {
   type DiscordAdapterConfig,
-  type DiscordCommandOption,
-  DiscordComponentType,
-  type DiscordContainer,
-  type DiscordContainerChild,
   DiscordContentFormat,
-  type DiscordFileComponent,
   type DiscordForwardedEvent,
   type DiscordGatewayEventType,
   type DiscordGatewayMessageData,
   type DiscordGatewayReactionData,
-  type DiscordInteraction,
   type DiscordInteractionFlagsContext,
-  type DiscordInteractionResponse,
   type DiscordInteractionResponseFlags,
-  type DiscordMediaGallery,
   DiscordMessageFlag,
   type DiscordMessagePayload,
   type DiscordRequestContext,
   type DiscordSlashCommandContext,
   type DiscordThreadId,
-  type DiscordUser,
   type DiscordWebhookVerifier,
-  InteractionResponseType,
 } from "./types";
 
 const DISCORD_API_BASE = "https://discord.com/api/v10";
@@ -132,11 +143,23 @@ function parseDiscordErrorCode(body: string): number | undefined {
   return undefined;
 }
 
-interface GatewayCommandOption {
-  name: string;
-  options?: readonly GatewayCommandOption[];
-  type: number;
-  value?: boolean | number | string;
+type DiscordInteractionChannel = NonNullable<APIInteraction["channel"]>;
+
+function isThreadChannelType(type: ChannelType | undefined): boolean {
+  return (
+    type === ChannelType.PublicThread || type === ChannelType.PrivateThread
+  );
+}
+
+function getInteractionThreadParentId(
+  channel: DiscordInteractionChannel | undefined
+): string | undefined {
+  if (!(channel && isThreadChannelType(channel.type))) {
+    return undefined;
+  }
+  return "parent_id" in channel && channel.parent_id
+    ? channel.parent_id
+    : undefined;
 }
 
 interface DiscordFileUpload {
@@ -331,7 +354,7 @@ export class DiscordAdapter implements Adapter<DiscordThreadId, unknown> {
   async getUser(userId: string): Promise<UserInfo | null> {
     try {
       const response = await this.discordFetch(`/users/${userId}`, "GET");
-      const user = (await response.json()) as DiscordUser;
+      const user = (await response.json()) as RESTGetAPIUserResult;
       return {
         avatarUrl: user.avatar
           ? `https://cdn.discordapp.com/avatars/${user.id}/${user.avatar}.png`
@@ -418,7 +441,7 @@ export class DiscordAdapter implements Adapter<DiscordThreadId, unknown> {
       this.logger.info("Discord signature verification passed");
     }
 
-    let interaction: DiscordInteraction;
+    let interaction: APIInteraction;
     try {
       interaction = JSON.parse(body);
     } catch {
@@ -434,13 +457,12 @@ export class DiscordAdapter implements Adapter<DiscordThreadId, unknown> {
 
     // Handle PING (Discord verification)
     if (interaction.type === InteractionType.Ping) {
-      // Use official discord-interactions response type
       const responseBody = JSON.stringify({
-        type: DiscordInteractionResponseType.PONG,
+        type: InteractionResponseType.Pong,
       });
       this.logger.info("Discord PING received, responding with PONG", {
         responseBody,
-        responseType: DiscordInteractionResponseType.PONG,
+        responseType: InteractionResponseType.Pong,
       });
       return new Response(responseBody, {
         status: 200,
@@ -453,7 +475,7 @@ export class DiscordAdapter implements Adapter<DiscordThreadId, unknown> {
       this.handleComponentInteraction(interaction, options);
       // ACK the interaction immediately
       return this.respondToInteraction({
-        type: InteractionResponseType.DeferredUpdateMessage,
+        type: InteractionResponseType.DeferredMessageUpdate,
       });
     }
 
@@ -541,9 +563,7 @@ export class DiscordAdapter implements Adapter<DiscordThreadId, unknown> {
   /**
    * Create a JSON response for Discord interactions.
    */
-  protected respondToInteraction(
-    response: DiscordInteractionResponse
-  ): Response {
+  protected respondToInteraction(response: APIInteractionResponse): Response {
     return Response.json(response);
   }
 
@@ -551,7 +571,7 @@ export class DiscordAdapter implements Adapter<DiscordThreadId, unknown> {
    * Handle MESSAGE_COMPONENT interactions (button clicks).
    */
   protected handleComponentInteraction(
-    interaction: DiscordInteraction,
+    interaction: APIMessageComponentInteraction,
     options?: WebhookOptions
   ): void {
     if (!this.chat) {
@@ -559,7 +579,7 @@ export class DiscordAdapter implements Adapter<DiscordThreadId, unknown> {
       return;
     }
 
-    const customId = interaction.data?.custom_id;
+    const customId = interaction.data.custom_id;
     if (!customId) {
       this.logger.warn("No custom_id in component interaction");
       return;
@@ -573,21 +593,19 @@ export class DiscordAdapter implements Adapter<DiscordThreadId, unknown> {
 
     const interactionChannelId = interaction.channel_id;
     const guildId = interaction.guild_id || "@me";
-    const messageId = interaction.message?.id;
+    const messageId = interaction.message.id;
 
     if (!(interactionChannelId && messageId)) {
       this.logger.warn("Missing channel_id or message_id in interaction");
       return;
     }
 
-    // Detect if the interaction is inside a thread channel
-    // Discord channel types: 11 = public thread, 12 = private thread
     const channel = interaction.channel;
-    const isThread = channel?.type === 11 || channel?.type === 12;
-    const parentChannelId =
-      isThread && channel?.parent_id ? channel.parent_id : interactionChannelId;
-    if (isThread && channel?.parent_id) {
-      this.rememberThreadParent(interactionChannelId, channel.parent_id);
+    const isThread = isThreadChannelType(channel?.type);
+    const threadParentId = getInteractionThreadParentId(channel);
+    const parentChannelId = threadParentId ?? interactionChannelId;
+    if (threadParentId) {
+      this.rememberThreadParent(interactionChannelId, threadParentId);
     }
 
     const threadId = isThread
@@ -602,7 +620,8 @@ export class DiscordAdapter implements Adapter<DiscordThreadId, unknown> {
         });
 
     const decoded = decodeDiscordCustomId(customId);
-    const selectedValue = interaction.data?.values?.[0];
+    const selectedValue =
+      "values" in interaction.data ? interaction.data.values[0] : undefined;
     const actionEvent: Omit<ActionEvent, "thread" | "openModal"> & {
       adapter: DiscordAdapter;
     } = {
@@ -634,9 +653,9 @@ export class DiscordAdapter implements Adapter<DiscordThreadId, unknown> {
    * Handle APPLICATION_COMMAND interactions (slash commands).
    */
   protected getApplicationCommandContext(
-    interaction: DiscordInteraction
+    interaction: APIApplicationCommandInteraction
   ): DiscordInteractionFlagsContext | null {
-    const commandName = interaction.data?.name;
+    const commandName = interaction.data.name;
     if (!commandName) {
       this.logger.warn("No command name in application command interaction");
       return null;
@@ -656,11 +675,11 @@ export class DiscordAdapter implements Adapter<DiscordThreadId, unknown> {
 
     const guildId = interaction.guild_id || "@me";
     const channel = interaction.channel;
-    const isThread = channel?.type === 11 || channel?.type === 12;
-    const parentChannelId =
-      isThread && channel?.parent_id ? channel.parent_id : interactionChannelId;
-    if (isThread && channel?.parent_id) {
-      this.rememberThreadParent(interactionChannelId, channel.parent_id);
+    const isThread = isThreadChannelType(channel?.type);
+    const threadParentId = getInteractionThreadParentId(channel);
+    const parentChannelId = threadParentId ?? interactionChannelId;
+    if (threadParentId) {
+      this.rememberThreadParent(interactionChannelId, threadParentId);
     }
 
     const channelId = isThread
@@ -676,7 +695,7 @@ export class DiscordAdapter implements Adapter<DiscordThreadId, unknown> {
 
     const { command, text } = this.parseSlashCommand(
       commandName,
-      interaction.data?.options
+      "options" in interaction.data ? interaction.data.options : undefined
     );
 
     return {
@@ -766,19 +785,25 @@ export class DiscordAdapter implements Adapter<DiscordThreadId, unknown> {
    */
   protected parseSlashCommand(
     name: string,
-    options?: DiscordCommandOption[]
+    options?: APIApplicationCommandInteractionDataOption[]
   ): { command: string; text: string } {
     const commandParts: string[] = [name.startsWith("/") ? name : `/${name}`];
     const valueParts: string[] = [];
 
-    const collect = (items: DiscordCommandOption[]): void => {
+    const collect = (
+      items: APIApplicationCommandInteractionDataOption[]
+    ): void => {
       for (const option of items) {
-        if (option.value !== undefined) {
+        if ("value" in option && option.value !== undefined) {
           valueParts.push(String(option.value));
           continue;
         }
         // Subcommand or subcommand-group — append name to command path
-        if (option.options && option.options.length > 0) {
+        if (
+          "options" in option &&
+          option.options &&
+          option.options.length > 0
+        ) {
           commandParts.push(option.name);
           collect(option.options);
         }
@@ -818,91 +843,131 @@ export class DiscordAdapter implements Adapter<DiscordThreadId, unknown> {
 
   protected normalizeGatewaySlashCommandInteraction(
     interaction: ChatInputCommandInteraction
-  ): DiscordInteraction {
+  ): APIChatInputApplicationCommandInteraction {
     return {
-      application_id: interaction.applicationId,
-      channel: this.normalizeGatewayChannel(interaction),
-      channel_id: interaction.channelId ?? undefined,
+      ...this.normalizeGatewayInteractionBase(interaction),
       data: {
+        guild_id: interaction.commandGuildId ?? undefined,
+        id: interaction.commandId,
         name: interaction.commandName,
         options: this.normalizeGatewayCommandOptions(interaction.options.data),
         type: interaction.commandType,
       },
-      guild_id: interaction.guildId ?? undefined,
-      id: interaction.id,
-      token: interaction.token,
       type: interaction.type,
-      user: this.normalizeGatewayUser(interaction.user),
-      version: interaction.version,
     };
   }
 
   protected normalizeGatewayComponentInteraction(
     interaction: MessageComponentInteraction
-  ): DiscordInteraction {
-    const values =
-      "values" in interaction && Array.isArray(interaction.values)
-        ? interaction.values
-        : undefined;
+  ): APIMessageComponentInteraction {
+    const data: APIMessageComponentInteractionData =
+      interaction.isAnySelectMenu()
+        ? ({
+            component_type: interaction.componentType,
+            custom_id: interaction.customId,
+            values: interaction.values,
+          } as APIMessageSelectMenuInteractionData)
+        : {
+            component_type: ComponentType.Button,
+            custom_id: interaction.customId,
+          };
 
     return {
-      application_id: interaction.applicationId,
-      channel: this.normalizeGatewayChannel(interaction),
-      channel_id: interaction.channelId ?? undefined,
-      data: {
-        component_type: interaction.componentType,
-        custom_id: interaction.customId,
-        values,
-      },
-      guild_id: interaction.guildId ?? undefined,
-      id: interaction.id,
+      ...this.normalizeGatewayInteractionBase(interaction),
+      data,
       message: { id: interaction.message.id } as APIMessage,
-      token: interaction.token,
       type: interaction.type,
+    };
+  }
+
+  /**
+   * Fields shared by every interaction, rebuilt from the discord.js object so
+   * Gateway interactions can flow through the same handlers as webhook payloads.
+   */
+  protected normalizeGatewayInteractionBase(
+    interaction: ChatInputCommandInteraction | MessageComponentInteraction
+  ): Omit<APIMessageComponentInteraction, "data" | "message" | "type"> {
+    if (!interaction.channel) {
+      throw new Error(
+        `Discord interaction ${interaction.id} has no channel ${interaction.channelId}`
+      );
+    }
+
+    return {
+      app_permissions: interaction.appPermissions.bitfield.toString(),
+      application_id: interaction.applicationId,
+      attachment_size_limit: interaction.attachmentSizeLimit,
+      authorizing_integration_owners: interaction.authorizingIntegrationOwners,
+      channel: this.normalizeGatewayChannel(interaction.channel),
+      channel_id: interaction.channelId,
+      context: interaction.context ?? undefined,
+      entitlements: interaction.entitlements.map((entitlement) =>
+        this.normalizeGatewayEntitlement(entitlement)
+      ),
+      guild_id: interaction.guildId ?? undefined,
+      guild_locale: interaction.guildLocale ?? undefined,
+      id: interaction.id,
+      locale: interaction.locale,
+      token: interaction.token,
       user: this.normalizeGatewayUser(interaction.user),
-      version: interaction.version,
+      version: 1,
     };
   }
 
   protected normalizeGatewayChannel(
-    interaction: ChatInputCommandInteraction | MessageComponentInteraction
-  ): DiscordInteraction["channel"] {
-    if (!interaction.channel) {
-      return undefined;
-    }
-
+    channel: NonNullable<MessageComponentInteraction["channel"]>
+  ): DiscordInteractionChannel {
     const parentId =
-      "parentId" in interaction.channel &&
-      typeof interaction.channel.parentId === "string"
-        ? interaction.channel.parentId
+      "parentId" in channel && typeof channel.parentId === "string"
+        ? channel.parentId
         : undefined;
 
     return {
-      id: interaction.channel.id,
+      id: channel.id,
       parent_id: parentId,
-      type: interaction.channel.type,
-    };
+      type: channel.type,
+    } as DiscordInteractionChannel;
   }
 
   protected normalizeGatewayCommandOptions(
-    options: readonly GatewayCommandOption[]
-  ): DiscordCommandOption[] {
-    return options.map((option) => ({
-      name: option.name,
-      options: option.options
-        ? this.normalizeGatewayCommandOptions(option.options)
-        : undefined,
-      type: option.type,
-      value: option.value,
-    }));
+    options: readonly CommandInteractionOption[]
+  ): APIApplicationCommandInteractionDataOption[] {
+    return options.map(
+      (option) =>
+        ({
+          name: option.name,
+          options: option.options
+            ? this.normalizeGatewayCommandOptions(option.options)
+            : undefined,
+          type: option.type,
+          value: option.value,
+        }) as APIApplicationCommandInteractionDataOption
+    );
   }
 
-  protected normalizeGatewayUser(user: DiscordJsUser): DiscordUser {
+  protected normalizeGatewayEntitlement(
+    entitlement: Entitlement
+  ): APIEntitlement {
     return {
-      avatar: user.avatar ?? undefined,
+      application_id: entitlement.applicationId,
+      consumed: entitlement.consumed,
+      deleted: entitlement.deleted,
+      ends_at: entitlement.endsAt?.toISOString() ?? null,
+      guild_id: entitlement.guildId ?? undefined,
+      id: entitlement.id,
+      sku_id: entitlement.skuId,
+      starts_at: entitlement.startsAt?.toISOString() ?? null,
+      type: entitlement.type,
+      user_id: entitlement.userId,
+    };
+  }
+
+  protected normalizeGatewayUser(user: DiscordJsUser): APIUser {
+    return {
+      avatar: user.avatar,
       bot: user.bot,
       discriminator: user.discriminator,
-      global_name: user.globalName ?? undefined,
+      global_name: user.globalName,
       id: user.id,
       username: user.username,
     };
@@ -976,15 +1041,14 @@ export class DiscordAdapter implements Adapter<DiscordThreadId, unknown> {
       discordThreadId = data.thread.id;
       parentChannelId = data.thread.parent_id;
       this.rememberThreadParent(discordThreadId, parentChannelId);
-    } else if (data.channel_type === 11 || data.channel_type === 12) {
-      // Message is in a thread (11 = public, 12 = private) but we don't have parent info
-      // Fetch the channel to get parent_id
+    } else if (isThreadChannelType(data.channel_type)) {
+      // Message is in a thread but we don't have parent info; fetch the channel to get parent_id
       try {
         const response = await this.discordFetch(
           `/channels/${channelId}`,
           "GET"
         );
-        const channel = (await response.json()) as { parent_id?: string };
+        const channel = (await response.json()) as APIThreadChannel;
         if (channel.parent_id) {
           discordThreadId = channelId;
           parentChannelId = channel.parent_id;
@@ -1002,8 +1066,9 @@ export class DiscordAdapter implements Adapter<DiscordThreadId, unknown> {
     }
 
     // Check if bot is mentioned (by user ID or configured role IDs)
-    const isUserMentioned =
-      data.is_mention || data.mentions.some((m) => m.id === this.applicationId);
+    const isUserMentioned = data.mentions.some(
+      (m) => m.id === this.applicationId
+    );
     const isRoleMentioned =
       this.mentionRoleIds.length > 0 &&
       data.mention_roles?.some((roleId) =>
@@ -1105,10 +1170,7 @@ export class DiscordAdapter implements Adapter<DiscordThreadId, unknown> {
     let discordThreadId: string | undefined;
     let parentChannelId = channelId;
 
-    if (
-      data.channel_type === ChannelType.GuildPublicThread ||
-      data.channel_type === ChannelType.GuildPrivateThread
-    ) {
+    if (isThreadChannelType(data.channel_type)) {
       const cached = this.threadParentCache.get(channelId);
       if (cached && cached.expiresAt > Date.now()) {
         discordThreadId = channelId;
@@ -1119,7 +1181,7 @@ export class DiscordAdapter implements Adapter<DiscordThreadId, unknown> {
             `/channels/${channelId}`,
             "GET"
           );
-          const channel = (await response.json()) as { parent_id?: string };
+          const channel = (await response.json()) as APIThreadChannel;
           if (channel.parent_id) {
             discordThreadId = channelId;
             parentChannelId = channel.parent_id;
@@ -1148,7 +1210,8 @@ export class DiscordAdapter implements Adapter<DiscordThreadId, unknown> {
     const normalizedEmoji = this.normalizeDiscordEmoji(emojiName);
 
     // Get user info from either data.user (DMs) or data.member.user (guilds)
-    const userInfo = data.user ?? data.member?.user;
+    const userInfo =
+      data.user ?? ("member" in data ? data.member?.user : undefined);
     if (!userInfo) {
       this.logger.warn("Reaction event missing user info", { data });
       return;
@@ -1253,8 +1316,8 @@ export class DiscordAdapter implements Adapter<DiscordThreadId, unknown> {
     );
 
     const container = payload.components?.find(
-      (component): component is DiscordContainer =>
-        component.type === DiscordComponentType.Container
+      (component): component is APIContainerComponent =>
+        component.type === ComponentType.Container
     );
 
     if (container) {
@@ -1268,25 +1331,25 @@ export class DiscordAdapter implements Adapter<DiscordThreadId, unknown> {
 
   protected fileUploadToComponentsV2Component(
     file: DiscordFileUpload
-  ): DiscordContainerChild {
+  ): APIComponentInContainer {
     const url = `attachment://${file.filename}`;
 
     if (this.isMediaGalleryUpload(file)) {
       return {
-        type: DiscordComponentType.MediaGallery,
+        type: ComponentType.MediaGallery,
         items: [
           {
             media: { url },
             description: file.filename,
           },
         ],
-      } satisfies DiscordMediaGallery;
+      } satisfies APIMediaGalleryComponent;
     }
 
     return {
-      type: DiscordComponentType.File,
+      type: ComponentType.File,
       file: { url },
-    } satisfies DiscordFileComponent;
+    } satisfies APIFileComponent;
   }
 
   protected isMediaGalleryUpload(file: DiscordFileUpload): boolean {
@@ -1436,7 +1499,7 @@ export class DiscordAdapter implements Adapter<DiscordThreadId, unknown> {
   protected async createDiscordThread(
     channelId: string,
     messageId: string
-  ): Promise<{ id: string; name: string }> {
+  ): Promise<Pick<APIThreadChannel, "id" | "name">> {
     const threadName = `Thread ${new Date().toLocaleString()}`;
 
     this.logger.debug("Discord API: POST thread", {
@@ -1455,7 +1518,7 @@ export class DiscordAdapter implements Adapter<DiscordThreadId, unknown> {
         }
       );
 
-      const result = (await response.json()) as { id: string; name: string };
+      const result = (await response.json()) as APIThreadChannel;
 
       this.logger.debug("Discord API: POST thread response", {
         threadId: result.id,
@@ -1714,7 +1777,7 @@ export class DiscordAdapter implements Adapter<DiscordThreadId, unknown> {
       `/channels/${discordThreadId}`,
       "GET"
     );
-    const channel = (await response.json()) as { parent_id?: string };
+    const channel = (await response.json()) as APIThreadChannel;
     if (channel.parent_id !== parentChannelId) {
       throw new ValidationError(
         "discord",
@@ -1722,7 +1785,7 @@ export class DiscordAdapter implements Adapter<DiscordThreadId, unknown> {
       );
     }
 
-    this.rememberThreadParent(discordThreadId, channel.parent_id);
+    this.rememberThreadParent(discordThreadId, parentChannelId);
     return discordThreadId;
   }
 
@@ -1932,16 +1995,12 @@ export class DiscordAdapter implements Adapter<DiscordThreadId, unknown> {
     this.logger.debug("Discord API: GET channel", { channelId });
 
     const response = await this.discordFetch(`/channels/${channelId}`, "GET");
-    const channel = (await response.json()) as {
-      id: string;
-      name?: string;
-      type: ChannelType;
-    };
+    const channel = (await response.json()) as RESTGetAPIChannelResult;
 
     return {
       id: threadId,
       channelId,
-      channelName: channel.name,
+      channelName: channel.name ?? undefined,
       isDM:
         channel.type === ChannelType.DM || channel.type === ChannelType.GroupDM,
       metadata: {
@@ -1978,10 +2037,8 @@ export class DiscordAdapter implements Adapter<DiscordThreadId, unknown> {
       recipient_id: userId,
     });
 
-    const dmChannel = (await response.json()) as {
-      id: string;
-      type: ChannelType;
-    };
+    const dmChannel =
+      (await response.json()) as RESTPostAPICurrentUserCreateDMChannelResult;
 
     this.logger.debug("Discord API: POST DM channel response", {
       channelId: dmChannel.id,
@@ -2322,6 +2379,16 @@ export class DiscordAdapter implements Adapter<DiscordThreadId, unknown> {
           }
         }
 
+        if (
+          packet.t === "MESSAGE_REACTION_ADD" ||
+          packet.t === "MESSAGE_REACTION_REMOVE"
+        ) {
+          data = await this.enrichForwardedReaction(
+            client,
+            packet.d as DiscordGatewayReactionData
+          );
+        }
+
         // Forward to webhook
         await this.forwardGatewayEvent(webhookUrl, {
           type: `GATEWAY_${packet.t}` as DiscordGatewayEventType,
@@ -2539,6 +2606,29 @@ export class DiscordAdapter implements Adapter<DiscordThreadId, unknown> {
         );
       }
     });
+  }
+
+  /**
+   * Discord omits the channel type and, outside guilds, the user from reaction
+   * events. Fill both from the Gateway client so the webhook side can resolve
+   * threads and DM reactors without extra API calls.
+   */
+  protected async enrichForwardedReaction(
+    client: Client,
+    reaction: DiscordGatewayReactionData
+  ): Promise<DiscordGatewayReactionData> {
+    const [channel, user] = await Promise.all([
+      client.channels.fetch(reaction.channel_id).catch(() => null),
+      "member" in reaction && reaction.member
+        ? null
+        : client.users.fetch(reaction.user_id).catch(() => null),
+    ]);
+
+    return {
+      ...reaction,
+      ...(channel ? { channel_type: channel.type } : {}),
+      ...(user ? { user: this.normalizeGatewayUser(user) } : {}),
+    };
   }
 
   /**
@@ -2879,33 +2969,24 @@ export class DiscordAdapter implements Adapter<DiscordThreadId, unknown> {
       `/guilds/${guildId}/threads/active`,
       "GET"
     );
-    const activeData = (await activeResponse.json()) as {
-      threads: Array<{
-        id: string;
-        name: string;
-        parent_id: string;
-        message_count?: number;
-        total_message_sent?: number;
-        thread_metadata?: { archive_timestamp?: string };
-      }>;
-    };
+    const activeData =
+      (await activeResponse.json()) as RESTGetAPIGuildThreadsResult;
 
     // Filter threads that belong to our channel
-    const channelThreads = (activeData.threads || []).filter(
-      (t) => t.parent_id === discordChannelId
-    );
+    const channelThreads = (
+      (activeData.threads || []) as APIThreadChannel[]
+    ).filter((t) => t.parent_id === discordChannelId);
 
     // Also fetch archived public threads
-    let archivedThreads: typeof channelThreads = [];
+    let archivedThreads: APIThreadChannel[] = [];
     try {
       const archivedResponse = await this.discordFetch(
         `/channels/${discordChannelId}/threads/archived/public?limit=${options.limit || 50}`,
         "GET"
       );
-      const archivedData = (await archivedResponse.json()) as {
-        threads: typeof channelThreads;
-      };
-      archivedThreads = archivedData.threads || [];
+      const archivedData =
+        (await archivedResponse.json()) as RESTGetAPIChannelThreadsArchivedPublicResult;
+      archivedThreads = (archivedData.threads || []) as APIThreadChannel[];
     } catch {
       // Archived threads may not be available (permissions)
       this.logger.debug(
@@ -2963,8 +3044,8 @@ export class DiscordAdapter implements Adapter<DiscordThreadId, unknown> {
           rootMessage: new Message({
             id: thread.id,
             threadId,
-            text: thread.name,
-            formatted: this.formatConverter.toAst(thread.name),
+            text: thread.name ?? "",
+            formatted: this.formatConverter.toAst(thread.name ?? ""),
             raw: thread,
             author: {
               userId: "unknown",
@@ -3012,19 +3093,14 @@ export class DiscordAdapter implements Adapter<DiscordThreadId, unknown> {
       `/channels/${discordChannelId}`,
       "GET"
     );
-    const channel = (await response.json()) as {
-      id: string;
-      name?: string;
-      type: ChannelType;
-      member_count?: number;
-    };
+    const channel = (await response.json()) as RESTGetAPIChannelResult;
 
     return {
       id: channelId,
-      name: channel.name,
+      name: channel.name ?? undefined,
       isDM:
         channel.type === ChannelType.DM || channel.type === ChannelType.GroupDM,
-      memberCount: channel.member_count,
+      memberCount: "member_count" in channel ? channel.member_count : undefined,
       metadata: {
         channelType: channel.type,
         raw: channel,

--- a/packages/adapter-discord/src/index.ts
+++ b/packages/adapter-discord/src/index.ts
@@ -53,11 +53,11 @@ import {
   type MessageComponentInteraction,
   Partials,
 } from "discord.js";
-import { MessageType } from "discord-api-types/v9";
 import {
   type APIMessage,
   ChannelType,
   InteractionType,
+  MessageType,
 } from "discord-api-types/v10";
 import {
   InteractionResponseType as DiscordInteractionResponseType,

--- a/packages/adapter-discord/src/index.ts
+++ b/packages/adapter-discord/src/index.ts
@@ -55,8 +55,8 @@ import {
   type MessageComponentInteraction,
   Partials,
 } from "discord.js";
+import { isChatInputApplicationCommandInteraction } from "discord-api-types/utils/v10";
 import {
-  type APIApplicationCommandInteraction,
   type APIApplicationCommandInteractionDataOption,
   type APIChatInputApplicationCommandInteraction,
   type APIComponentInContainer,
@@ -481,6 +481,14 @@ export class DiscordAdapter implements Adapter<DiscordThreadId, unknown> {
 
     // Handle APPLICATION_COMMAND (slash commands)
     if (interaction.type === InteractionType.ApplicationCommand) {
+      if (!isChatInputApplicationCommandInteraction(interaction)) {
+        this.logger.warn("Unsupported Discord application command type", {
+          commandType: interaction.data.type,
+        });
+        return new Response("Unsupported application command type", {
+          status: 400,
+        });
+      }
       const context = this.getApplicationCommandContext(interaction);
       const flags = this.getInteractionFlags(context);
       this.handleApplicationCommandInteraction(context, flags, options);
@@ -653,7 +661,7 @@ export class DiscordAdapter implements Adapter<DiscordThreadId, unknown> {
    * Handle APPLICATION_COMMAND interactions (slash commands).
    */
   protected getApplicationCommandContext(
-    interaction: APIApplicationCommandInteraction
+    interaction: APIChatInputApplicationCommandInteraction
   ): DiscordInteractionFlagsContext | null {
     const commandName = interaction.data.name;
     if (!commandName) {
@@ -695,7 +703,7 @@ export class DiscordAdapter implements Adapter<DiscordThreadId, unknown> {
 
     const { command, text } = this.parseSlashCommand(
       commandName,
-      "options" in interaction.data ? interaction.data.options : undefined
+      interaction.data.options
     );
 
     return {

--- a/packages/adapter-discord/src/types.ts
+++ b/packages/adapter-discord/src/types.ts
@@ -1,14 +1,27 @@
 /**
  * Discord adapter types.
+ *
+ * Discord payload shapes come from `discord-api-types`. Only adapter-specific
+ * configuration and the Gateway forwarding envelope are declared here.
  */
 
 import type { Logger } from "chat";
-import type {
-  APIEmbed,
-  APIMessage,
-  ButtonStyle,
-  ChannelType,
-  InteractionType,
+import {
+  type APIApplicationCommandInteraction,
+  type APIUser,
+  type ChannelType,
+  type ComponentType,
+  type GatewayMessageCreateDispatchData,
+  type GatewayMessageReactionAddDispatchData,
+  type GatewayMessageReactionRemoveDispatchData,
+  MessageFlags,
+  type RESTPatchAPIChannelMessageJSONBody,
+  type RESTPostAPIChannelMessageJSONBody,
+} from "discord-api-types/v10";
+
+export {
+  ComponentType as DiscordComponentType,
+  MessageFlags as DiscordMessageFlag,
 } from "discord-api-types/v10";
 
 /**
@@ -69,11 +82,11 @@ export interface DiscordInteractionFlagsContext {
   /** Parsed slash command name, including subcommands (e.g. "/project issue create"). */
   command: string;
   /** Raw Discord interaction payload. */
-  interaction: DiscordInteraction;
+  interaction: APIApplicationCommandInteraction;
   /** Flattened slash command option text. */
   text: string;
   /** User who invoked the command. */
-  user: DiscordUser;
+  user: APIUser;
 }
 
 /**
@@ -107,279 +120,30 @@ export interface DiscordRequestContext {
 }
 
 /**
- * Incoming Discord interaction from webhook.
+ * Message body sent when creating or editing a message, or responding to an
+ * interaction. `content: null` is only meaningful on edits.
  */
-export interface DiscordInteraction {
-  application_id: string;
-  channel?: {
-    id: string;
-    type: ChannelType;
-    name?: string;
-    /** Parent channel ID (present when channel is a thread) */
-    parent_id?: string;
-  };
-  channel_id?: string;
-  data?: DiscordInteractionData;
-  guild_id?: string;
-  id: string;
-  member?: {
-    user: DiscordUser;
-    nick?: string;
-    roles: string[];
-    joined_at: string;
-  };
-  message?: APIMessage;
-  token: string;
-  type: InteractionType;
-  user?: DiscordUser;
-  version: number;
-}
+export type DiscordMessagePayload = Omit<
+  RESTPostAPIChannelMessageJSONBody,
+  "content"
+> &
+  Pick<RESTPatchAPIChannelMessageJSONBody, "content">;
+
+export type DiscordComponentTypeValue = ComponentType;
+
+export type DiscordMessageFlagValue = MessageFlags;
+
+export type DiscordMessageFlags = MessageFlags;
 
 /**
- * Discord user object.
+ * Flags accepted on the initial deferred interaction response.
  */
-export interface DiscordUser {
-  avatar?: string;
-  bot?: boolean;
-  discriminator: string;
-  global_name?: string;
-  id: string;
-  username: string;
-}
-
-/**
- * Discord interaction data (for components/commands).
- */
-export interface DiscordInteractionData {
-  component_type?: number;
-  custom_id?: string;
-  name?: string;
-  options?: DiscordCommandOption[];
-  type?: number;
-  values?: string[];
-}
-
-/**
- * Discord command option.
- */
-export interface DiscordCommandOption {
-  name: string;
-  options?: DiscordCommandOption[];
-  type: number;
-  value?: string | number | boolean;
-}
-
-/**
- * Discord emoji.
- */
-export interface DiscordEmoji {
-  animated?: boolean;
-  id?: string;
-  name: string;
-}
-
-export const DiscordComponentType = {
-  ActionRow: 1,
-  Button: 2,
-  StringSelect: 3,
-  Section: 9,
-  TextDisplay: 10,
-  Thumbnail: 11,
-  MediaGallery: 12,
-  File: 13,
-  Separator: 14,
-  Container: 17,
-} as const;
-
-export type DiscordComponentTypeValue =
-  (typeof DiscordComponentType)[keyof typeof DiscordComponentType];
-
-/**
- * Discord button component.
- */
-export interface DiscordButton {
-  custom_id?: string;
-  disabled?: boolean;
-  emoji?: DiscordEmoji;
-  label?: string;
-  style: ButtonStyle;
-  type: typeof DiscordComponentType.Button;
-  url?: string;
-}
-
-/**
- * Discord string select component.
- */
-export interface DiscordStringSelect {
-  custom_id: string;
-  disabled?: boolean;
-  max_values?: number;
-  min_values?: number;
-  options: {
-    default?: boolean;
-    description?: string;
-    emoji?: DiscordEmoji;
-    label: string;
-    value: string;
-  }[];
-  placeholder?: string;
-  type: typeof DiscordComponentType.StringSelect;
-}
-
-export type DiscordActionRowComponent = DiscordButton | DiscordStringSelect;
-
-/**
- * Discord action row component.
- */
-export interface DiscordActionRow {
-  components: DiscordActionRowComponent[];
-  type: typeof DiscordComponentType.ActionRow;
-}
-
-export interface DiscordTextDisplay {
-  content: string;
-  type: typeof DiscordComponentType.TextDisplay;
-}
-
-export interface DiscordThumbnail {
-  description?: string;
-  media: {
-    url: string;
-  };
-  spoiler?: boolean;
-  type: typeof DiscordComponentType.Thumbnail;
-}
-
-export interface DiscordMediaGallery {
-  items: {
-    description?: string;
-    media: {
-      url: string;
-    };
-    spoiler?: boolean;
-  }[];
-  type: typeof DiscordComponentType.MediaGallery;
-}
-
-export interface DiscordFileComponent {
-  file: {
-    url: string;
-  };
-  spoiler?: boolean;
-  type: typeof DiscordComponentType.File;
-}
-
-export interface DiscordSeparator {
-  divider?: boolean;
-  spacing?: 1 | 2;
-  type: typeof DiscordComponentType.Separator;
-}
-
-export interface DiscordSection {
-  accessory: DiscordButton | DiscordThumbnail;
-  components: DiscordTextDisplay[];
-  type: typeof DiscordComponentType.Section;
-}
-
-export type DiscordContainerChild =
-  | DiscordActionRow
-  | DiscordFileComponent
-  | DiscordMediaGallery
-  | DiscordSection
-  | DiscordSeparator
-  | DiscordTextDisplay;
-
-export interface DiscordContainer {
-  accent_color?: number;
-  components: DiscordContainerChild[];
-  spoiler?: boolean;
-  type: typeof DiscordComponentType.Container;
-}
-
-export type DiscordMessageComponent =
-  | DiscordActionRow
-  | DiscordContainer
-  | DiscordFileComponent
-  | DiscordMediaGallery
-  | DiscordSection
-  | DiscordSeparator
-  | DiscordTextDisplay;
-
-/**
- * Discord message create payload.
- */
-export interface DiscordMessagePayload {
-  allowed_mentions?: {
-    parse?: ("roles" | "users" | "everyone")[];
-    roles?: string[];
-    users?: string[];
-    replied_user?: boolean;
-  };
-  attachments?: {
-    id: string;
-    filename: string;
-    description?: string;
-  }[];
-  components?: DiscordMessageComponent[];
-  content?: string | null;
-  embeds?: APIEmbed[];
-  flags?: number;
-  message_reference?: {
-    message_id: string;
-    fail_if_not_exists?: boolean;
-  };
-}
-
-export const DiscordMessageFlag = {
-  Crossposted: 1,
-  IsCrosspost: 2,
-  SuppressEmbeds: 4,
-  SourceMessageDeleted: 8,
-  Urgent: 16,
-  HasThread: 32,
-  Ephemeral: 64,
-  Loading: 128,
-  FailedToMentionSomeRolesInThread: 256,
-  SuppressNotifications: 4096,
-  IsVoiceMessage: 8192,
-  HasSnapshot: 16_384,
-  IsComponentsV2: 32_768,
-} as const;
-
-export type DiscordMessageFlagValue =
-  (typeof DiscordMessageFlag)[keyof typeof DiscordMessageFlag];
-
-export type DiscordMessageFlags = DiscordMessageFlagValue;
-
 export const DiscordInteractionResponseFlag = {
-  Ephemeral: 64,
+  Ephemeral: MessageFlags.Ephemeral,
 } as const;
 
 export type DiscordInteractionResponseFlags =
   (typeof DiscordInteractionResponseFlag)[keyof typeof DiscordInteractionResponseFlag];
-
-/**
- * Discord interaction response types.
- * Note: Only the types currently used are defined here.
- * Additional types: ChannelMessageWithSource (4), UpdateMessage (7)
- */
-export const InteractionResponseType = {
-  /** ACK and edit later (deferred) */
-  DeferredChannelMessageWithSource: 5,
-  /** ACK component interaction, update message later */
-  DeferredUpdateMessage: 6,
-} as const;
-
-export type InteractionResponseType =
-  (typeof InteractionResponseType)[keyof typeof InteractionResponseType];
-
-/**
- * Discord interaction response.
- */
-export interface DiscordInteractionResponse {
-  data?: DiscordMessagePayload;
-  type: InteractionResponseType;
-}
 
 // ============================================================================
 // Gateway Forwarded Events
@@ -410,90 +174,26 @@ export interface DiscordForwardedEvent {
 }
 
 /**
- * Message data from a MESSAGE_CREATE Gateway event.
+ * MESSAGE_CREATE dispatch data as forwarded by the Gateway listener.
  */
-export interface DiscordGatewayMessageData {
-  /** File attachments */
-  attachments: Array<{
-    id: string;
-    url: string;
-    filename: string;
-    content_type?: string;
-    size: number;
-  }>;
-  /** Message author */
-  author: {
-    id: string;
-    username: string;
-    global_name?: string;
-    bot: boolean;
-  };
-  /** Channel where the message was sent */
-  channel_id: string;
-  /** Channel type (11 = public thread, 12 = private thread) */
-  channel_type?: number;
-  /** Message content */
-  content: string;
-  /** Guild ID, or null for DMs */
-  guild_id: string | null;
-  /** Message ID */
-  id: string;
-  /** Whether the bot was mentioned */
-  is_mention?: boolean;
-  /** Whether the message pings @everyone or @here */
-  mention_everyone?: boolean;
-  /** Role IDs mentioned in the message */
-  mention_roles?: string[];
-  /** Users mentioned in the message */
-  mentions: Array<{ id: string; username: string }>;
-  /** Immutable content captured from a forwarded message */
-  message_snapshots?: Array<{
-    message: {
-      attachments: DiscordGatewayMessageData["attachments"];
-      content: string;
-    };
-  }>;
-  /** Thread info if message is in a thread */
+export type DiscordGatewayMessageData = GatewayMessageCreateDispatchData & {
+  /** Set by the forwarder when it resolved the thread the message was posted in. */
   thread?: {
     id: string;
     parent_id: string;
   };
-  /** ISO timestamp */
-  timestamp: string;
-}
+};
 
 /**
- * Reaction data from REACTION_ADD or REACTION_REMOVE Gateway events.
+ * MESSAGE_REACTION_ADD / MESSAGE_REACTION_REMOVE dispatch data as forwarded by
+ * the Gateway listener.
  */
-export interface DiscordGatewayReactionData {
-  /** Channel containing the message */
-  channel_id: string;
-  /** Channel type (11 = public thread, 12 = private thread) */
-  channel_type?: number;
-  /** Emoji used for the reaction */
-  emoji: {
-    name: string | null;
-    id: string | null;
-  };
-  /** Guild ID, or null for DMs */
-  guild_id: string | null;
-  /** Member details (for guild reactions) */
-  member?: {
-    user: {
-      id: string;
-      username: string;
-      global_name?: string;
-      bot?: boolean;
-    };
-  };
-  /** ID of the message that was reacted to */
-  message_id: string;
-  /** User details (for DMs) */
-  user?: {
-    id: string;
-    username: string;
-    bot?: boolean;
-  };
-  /** User who added/removed the reaction */
-  user_id: string;
-}
+export type DiscordGatewayReactionData = (
+  | GatewayMessageReactionAddDispatchData
+  | GatewayMessageReactionRemoveDispatchData
+) & {
+  /** Set by the forwarder from its channel cache. Discord does not send it. */
+  channel_type?: ChannelType;
+  /** Set by the forwarder for DM reactions, where Discord sends no `member`. */
+  user?: APIUser;
+};

--- a/packages/adapter-discord/src/types.ts
+++ b/packages/adapter-discord/src/types.ts
@@ -7,7 +7,7 @@
 
 import type { Logger } from "chat";
 import {
-  type APIApplicationCommandInteraction,
+  type APIChatInputApplicationCommandInteraction,
   type APIUser,
   type ChannelType,
   type ComponentType,
@@ -82,7 +82,7 @@ export interface DiscordInteractionFlagsContext {
   /** Parsed slash command name, including subcommands (e.g. "/project issue create"). */
   command: string;
   /** Raw Discord interaction payload. */
-  interaction: APIApplicationCommandInteraction;
+  interaction: APIChatInputApplicationCommandInteraction;
   /** Flattened slash command option text. */
   text: string;
   /** User who invoked the command. */

--- a/packages/integration-tests/package.json
+++ b/packages/integration-tests/package.json
@@ -32,6 +32,6 @@
     "@chat-adapter/telegram": "workspace:*",
     "@chat-adapter/whatsapp": "workspace:*",
     "chat": "workspace:*",
-    "discord-api-types": "^0.37.119"
+    "discord-api-types": "^0.38.55"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -350,8 +350,8 @@ importers:
         specifier: workspace:*
         version: link:../chat
       discord-api-types:
-        specifier: ^0.37.119
-        version: 0.37.120
+        specifier: ^0.38.55
+        version: 0.38.55
       discord-interactions:
         specifier: ^4.4.0
         version: 4.4.0
@@ -913,8 +913,8 @@ importers:
         specifier: workspace:*
         version: link:../chat
       discord-api-types:
-        specifier: ^0.37.119
-        version: 0.37.120
+        specifier: ^0.38.55
+        version: 0.38.55
     devDependencies:
       '@changesets/config':
         specifier: ^3.1.2
@@ -8485,11 +8485,8 @@ packages:
     resolution: {integrity: sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==}
     engines: {node: '>=8'}
 
-  discord-api-types@0.37.120:
-    resolution: {integrity: sha512-7xpNK0EiWjjDFp2nAhHXezE4OUWm7s1zhc/UXXN6hnFFU8dfoPHgV0Hx0RPiCa3ILRpdeh152icc68DGCyXYIw==}
-
-  discord-api-types@0.38.37:
-    resolution: {integrity: sha512-Cv47jzY1jkGkh5sv0bfHYqGgKOWO1peOrGMkDFM4UmaGMOTgOW8QSexhvixa9sVOiz8MnVOBryWYyw/CEVhj7w==}
+  discord-api-types@0.38.55:
+    resolution: {integrity: sha512-ytuaRTzdnHUCXJ6KjL9MrItQX0xKncBKEeYI1Bst4+ud47eejH3cG6gaesYakjpPcUhh68XYS2YwGq3mmujFsA==}
 
   discord-interactions@4.4.0:
     resolution: {integrity: sha512-jjJx8iwAeJcj8oEauV43fue9lNqkf38fy60aSs2+G8D1nJmDxUIrk08o3h0F3wgwuBWWJUZO+X/VgfXsxpCiJA==}
@@ -13648,7 +13645,7 @@ snapshots:
       '@discordjs/formatters': 0.6.2
       '@discordjs/util': 1.2.0
       '@sapphire/shapeshift': 4.0.0
-      discord-api-types: 0.38.37
+      discord-api-types: 0.38.55
       fast-deep-equal: 3.1.3
       ts-mixer: 6.0.4
       tslib: 2.8.1
@@ -13659,7 +13656,7 @@ snapshots:
 
   '@discordjs/formatters@0.6.2':
     dependencies:
-      discord-api-types: 0.38.37
+      discord-api-types: 0.38.55
 
   '@discordjs/rest@2.6.0':
     dependencies:
@@ -13668,14 +13665,14 @@ snapshots:
       '@sapphire/async-queue': 1.5.5
       '@sapphire/snowflake': 3.5.3
       '@vladfrangu/async_event_emitter': 2.4.7
-      discord-api-types: 0.38.37
+      discord-api-types: 0.38.55
       magic-bytes.js: 1.12.1
       tslib: 2.8.1
       undici: 6.21.3
 
   '@discordjs/util@1.2.0':
     dependencies:
-      discord-api-types: 0.38.37
+      discord-api-types: 0.38.55
 
   '@discordjs/ws@1.2.3':
     dependencies:
@@ -13685,7 +13682,7 @@ snapshots:
       '@sapphire/async-queue': 1.5.5
       '@types/ws': 8.18.1
       '@vladfrangu/async_event_emitter': 2.4.7
-      discord-api-types: 0.38.37
+      discord-api-types: 0.38.55
       tslib: 2.8.1
       ws: 8.20.1
     transitivePeerDependencies:
@@ -20722,9 +20719,7 @@ snapshots:
     dependencies:
       path-type: 4.0.0
 
-  discord-api-types@0.37.120: {}
-
-  discord-api-types@0.38.37: {}
+  discord-api-types@0.38.55: {}
 
   discord-interactions@4.4.0: {}
 
@@ -20737,7 +20732,7 @@ snapshots:
       '@discordjs/util': 1.2.0
       '@discordjs/ws': 1.2.3
       '@sapphire/snowflake': 3.5.3
-      discord-api-types: 0.38.37
+      discord-api-types: 0.38.55
       fast-deep-equal: 3.1.3
       lodash.snakecase: 4.1.1
       magic-bytes.js: 1.12.1


### PR DESCRIPTION
## Summary

Bumps `discord-api-types` to `^0.38.55` in `@chat-adapter/discord` and `@chat-adapter/integration-tests` (dedupes the copy `discord.js` already pulls in) and replaces the adapter's hand-written Discord types with the upstream ones. `types.ts` now only holds adapter config and the Gateway forwarding envelope.

- Public API unchanged: `DiscordComponentType` and `DiscordMessageFlag` re-export `ComponentType` and `MessageFlags` with identical values.
- Fixes forwarded reactions in threads and DMs: the forwarder now sets `channel_type` and, when there is no `member`, `user`. The webhook side read both but nothing populated them.
- Cleans up the deprecated `v9` import and `GuildPublicThread` aliases, raw `11`/`12` channel comparisons, the unused `is_mention` field, and the duplicate `InteractionResponseType` from `discord-interactions`.

I have done this PR with the help of Claude Code using Fable 5.1, however the changes have been checked by me (the human). I have thoughts on some of the structures but I understand that you guys want to offer a consistent interface across different adapters.

There's also a secondary PR I want to open that moves off of raw fetch calls to discord and use `@discordjs/rest` (which discord.js uses internally) but I'll wait for this PR first. I can open it in parallel if wanted

## Test plan

- `pnpm validate` passes.
- 294 adapter tests and 66 Discord replay/integration tests pass. Three legacy-gateway test fakes gained the fields real discord.js interactions always carry.

## Checklist

- [x] All commits are signed and verified
- [x] All commits are signed off for the DCO (`git commit -s`)
- [x] `pnpm validate` passes
- [x] Changeset added (or N/A — see [CONTRIBUTING.md](./CONTRIBUTING.md))
- [x] Documentation updated (or N/A) — no user-facing behavior or config changed; adapter `AGENTS.md` updated to point at `discord-api-types`
